### PR TITLE
test (graphql-transformers-e2e-tests): fix @auth delete with partial access test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "lerna run test",
     "test-ci": "lerna run test --concurrency 1 -- --ci -i",
     "e2e": "lerna run e2e",
-    "cloud-e2e": "CURR_BRANCH=$(git branch | awk '/\\*/{printf \"%s\", $2}') && UPSTREAM_BRANCH=run-e2e/$USER/$CURR_BRANCH && git push $(git remote -v | grep aws-amplify/amplify-category-api | head -n1 | awk '{print $1;}') $CURR_BRANCH:$UPSTREAM_BRANCH --no-verify --force-with-lease && echo \"\n\n 🏃 E2E test are running at:\nhttps://app.circleci.com/pipelines/github/aws-amplifyamplify-category-apii?branch=$UPSTREAM_BRANCH\"",
+    "cloud-e2e": "CURR_BRANCH=$(git branch | awk '/\\*/{printf \"%s\", $2}') && UPSTREAM_BRANCH=run-e2e/$USER/$CURR_BRANCH && git push $(git remote -v | grep aws-amplify/amplify-category-api | head -n1 | awk '{print $1;}') $CURR_BRANCH:$UPSTREAM_BRANCH --no-verify --force-with-lease && echo \"\n\n 🏃 E2E test are running at:\nhttps://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api?branch=$UPSTREAM_BRANCH\"",
     "lint-fix": "git diff --name-only --cached --diff-filter d | grep -E '\\.(js|jsx|ts|tsx)$' | xargs eslint --fix --quiet",
     "addwords": "node ./scripts/add-to-dict.js",
     "mergewords": "yarn ts-node ./scripts/handle-dict-conflicts.ts",

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2ExhaustiveT1B.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2ExhaustiveT1B.test.ts
@@ -74,7 +74,7 @@ describe('e2e auth resolvers tests', () => {
       modelName, strategy, provider, operation,
     }) => {
       expect(true).toBeTruthy();
-      await testAuthResolver(GRAPHQL_ENDPOINT, modelName, strategy, provider, operation, ID_TOKEN, ACCESS_TOKEN, API_KEY);
+      await testAuthResolver(GRAPHQL_ENDPOINT, modelName, strategy, provider, operation, ID_TOKEN, ACCESS_TOKEN, API_KEY, false, true);
     },
   );
 });

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2ExhaustiveT1D.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2ExhaustiveT1D.test.ts
@@ -74,7 +74,7 @@ describe('e2e auth resolvers tests', () => {
       modelName, strategy, provider, operation,
     }) => {
       expect(true).toBeTruthy();
-      await testAuthResolver(GRAPHQL_ENDPOINT, modelName, strategy, provider, operation, ID_TOKEN, ACCESS_TOKEN, API_KEY, true);
+      await testAuthResolver(GRAPHQL_ENDPOINT, modelName, strategy, provider, operation, ID_TOKEN, ACCESS_TOKEN, API_KEY, true, true);
     },
   );
 });

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2ExhaustiveT2B.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2ExhaustiveT2B.test.ts
@@ -74,7 +74,7 @@ describe('e2e auth resolvers tests', () => {
       modelName, strategy, provider, operation,
     }) => {
       expect(true).toBeTruthy();
-      await testAuthResolver(GRAPHQL_ENDPOINT, modelName, strategy, provider, operation, ID_TOKEN, ACCESS_TOKEN, API_KEY);
+      await testAuthResolver(GRAPHQL_ENDPOINT, modelName, strategy, provider, operation, ID_TOKEN, ACCESS_TOKEN, API_KEY, false, true);
     },
   );
 });

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2ExhaustiveT2D.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2ExhaustiveT2D.test.ts
@@ -74,7 +74,7 @@ describe('e2e auth resolvers tests', () => {
       modelName, strategy, provider, operation,
     }) => {
       expect(true).toBeTruthy();
-      await testAuthResolver(GRAPHQL_ENDPOINT, modelName, strategy, provider, operation, ID_TOKEN, ACCESS_TOKEN, API_KEY, true);
+      await testAuthResolver(GRAPHQL_ENDPOINT, modelName, strategy, provider, operation, ID_TOKEN, ACCESS_TOKEN, API_KEY, true, true);
     },
   );
 });

--- a/packages/graphql-transformers-e2e-tests/src/authExhaustiveTestUtils.ts
+++ b/packages/graphql-transformers-e2e-tests/src/authExhaustiveTestUtils.ts
@@ -226,6 +226,7 @@ export const testAuthResolver = async (
   accessToken: string,
   apiKey: string,
   hasCustomPrimaryKey = false,
+  hasPartialAccess = false,
 ): Promise<void> => {
   const client = await createGraphQLClient(
     graphqlEndpoint,
@@ -345,11 +346,20 @@ export const testAuthResolver = async (
       }
     `;
 
-    const response = await client.mutate<any>({
-      mutation,
-      fetchPolicy: 'no-cache',
-    });
-    expect(response.errors).not.toBeDefined();
+    try {
+      const response = await client.mutate<any>({
+        mutation,
+        fetchPolicy: 'no-cache',
+      });
+
+      if (hasPartialAccess && operation === 'delete') {
+        expect(response.errors).toBeDefined();
+      } else {
+        expect(response.errors).not.toBeDefined();
+      }
+    } catch (e) {
+      expect(hasPartialAccess && operation === 'delete').toBeTruthy();
+    }
 
     try {
       const failResponse = await invalidClient.mutate<any>({


### PR DESCRIPTION
#### Description of changes
- fixes auth tests for delete with partial access
#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
