### PR TITLE
fix: use concatenated identity claim for primary key queries

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
@@ -360,7 +360,12 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
         #foreach( $entry in $primaryFieldMap.entrySet() )
           #set( $modelQueryExpression.expression = \\"\${modelQueryExpression.expression} AND #\${entry.key} = :\${entry.key}\\" )
           $util.qr($modelQueryExpression.expressionNames.put(\\"#\${entry.key}\\", $entry.key))
-          $util.qr($modelQueryExpression.expressionValues.put(\\":\${entry.key}\\", $util.dynamodb.toDynamoDB($entry.value)))
+          #if( $util.isList($entry.value) )
+            #set( $lastClaim = $entry.value.size() - 1 )
+            $util.qr($modelQueryExpression.expressionValues.put(\\":\${entry.key}\\", $util.dynamodb.toDynamoDB($entry.value[$lastClaim])))
+          #else
+            $util.qr($modelQueryExpression.expressionValues.put(\\":\${entry.key}\\", $util.dynamodb.toDynamoDB($entry.value)))
+          #end
         #end
         $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
         #set( $isAuthorized = true )
@@ -735,7 +740,12 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
         #foreach( $entry in $primaryFieldMap.entrySet() )
           #set( $modelQueryExpression.expression = \\"\${modelQueryExpression.expression} AND #\${entry.key} = :\${entry.key}\\" )
           $util.qr($modelQueryExpression.expressionNames.put(\\"#\${entry.key}\\", $entry.key))
-          $util.qr($modelQueryExpression.expressionValues.put(\\":\${entry.key}\\", $util.dynamodb.toDynamoDB($entry.value)))
+          #if( $util.isList($entry.value) )
+            #set( $lastClaim = $entry.value.size() - 1 )
+            $util.qr($modelQueryExpression.expressionValues.put(\\":\${entry.key}\\", $util.dynamodb.toDynamoDB($entry.value[$lastClaim])))
+          #else
+            $util.qr($modelQueryExpression.expressionValues.put(\\":\${entry.key}\\", $util.dynamodb.toDynamoDB($entry.value)))
+          #end
         #end
         $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
         #set( $isAuthorized = true )

--- a/packages/amplify-util-mock/src/__tests__/velocity/model-auth.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/velocity/model-auth.test.ts
@@ -834,17 +834,7 @@ describe("@model @primaryIndex @index auth", () => {
         },
         "expressionValues": Object {
           ":child": Object {
-            "L": Array [
-              Object {
-                "S": "${ownerRequest.jwt.sub}",
-              },
-              Object {
-                "S": "user1",
-              },
-              Object {
-                "S": "${ownerRequest.jwt.sub}::user1",
-              },
-            ],
+            "S": "${ownerRequest.jwt.sub}::user1",
           },
           ":parent": Object {
             "S": "$ctx.args.parent",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Updates the list query when querying by primary key to use the `<sub>::<username>` identity claim for the sort key (and not have a set of sort keys as the other query types work).
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
