### PR TITLE
fix: correct behavior for CreateApiKey config

### DIFF
--- a/packages/amplify-graphql-transformer-core/src/__tests__/transformation/transform.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transformation/transform.test.ts
@@ -1,0 +1,136 @@
+import { AppSyncAuthConfiguration, TransformerPluginProvider, TransformerPluginType } from '@aws-amplify/graphql-transformer-interfaces';
+import { App } from '@aws-cdk/core';
+import { GraphQLApi } from '../../graphql-api';
+import { GraphQLTransform } from '../../transformation/transform';
+import { TransformerOutput } from '../../transformer-context/output';
+import { StackManager } from '../../transformer-context/stack-manager';
+
+class TestGraphQLTransform extends GraphQLTransform {
+  testGenerateGraphQlApi(stackManager: StackManager, output: TransformerOutput): GraphQLApi {
+    return this.generateGraphQlApi(stackManager, output);
+  }
+}
+
+const mockTransformer: TransformerPluginProvider = {
+  pluginType: TransformerPluginType.DATA_SOURCE_PROVIDER,
+  name: '',
+  directive: {
+    kind: 'DirectiveDefinition',
+    name: {
+      kind: 'Name',
+      value: '',
+    },
+    repeatable: false,
+    locations: [],
+  },
+  typeDefinitions: [],
+};
+
+describe('GraphQLTransform', () => {
+  it('throws on construction with no transformers', () => {
+    expect(() => {
+      // eslint-disable-next-line no-new
+      new GraphQLTransform({
+        transformers: [],
+      });
+    }).toThrowErrorMatchingInlineSnapshot('"Must provide at least one transformer."');
+  });
+
+  it('can be constructed with a single transformer', () => {
+    const transform = new GraphQLTransform({
+      transformers: [mockTransformer],
+    });
+    expect(transform).toBeDefined();
+  });
+
+  describe('generateGraphQlApi', () => {
+    const invokeAndVerifyIfAPIKeyIsDefined = (
+      { transform, isAPIKeyExpected }: { transform: TestGraphQLTransform, isAPIKeyExpected: boolean },
+    ): void => {
+      const stackManager = new StackManager(new App(), {});
+      const transformerOutput = {
+        buildSchema: jest.fn(() => ''),
+      } as unknown as TransformerOutput;
+      transform.testGenerateGraphQlApi(stackManager, transformerOutput);
+      if (isAPIKeyExpected) {
+        expect(stackManager.rootStack.node.tryFindChild('GraphQLAPIKeyOutput')).toBeDefined();
+      } else {
+        expect(stackManager.rootStack.node.tryFindChild('GraphQLAPIKeyOutput')).toBeUndefined();
+      }
+    };
+
+    const apiKeyAuthConfig: AppSyncAuthConfiguration = {
+      defaultAuthentication: {
+        authenticationType: 'API_KEY',
+        apiKeyConfig: { apiKeyExpirationDays: 7 },
+      },
+      additionalAuthenticationProviders: [],
+    };
+
+    const iamAuthConfig: AppSyncAuthConfiguration = {
+      defaultAuthentication: { authenticationType: 'AWS_IAM' },
+      additionalAuthenticationProviders: [],
+    };
+
+    it('can be invoked', () => {
+      const transform = new TestGraphQLTransform({ transformers: [mockTransformer] });
+      const stackManager = new StackManager(new App(), {});
+      const transformerOutput = {
+        buildSchema: jest.fn(() => ''),
+      } as unknown as TransformerOutput;
+      transform.testGenerateGraphQlApi(stackManager, transformerOutput);
+    });
+
+    it('creates an api key for apps with API_KEY authorization', () => {
+      const transform = new TestGraphQLTransform({
+        transformers: [mockTransformer],
+        authConfig: apiKeyAuthConfig,
+      });
+      invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: true });
+    });
+
+    it('does not create an api key for apps with IAM authorization', () => {
+      const transform = new TestGraphQLTransform({
+        transformers: [mockTransformer],
+        authConfig: iamAuthConfig,
+      });
+      invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: false });
+    });
+
+    it('creates an api key for apps with API_KEY authorization if CreateApiKey is set to 1', () => {
+      const transform = new TestGraphQLTransform({
+        transformers: [mockTransformer],
+        authConfig: apiKeyAuthConfig,
+        buildParameters: { CreateAPIKey: 1 },
+      });
+      invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: true });
+    });
+
+    it('does not create an api key for apps with API_KEY authorization if CreateApiKey is set to 0', () => {
+      const transform = new TestGraphQLTransform({
+        transformers: [mockTransformer],
+        authConfig: apiKeyAuthConfig,
+        buildParameters: { CreateAPIKey: 0 },
+      });
+      invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: false });
+    });
+
+    it('does not create an api key for apps with API_KEY authorization if CreateApiKey is set to -1', () => {
+      const transform = new TestGraphQLTransform({
+        transformers: [mockTransformer],
+        authConfig: apiKeyAuthConfig,
+        buildParameters: { CreateAPIKey: -1 },
+      });
+      invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: false });
+    });
+
+    it('does not create an api key for apps with API_KEY authorization if CreateApiKey is set to an empty string', () => {
+      const transform = new TestGraphQLTransform({
+        transformers: [mockTransformer],
+        authConfig: apiKeyAuthConfig,
+        buildParameters: { CreateAPIKey: '' },
+      });
+      invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: false });
+    });
+  });
+});

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -338,7 +338,7 @@ export class GraphQLTransform {
     }
   };
 
-  private generateGraphQlApi(stackManager: StackManager, output: TransformerOutput) {
+  protected generateGraphQlApi(stackManager: StackManager, output: TransformerOutput): GraphQLApi {
     // Todo: Move this to its own transformer plugin to support modifying the API
     // Like setting the auth mode and enabling logging and such
 
@@ -361,10 +361,9 @@ export class GraphQLTransform {
       mode => mode?.authorizationType,
     );
 
-    if (
-      authModes.includes(AuthorizationType.API_KEY)
-      && !(this.buildParameters.CreateAPIKey && this.buildParameters.CreateAPIKey !== false)
-    ) {
+    const hasLegacyAPIKeyConfigDisabled = 'CreateAPIKey' in this.buildParameters && this.buildParameters.CreateAPIKey !== 1;
+
+    if (authModes.includes(AuthorizationType.API_KEY) && !hasLegacyAPIKeyConfigDisabled) {
       const apiKeyConfig: AuthorizationMode | undefined = [
         authorizationConfig.defaultAuthorization,
         ...(authorizationConfig.additionalAuthorizationModes || []),


### PR DESCRIPTION
#### Description of changes
Update the behavior where we look at the old CreateAPIKey flag from transformer v1. We had implemented this in v1 to just look for truthy behavior, which isn't consistent with the previous implementation. Explicitly updating this to only disable for value 0.

#### Issue #, if available
https://github.com/aws-amplify/amplify-category-api/issues/80

#### Description of how you validated changes
Ran in my local CLI to verify the 0/1 behavior a few times, and added unit tests for this behavior to ensure we have consistency in how we're handling these parameters.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
