### PR TITLE
fix: update cleanup circle contexts, remove unnecessary branches

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -395,8 +395,6 @@ workflows:
             branches:
               only:
                 - main
-                - api-split-m1-test
-                - api-split-m1
     jobs:
       - build
       - cleanup_resources:
@@ -432,8 +430,6 @@ workflows:
                 - main
                 - /tagged-release\/.*/
                 - /run-e2e\/.*/
-                - api-split-m1-test
-                - api-split-m1
           requires:
             - build
             - publish_to_local_registry
@@ -447,9 +443,6 @@ workflows:
                 - beta
                 - /tagged-release\/.*/
                 - /run-e2e\/.*/
-                - api-split-m1-test
-                - api-split-m1
-                - api-split-m1-staging
           requires:
             - build
       - publish_to_local_registry:
@@ -462,8 +455,6 @@ workflows:
                 - /tagged-release\/.*/
                 - /tagged-release-without-e2e-tests\/.*/
                 - /run-e2e\/.*/
-                - api-split-m1-test
-                - api-split-m1
           requires:
             - build
       - amplify_e2e_tests:
@@ -477,8 +468,6 @@ workflows:
                 - main
                 - /tagged-release\/.*/
                 - /run-e2e\/.*/
-                - api-split-m1-test
-                - api-split-m1
           requires:
             - publish_to_local_registry
       - amplify_migration_tests_v6:
@@ -492,8 +481,6 @@ workflows:
                 - main
                 - /tagged-release\/.*/
                 - /run-e2e\/.*/
-                - api-split-m1-test
-                - api-split-m1
           requires:
             - publish_to_local_registry
             - integration_test
@@ -508,8 +495,6 @@ workflows:
                 - main
                 - /tagged-release\/.*/
                 - /run-e2e\/.*/
-                - api-split-m1-test
-                - api-split-m1
           requires:
             - publish_to_local_registry
             - integration_test
@@ -542,7 +527,6 @@ workflows:
                 - beta
                 - /tagged-release\/.*/
                 - /tagged-release-without-e2e-tests\/.*/
-
 commands:
   install_yarn:
     description: "Install yarn dependency for windows"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ workflows:
       - build
       - cleanup_resources:
           context:
-            - cleanup-resources
-            - e2e-test-context
+            - api-cleanup-resources
+            - api-e2e-test-context
           requires:
             - build


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

We were using the wrong contexts for our setup job for e2e cleanup. Updating those, and removing the interim branches we were using during migration.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
