### PR TITLE
feat(amplify-category-api): rename private packages to scope them down

### DIFF
--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-amplify/amplify-category-api",
   "version": "3.0.1",
-  "description": "Amplify CLI API category plugin",
+  "description": "Amplify CLIs API category plugin",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws-amplify/amplify-category-api.git",

--- a/packages/amplify-dynamodb-simulator/package.json
+++ b/packages/amplify-dynamodb-simulator/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "amplify-dynamodb-simulator",
+  "name": "amplify-category-api-dynamodb-simulator",
   "version": "2.3.2",
   "description": "DynamoDB emulator NodeJS wrapper",
   "private": "true",

--- a/packages/amplify-e2e-core/package.json
+++ b/packages/amplify-e2e-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "amplify-e2e-core",
+  "name": "amplify-category-api-e2e-core",
   "version": "3.1.6",
   "description": "Core testing library",
   "repository": {

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "amplify-e2e-tests",
+  "name": "amplify-category-api-e2e-tests",
   "version": "3.9.4",
   "description": "E2e test suite",
   "repository": {
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@aws-amplify/graphql-transformer-core": "0.17.4",
-    "amplify-e2e-core": "3.1.6",
+    "amplify-category-api-e2e-core": "3.1.6",
     "aws-amplify": "^4.2.8",
     "aws-appsync": "^4.1.1",
     "aws-sdk": "^2.1113.0",

--- a/packages/amplify-graphql-migration-tests/package.json
+++ b/packages/amplify-graphql-migration-tests/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "amplify-graphql-migration-tests",
+  "name": "amplify-category-api-graphql-migration-tests",
   "version": "2.2.43",
   "description": "Tests migration from v1 to v2 of the Amplify GraphQL transformer",
   "main": "lib/index.js",

--- a/packages/amplify-migration-tests/package.json
+++ b/packages/amplify-migration-tests/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "amplify-migration-tests",
+  "name": "amplify-category-api-migration-tests",
   "version": "4.4.35",
   "description": "Test suites for migration scenarios",
   "repository": {
@@ -25,7 +25,7 @@
     "setup-profile": "ts-node ./src/configure_tests.ts"
   },
   "dependencies": {
-    "amplify-e2e-core": "3.1.6",
+    "amplify-category-api-e2e-core": "3.1.6",
     "aws-sdk": "^2.1113.0",
     "dotenv": "^8.2.0",
     "esm": "^3.2.25",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "amplify-util-mock",
+  "name": "amplify-category-api-util-mock",
   "version": "4.4.4",
   "description": "Amplify CLI plugin providing local testing",
   "repository": {
@@ -33,7 +33,7 @@
     "amplify-appsync-simulator": "^2.3.12",
     "amplify-category-function": "^4.0.3",
     "amplify-codegen": "^3.0.0",
-    "amplify-dynamodb-simulator": "2.3.2",
+    "amplify-category-api-dynamodb-simulator": "2.3.2",
     "amplify-provider-awscloudformation": "^6.1.3",
     "amplify-storage-simulator": "^1.6.7",
     "chokidar": "^3.5.3",

--- a/packages/amplify-util-mock/src/__e2e__/utils/index.ts
+++ b/packages/amplify-util-mock/src/__e2e__/utils/index.ts
@@ -1,5 +1,5 @@
 import { AmplifyAppSyncSimulator } from 'amplify-appsync-simulator';
-import * as dynamoEmulator from 'amplify-dynamodb-simulator';
+import * as dynamoEmulator from 'amplify-category-api-dynamodb-simulator';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { v4 } from 'uuid';

--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs-extra';
-import * as dynamoEmulator from 'amplify-dynamodb-simulator';
+import * as dynamoEmulator from 'amplify-category-api-dynamodb-simulator';
 import { AmplifyAppSyncSimulator, AmplifyAppSyncSimulatorConfig } from 'amplify-appsync-simulator';
 import { add, generate, isCodegenConfigured, switchToSDLSchema } from 'amplify-codegen';
 import * as path from 'path';

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "graphql-transformers-e2e-tests",
+  "name": "amplify-category-api-graphql-transformers-e2e-tests",
   "version": "7.5.4",
   "description": "End to end functional tests for appsync supported transformers.",
   "private": true,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
We've seen errors in deploy flow when these private packages are published since the git tags already exist in CLI repo.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
