### PR TITLE
fix: create owner field resolvers for all operations

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
@@ -531,6 +531,31 @@ $util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
 ## [End] Authorization Steps. **"
 `;
 
+exports[`owner based @auth owner where field is "::" delimited with only mutation 1`] = `"$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})"`;
+
+exports[`owner based @auth owner where field is "::" delimited with only mutation 2`] = `
+"## [Start] Parse owner field auth for Get. **
+#if( $util.isList($ctx.source.owner) )
+  #set( $ownerEntitiesList = [] )
+  #set( $owner = $ctx.source.owner )
+  #foreach( $entities in $owner )
+    #set( $ownerEntities = $entities.split(\\"::\\") )
+    #set( $ownerEntitiesLastIdx = $ownerEntities.size() - 1 )
+    #set( $ownerEntitiesLast = $ownerEntities[$ownerEntitiesLastIdx] )
+    $util.qr($ownerEntitiesList.add($ownerEntitiesLast))
+  #end
+  $util.qr($ctx.source.owner.put($ownerEntitiesList))
+  $util.toJson($ownerEntitiesList)
+#else
+  #set( $ownerEntities = $ctx.source.owner.split(\\"::\\") )
+  #set( $ownerEntitiesLastIdx = $ownerEntities.size() - 1 )
+  #set( $ownerEntitiesLast = $ownerEntities[$ownerEntitiesLastIdx] )
+  $util.qr($ctx.source.put(\\"owner\\", $ownerEntitiesLast))
+  $util.toJson($ctx.source.owner)
+#end
+## [End] Parse owner field auth for Get. **"
+`;
+
 exports[`owner based @auth with identity claim feature flag disabled owner field where the field is a list 1`] = `
 "## [Start] Authorization Steps. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
@@ -100,6 +100,28 @@ describe('owner based @auth', () => {
     expect(out.resolvers['Query.listPosts.auth.1.req.vtl']).toMatchSnapshot();
   });
 
+  test('owner where field is "::" delimited with only mutation', () => {
+    const authConfig: AppSyncAuthConfiguration = {
+      defaultAuthentication: {
+        authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+      },
+      additionalAuthenticationProviders: [],
+    };
+    const validSchema = `
+    type Post @model @auth(rules: [{allow: owner, operations: [create, delete] }]) {
+      id: ID!
+      title: String!
+    }`;
+    const transformer = new GraphQLTransform({
+      authConfig,
+      transformers: [new ModelTransformer(), new AuthTransformer()],
+      featureFlags,
+    });
+    const out = transformer.transform(validSchema);
+    expect(out.resolvers['Post.owner.req.vtl']).toMatchSnapshot();
+    expect(out.resolvers['Post.owner.res.vtl']).toMatchSnapshot();
+  });
+
   test('owner field with subscriptions', () => {
     const authConfig: AppSyncAuthConfiguration = {
       defaultAuthentication: {

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -349,7 +349,6 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
       // if there is a role that does not have read access on the field then we create a field resolver
       // or there is a relational directive on the field then we should protect that as well
       const readRoles = [...new Set(...READ_MODEL_OPERATIONS.map(op => acm.getRolesPerOperation(op)))];
-      const roleDefinitions = readRoles.map(role => this.roleMap.get(role)!);
       const modelFields = def.fields?.filter((f: { name: { value: string; }; }) => acm.hasResource(f.name.value)) ?? [];
       const errorFields = new Array<string>();
       modelFields.forEach((field: FieldDefinitionNode) => {
@@ -402,6 +401,8 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
       });
 
       if (context.featureFlags.getBoolean('useSubUsernameForDefaultIdentityClaim')) {
+        const roleDefinitions = acm.getRoles().map(role => this.roleMap.get(role)!);
+
         roleDefinitions.forEach(role => {
           const hasMultiClaims = role.claim?.split(IDENTITY_CLAIM_DELIMITER)?.length > 1;
           const createOwnerFieldResolver = role.strategy === 'owner' && hasMultiClaims;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Bug fix: when operations don't include `read` operation with the `sub::username` identity claim, the sub prefix does not get stripped out from the return value, so clients would see `sub::username`.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
