### PR TITLE
fix(graphql): handle begin and end vtl keywords in index name

### DIFF
--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
@@ -627,14 +627,12 @@ $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
 #end
 ## [End] Validate create mutation for @index 'GSI'. **
 #if( $util.isNull($ctx.stash.metadata.dynamodbNameOverrideMap) )
-  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", {
-  \\"kind#date\\": \\"kindDate\\"
-}))
+  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", { 'kind#date': \\"kindDate\\" }))
 #else
-  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put(\\"kind#date\\", \\"kindDate\\"))
+  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put('kind#date', \\"kindDate\\"))
 #end
 #if( $hasSeenSomeKeyArg )
-  $util.qr($ctx.args.input.put(\\"kind#date\\",\\"\${mergedValues.kind}#\${mergedValues.date}\\"))
+  $util.qr($ctx.args.input.put('kind#date',\\"\${mergedValues.kind}#\${mergedValues.date}\\"))
 #end
 {}",
   "Mutation.createTest.req.vtl": "## [Start] Create Request template. **
@@ -730,13 +728,11 @@ $util.toJson({})
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
 ## [End] Merge default values and inputs. **
 #if( $util.isNull($ctx.stash.metadata.dynamodbNameOverrideMap) )
-  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", {
-  \\"kind#date\\": \\"kindDate\\"
-}))
+  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", { 'kind#date': \\"kindDate\\" }))
 #else
-  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put(\\"kind#date\\", \\"kindDate\\"))
+  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put('kind#date', \\"kindDate\\"))
 #end
-$util.qr($ctx.args.input.put(\\"kind#date\\",\\"\${mergedValues.kind}#\${mergedValues.date}\\"))
+$util.qr($ctx.args.input.put('kind#date',\\"\${mergedValues.kind}#\${mergedValues.date}\\"))
 {}",
   "Mutation.deleteTest.req.vtl": "## [Start] Delete Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
@@ -836,14 +832,12 @@ $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
 #end
 ## [End] Validate update mutation for @index 'GSI'. **
 #if( $util.isNull($ctx.stash.metadata.dynamodbNameOverrideMap) )
-  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", {
-  \\"kind#date\\": \\"kindDate\\"
-}))
+  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", { 'kind#date': \\"kindDate\\" }))
 #else
-  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put(\\"kind#date\\", \\"kindDate\\"))
+  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put('kind#date', \\"kindDate\\"))
 #end
 #if( $hasSeenSomeKeyArg )
-  $util.qr($ctx.args.input.put(\\"kind#date\\",\\"\${mergedValues.kind}#\${mergedValues.date}\\"))
+  $util.qr($ctx.args.input.put('kind#date',\\"\${mergedValues.kind}#\${mergedValues.date}\\"))
 #end
 {}",
   "Mutation.updateTest.req.vtl": "## [Start] Mutation Update resolver. **
@@ -2781,13 +2775,11 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
 }))
 ## [End] Set the primary key. **
 #if( $util.isNull($ctx.stash.metadata.dynamodbNameOverrideMap) )
-  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", {
-  \\"status#createdAt\\": \\"statusCreatedAt\\"
-}))
+  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", { 'status#createdAt': \\"statusCreatedAt\\" }))
 #else
-  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put(\\"status#createdAt\\", \\"statusCreatedAt\\"))
+  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put('status#createdAt', \\"statusCreatedAt\\"))
 #end
-$util.qr($ctx.args.input.put(\\"status#createdAt\\",\\"\${mergedValues.status}#\${mergedValues.createdAt}\\"))
+$util.qr($ctx.args.input.put('status#createdAt',\\"\${mergedValues.status}#\${mergedValues.createdAt}\\"))
 {}",
   "Mutation.createItem.req.vtl": "## [Start] Create Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
@@ -2981,13 +2973,11 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
 }))
 ## [End] Set the primary key. **
 #if( $util.isNull($ctx.stash.metadata.dynamodbNameOverrideMap) )
-  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", {
-  \\"status#createdAt\\": \\"statusCreatedAt\\"
-}))
+  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", { 'status#createdAt': \\"statusCreatedAt\\" }))
 #else
-  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put(\\"status#createdAt\\", \\"statusCreatedAt\\"))
+  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put('status#createdAt', \\"statusCreatedAt\\"))
 #end
-$util.qr($ctx.args.input.put(\\"status#createdAt\\",\\"\${mergedValues.status}#\${mergedValues.createdAt}\\"))
+$util.qr($ctx.args.input.put('status#createdAt',\\"\${mergedValues.status}#\${mergedValues.createdAt}\\"))
 {}",
   "Mutation.updateItem.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
@@ -3953,13 +3943,11 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
 }))
 ## [End] Set the primary key. **
 #if( $util.isNull($ctx.stash.metadata.dynamodbNameOverrideMap) )
-  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", {
-  \\"status#createdAt\\": \\"statusCreatedAt\\"
-}))
+  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", { 'status#createdAt': \\"statusCreatedAt\\" }))
 #else
-  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put(\\"status#createdAt\\", \\"statusCreatedAt\\"))
+  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put('status#createdAt', \\"statusCreatedAt\\"))
 #end
-$util.qr($ctx.args.input.put(\\"status#createdAt\\",\\"\${mergedValues.status}#\${mergedValues.createdAt}\\"))
+$util.qr($ctx.args.input.put('status#createdAt',\\"\${mergedValues.status}#\${mergedValues.createdAt}\\"))
 {}",
   "Mutation.createItem.req.vtl": "## [Start] Create Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
@@ -4152,13 +4140,11 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
 }))
 ## [End] Set the primary key. **
 #if( $util.isNull($ctx.stash.metadata.dynamodbNameOverrideMap) )
-  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", {
-  \\"status#createdAt\\": \\"statusCreatedAt\\"
-}))
+  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", { 'status#createdAt': \\"statusCreatedAt\\" }))
 #else
-  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put(\\"status#createdAt\\", \\"statusCreatedAt\\"))
+  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put('status#createdAt', \\"statusCreatedAt\\"))
 #end
-$util.qr($ctx.args.input.put(\\"status#createdAt\\",\\"\${mergedValues.status}#\${mergedValues.createdAt}\\"))
+$util.qr($ctx.args.input.put('status#createdAt',\\"\${mergedValues.status}#\${mergedValues.createdAt}\\"))
 {}",
   "Mutation.updateItem.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
@@ -30,13 +30,11 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
 }))
 ## [End] Set the primary key. **
 #if( $util.isNull($ctx.stash.metadata.dynamodbNameOverrideMap) )
-  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", {
-  \\"kind#other\\": \\"kindOther\\"
-}))
+  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", { 'kind#other': \\"kindOther\\" }))
 #else
-  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put(\\"kind#other\\", \\"kindOther\\"))
+  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put('kind#other', \\"kindOther\\"))
 #end
-$util.qr($ctx.args.input.put(\\"kind#other\\",\\"\${mergedValues.kind}#\${mergedValues.other}\\"))
+$util.qr($ctx.args.input.put('kind#other',\\"\${mergedValues.kind}#\${mergedValues.other}\\"))
 {}",
   "Mutation.createTest.req.vtl": "## [Start] Create Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
@@ -221,13 +219,11 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
 }))
 ## [End] Set the primary key. **
 #if( $util.isNull($ctx.stash.metadata.dynamodbNameOverrideMap) )
-  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", {
-  \\"kind#other\\": \\"kindOther\\"
-}))
+  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", { 'kind#other': \\"kindOther\\" }))
 #else
-  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put(\\"kind#other\\", \\"kindOther\\"))
+  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put('kind#other', \\"kindOther\\"))
 #end
-$util.qr($ctx.args.input.put(\\"kind#other\\",\\"\${mergedValues.kind}#\${mergedValues.other}\\"))
+$util.qr($ctx.args.input.put('kind#other',\\"\${mergedValues.kind}#\${mergedValues.other}\\"))
 {}",
   "Mutation.updateTest.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )

--- a/packages/amplify-graphql-index-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers.ts
@@ -51,7 +51,7 @@ import { lookupResolverName } from './utils';
 const API_KEY = 'API Key Authorization';
 
 /**
- *
+ * replaceDdbPrimaryKey
  */
 export function replaceDdbPrimaryKey(config: PrimaryKeyDirectiveConfiguration, ctx: TransformerContextProvider): void {
   // Replace the table's primary key with the value from @primaryKey.
@@ -90,7 +90,7 @@ export function replaceDdbPrimaryKey(config: PrimaryKeyDirectiveConfiguration, c
 }
 
 /**
- *
+ * updateResolvers
  */
 export function updateResolvers(
   config: PrimaryKeyDirectiveConfiguration,
@@ -316,7 +316,7 @@ function setQuerySnippet(config: PrimaryKeyDirectiveConfiguration, ctx: Transfor
 }
 
 /**
- *
+ * appendSecondaryIndex
  */
 export function appendSecondaryIndex(config: IndexDirectiveConfiguration, ctx: TransformerContextProvider): void {
   const { name, object, primaryKeyField } = config;
@@ -387,7 +387,7 @@ function appendIndex(list: any, newIndex: any): any[] {
 }
 
 /**
- *
+ * updateResolversForIndex
  */
 export function updateResolversForIndex(
   config: IndexDirectiveConfiguration,
@@ -611,7 +611,7 @@ function setSyncQueryMapSnippet(name: string, config: PrimaryKeyDirectiveConfigu
 }
 
 /**
- *
+ * constructSyncVTL
  */
 export function constructSyncVTL(syncVTLContent: string, resolver: TransformerResolverProvider) {
   const checks = [

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
@@ -8845,13 +8845,11 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
 }))
 ## [End] Set the primary key. **
 #if( $util.isNull($ctx.stash.metadata.dynamodbNameOverrideMap) )
-  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", {
-  \\"name#surname\\": \\"nameSurname\\"
-}))
+  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", { 'name#surname': \\"nameSurname\\" }))
 #else
-  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put(\\"name#surname\\", \\"nameSurname\\"))
+  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put('name#surname', \\"nameSurname\\"))
 #end
-$util.qr($ctx.args.input.put(\\"name#surname\\",\\"\${mergedValues.name}#\${mergedValues.surname}\\"))
+$util.qr($ctx.args.input.put('name#surname',\\"\${mergedValues.name}#\${mergedValues.surname}\\"))
 {}",
   "Mutation.createUser.req.vtl": "## [Start] Create Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
@@ -8973,14 +8971,12 @@ $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
 #end
 ## [End] Validate create mutation for @index 'composite'. **
 #if( $util.isNull($ctx.stash.metadata.dynamodbNameOverrideMap) )
-  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", {
-  \\"name#surname\\": \\"nameSurname\\"
-}))
+  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", { 'name#surname': \\"nameSurname\\" }))
 #else
-  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put(\\"name#surname\\", \\"nameSurname\\"))
+  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put('name#surname', \\"nameSurname\\"))
 #end
 #if( $hasSeenSomeKeyArg )
-  $util.qr($ctx.args.input.put(\\"name#surname\\",\\"\${mergedValues.name}#\${mergedValues.surname}\\"))
+  $util.qr($ctx.args.input.put('name#surname',\\"\${mergedValues.name}#\${mergedValues.surname}\\"))
 #end
 {}",
   "Mutation.createUserModel.req.vtl": "## [Start] Create Request template. **
@@ -9613,13 +9609,11 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
 $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
 ## [End] Merge default values and inputs. **
 #if( $util.isNull($ctx.stash.metadata.dynamodbNameOverrideMap) )
-  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", {
-  \\"name#surname\\": \\"nameSurname\\"
-}))
+  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", { 'name#surname': \\"nameSurname\\" }))
 #else
-  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put(\\"name#surname\\", \\"nameSurname\\"))
+  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put('name#surname', \\"nameSurname\\"))
 #end
-$util.qr($ctx.args.input.put(\\"name#surname\\",\\"\${mergedValues.name}#\${mergedValues.surname}\\"))
+$util.qr($ctx.args.input.put('name#surname',\\"\${mergedValues.name}#\${mergedValues.surname}\\"))
 {}",
   "Mutation.deleteUserModel.req.vtl": "## [Start] Delete Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
@@ -10643,13 +10637,11 @@ $util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
 }))
 ## [End] Set the primary key. **
 #if( $util.isNull($ctx.stash.metadata.dynamodbNameOverrideMap) )
-  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", {
-  \\"name#surname\\": \\"nameSurname\\"
-}))
+  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", { 'name#surname': \\"nameSurname\\" }))
 #else
-  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put(\\"name#surname\\", \\"nameSurname\\"))
+  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put('name#surname', \\"nameSurname\\"))
 #end
-$util.qr($ctx.args.input.put(\\"name#surname\\",\\"\${mergedValues.name}#\${mergedValues.surname}\\"))
+$util.qr($ctx.args.input.put('name#surname',\\"\${mergedValues.name}#\${mergedValues.surname}\\"))
 {}",
   "Mutation.updateUser.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
@@ -10833,14 +10825,12 @@ $util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
 #end
 ## [End] Validate update mutation for @index 'composite'. **
 #if( $util.isNull($ctx.stash.metadata.dynamodbNameOverrideMap) )
-  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", {
-  \\"name#surname\\": \\"nameSurname\\"
-}))
+  $util.qr($ctx.stash.metadata.put(\\"dynamodbNameOverrideMap\\", { 'name#surname': \\"nameSurname\\" }))
 #else
-  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put(\\"name#surname\\", \\"nameSurname\\"))
+  $util.qr($ctx.stash.metadata.dynamodbNameOverrideMap.put('name#surname', \\"nameSurname\\"))
 #end
 #if( $hasSeenSomeKeyArg )
-  $util.qr($ctx.args.input.put(\\"name#surname\\",\\"\${mergedValues.name}#\${mergedValues.surname}\\"))
+  $util.qr($ctx.args.input.put('name#surname',\\"\${mergedValues.name}#\${mergedValues.surname}\\"))
 #end
 {}",
   "Mutation.updateUserModel.req.vtl": "## [Start] Mutation Update resolver. **


### PR DESCRIPTION
#### Description of changes

Handle begin and end VTL keywords in the index name. Currently the index name is wrapped with double quotes which doesn't handle the vtl keywords. Changing it to single quote to handle begin and end keyword in vtl.

#### Issue #, if available

Fixes https://github.com/aws-amplify/amplify-category-api/issues/40

#### Description of how you validated changes
- yarn test
- manual test
- new unit and e2e tests added

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
