### PR TITLE
chore: parallelize account and resource cleanup for e2e testing

### DIFF
--- a/packages/amplify-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-core/src/utils/sdk-calls.ts
@@ -72,8 +72,9 @@ export const getBucketKeys = async (params: S3.ListObjectsRequest) => {
   }
 };
 
-export const deleteS3Bucket = async (bucket: string) => {
-  const s3 = new S3();
+
+export const deleteS3Bucket = async (bucket: string, providedS3Client: S3 | undefined = undefined) => {
+  const s3 = providedS3Client ? providedS3Client : new S3();
   let continuationToken: Required<Pick<S3.ListObjectVersionsOutput, 'KeyMarker' | 'VersionIdMarker'>> = undefined;
   const objectKeyAndVersion = <S3.ObjectIdentifier[]>[];
   let truncated = false;

--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -68,6 +68,8 @@ type ReportEntry = {
   buckets: Record<string, S3BucketInfo>;
 };
 
+type JobFilterPredicate = (job: ReportEntry) => boolean;
+
 type CCIJobInfo = {
   workflowId: string;
   workflowName: string;
@@ -76,21 +78,24 @@ type CCIJobInfo = {
   status: string;
 };
 
-/**
- * Configure the AWS SDK with credentials and retry
- */
-const configureAws = (
-  { accessKeyId, secretAccessKey, sessionToken }: { accessKeyId: string, secretAccessKey: string, sessionToken?: string },
-): void => {
-  aws.config.update({
-    credentials: {
-      accessKeyId,
-      secretAccessKey,
-      ...(sessionToken ? { sessionToken } : {}),
-    },
-    maxRetries: 10,
-  });
+type AWSAccountInfo = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken: string;
 };
+
+/**
+ * Get the relevant AWS config object for a given account and region.
+ */
+const getAWSConfig = ({ accessKeyId, secretAccessKey, sessionToken }: AWSAccountInfo, region?: string): any => ({
+  credentials: {
+    accessKeyId,
+    secretAccessKey,
+    sessionToken,
+  },
+  ...(region ? { region } : {}),
+  maxRetries: 10,
+});
 
 /**
  * Returns a list of Amplify Apps in the region. The apps includes information about the CircleCI build that created the app
@@ -98,8 +103,8 @@ const configureAws = (
  * @param region aws region to query for amplify Apps
  * @returns Promise<AmplifyAppInfo[]> a list of Amplify Apps in the region with build info
  */
-const getAmplifyApps = async (region: string): Promise<AmplifyAppInfo[]> => {
-  const amplifyClient = new aws.Amplify({ region });
+const getAmplifyApps = async (account: AWSAccountInfo, region: string): Promise<AmplifyAppInfo[]> => {
+  const amplifyClient = new aws.Amplify(getAWSConfig(account, region));
   const amplifyApps = await amplifyClient.listApps({ maxResults: 50 }).promise(); // keeping it to 50 as max supported is 50
   const result: AmplifyAppInfo[] = [];
   for (const app of amplifyApps.apps) {
@@ -107,7 +112,7 @@ const getAmplifyApps = async (region: string): Promise<AmplifyAppInfo[]> => {
     try {
       const backendEnvironments = await amplifyClient.listBackendEnvironments({ appId: app.appId, maxResults: 50 }).promise();
       for (const backendEnv of backendEnvironments.backendEnvironments) {
-        const buildInfo = await getStackDetails(backendEnv.stackName, region);
+        const buildInfo = await getStackDetails(backendEnv.stackName, account, region);
         if (buildInfo) {
           backends[backendEnv.environmentName] = buildInfo;
         }
@@ -144,8 +149,8 @@ const getJobId = (tags: aws.CloudFormation.Tags = []): number | undefined => {
  * @param region region
  * @returns stack details
  */
-const getStackDetails = async (stackName: string, region: string): Promise<StackInfo | void> => {
-  const cfnClient = new aws.CloudFormation({ region });
+const getStackDetails = async (stackName: string, account: AWSAccountInfo, region: string): Promise<StackInfo | void> => {
+  const cfnClient = new aws.CloudFormation(getAWSConfig(account, region));
   const stack = await cfnClient.describeStacks({ StackName: stackName }).promise();
   const tags = stack.Stacks.length && stack.Stacks[0].Tags;
   const stackStatus = stack.Stacks[0].StackStatus;
@@ -168,8 +173,8 @@ const getStackDetails = async (stackName: string, region: string): Promise<Stack
   };
 };
 
-const getStacks = async (region: string): Promise<StackInfo[]> => {
-  const cfnClient = new aws.CloudFormation({ region });
+const getStacks = async (account: AWSAccountInfo, region: string): Promise<StackInfo[]> => {
+  const cfnClient = new aws.CloudFormation(getAWSConfig(account, region));
   const stacks = await cfnClient
     .listStacks({
       StackStatusFilter: [
@@ -191,7 +196,7 @@ const getStacks = async (region: string): Promise<StackInfo[]> => {
   const results: StackInfo[] = [];
   for (const stack of rootStacks) {
     try {
-      const details = await getStackDetails(stack.StackName, region);
+      const details = await getStackDetails(stack.StackName, account, region);
       details && results.push(details);
     } catch {
       // don't want to barf and fail e2e tests
@@ -231,8 +236,8 @@ const getJobCircleCIDetails = async (jobId: number): Promise<CircleCIJobDetails>
   return r;
 };
 
-const getS3Buckets = async (): Promise<S3BucketInfo[]> => {
-  const s3Client = new aws.S3();
+const getS3Buckets = async (account: AWSAccountInfo): Promise<S3BucketInfo[]> => {
+  const s3Client = new aws.S3(getAWSConfig(account));
   const buckets = await s3Client.listBuckets().promise();
   const result: S3BucketInfo[] = [];
   for (const bucket of buckets.Buckets) {
@@ -330,52 +335,51 @@ const mergeResourcesByCCIJob = (
   return result;
 };
 
-const deleteAmplifyApps = async (apps: AmplifyAppInfo[]): Promise<void> => {
-  for (const appInfo of apps) {
-    console.log(`Deleting App ${appInfo.name}(${appInfo.appId})`);
-    await deleteAmplifyApp(appInfo.appId, appInfo.region);
-  }
+const deleteAmplifyApps = async (account: AWSAccountInfo, accountIndex: number, apps: AmplifyAppInfo[]): Promise<void> => {
+  await Promise.all(apps.map(app => deleteAmplifyApp(account, accountIndex, app)));
 };
 
-const deleteAmplifyApp = async (appId: string, region: string): Promise<void> => {
-  const amplifyClient = new aws.Amplify({ region });
+const deleteAmplifyApp = async (account: AWSAccountInfo, accountIndex: number, app: AmplifyAppInfo): Promise<void> => {
+  const { name, appId, region } = app;
+  console.log(`[ACCOUNT ${accountIndex}] Deleting App ${name}(${appId})`);
+  const amplifyClient = new aws.Amplify(getAWSConfig(account, region));
   try {
     await amplifyClient.deleteApp({ appId }).promise();
   } catch (e) {
-    console.log(`Deleting Amplify App ${appId} failed with the following error`, e);
+    console.log(`[ACCOUNT ${accountIndex}] Deleting Amplify App ${appId} failed with the following error`, e);
   }
 };
 
-const deleteBuckets = async (buckets: S3BucketInfo[]): Promise<void> => {
-  for (const bucketInfo of buckets) {
-    try {
-      console.log(`Deleting S3 Bucket ${bucketInfo.name}`);
-      await deleteS3Bucket(bucketInfo.name);
-    } catch (e) {
-      console.log(`Deleting bucket ${bucketInfo.name} failed with error ${e.message}`);
-    }
+const deleteBuckets = async (account: AWSAccountInfo, accountIndex: number, buckets: S3BucketInfo[]): Promise<void> => {
+  await Promise.all(buckets.map(bucket => deleteBucket(account, accountIndex, bucket)));
+};
+
+const deleteBucket = async (account: AWSAccountInfo, accountIndex: number, bucket: S3BucketInfo): Promise<void> => {
+  const { name } = bucket;
+  try {
+    console.log(`[ACCOUNT ${accountIndex}] Deleting S3 Bucket ${name}`);
+    const s3 = new aws.S3(getAWSConfig(account));
+    await deleteS3Bucket(name, s3);
+  } catch (e) {
+    console.log(`[ACCOUNT ${accountIndex}] Deleting bucket ${name} failed with error ${e.message}`);
   }
 };
 
-const deleteCfnStacks = async (stacks: StackInfo[]): Promise<void> => {
-  for (const stackInfo of stacks) {
-    try {
-      console.log(`Deleting CloudFormation stack ${stackInfo.stackName}`);
-      await deleteCfnStack(
-        stackInfo.stackName,
-        stackInfo.region,
-        stackInfo.resourcesFailedToDelete.length ? stackInfo.resourcesFailedToDelete : undefined,
-      );
-    } catch (e) {
-      console.log(`Deleting CloudFormation stack ${stackInfo.stackName} failed with error ${e.message}`);
-    }
-  }
+const deleteCfnStacks = async (account: AWSAccountInfo, accountIndex: number, stacks: StackInfo[]): Promise<void> => {
+  await Promise.all(stacks.map(stack => deleteCfnStack(account, accountIndex, stack)));
 };
 
-const deleteCfnStack = async (stackName: string, region: string, resourceToRetain?: string[]): Promise<void> => {
-  const cfnClient = new aws.CloudFormation({ region });
-  await cfnClient.deleteStack({ StackName: stackName, RetainResources: resourceToRetain }).promise();
-  await cfnClient.waitFor('stackDeleteComplete', { StackName: stackName }).promise();
+const deleteCfnStack = async (account: AWSAccountInfo, accountIndex: number, stack: StackInfo): Promise<void> => {
+  const { stackName, region, resourcesFailedToDelete } = stack;
+  const resourceToRetain = resourcesFailedToDelete.length ? resourcesFailedToDelete : undefined;
+  console.log(`[ACCOUNT ${accountIndex}] Deleting CloudFormation stack ${stackName}`);
+  try {
+    const cfnClient = new aws.CloudFormation(getAWSConfig(account, region));
+    await cfnClient.deleteStack({ StackName: stackName, RetainResources: resourceToRetain }).promise();
+    await cfnClient.waitFor('stackDeleteComplete', { StackName: stackName }).promise();
+  } catch (e) {
+    console.log(`Deleting CloudFormation stack ${stackName} failed with error ${e.message}`);
+  }
 };
 
 const generateReport = (jobs): void => {
@@ -383,19 +387,27 @@ const generateReport = (jobs): void => {
   fs.writeFileSync(reportPath, JSON.stringify(jobs, null, 4));
 };
 
-const deleteResources = async (staleResources: Record<string, ReportEntry>): Promise<void> => {
+/**
+ * While we basically fan-out deletes elsewhere in this script, leaving the app->cfn->bucket delete process
+ * serial within a given account, it's not immediately clear if this is necessary, but seems possibly valuable.
+ */
+const deleteResources = async (
+  account: AWSAccountInfo,
+  accountIndex: number,
+  staleResources: Record<string, ReportEntry>,
+): Promise<void> => {
   for (const jobId of Object.keys(staleResources)) {
     const resources = staleResources[jobId];
     if (resources.amplifyApps) {
-      await deleteAmplifyApps(Object.values(resources.amplifyApps));
+      await deleteAmplifyApps(account, accountIndex, Object.values(resources.amplifyApps));
     }
 
     if (resources.stacks) {
-      await deleteCfnStacks(Object.values(resources.stacks));
+      await deleteCfnStacks(account, accountIndex, Object.values(resources.stacks));
     }
 
     if (resources.buckets) {
-      await deleteBuckets(Object.values(resources.buckets));
+      await deleteBuckets(account, accountIndex, Object.values(resources.buckets));
     }
   }
 };
@@ -403,7 +415,7 @@ const deleteResources = async (staleResources: Record<string, ReportEntry>): Pro
 /**
  * Grab the right CircleCI filter based on args passed in.
  */
-const getFilterPredicate = (args: any): any => {
+const getFilterPredicate = (args: any): JobFilterPredicate => {
   const filterByJobId = (jobId: string) => (job: ReportEntry) => job.jobId === jobId;
   const filterByWorkflowId = (workflowId: string) => (job: ReportEntry) => job.workflowId === workflowId;
   const filterAllStaleResources = () => (job: ReportEntry) => job.lifecycle === 'finished' || job.jobId === ORPHAN;
@@ -427,7 +439,7 @@ const getFilterPredicate = (args: any): any => {
  * Retrieve the accounts to process for potential cleanup. By default we will attempt
  * to get all accounts within the root account organization.
  */
-const getAccountsToCleanup = async (): Promise<any[]> => {
+const getAccountsToCleanup = async (): Promise<AWSAccountInfo[]> => {
   const stsRes = new aws.STS({
     apiVersion: '2011-06-15',
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
@@ -445,7 +457,6 @@ const getAccountsToCleanup = async (): Promise<any[]> => {
     const accountCredentialPromises = orgAccounts.Accounts.map(async account => {
       if (account.Id === parentAccountIdentity.Account) {
         return {
-          accountId: account.Id,
           accessKeyId: process.env.AWS_ACCESS_KEY_ID,
           secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
           sessionToken: process.env.AWS_SESSION_TOKEN,
@@ -462,7 +473,6 @@ const getAccountsToCleanup = async (): Promise<any[]> => {
         })
         .promise();
       return {
-        accountId: account.Id,
         accessKeyId: assumeRoleRes.Credentials.AccessKeyId,
         secretAccessKey: assumeRoleRes.Credentials.SecretAccessKey,
         sessionToken: assumeRoleRes.Credentials.SessionToken,
@@ -474,7 +484,6 @@ const getAccountsToCleanup = async (): Promise<any[]> => {
     console.log('Error assuming child account role. This could be because the script is already running from within a child account. Running on current AWS account only.');
     return [
       {
-        accountId: parentAccountIdentity.Account,
         accessKeyId: process.env.AWS_ACCESS_KEY_ID,
         secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
         sessionToken: process.env.AWS_SESSION_TOKEN,
@@ -483,8 +492,28 @@ const getAccountsToCleanup = async (): Promise<any[]> => {
   }
 };
 
+const cleanupAccount = async (account: AWSAccountInfo, accountIndex: number, filterPredicate: JobFilterPredicate): Promise<void> => {
+  const appPromises = AWS_REGIONS_TO_RUN_TESTS.map(region => getAmplifyApps(account, region));
+  const stackPromises = AWS_REGIONS_TO_RUN_TESTS.map(region => getStacks(account, region));
+  const bucketPromise = getS3Buckets(account);
+
+  const apps = (await Promise.all(appPromises)).flat();
+  const stacks = (await Promise.all(stackPromises)).flat();
+  const buckets = await bucketPromise;
+
+  const allResources = mergeResourcesByCCIJob(apps, stacks, buckets);
+  const staleResources = _.pickBy(allResources, filterPredicate);
+  generateReport(staleResources);
+  await deleteResources(account, accountIndex, staleResources);
+  console.log(`[ACCOUNT ${accountIndex}] Cleanup done!`);
+};
+
 /**
  * Execute the cleanup script.
+ * Cleanup will happen in parallel across all accounts within a given organization,
+ * based on the requested filter parameters (i.e. for a given workfow, job, or all stale resources).
+ * Logs are emitted for given account ids anywhere we've fanned out, but we use an indexing scheme instead
+ * of account ids since the logs these are written to will be effectively public.
  */
 const cleanup = async (): Promise<void> => {
   const args = yargs
@@ -508,24 +537,8 @@ const cleanup = async (): Promise<void> => {
   const filterPredicate = getFilterPredicate(args);
   const accounts = await getAccountsToCleanup();
 
-  for (const account of accounts) {
-    configureAws(account);
-
-    // Kick off all GET/LIST requests, then yield for them all.
-    const appPromises = AWS_REGIONS_TO_RUN_TESTS.map(region => getAmplifyApps(region));
-    const stackPromises = AWS_REGIONS_TO_RUN_TESTS.map(region => getStacks(region));
-    const bucketPromise = getS3Buckets();
-
-    const apps = (await Promise.all(appPromises)).flat();
-    const stacks = (await Promise.all(stackPromises)).flat();
-    const buckets = await bucketPromise;
-
-    const allResources = mergeResourcesByCCIJob(apps, stacks, buckets);
-    const staleResources = _.pickBy(allResources, filterPredicate);
-    generateReport(staleResources);
-    await deleteResources(staleResources);
-    console.log('Cleanup done!');
-  }
+  await Promise.all(accounts.map((account, i) => cleanupAccount(account, i, filterPredicate)));
+  console.log('Done cleaning all accounts!');
 };
 
 cleanup();


### PR DESCRIPTION
#### Description of changes
Parallelize cleanup both across all accounts simultaneously, and across all resources of a given type at once. This requires configuring all AWS clients with an explicit account and region (except s3, which is global), so there's a bit of a refactor to pass account and regional info all the way down to client construction.

Because logs are all jumbled up now, I've added an `accountIndex` to each output per-account. Accounts were already opaque, but this way we can at least correlate errors, etc. within an account.

E.g.

```
[ACCOUNT 5] Deleting S3 Bucket amplify-e02de3f283b84aa5ab02-integtest-210400-deployment
[ACCOUNT 1] Deleting S3 Bucket amplify-iterativetest1-integtest-210353-deployment
[ACCOUNT 5] Deleting CloudFormation stack amplify-auth22dc3507d274a102-integtest-211220
[ACCOUNT 1] Deleting S3 Bucket amplify-a0b27ac02ef4470ab089-integtest-210407-deployment
[ACCOUNT 1] Deleting App lambdaauthenv(dyknllcal7gvg)
[ACCOUNT 1] Cleanup done!
[ACCOUNT 2] Deleting CloudFormation stack amplify-model2dc3507d2f4f1d0-integtest-211447
[ACCOUNT 3] Deleting CloudFormation stack amplify-simplemodel-devtest-204508
[ACCOUNT 4] Deleting CloudFormation stack amplify-deletekeys-integtest-210345
[ACCOUNT 3] Deleting CloudFormation stack amplify-auth32dc3507d2dee8ae-integtest-211423
[ACCOUNT 2] Deleting S3 Bucket amplify-model2dc3507d2f4f1d0-integtest-211447-deployment
[ACCOUNT 4] Deleting S3 Bucket amplify-deletekeys-integtest-210345-deployment
[ACCOUNT 2] Deleting CloudFormation stack amplify-auth52dc3507d25bcf05-integtest-211316
[ACCOUNT 4] Deleting S3 Bucket amplify-817596ddeff44deb970a-integtest-210330-deployment
[ACCOUNT 4] Deleting CloudFormation stack amplify-removeaddconnection-integtest-210951
[ACCOUNT 5] Deleting S3 Bucket amplify-auth22dc3507d274a102-integtest-211220-deployment
[ACCOUNT 5] Deleting CloudFormation stack amplify-auth42dc3507d267ecf7-integtest-211058
```

#### Issue #, if available
N/A

#### Description of how you validated changes
Ran `yarn setup-dev && yarn test`, and then manually ran cleanup.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
