### PR TITLE
Force HTTP graphQL E2E tests to error out if S3 bucket creation fails

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/__tests__/HttpTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/HttpTransformer.e2e.test.ts
@@ -16,7 +16,6 @@ jest.setTimeout(2000000);
 
 const cf = new CloudFormationClient('us-west-2');
 const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
     if (name === 'improvePluralization') {
@@ -93,7 +92,7 @@ beforeAll(async () => {
     `;
 
   try {
-    await awsS3Client.createBucket({ Bucket: BUCKET_NAME }).promise();
+    await customS3Client.createBucket(BUCKET_NAME);
   } catch (e) {
     console.error(`Failed to create bucket: ${e}`);
     expect(true).toEqual(false);

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/HttpTransformerV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/HttpTransformerV2.e2e.test.ts
@@ -16,7 +16,6 @@ jest.setTimeout(2000000);
 const REGION = 'us-west-2';
 const cf = new CloudFormationClient(REGION);
 const customS3Client = new S3Client(REGION);
-const awsS3Client = new S3({ region: REGION });
 const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
 const STACK_NAME = `HttpTransformerV2Test-${BUILD_TIMESTAMP}`;
 const BUCKET_NAME = `appsync-http-transformer-v2-test-bucket-${BUILD_TIMESTAMP}`;
@@ -93,7 +92,7 @@ beforeAll(async () => {
     `;
 
   try {
-    await awsS3Client.createBucket({ Bucket: BUCKET_NAME }).promise();
+    await customS3Client.createBucket(BUCKET_NAME);
   } catch (e) {
     console.error(`Failed to create bucket: ${e}`);
     expect(true).toEqual(false);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
