### PR TITLE
fix: set searchable streaming lambda debug env var default to 0

### DIFF
--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-cfnParameters.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-cfnParameters.ts
@@ -80,7 +80,7 @@ export function createParametersStack(stack: Stack): Map<string, CfnParameter> {
       OpenSearchDebugStreamingLambda,
       new CfnParameter(stack, OpenSearchDebugStreamingLambda, {
         description: 'Enable debug logs for the Dynamo -> OpenSearch streaming lambda.',
-        default: 1,
+        default: 0,
         type: 'Number',
         allowedValues: ['0', '1'],
       }),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

ref https://github.com/aws-amplify/amplify-cli/pull/10318

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

n/a

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
