### PR TITLE
chore: remove dependency on integration-test for migration tests v5 and v6

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -483,7 +483,6 @@ workflows:
                 - /run-e2e\/.*/
           requires:
             - publish_to_local_registry
-            - integration_test
       - amplify_migration_tests_v5:
           context:
             - e2e-auth-credentials
@@ -497,7 +496,6 @@ workflows:
                 - /run-e2e\/.*/
           requires:
             - publish_to_local_registry
-            - integration_test
       - cleanup_resources_after_e2e_runs:
           context:
             - api-cleanup-resources


### PR DESCRIPTION
#### Description of changes
chore: remove dependency on integration-test for migration tests v5 and v6, I see no good reason for this dep, so removing it so that a failing 'integration test' doesn't block me from getting signal on these additional tests.

#### Issue #, if available
N/A

#### Description of how you validated changes
N/A, will verify in CircleCI
#### Checklist
- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
