### PR TITLE
fix: run CDK bootstrap prior to deploy in GQL E2E

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/cdkUtils.ts
+++ b/packages/graphql-transformers-e2e-tests/src/cdkUtils.ts
@@ -26,6 +26,20 @@ export const deployJsonServer = () => {
     throw new Error (`'yarn' failed with exit code: ${yarnServerResult.exitCode}`);
   }
 
+  const cdkBootstrapResult = execa.sync('npx', [
+    'cdk',
+    'bootstrap',
+    '--require-approval',
+    'never',
+  ], {
+    cwd: jsonServerRootDirectory,
+    stdio: 'inherit',
+  });
+
+  if (cdkBootstrapResult.exitCode !== 0) {
+    throw new Error (`CDK bootstrap failed with exit code: ${cdkBootstrapResult.exitCode}`);
+  }
+
   const cdkDeployResult = execa.sync('npx', [
     'cdk',
     'deploy',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Possible Fix for HttpTransformer Tests inside `graphql-transformer-e2e-tests`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
