### PR TITLE
fix(searchable): change delete and update policy for os instance

### DIFF
--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
@@ -1,7 +1,7 @@
 import { ConflictHandlerType, GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import {
-  anything, countResources, expect as cdkExpect, haveResource,
+  anything, countResources, expect as cdkExpect, haveResource, ResourcePart
 } from '@aws-cdk/assert';
 import { parse } from 'graphql';
 import { SearchableModelTransformer } from '..';
@@ -226,8 +226,13 @@ test('it generates expected resources', () => {
       EBSOptions: anything(),
       ElasticsearchClusterConfig: anything(),
       ElasticsearchVersion: '7.10',
-    }),
+    }, ResourcePart.Properties),
   );
+  cdkExpect(searchableStack).to(
+    haveResource('AWS::Elasticsearch::Domain', {
+      UpdateReplacePolicy: "Delete",
+      DeletionPolicy: "Delete"
+  }, ResourcePart.CompleteDefinition));
   cdkExpect(searchableStack).to(
     haveResource('AWS::AppSync::DataSource', {
       ApiId: {

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
@@ -2,7 +2,7 @@ import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-int
 import { EbsDeviceVolumeType } from '@aws-cdk/aws-ec2';
 import { CfnDomain, Domain, ElasticsearchVersion } from '@aws-cdk/aws-elasticsearch';
 import { IRole, Role, ServicePrincipal } from '@aws-cdk/aws-iam';
-import { CfnParameter, Construct, Fn } from '@aws-cdk/core';
+import { CfnParameter, Construct, Fn, RemovalPolicy } from '@aws-cdk/core';
 import { ResourceConstants } from 'graphql-transformer-common';
 import assert from 'assert';
 export const createSearchableDomain = (stack: Construct, parameterMap: Map<string, CfnParameter>, apiId: string): Domain => {
@@ -21,6 +21,7 @@ export const createSearchableDomain = (stack: Construct, parameterMap: Map<strin
       enabled: false,
     },
     domainName: Fn.conditionIf(HasEnvironmentParameter, Fn.ref('AWS::NoValue'), 'd' + apiId).toString(),
+    removalPolicy: RemovalPolicy.DESTROY
   });
 
   (domain.node.defaultChild as CfnDomain).elasticsearchClusterConfig = {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Change the update and delete policy for os domain from `Retain` to `Delete` in CFN (in cdk from `RETAIN` to `DESTROY`), which will delete os domain when either removing `@searchable` from GQL schema or running `amplify delete`

`aws-cdk` is used as main dependency for `@searchable` v2. When constructing the cloud formation stack, the default update/delete status of OS domain is set as `Retain` because of its stateful property. Refer https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.RemovalPolicy.html
#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
fix https://github.com/aws-amplify/amplify-cli/issues/10401
#### Description of how you validated changes

- `yarn test`
-  Use `amplify-dev` in a sample app with `@searchable` defined, including `amplify-dev push` after removing `@searchable` and `amplify-dev delete`. The OS domain is deleted successfully in both cases.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
