### PR TITLE
chore: update function test to point to node 14

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/migration/node.function.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/node.function.test.ts
@@ -57,7 +57,7 @@ describe('nodejs version migration tests', () => {
     );
     let authStackContent = fs.readFileSync(authStackFileName).toString();
 
-    authStackContent = authStackContent.replace('nodejs12.x', 'nodejs10.x');
+    authStackContent = authStackContent.replace('nodejs14.x', 'nodejs10.x');
 
     fs.writeFileSync(authStackFileName, authStackContent, 'utf-8');
 
@@ -84,8 +84,8 @@ describe('nodejs version migration tests', () => {
     functionStackContent = fs.readFileSync(functionStackFileName).toString();
 
     expect(projectConfigContent.indexOf('3.1')).toBeGreaterThan(0);
-    expect(authStackContent.indexOf('nodejs12.x')).toBeGreaterThan(0);
-    expect(functionStackContent.indexOf('nodejs12.x')).toBeGreaterThan(0);
+    expect(authStackContent.indexOf('nodejs14.x')).toBeGreaterThan(0);
+    expect(functionStackContent.indexOf('nodejs14.x')).toBeGreaterThan(0);
   });
 
   function amplifyNodeMigrationAndPush(cwd: string) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Function now uses node14, need to update our tests accordingly.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
