### PR TITLE
[DO NOT MERGE] chore: use latest amplify-cli and amplify-app packages for testing

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -51,8 +51,8 @@ install_cli_from_local_registry: &install_cli_from_local_registry
     startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
     setNpmRegistryUrlToLocal
     changeNpmGlobalPath
-    npm install -g @aws-amplify/cli-internal@apiSplitM1Refresh3
-    npm install -g amplify-app@apiSplitM1
+    npm install -g @aws-amplify/cli-internal
+    npm install -g amplify-app
     echo "using Amplify CLI version: "$(amplify --version)
     echo "using amplify-app version: "$(amplify-app --version)
     unsetNpmRegistryUrl

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "update-versions": "lerna version --yes --no-commit-hooks --no-push --exact --conventional-commits --no-git-tag-version",
     "commit": "git-cz",
     "coverage": "codecov || exit 0",
-    "add-cli-no-save": "yarn add @aws-amplify/cli-internal@apiSplitM1Refresh3 -W  && git checkout -- package.json",
+    "add-cli-no-save": "yarn add @aws-amplify/cli-internal -W  && git checkout -- package.json",
     "hoist-cli": "rm -rf node_modules/amplify-cli-internal && mkdir node_modules/amplify-cli-internal && cp -r node_modules/@aws-amplify/cli-internal/* node_modules/amplify-cli-internal",
     "publish:main": "lerna publish --canary --force-publish --preid=alpha --exact --include-merged-tags --conventional-prerelease --no-verify-access --yes"
   },


### PR DESCRIPTION
#### Description of changes
We needed to use a tagged release of CLI for testing purposes, and were refreshing during the release period. Once >8.1.0 is released, we should flip back to using `latest` for our test purposes.

#### Issue #, if available
N/A

#### Description of how you validated changes
N/A - will validate in CI

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
