### PR TITLE
chore: manually clean graphql-transformer-core on each build to avoid type override issues

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -291,7 +291,7 @@ jobs:
       - run:
           name: Configure Amplify CLI
           command: |
-            yarn clean && yarn setup-dev && yarn rm-aa-dev-link && yarn link-aa-dev
+            yarn setup-dev && yarn rm-aa-dev-link && yarn link-aa-dev
             echo 'export PATH="$(yarn global bin):$PATH"' >> $BASH_ENV
             source $BASH_ENV
             amplify-dev --version

--- a/packages/graphql-transformer-core/package.json
+++ b/packages/graphql-transformer-core/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "build": "tsc",
+    "build": "rimraf ./lib ./tsconfig.tsbuildinfo && tsc",
     "watch": "tsc -w",
     "clean": "rimraf ./lib"
   },


### PR DESCRIPTION
#### Description of changes
manually clean graphql-transformer-core on each build to avoid type override issues, this is a mitigation, not a solution.

I'll create an item in the backlog to dig into this later, but for now this unblocks happy-case development paths without needing to manually rebuild the env on each change.

#### Issue #, if available
N/A

#### Description of how you validated changes
Ran build a great many times in a row, ran setup-dev a few times, and ran unit tests.
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
