### PR TITLE
feat(graphql): add runtime filtering support for subscriptions

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
@@ -338,10 +338,13 @@ describe('schema generation directive tests', () => {
 
     // Check that owner is required when only using owner auth rules
     subscriptionType.fields.forEach(field => {
-      expect(field.arguments).toHaveLength(1);
-      const arg: InputValueDefinitionNode = field.arguments[0];
-      expect(arg.name.value).toEqual('owner');
-      expect(arg.type.kind).toEqual(Kind.NAMED_TYPE);
+      expect(field.arguments).toHaveLength(2);
+      const ownerArg: InputValueDefinitionNode = field.arguments[1];
+      expect(ownerArg.name.value).toEqual('owner');
+      expect(ownerArg.type.kind).toEqual(Kind.NAMED_TYPE);
+      const filterArg: InputValueDefinitionNode = field.arguments[0];
+      expect(filterArg.name.value).toEqual('filter');
+      expect(filterArg.type.kind).toEqual(Kind.NAMED_TYPE);
     });
 
     // Check that resolvers containing the authMode check block

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
@@ -147,9 +147,9 @@ describe('owner based @auth', () => {
     expect(out).toBeDefined();
 
     // expect 'postOwner' as an argument for subscription operations
-    expect(out.schema).toContain('onCreatePost(postOwner: String)');
-    expect(out.schema).toContain('onUpdatePost(postOwner: String)');
-    expect(out.schema).toContain('onDeletePost(postOwner: String)');
+    expect(out.schema).toContain('onCreatePost(filter: ModelSubscriptionPostFilterInput, postOwner: String)');
+    expect(out.schema).toContain('onUpdatePost(filter: ModelSubscriptionPostFilterInput, postOwner: String)');
+    expect(out.schema).toContain('onDeletePost(filter: ModelSubscriptionPostFilterInput, postOwner: String)');
 
     // expect logic in the resolvers to check for postOwner args as an allowed owner
     expect(out.resolvers['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
@@ -193,9 +193,9 @@ describe('owner based @auth', () => {
     expect(out).toBeDefined();
 
     // expect 'owner' and 'editors' as arguments for subscription operations
-    expect(out.schema).toContain('onCreatePost(owner: String, editor: String)');
-    expect(out.schema).toContain('onUpdatePost(owner: String, editor: String)');
-    expect(out.schema).toContain('onDeletePost(owner: String, editor: String)');
+    expect(out.schema).toContain('onCreatePost(filter: ModelSubscriptionPostFilterInput, owner: String, editor: String)');
+    expect(out.schema).toContain('onUpdatePost(filter: ModelSubscriptionPostFilterInput, owner: String, editor: String)');
+    expect(out.schema).toContain('onDeletePost(filter: ModelSubscriptionPostFilterInput, owner: String, editor: String)');
 
     // expect logic in the resolvers to check for owner args as an allowedOwner
     expect(out.resolvers['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
@@ -629,9 +629,9 @@ describe('owner based @auth', () => {
       expect(out).toBeDefined();
 
       // expect 'postOwner' as an argument for subscription operations
-      expect(out.schema).toContain('onCreatePost(postOwner: String)');
-      expect(out.schema).toContain('onUpdatePost(postOwner: String)');
-      expect(out.schema).toContain('onDeletePost(postOwner: String)');
+      expect(out.schema).toContain('onCreatePost(filter: ModelSubscriptionPostFilterInput, postOwner: String)');
+      expect(out.schema).toContain('onUpdatePost(filter: ModelSubscriptionPostFilterInput, postOwner: String)');
+      expect(out.schema).toContain('onDeletePost(filter: ModelSubscriptionPostFilterInput, postOwner: String)');
 
       // expect logic in the resolvers to check for postOwner args as an allowed owner
       expect(out.resolvers['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
@@ -677,9 +677,9 @@ describe('owner based @auth', () => {
       expect(out).toBeDefined();
 
       // expect 'owner' and 'editors' as arguments for subscription operations
-      expect(out.schema).toContain('onCreatePost(owner: String, editor: String)');
-      expect(out.schema).toContain('onUpdatePost(owner: String, editor: String)');
-      expect(out.schema).toContain('onDeletePost(owner: String, editor: String)');
+      expect(out.schema).toContain('onCreatePost(filter: ModelSubscriptionPostFilterInput, owner: String, editor: String)');
+      expect(out.schema).toContain('onUpdatePost(filter: ModelSubscriptionPostFilterInput, owner: String, editor: String)');
+      expect(out.schema).toContain('onDeletePost(filter: ModelSubscriptionPostFilterInput, owner: String, editor: String)');
 
       // expect logic in the resolvers to check for owner args as an allowedOwner
       expect(out.resolvers['Subscription.onCreatePost.auth.1.req.vtl']).toContain(

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -41,6 +41,7 @@ import {
   ModelResourceIDs,
   ResolverResourceIDs,
   toUpper,
+  isListType,
 } from 'graphql-transformer-common';
 import * as iam from '@aws-cdk/aws-iam';
 import * as cdk from '@aws-cdk/core';
@@ -944,6 +945,8 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
               };
             } else if (rule.allow === 'owner') {
               const ownerField = rule.ownerField || DEFAULT_OWNER_FIELD;
+              const fieldType = (context.output.getType(acm.getName()) as any).fields.find(field => field.name.value == ownerField);
+              const isOwnerFieldList = fieldType ? isListType(fieldType.type) : false;
               const useSub = context.featureFlags.getBoolean('useSubUsernameForDefaultIdentityClaim');
               const ownerClaim = rule.identityClaim || (useSub ? DEFAULT_UNIQUE_IDENTITY_CLAIM : DEFAULT_IDENTITY_CLAIM);
               roleName = `${rule.provider}:owner:${ownerField}:${ownerClaim}`;
@@ -953,6 +956,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
                 static: false,
                 claim: ownerClaim,
                 entity: ownerField,
+                isEntityList: isOwnerFieldList,
               };
             } else if (rule.allow === 'private') {
               roleName = `${rule.provider}:${rule.allow}`;

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -31,7 +31,7 @@ import {
   ListValueNode,
   StringValueNode,
 } from 'graphql';
-import { SubscriptionLevel, ModelDirectiveConfiguration } from '@aws-amplify/graphql-model-transformer';
+import { SubscriptionLevel, ModelDirectiveConfiguration, removeSubscriptionFilterInputAttribute } from '@aws-amplify/graphql-model-transformer';
 import {
   getBaseType,
   makeDirective,
@@ -272,6 +272,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
       if (this.roleMap.get(role)!.strategy === 'owner') prev.push(this.roleMap.get(role)!.entity!);
       return prev;
     }, []);
+    this.removeAuthFieldsFromSubscriptionFilter(context);
     this.authModelConfig.forEach((acm, modelName) => {
       const def = context.output.getObject(modelName)!;
       const modelHasSearchable = def.directives.some(dir => dir.name.value === 'searchable');
@@ -398,7 +399,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
         // for subscriptions we only use static rules or owner rule where the field is not a list
         .filter(roleDef => (roleDef.strategy === 'owner' && !fieldIsList(def.fields ?? [], roleDef.entity!)) || roleDef.static);
       subscriptionFieldNames.forEach(subscription => {
-        this.protectSubscriptionResolver(context, subscription.typeName, subscription.fieldName, subscriptionRoles);
+        this.protectSubscriptionResolver(context, subscription.typeName, subscription.fieldName, roleDefinitions);
       });
 
       if (context.featureFlags.getBoolean('useSubUsernameForDefaultIdentityClaim')) {
@@ -420,6 +421,22 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
       const [typeName, fieldName] = typeFieldName.split(':');
       const def = context.output.getObject(typeName);
       this.protectFieldResolver(context, def, typeName, fieldName, acm.getRoles());
+    });
+  };
+
+  /**
+   * Amplify will not include the dynamic auth fields in the generated subscription filter input type.
+   * This is because of a limitation of AppSync service. AppSync doesn't allow multiple conditions on the same field in a filter.
+   * Amplify automatically applies filter on the dynamic auth fields, so we don't accept filters on these fields from client.
+   * @param context TransformerTransformSchemaStepContextProvider
+   */
+  removeAuthFieldsFromSubscriptionFilter = (context: TransformerTransformSchemaStepContextProvider): void => {
+    this.authModelConfig.forEach((acm, modelName) => {
+      acm.getRoles().map(role => this.roleMap.get(role)).forEach(role => {
+        if (!role.static && (role.provider === 'userPools' || role.provider === 'oidc')) {
+          removeSubscriptionFilterInputAttribute(context, modelName, role.entity);
+        }
+      });
     });
   };
 
@@ -935,6 +952,8 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
             if (rule.allow === 'groups') {
               const groupClaim = rule.groupClaim || DEFAULT_GROUP_CLAIM;
               const groupsField = rule.groupsField || DEFAULT_GROUPS_FIELD;
+              const fieldType = (context.output.getType(acm.getName()) as any).fields.find(f => f.name.value === groupsField);
+              const isGroupFieldList = fieldType ? isListType(fieldType.type) : false;
               roleName = `${rule.provider}:dynamicGroup:${groupsField}:${groupClaim}`;
               roleDefinition = {
                 provider: rule.provider,
@@ -942,10 +961,11 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
                 static: false,
                 claim: groupClaim,
                 entity: groupsField,
+                isEntityList: isGroupFieldList,
               };
             } else if (rule.allow === 'owner') {
               const ownerField = rule.ownerField || DEFAULT_OWNER_FIELD;
-              const fieldType = (context.output.getType(acm.getName()) as any).fields.find(field => field.name.value == ownerField);
+              const fieldType = (context.output.getType(acm.getName()) as any).fields.find(f => f.name.value === ownerField);
               const isOwnerFieldList = fieldType ? isListType(fieldType.type) : false;
               const useSub = context.featureFlags.getBoolean('useSubUsernameForDefaultIdentityClaim');
               const ownerClaim = rule.identityClaim || (useSub ? DEFAULT_UNIQUE_IDENTITY_CLAIM : DEFAULT_IDENTITY_CLAIM);

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -397,9 +397,9 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
         .getRolesPerOperation('listen')
         .map(role => this.roleMap.get(role)!)
         // for subscriptions we only use static rules or owner rule where the field is not a list
-        .filter(roleDef => (roleDef.strategy === 'owner' && !fieldIsList(def.fields ?? [], roleDef.entity!)) || roleDef.static);
+        .filter(roleDef => roleDef.strategy === 'owner' || roleDef.static);
       subscriptionFieldNames.forEach(subscription => {
-        this.protectSubscriptionResolver(context, subscription.typeName, subscription.fieldName, roleDefinitions);
+        this.protectSubscriptionResolver(context, subscription.typeName, subscription.fieldName, subscriptionRoles);
       });
 
       if (context.featureFlags.getBoolean('useSubUsernameForDefaultIdentityClaim')) {

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -396,7 +396,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
       const subscriptionRoles = acm
         .getRolesPerOperation('listen')
         .map(role => this.roleMap.get(role)!)
-        // for subscriptions we only use static rules or owner rule where the field is not a list
+        // for subscriptions we only use static rules or owner rule
         .filter(roleDef => roleDef.strategy === 'owner' || roleDef.static);
       subscriptionFieldNames.forEach(subscription => {
         this.protectSubscriptionResolver(context, subscription.typeName, subscription.fieldName, subscriptionRoles);

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/helpers.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/helpers.ts
@@ -252,6 +252,27 @@ export const generateOwnerClaimExpression = (ownerClaim: string, refName: string
 };
 
 /**
+ *
+ */
+export const getOwnerClaimReference = (ownerClaim: string, refName: string): string => {
+  const expressions: Expression[] = [];
+  const identityClaims = ownerClaim.split(IDENTITY_CLAIM_DELIMITER);
+  const hasMultiIdentityClaims = identityClaims.length > 1;
+  let ownerRef = refName;
+
+  if (hasMultiIdentityClaims) {
+    identityClaims.forEach((_, idx) => {
+      expressions.push();
+      if (idx > 0) {
+        ownerRef = `currentClaim${idx}`;
+      }
+    });
+  }
+
+  return ownerRef;
+};
+
+/**
  * Creates field resolver for owner
  */
 export const generateFieldResolverForOwner = (entity: string): string => {

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/subscriptions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/subscriptions.ts
@@ -14,6 +14,11 @@ import {
   or,
   raw,
   qref,
+  and,
+  list,
+  forEach,
+  comment,
+  ifElse,
 } from 'graphql-mapping-template';
 import {
   COGNITO_AUTH_TYPE,
@@ -32,20 +37,22 @@ import {
   setHasAuthExpression,
   generateOwnerClaimExpression,
   generateOwnerClaimListExpression,
+  getIdentityClaimExp,
+  getOwnerClaimReference,
 } from './helpers';
 
 const dynamicRoleExpression = (roles: Array<RoleDefinition>): Array<Expression> => {
+  const dynamicExpression = new Array<Expression>();
   const ownerExpression = new Array<Expression>();
+  const groupExpression = new Array<Expression>();
   // we only check against owner rules which are not list fields
   roles.forEach((role, idx) => {
     if (role.strategy === 'owner') {
+      const ownerClaimRef = getOwnerClaimReference(role.claim!, `ownerClaim${idx}`);
       ownerExpression.push(
         generateOwnerClaimExpression(role.claim!, `ownerClaim${idx}`),
         generateOwnerClaimListExpression(role.claim!, `ownerClaimsList${idx}`),
-        set(ref(`authRuntimeFilter`), raw(`[]`)),
-        qref(methodCall(ref('authRuntimeFilter.add'), raw(`{ "${role.entity}": { "eq": $ownerClaim${idx} } }`))),
-        set(ref('ctx.args.filter'), raw(`{ "and": [ "or": $util.toJson($authRuntimeFilter), $ctx.args.filter ]}`)),
-        set(ref(IS_AUTHORIZED_FLAG), bool(true)),
+        qref(methodCall(ref('authOwnerRuntimeFilter.add'), raw(`{ "${role.entity}": { "${role.isEntityList ? 'contains' : 'eq'}": $${ownerClaimRef} } }`))),
         set(
           ref(`ownerEntity${idx}`),
           methodCall(ref('util.defaultIfNull'), ref(`ctx.args.${role.entity!}`), nul()),
@@ -58,15 +65,74 @@ const dynamicRoleExpression = (roles: Array<RoleDefinition>): Array<Expression> 
                 equals(ref(`ownerEntity${idx}`), ref(`ownerClaim${idx}`)),
                 methodCall(ref(`ownerClaimsList${idx}.contains`), ref(`ownerEntity${idx}`)),
               ]),
-              set(ref(IS_AUTHORIZED_FLAG), bool(true))),
+              set(ref(IS_AUTHORIZED_FLAG), bool(true)),
+            ),
           ]),
         ),
+      );
+    } else if (role.strategy === 'groups' && !role.static) {
+      // Loop through the cognito groups and set as runtime filter
+      groupExpression.push(
+        set(ref(`groupClaim${idx}`), getIdentityClaimExp(str(role.claim!), list([]))),
+        iff(
+          methodCall(ref('util.isString'), ref(`groupClaim${idx}`)),
+          ifElse(
+            methodCall(ref('util.isList'), methodCall(ref('util.parseJson'), ref(`groupClaim${idx}`))),
+            set(ref(`groupClaim${idx}`), methodCall(ref('util.parseJson'), ref(`groupClaim${idx}`))),
+            set(ref(`groupClaim${idx}`), list([ref(`groupClaim${idx}`)])),
+          ),
+        ),
+        forEach(ref('groupRole'), ref(`groupClaim${idx}`), [
+          qref(methodCall(ref('authGroupRuntimeFilter.add'), raw(`{ "${role.entity}": { "${role.isEntityList ? 'contains' : 'eq'}": $groupRole } }`))),
+        ]),
       );
     }
   });
 
-  return [...(ownerExpression.length > 0 ? ownerExpression : [])];
+  dynamicExpression.push(
+    ...combineAuthExpressionAndFilter(ownerExpression, groupExpression),
+  );
+
+  return dynamicExpression;
 };
+
+const combineAuthExpressionAndFilter = (ownerExpression: Array<Expression>, groupExpression: Array<Expression>): Array<Expression> => [
+  set(ref('authRuntimeFilter'), raw('[]')),
+  set(ref('authOwnerRuntimeFilter'), raw('[]')),
+  set(ref('authGroupRuntimeFilter'), raw('[]')),
+  ...(ownerExpression.length > 0 ? ownerExpression : []),
+  ...(groupExpression.length > 0 ? groupExpression : []),
+  comment('Apply dynamic roles auth if not previously authorized by static groups and owner argument'),
+  iff(
+    raw('$authOwnerRuntimeFilter.size() > 0'),
+    forEach(ref('ownerAuthFilter'), ref('authOwnerRuntimeFilter'), [
+      qref(methodCall(ref('authRuntimeFilter.add'), ref('ownerAuthFilter'))),
+    ]),
+  ),
+  iff(
+    and([
+      raw('$authGroupRuntimeFilter.size() > 0'),
+      raw('$authGroupRuntimeFilter.size() + $authRuntimeFilter.size() <= 10'),
+    ]),
+    forEach(ref('groupAuthFilter'), ref('authGroupRuntimeFilter'), [
+      qref(methodCall(ref('authRuntimeFilter.add'), ref('groupAuthFilter'))),
+    ]),
+  ),
+  iff(
+    and([
+      not(ref(IS_AUTHORIZED_FLAG)),
+      raw('$authRuntimeFilter.size() > 0'),
+    ]),
+    compoundExpression([
+      ifElse(
+        methodCall(ref('util.isNullOrEmpty'), ref('ctx.args.filter')),
+        set(ref('ctx.args.filter'), raw('{ "or": $authRuntimeFilter }')),
+        set(ref('ctx.args.filter'), raw('{ "and": [ { "or": $authRuntimeFilter }, $ctx.args.filter ]}')),
+      ),
+      set(ref(IS_AUTHORIZED_FLAG), bool(true)),
+    ]),
+  ),
+];
 
 /**
  * Generates auth expressions for each auth type for Subscription requests

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/subscriptions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/subscriptions.ts
@@ -12,6 +12,8 @@ import {
   nul,
   printBlock,
   or,
+  raw,
+  qref,
 } from 'graphql-mapping-template';
 import {
   COGNITO_AUTH_TYPE,
@@ -40,6 +42,10 @@ const dynamicRoleExpression = (roles: Array<RoleDefinition>): Array<Expression> 
       ownerExpression.push(
         generateOwnerClaimExpression(role.claim!, `ownerClaim${idx}`),
         generateOwnerClaimListExpression(role.claim!, `ownerClaimsList${idx}`),
+        set(ref(`authRuntimeFilter`), raw(`[]`)),
+        qref(methodCall(ref('authRuntimeFilter.add'), raw(`{ "${role.entity}": { "eq": $ownerClaim${idx} } }`))),
+        set(ref('ctx.args.filter'), raw(`{ "and": [ "or": $util.toJson($authRuntimeFilter), $ctx.args.filter ]}`)),
+        set(ref(IS_AUTHORIZED_FLAG), bool(true)),
         set(
           ref(`ownerEntity${idx}`),
           methodCall(ref('util.defaultIfNull'), ref(`ctx.args.${role.entity!}`), nul()),

--- a/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
@@ -85,6 +85,7 @@ export interface RoleDefinition {
   nullAllowedFields?: Array<string>;
   areAllFieldsAllowed?: boolean;
   areAllFieldsNullAllowed?: boolean;
+  isEntityList?: boolean;
 }
 
 /**

--- a/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
@@ -203,6 +203,7 @@ export const addDirectivesToField = (
 /**
  * addSubscriptionArguments
  */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const addSubscriptionArguments = (
   ctx: TransformerTransformSchemaStepContextProvider,
   operationName: string,
@@ -213,7 +214,7 @@ export const addSubscriptionArguments = (
   const subscriptionArgumentList = subscriptionRoles.map(role => makeInputValueDefinition(role.entity!, makeNamedType('String')));
   createField = {
     ...createField,
-    arguments: [...createField.arguments, ...subcriptionArgumentList],
+    arguments: [...createField.arguments, ...subscriptionArgumentList],
   };
   subscription = {
     ...subscription,

--- a/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
@@ -213,7 +213,7 @@ export const addSubscriptionArguments = (
   const subscriptionArgumentList = subscriptionRoles.map(role => makeInputValueDefinition(role.entity!, makeNamedType('String')));
   createField = {
     ...createField,
-    arguments: subscriptionArgumentList,
+    arguments: [...createField.arguments, ...subcriptionArgumentList],
   };
   subscription = {
     ...subscription,

--- a/packages/amplify-graphql-default-value-transformer/src/__tests__/__snapshots__/amplify-grapphql-default-value-transformer.test.ts.snap
+++ b/packages/amplify-graphql-default-value-transformer/src/__tests__/__snapshots__/amplify-grapphql-default-value-transformer.test.ts.snap
@@ -72,6 +72,65 @@ input ModelIDInput {
   size: ModelSizeInput
 }
 
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
 enum ModelAttributeTypes {
   binary
   binarySet
@@ -145,10 +204,17 @@ type Mutation {
   deleteTest(input: DeleteTestInput!, condition: ModelTestConditionInput): Test
 }
 
+input ModelSubscriptionTestFilterInput {
+  id: ModelSubscriptionIDInput
+  stringValue: ModelSubscriptionStringInput
+  and: [ModelSubscriptionTestFilterInput]
+  or: [ModelSubscriptionTestFilterInput]
+}
+
 type Subscription {
-  onCreateTest: Test @aws_subscribe(mutations: [\\"createTest\\"])
-  onUpdateTest: Test @aws_subscribe(mutations: [\\"updateTest\\"])
-  onDeleteTest: Test @aws_subscribe(mutations: [\\"deleteTest\\"])
+  onCreateTest(filter: ModelSubscriptionTestFilterInput): Test @aws_subscribe(mutations: [\\"createTest\\"])
+  onUpdateTest(filter: ModelSubscriptionTestFilterInput): Test @aws_subscribe(mutations: [\\"updateTest\\"])
+  onDeleteTest(filter: ModelSubscriptionTestFilterInput): Test @aws_subscribe(mutations: [\\"deleteTest\\"])
 }
 
 "
@@ -243,6 +309,65 @@ input ModelIDInput {
   attributeExists: Boolean
   attributeType: ModelAttributeTypes
   size: ModelSizeInput
+}
+
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
 }
 
 enum ModelAttributeTypes {
@@ -379,10 +504,31 @@ type Mutation {
   deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  stringValue: ModelSubscriptionStringInput
+  intVal: ModelSubscriptionIntInput
+  floatValue: ModelSubscriptionFloatInput
+  booleanValue: ModelSubscriptionBooleanInput
+  awsJsonValue: ModelSubscriptionStringInput
+  awsDateValue: ModelSubscriptionStringInput
+  awsTimestampValue: ModelSubscriptionIntInput
+  awsEmailValue: ModelSubscriptionStringInput
+  awsURLValue: ModelSubscriptionStringInput
+  awsPhoneValue: ModelSubscriptionStringInput
+  awsIPAddressValue1: ModelSubscriptionStringInput
+  awsIPAddressValue2: ModelSubscriptionStringInput
+  enumValue: ModelSubscriptionStringInput
+  awsTimeValue: ModelSubscriptionStringInput
+  awsDateTime: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
 }
 
 "

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
@@ -556,6 +556,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -571,6 +574,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -586,6 +592,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -1254,6 +1263,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1269,6 +1281,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1284,6 +1299,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -1805,6 +1823,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1820,6 +1841,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1835,6 +1859,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -2710,6 +2737,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2725,6 +2755,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2740,6 +2773,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -3878,6 +3914,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateItem.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -3893,6 +3932,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteItem.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -3908,6 +3950,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateItem.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -4733,6 +4778,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateItem.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -4748,6 +4796,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteItem.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -4763,6 +4814,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateItem.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
@@ -604,6 +604,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -619,6 +622,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -634,6 +640,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -1187,6 +1196,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1202,6 +1214,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1217,6 +1232,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -1723,6 +1741,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1738,6 +1759,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1753,6 +1777,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -2306,6 +2333,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2321,6 +2351,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2336,6 +2369,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -2767,6 +2803,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2782,6 +2821,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2797,6 +2839,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -3350,6 +3395,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -3365,6 +3413,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -3380,6 +3431,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -78,6 +78,65 @@ input ModelIDInput {
   size: ModelSizeInput
 }
 
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
 enum ModelAttributeTypes {
   binary
   binarySet
@@ -152,13 +211,19 @@ type Mutation {
   deleteEmail(input: DeleteEmailInput!, condition: ModelEmailConditionInput): Email
 }
 
+input ModelSubscriptionTestFilterInput {
+  id: ModelSubscriptionIDInput
+  and: [ModelSubscriptionTestFilterInput]
+  or: [ModelSubscriptionTestFilterInput]
+}
+
 type Subscription {
-  onCreateTest: Test @aws_subscribe(mutations: [\\"createTest\\"])
-  onUpdateTest: Test @aws_subscribe(mutations: [\\"updateTest\\"])
-  onDeleteTest: Test @aws_subscribe(mutations: [\\"deleteTest\\"])
-  onCreateEmail: Email @aws_subscribe(mutations: [\\"createEmail\\"])
-  onUpdateEmail: Email @aws_subscribe(mutations: [\\"updateEmail\\"])
-  onDeleteEmail: Email @aws_subscribe(mutations: [\\"deleteEmail\\"])
+  onCreateTest(filter: ModelSubscriptionTestFilterInput): Test @aws_subscribe(mutations: [\\"createTest\\"])
+  onUpdateTest(filter: ModelSubscriptionTestFilterInput): Test @aws_subscribe(mutations: [\\"updateTest\\"])
+  onDeleteTest(filter: ModelSubscriptionTestFilterInput): Test @aws_subscribe(mutations: [\\"deleteTest\\"])
+  onCreateEmail(filter: ModelSubscriptionEmailFilterInput): Email @aws_subscribe(mutations: [\\"createEmail\\"])
+  onUpdateEmail(filter: ModelSubscriptionEmailFilterInput): Email @aws_subscribe(mutations: [\\"updateEmail\\"])
+  onDeleteEmail(filter: ModelSubscriptionEmailFilterInput): Email @aws_subscribe(mutations: [\\"deleteEmail\\"])
 }
 
 type ModelEmailConnection {
@@ -189,6 +254,12 @@ input UpdateEmailInput {
 
 input DeleteEmailInput {
   id: ID!
+}
+
+input ModelSubscriptionEmailFilterInput {
+  id: ModelSubscriptionIDInput
+  and: [ModelSubscriptionEmailFilterInput]
+  or: [ModelSubscriptionEmailFilterInput]
 }
 
 "
@@ -312,6 +383,65 @@ input ModelIDInput {
   attributeExists: Boolean
   attributeType: ModelAttributeTypes
   size: ModelSizeInput
+}
+
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
 }
 
 enum ModelAttributeTypes {
@@ -447,19 +577,30 @@ type Mutation {
   deleteComment(input: DeleteCommentInput!, condition: ModelCommentConditionInput): Comment
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionStringInput
+  updatedAt: ModelSubscriptionStringInput
+  appearsIn: ModelSubscriptionEpisodeListInput
+  episode: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
-  onCreateAuthor: Author @aws_subscribe(mutations: [\\"createAuthor\\"])
-  onUpdateAuthor: Author @aws_subscribe(mutations: [\\"updateAuthor\\"])
-  onDeleteAuthor: Author @aws_subscribe(mutations: [\\"deleteAuthor\\"])
-  onCreateRequire: Require @aws_subscribe(mutations: [\\"createRequire\\"])
-  onUpdateRequire: Require @aws_subscribe(mutations: [\\"updateRequire\\"])
-  onDeleteRequire: Require @aws_subscribe(mutations: [\\"deleteRequire\\"])
-  onCreateComment: Comment @aws_subscribe(mutations: [\\"createComment\\"])
-  onUpdateComment: Comment @aws_subscribe(mutations: [\\"updateComment\\"])
-  onDeleteComment: Comment @aws_subscribe(mutations: [\\"deleteComment\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreateAuthor(filter: ModelSubscriptionAuthorFilterInput): Author @aws_subscribe(mutations: [\\"createAuthor\\"])
+  onUpdateAuthor(filter: ModelSubscriptionAuthorFilterInput): Author @aws_subscribe(mutations: [\\"updateAuthor\\"])
+  onDeleteAuthor(filter: ModelSubscriptionAuthorFilterInput): Author @aws_subscribe(mutations: [\\"deleteAuthor\\"])
+  onCreateRequire(filter: ModelSubscriptionRequireFilterInput): Require @aws_subscribe(mutations: [\\"createRequire\\"])
+  onUpdateRequire(filter: ModelSubscriptionRequireFilterInput): Require @aws_subscribe(mutations: [\\"updateRequire\\"])
+  onDeleteRequire(filter: ModelSubscriptionRequireFilterInput): Require @aws_subscribe(mutations: [\\"deleteRequire\\"])
+  onCreateComment(filter: ModelSubscriptionCommentFilterInput): Comment @aws_subscribe(mutations: [\\"createComment\\"])
+  onUpdateComment(filter: ModelSubscriptionCommentFilterInput): Comment @aws_subscribe(mutations: [\\"updateComment\\"])
+  onDeleteComment(filter: ModelSubscriptionCommentFilterInput): Comment @aws_subscribe(mutations: [\\"deleteComment\\"])
 }
 
 type ModelAuthorConnection {
@@ -500,6 +641,13 @@ input DeleteAuthorInput {
   id: ID!
 }
 
+input ModelSubscriptionAuthorFilterInput {
+  id: ModelSubscriptionIDInput
+  name: ModelSubscriptionStringInput
+  and: [ModelSubscriptionAuthorFilterInput]
+  or: [ModelSubscriptionAuthorFilterInput]
+}
+
 type ModelRequireConnection {
   items: [Require]!
   nextToken: String
@@ -536,6 +684,14 @@ input UpdateRequireInput {
 
 input DeleteRequireInput {
   id: ID!
+}
+
+input ModelSubscriptionRequireFilterInput {
+  id: ModelSubscriptionIDInput
+  requiredField: ModelSubscriptionStringInput
+  notRequiredField: ModelSubscriptionStringInput
+  and: [ModelSubscriptionRequireFilterInput]
+  or: [ModelSubscriptionRequireFilterInput]
 }
 
 type ModelCommentConnection {
@@ -578,6 +734,15 @@ input UpdateCommentInput {
 
 input DeleteCommentInput {
   id: ID!
+}
+
+input ModelSubscriptionCommentFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  content: ModelSubscriptionStringInput
+  updatedOn: ModelSubscriptionIntInput
+  and: [ModelSubscriptionCommentFilterInput]
+  or: [ModelSubscriptionCommentFilterInput]
 }
 
 "
@@ -1078,6 +1243,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1093,6 +1261,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeletePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1108,6 +1279,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -1608,6 +1782,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1623,6 +1800,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeletePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1638,6 +1818,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -2138,6 +2321,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2153,6 +2339,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeletePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2168,6 +2357,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -2243,6 +2435,65 @@ input ModelIDInput {
   attributeExists: Boolean
   attributeType: ModelAttributeTypes
   size: ModelSizeInput
+}
+
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
 }
 
 enum ModelAttributeTypes {
@@ -2326,10 +2577,19 @@ type Mutation {
   deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  str: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionStringInput
+  updatedAt: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
 }
 
 "
@@ -2678,6 +2938,65 @@ input ModelIDInput {
   size: ModelSizeInput
 }
 
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
 enum ModelAttributeTypes {
   binary
   binarySet
@@ -2785,6 +3104,65 @@ input ModelIDInput {
   size: ModelSizeInput
 }
 
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
 enum ModelAttributeTypes {
   binary
   binarySet
@@ -2866,10 +3244,19 @@ type Mutation {
   deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  str: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionIntInput
+  updatedAt: ModelSubscriptionIntInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
 }
 
 "
@@ -3147,6 +3534,65 @@ input ModelIDInput {
   size: ModelSizeInput
 }
 
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
 enum ModelAttributeTypes {
   binary
   binarySet
@@ -3220,10 +3666,17 @@ type Mutation {
   deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  str: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
 }
 
 "
@@ -3503,6 +3956,65 @@ input ModelIDInput {
   size: ModelSizeInput
 }
 
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
 enum ModelAttributeTypes {
   binary
   binarySet
@@ -3576,10 +4088,17 @@ type Mutation {
   deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  str: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
 }
 
 "

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -582,7 +582,7 @@ input ModelSubscriptionPostFilterInput {
   title: ModelSubscriptionStringInput
   createdAt: ModelSubscriptionStringInput
   updatedAt: ModelSubscriptionStringInput
-  appearsIn: ModelSubscriptionEpisodeListInput
+  appearsIn: ModelSubscriptionStringInput
   episode: ModelSubscriptionStringInput
   and: [ModelSubscriptionPostFilterInput]
   or: [ModelSubscriptionPostFilterInput]

--- a/packages/amplify-graphql-model-transformer/src/definitions.ts
+++ b/packages/amplify-graphql-model-transformer/src/definitions.ts
@@ -5,6 +5,12 @@ export const FLOAT_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'between'];
 export const BOOLEAN_CONDITIONS = ['ne', 'eq'];
 export const SIZE_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'between'];
 
+export const SUBSCRIPTION_STRING_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'contains', 'notContains', 'between', 'beginsWith', 'in', 'notIn'];
+export const SUBSCRIPTION_ID_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'contains', 'notContains', 'between', 'beginsWith', 'in', 'notIn'];
+export const SUBSCRIPTION_INT_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'between', 'in', 'notIn'];
+export const SUBSCRIPTION_FLOAT_CONDITIONS = ['ne', 'eq', 'le', 'lt', 'ge', 'gt', 'between', 'in', 'notIn'];
+export const SUBSCRIPTION_BOOLEAN_CONDITIONS = ['ne', 'eq'];
+
 export const STRING_FUNCTIONS = new Set<string>(['attributeExists', 'attributeType', 'size']);
 export const ID_FUNCTIONS = new Set<string>(['attributeExists', 'attributeType', 'size']);
 export const INT_FUNCTIONS = new Set<string>(['attributeExists', 'attributeType']);

--- a/packages/amplify-graphql-model-transformer/src/graphql-types/common.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-types/common.ts
@@ -137,6 +137,9 @@ export const removeSubscriptionFilterInputAttribute = (
 ): void => {
   const filterTypeName = getSubscriptionFilterInputName(typeName);
   const filterType = ctx.output.getType(filterTypeName) as InputObjectTypeDefinitionNode;
+  if (!filterType) {
+    return;
+  }
   const newFilterType: InputObjectTypeDefinitionNode = {
     ...filterType,
     fields: filterType.fields?.filter(field => field.name.value !== fieldName),

--- a/packages/amplify-graphql-model-transformer/src/graphql-types/common.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-types/common.ts
@@ -105,9 +105,11 @@ export const makeSubscriptionFilterInput = (
     const fieldType = ctx.output.getType(field.getTypeName());
     const isEnumType = fieldType && fieldType.kind === Kind.ENUM_TYPE_DEFINITION;
     if (field.isScalar() || isEnumType) {
-      const conditionTypeName = isEnumType && field.isList()
-        ? ModelResourceIDs.ModelFilterListInputTypeName(field.getTypeName(), !supportsConditions, true)
-        : ModelResourceIDs.ModelFilterScalarInputTypeName(isEnumType ? 'String' : field.getTypeName(), !supportsConditions, true);
+      const conditionTypeName = ModelResourceIDs.ModelFilterScalarInputTypeName(
+        isEnumType ? 'String' : field.getTypeName(),
+        !supportsConditions,
+        true,
+      );
       const inputField = InputFieldWrapper.create(field.name, conditionTypeName, true);
       input.addField(inputField);
     }

--- a/packages/amplify-graphql-model-transformer/src/graphql-types/query.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-types/query.ts
@@ -1,13 +1,21 @@
 import { TransformerTransformSchemaStepContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { InputObjectTypeDefinitionNode, ObjectTypeDefinitionNode } from 'graphql';
 import { FieldWrapper, ObjectDefinitionWrapper } from '@aws-amplify/graphql-transformer-core';
-import { makeConditionFilterInput } from './common';
+import { makeConditionFilterInput, makeSubscriptionFilterInput } from './common';
 export const makeListQueryFilterInput = (
   ctx: TransformerTransformSchemaStepContextProvider,
   name: string,
   object: ObjectTypeDefinitionNode,
 ): InputObjectTypeDefinitionNode => {
   return makeConditionFilterInput(ctx, name, object).serialize();
+};
+
+export const makeSubscriptionQueryFilterInput = (
+  ctx: TransformerTransformSchemaStepContextProvider,
+  name: string,
+  object: ObjectTypeDefinitionNode,
+): InputObjectTypeDefinitionNode => {
+  return makeSubscriptionFilterInput(ctx, name, object).serialize();
 };
 
 export const makeListQueryModel = (type: ObjectTypeDefinitionNode, modelName: string, isSyncEnabled: boolean): ObjectTypeDefinitionNode => {

--- a/packages/amplify-graphql-model-transformer/src/resolvers/subscriptions.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/subscriptions.ts
@@ -1,17 +1,25 @@
-import { compoundExpression, Expression, obj, printBlock, str, toJson, nul, iff, not, isNullOrEmpty, ref } from 'graphql-mapping-template';
+import {
+  compoundExpression, Expression, obj, printBlock, str, toJson, nul, iff, not, isNullOrEmpty, ref,
+} from 'graphql-mapping-template';
 
+/**
+ * Generates subscription request template
+ */
 export const generateSubscriptionRequestTemplate = (): string => {
   const statements: Expression[] = [toJson(obj({ version: str('2018-05-29'), payload: obj({}) }))];
   return printBlock('Subscription Request template')(compoundExpression(statements));
 };
 
+/**
+ * Generates subscription response template
+ */
 export const generateSubscriptionResponseTemplate = (): string => {
   const statements: Expression[] = [
     iff(
       not(isNullOrEmpty(ref('ctx.args.filter'))),
       ref('extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))'),
     ),
-    toJson(nul())
+    toJson(nul()),
   ];
   return printBlock('Subscription Response template')(compoundExpression(statements));
 };

--- a/packages/amplify-graphql-model-transformer/src/resolvers/subscriptions.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/subscriptions.ts
@@ -1,4 +1,4 @@
-import { compoundExpression, Expression, obj, printBlock, str, toJson, nul } from 'graphql-mapping-template';
+import { compoundExpression, Expression, obj, printBlock, str, toJson, nul, iff, not, isNullOrEmpty, ref } from 'graphql-mapping-template';
 
 export const generateSubscriptionRequestTemplate = (): string => {
   const statements: Expression[] = [toJson(obj({ version: str('2018-05-29'), payload: obj({}) }))];
@@ -6,6 +6,12 @@ export const generateSubscriptionRequestTemplate = (): string => {
 };
 
 export const generateSubscriptionResponseTemplate = (): string => {
-  const statements: Expression[] = [toJson(nul())];
+  const statements: Expression[] = [
+    iff(
+      not(isNullOrEmpty(ref('ctx.args.filter'))),
+      ref('extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))'),
+    ),
+    toJson(nul())
+  ];
   return printBlock('Subscription Response template')(compoundExpression(statements));
 };

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
@@ -2771,16 +2771,1647 @@ Object {
     Object {
       "description": undefined,
       "directives": Array [],
-      "kind": "EnumTypeDefinition",
+      "fields": Array [
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1705,
+            "start": 1695,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1697,
+              "start": 1695,
+            },
+            "value": "ne",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 1705,
+              "start": 1699,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 1705,
+                "start": 1699,
+              },
+              "value": "String",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1718,
+            "start": 1708,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1710,
+              "start": 1708,
+            },
+            "value": "eq",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 1718,
+              "start": 1712,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 1718,
+                "start": 1712,
+              },
+              "value": "String",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1731,
+            "start": 1721,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1723,
+              "start": 1721,
+            },
+            "value": "le",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 1731,
+              "start": 1725,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 1731,
+                "start": 1725,
+              },
+              "value": "String",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1744,
+            "start": 1734,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1736,
+              "start": 1734,
+            },
+            "value": "lt",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 1744,
+              "start": 1738,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 1744,
+                "start": 1738,
+              },
+              "value": "String",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1757,
+            "start": 1747,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1749,
+              "start": 1747,
+            },
+            "value": "ge",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 1757,
+              "start": 1751,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 1757,
+                "start": 1751,
+              },
+              "value": "String",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1770,
+            "start": 1760,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1762,
+              "start": 1760,
+            },
+            "value": "gt",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 1770,
+              "start": 1764,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 1770,
+                "start": 1764,
+              },
+              "value": "String",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1789,
+            "start": 1773,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1781,
+              "start": 1773,
+            },
+            "value": "contains",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 1789,
+              "start": 1783,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 1789,
+                "start": 1783,
+              },
+              "value": "String",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1811,
+            "start": 1792,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1803,
+              "start": 1792,
+            },
+            "value": "notContains",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 1811,
+              "start": 1805,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 1811,
+                "start": 1805,
+              },
+              "value": "String",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1831,
+            "start": 1814,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1821,
+              "start": 1814,
+            },
+            "value": "between",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 1831,
+              "start": 1823,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 1830,
+                "start": 1824,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 1830,
+                  "start": 1824,
+                },
+                "value": "String",
+              },
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1852,
+            "start": 1834,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1844,
+              "start": 1834,
+            },
+            "value": "beginsWith",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 1852,
+              "start": 1846,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 1852,
+                "start": 1846,
+              },
+              "value": "String",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1867,
+            "start": 1855,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1857,
+              "start": 1855,
+            },
+            "value": "in",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 1867,
+              "start": 1859,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 1866,
+                "start": 1860,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 1866,
+                  "start": 1860,
+                },
+                "value": "String",
+              },
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1885,
+            "start": 1870,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1875,
+              "start": 1870,
+            },
+            "value": "notIn",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 1885,
+              "start": 1877,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 1884,
+                "start": 1878,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 1884,
+                  "start": 1878,
+                },
+                "value": "String",
+              },
+            },
+          },
+        },
+      ],
+      "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 1775,
+        "end": 1887,
         "start": 1656,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 1680,
-          "start": 1661,
+          "end": 1690,
+          "start": 1662,
+        },
+        "value": "ModelSubscriptionStringInput",
+      },
+    },
+    Object {
+      "description": undefined,
+      "directives": Array [],
+      "fields": Array [
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1932,
+            "start": 1925,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1927,
+              "start": 1925,
+            },
+            "value": "ne",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 1932,
+              "start": 1929,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 1932,
+                "start": 1929,
+              },
+              "value": "Int",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1942,
+            "start": 1935,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1937,
+              "start": 1935,
+            },
+            "value": "eq",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 1942,
+              "start": 1939,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 1942,
+                "start": 1939,
+              },
+              "value": "Int",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1952,
+            "start": 1945,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1947,
+              "start": 1945,
+            },
+            "value": "le",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 1952,
+              "start": 1949,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 1952,
+                "start": 1949,
+              },
+              "value": "Int",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1962,
+            "start": 1955,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1957,
+              "start": 1955,
+            },
+            "value": "lt",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 1962,
+              "start": 1959,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 1962,
+                "start": 1959,
+              },
+              "value": "Int",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1972,
+            "start": 1965,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1967,
+              "start": 1965,
+            },
+            "value": "ge",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 1972,
+              "start": 1969,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 1972,
+                "start": 1969,
+              },
+              "value": "Int",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1982,
+            "start": 1975,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1977,
+              "start": 1975,
+            },
+            "value": "gt",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 1982,
+              "start": 1979,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 1982,
+                "start": 1979,
+              },
+              "value": "Int",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 1999,
+            "start": 1985,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 1992,
+              "start": 1985,
+            },
+            "value": "between",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 1999,
+              "start": 1994,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 1998,
+                "start": 1995,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 1998,
+                  "start": 1995,
+                },
+                "value": "Int",
+              },
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2011,
+            "start": 2002,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2004,
+              "start": 2002,
+            },
+            "value": "in",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 2011,
+              "start": 2006,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 2010,
+                "start": 2007,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 2010,
+                  "start": 2007,
+                },
+                "value": "Int",
+              },
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2026,
+            "start": 2014,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2019,
+              "start": 2014,
+            },
+            "value": "notIn",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 2026,
+              "start": 2021,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 2025,
+                "start": 2022,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 2025,
+                  "start": 2022,
+                },
+                "value": "Int",
+              },
+            },
+          },
+        },
+      ],
+      "kind": "InputObjectTypeDefinition",
+      "loc": Object {
+        "end": 2028,
+        "start": 1889,
+      },
+      "name": Object {
+        "kind": "Name",
+        "loc": Object {
+          "end": 1920,
+          "start": 1895,
+        },
+        "value": "ModelSubscriptionIntInput",
+      },
+    },
+    Object {
+      "description": undefined,
+      "directives": Array [],
+      "fields": Array [
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2077,
+            "start": 2068,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2070,
+              "start": 2068,
+            },
+            "value": "ne",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 2077,
+              "start": 2072,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 2077,
+                "start": 2072,
+              },
+              "value": "Float",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2089,
+            "start": 2080,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2082,
+              "start": 2080,
+            },
+            "value": "eq",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 2089,
+              "start": 2084,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 2089,
+                "start": 2084,
+              },
+              "value": "Float",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2101,
+            "start": 2092,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2094,
+              "start": 2092,
+            },
+            "value": "le",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 2101,
+              "start": 2096,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 2101,
+                "start": 2096,
+              },
+              "value": "Float",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2113,
+            "start": 2104,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2106,
+              "start": 2104,
+            },
+            "value": "lt",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 2113,
+              "start": 2108,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 2113,
+                "start": 2108,
+              },
+              "value": "Float",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2125,
+            "start": 2116,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2118,
+              "start": 2116,
+            },
+            "value": "ge",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 2125,
+              "start": 2120,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 2125,
+                "start": 2120,
+              },
+              "value": "Float",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2137,
+            "start": 2128,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2130,
+              "start": 2128,
+            },
+            "value": "gt",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 2137,
+              "start": 2132,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 2137,
+                "start": 2132,
+              },
+              "value": "Float",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2156,
+            "start": 2140,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2147,
+              "start": 2140,
+            },
+            "value": "between",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 2156,
+              "start": 2149,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 2155,
+                "start": 2150,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 2155,
+                  "start": 2150,
+                },
+                "value": "Float",
+              },
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2170,
+            "start": 2159,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2161,
+              "start": 2159,
+            },
+            "value": "in",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 2170,
+              "start": 2163,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 2169,
+                "start": 2164,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 2169,
+                  "start": 2164,
+                },
+                "value": "Float",
+              },
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2187,
+            "start": 2173,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2178,
+              "start": 2173,
+            },
+            "value": "notIn",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 2187,
+              "start": 2180,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 2186,
+                "start": 2181,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 2186,
+                  "start": 2181,
+                },
+                "value": "Float",
+              },
+            },
+          },
+        },
+      ],
+      "kind": "InputObjectTypeDefinition",
+      "loc": Object {
+        "end": 2189,
+        "start": 2030,
+      },
+      "name": Object {
+        "kind": "Name",
+        "loc": Object {
+          "end": 2063,
+          "start": 2036,
+        },
+        "value": "ModelSubscriptionFloatInput",
+      },
+    },
+    Object {
+      "description": undefined,
+      "directives": Array [],
+      "fields": Array [
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2242,
+            "start": 2231,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2233,
+              "start": 2231,
+            },
+            "value": "ne",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 2242,
+              "start": 2235,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 2242,
+                "start": 2235,
+              },
+              "value": "Boolean",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2256,
+            "start": 2245,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2247,
+              "start": 2245,
+            },
+            "value": "eq",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 2256,
+              "start": 2249,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 2256,
+                "start": 2249,
+              },
+              "value": "Boolean",
+            },
+          },
+        },
+      ],
+      "kind": "InputObjectTypeDefinition",
+      "loc": Object {
+        "end": 2258,
+        "start": 2191,
+      },
+      "name": Object {
+        "kind": "Name",
+        "loc": Object {
+          "end": 2226,
+          "start": 2197,
+        },
+        "value": "ModelSubscriptionBooleanInput",
+      },
+    },
+    Object {
+      "description": undefined,
+      "directives": Array [],
+      "fields": Array [
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2301,
+            "start": 2295,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2297,
+              "start": 2295,
+            },
+            "value": "ne",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 2301,
+              "start": 2299,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 2301,
+                "start": 2299,
+              },
+              "value": "ID",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2310,
+            "start": 2304,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2306,
+              "start": 2304,
+            },
+            "value": "eq",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 2310,
+              "start": 2308,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 2310,
+                "start": 2308,
+              },
+              "value": "ID",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2319,
+            "start": 2313,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2315,
+              "start": 2313,
+            },
+            "value": "le",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 2319,
+              "start": 2317,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 2319,
+                "start": 2317,
+              },
+              "value": "ID",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2328,
+            "start": 2322,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2324,
+              "start": 2322,
+            },
+            "value": "lt",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 2328,
+              "start": 2326,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 2328,
+                "start": 2326,
+              },
+              "value": "ID",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2337,
+            "start": 2331,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2333,
+              "start": 2331,
+            },
+            "value": "ge",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 2337,
+              "start": 2335,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 2337,
+                "start": 2335,
+              },
+              "value": "ID",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2346,
+            "start": 2340,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2342,
+              "start": 2340,
+            },
+            "value": "gt",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 2346,
+              "start": 2344,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 2346,
+                "start": 2344,
+              },
+              "value": "ID",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2361,
+            "start": 2349,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2357,
+              "start": 2349,
+            },
+            "value": "contains",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 2361,
+              "start": 2359,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 2361,
+                "start": 2359,
+              },
+              "value": "ID",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2379,
+            "start": 2364,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2375,
+              "start": 2364,
+            },
+            "value": "notContains",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 2379,
+              "start": 2377,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 2379,
+                "start": 2377,
+              },
+              "value": "ID",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2395,
+            "start": 2382,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2389,
+              "start": 2382,
+            },
+            "value": "between",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 2395,
+              "start": 2391,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 2394,
+                "start": 2392,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 2394,
+                  "start": 2392,
+                },
+                "value": "ID",
+              },
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2412,
+            "start": 2398,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2408,
+              "start": 2398,
+            },
+            "value": "beginsWith",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 2412,
+              "start": 2410,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 2412,
+                "start": 2410,
+              },
+              "value": "ID",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2423,
+            "start": 2415,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2417,
+              "start": 2415,
+            },
+            "value": "in",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 2423,
+              "start": 2419,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 2422,
+                "start": 2420,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 2422,
+                  "start": 2420,
+                },
+                "value": "ID",
+              },
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 2437,
+            "start": 2426,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 2431,
+              "start": 2426,
+            },
+            "value": "notIn",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 2437,
+              "start": 2433,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 2436,
+                "start": 2434,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 2436,
+                  "start": 2434,
+                },
+                "value": "ID",
+              },
+            },
+          },
+        },
+      ],
+      "kind": "InputObjectTypeDefinition",
+      "loc": Object {
+        "end": 2439,
+        "start": 2260,
+      },
+      "name": Object {
+        "kind": "Name",
+        "loc": Object {
+          "end": 2290,
+          "start": 2266,
+        },
+        "value": "ModelSubscriptionIDInput",
+      },
+    },
+    Object {
+      "description": undefined,
+      "directives": Array [],
+      "kind": "EnumTypeDefinition",
+      "loc": Object {
+        "end": 2560,
+        "start": 2441,
+      },
+      "name": Object {
+        "kind": "Name",
+        "loc": Object {
+          "end": 2465,
+          "start": 2446,
         },
         "value": "ModelAttributeTypes",
       },
@@ -2790,14 +4421,14 @@ Object {
           "directives": Array [],
           "kind": "EnumValueDefinition",
           "loc": Object {
-            "end": 1691,
-            "start": 1685,
+            "end": 2476,
+            "start": 2470,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1691,
-              "start": 1685,
+              "end": 2476,
+              "start": 2470,
             },
             "value": "binary",
           },
@@ -2807,14 +4438,14 @@ Object {
           "directives": Array [],
           "kind": "EnumValueDefinition",
           "loc": Object {
-            "end": 1703,
-            "start": 1694,
+            "end": 2488,
+            "start": 2479,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1703,
-              "start": 1694,
+              "end": 2488,
+              "start": 2479,
             },
             "value": "binarySet",
           },
@@ -2824,14 +4455,14 @@ Object {
           "directives": Array [],
           "kind": "EnumValueDefinition",
           "loc": Object {
-            "end": 1710,
-            "start": 1706,
+            "end": 2495,
+            "start": 2491,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1710,
-              "start": 1706,
+              "end": 2495,
+              "start": 2491,
             },
             "value": "bool",
           },
@@ -2841,14 +4472,14 @@ Object {
           "directives": Array [],
           "kind": "EnumValueDefinition",
           "loc": Object {
-            "end": 1717,
-            "start": 1713,
+            "end": 2502,
+            "start": 2498,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1717,
-              "start": 1713,
+              "end": 2502,
+              "start": 2498,
             },
             "value": "list",
           },
@@ -2858,14 +4489,14 @@ Object {
           "directives": Array [],
           "kind": "EnumValueDefinition",
           "loc": Object {
-            "end": 1723,
-            "start": 1720,
+            "end": 2508,
+            "start": 2505,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1723,
-              "start": 1720,
+              "end": 2508,
+              "start": 2505,
             },
             "value": "map",
           },
@@ -2875,14 +4506,14 @@ Object {
           "directives": Array [],
           "kind": "EnumValueDefinition",
           "loc": Object {
-            "end": 1732,
-            "start": 1726,
+            "end": 2517,
+            "start": 2511,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1732,
-              "start": 1726,
+              "end": 2517,
+              "start": 2511,
             },
             "value": "number",
           },
@@ -2892,14 +4523,14 @@ Object {
           "directives": Array [],
           "kind": "EnumValueDefinition",
           "loc": Object {
-            "end": 1744,
-            "start": 1735,
+            "end": 2529,
+            "start": 2520,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1744,
-              "start": 1735,
+              "end": 2529,
+              "start": 2520,
             },
             "value": "numberSet",
           },
@@ -2909,14 +4540,14 @@ Object {
           "directives": Array [],
           "kind": "EnumValueDefinition",
           "loc": Object {
-            "end": 1753,
-            "start": 1747,
+            "end": 2538,
+            "start": 2532,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1753,
-              "start": 1747,
+              "end": 2538,
+              "start": 2532,
             },
             "value": "string",
           },
@@ -2926,14 +4557,14 @@ Object {
           "directives": Array [],
           "kind": "EnumValueDefinition",
           "loc": Object {
-            "end": 1765,
-            "start": 1756,
+            "end": 2550,
+            "start": 2541,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1765,
-              "start": 1756,
+              "end": 2550,
+              "start": 2541,
             },
             "value": "stringSet",
           },
@@ -2943,14 +4574,14 @@ Object {
           "directives": Array [],
           "kind": "EnumValueDefinition",
           "loc": Object {
-            "end": 1773,
-            "start": 1768,
+            "end": 2558,
+            "start": 2553,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1773,
-              "start": 1768,
+              "end": 2558,
+              "start": 2553,
             },
             "value": "_null",
           },
@@ -2967,28 +4598,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 1809,
-            "start": 1802,
+            "end": 2594,
+            "start": 2587,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1804,
-              "start": 1802,
+              "end": 2589,
+              "start": 2587,
             },
             "value": "ne",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 1809,
-              "start": 1806,
+              "end": 2594,
+              "start": 2591,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 1809,
-                "start": 1806,
+                "end": 2594,
+                "start": 2591,
               },
               "value": "Int",
             },
@@ -3000,28 +4631,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 1819,
-            "start": 1812,
+            "end": 2604,
+            "start": 2597,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1814,
-              "start": 1812,
+              "end": 2599,
+              "start": 2597,
             },
             "value": "eq",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 1819,
-              "start": 1816,
+              "end": 2604,
+              "start": 2601,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 1819,
-                "start": 1816,
+                "end": 2604,
+                "start": 2601,
               },
               "value": "Int",
             },
@@ -3033,28 +4664,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 1829,
-            "start": 1822,
+            "end": 2614,
+            "start": 2607,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1824,
-              "start": 1822,
+              "end": 2609,
+              "start": 2607,
             },
             "value": "le",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 1829,
-              "start": 1826,
+              "end": 2614,
+              "start": 2611,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 1829,
-                "start": 1826,
+                "end": 2614,
+                "start": 2611,
               },
               "value": "Int",
             },
@@ -3066,28 +4697,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 1839,
-            "start": 1832,
+            "end": 2624,
+            "start": 2617,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1834,
-              "start": 1832,
+              "end": 2619,
+              "start": 2617,
             },
             "value": "lt",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 1839,
-              "start": 1836,
+              "end": 2624,
+              "start": 2621,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 1839,
-                "start": 1836,
+                "end": 2624,
+                "start": 2621,
               },
               "value": "Int",
             },
@@ -3099,28 +4730,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 1849,
-            "start": 1842,
+            "end": 2634,
+            "start": 2627,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1844,
-              "start": 1842,
+              "end": 2629,
+              "start": 2627,
             },
             "value": "ge",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 1849,
-              "start": 1846,
+              "end": 2634,
+              "start": 2631,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 1849,
-                "start": 1846,
+                "end": 2634,
+                "start": 2631,
               },
               "value": "Int",
             },
@@ -3132,28 +4763,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 1859,
-            "start": 1852,
+            "end": 2644,
+            "start": 2637,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1854,
-              "start": 1852,
+              "end": 2639,
+              "start": 2637,
             },
             "value": "gt",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 1859,
-              "start": 1856,
+              "end": 2644,
+              "start": 2641,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 1859,
-                "start": 1856,
+                "end": 2644,
+                "start": 2641,
               },
               "value": "Int",
             },
@@ -3165,34 +4796,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 1876,
-            "start": 1862,
+            "end": 2661,
+            "start": 2647,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1869,
-              "start": 1862,
+              "end": 2654,
+              "start": 2647,
             },
             "value": "between",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 1876,
-              "start": 1871,
+              "end": 2661,
+              "start": 2656,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 1875,
-                "start": 1872,
+                "end": 2660,
+                "start": 2657,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 1875,
-                  "start": 1872,
+                  "end": 2660,
+                  "start": 2657,
                 },
                 "value": "Int",
               },
@@ -3202,14 +4833,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 1878,
-        "start": 1777,
+        "end": 2663,
+        "start": 2562,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 1797,
-          "start": 1783,
+          "end": 2582,
+          "start": 2568,
         },
         "value": "ModelSizeInput",
       },
@@ -3219,14 +4850,14 @@ Object {
       "directives": Array [],
       "kind": "EnumTypeDefinition",
       "loc": Object {
-        "end": 1920,
-        "start": 1880,
+        "end": 2705,
+        "start": 2665,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 1903,
-          "start": 1885,
+          "end": 2688,
+          "start": 2670,
         },
         "value": "ModelSortDirection",
       },
@@ -3236,14 +4867,14 @@ Object {
           "directives": Array [],
           "kind": "EnumValueDefinition",
           "loc": Object {
-            "end": 1911,
-            "start": 1908,
+            "end": 2696,
+            "start": 2693,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1911,
-              "start": 1908,
+              "end": 2696,
+              "start": 2693,
             },
             "value": "ASC",
           },
@@ -3253,14 +4884,14 @@ Object {
           "directives": Array [],
           "kind": "EnumValueDefinition",
           "loc": Object {
-            "end": 1918,
-            "start": 1914,
+            "end": 2703,
+            "start": 2699,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1918,
-              "start": 1914,
+              "end": 2703,
+              "start": 2699,
             },
             "value": "DESC",
           },
@@ -3277,40 +4908,40 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 1965,
-            "start": 1951,
+            "end": 2750,
+            "start": 2736,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1956,
-              "start": 1951,
+              "end": 2741,
+              "start": 2736,
             },
             "value": "items",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 1965,
-              "start": 1958,
+              "end": 2750,
+              "start": 2743,
             },
             "type": Object {
               "kind": "ListType",
               "loc": Object {
-                "end": 1964,
-                "start": 1958,
+                "end": 2749,
+                "start": 2743,
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 1963,
-                  "start": 1959,
+                  "end": 2748,
+                  "start": 2744,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 1963,
-                    "start": 1959,
+                    "end": 2748,
+                    "start": 2744,
                   },
                   "value": "Post",
                 },
@@ -3324,28 +4955,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 1985,
-            "start": 1968,
+            "end": 2770,
+            "start": 2753,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 1977,
-              "start": 1968,
+              "end": 2762,
+              "start": 2753,
             },
             "value": "nextToken",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 1985,
-              "start": 1979,
+              "end": 2770,
+              "start": 2764,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 1985,
-                "start": 1979,
+                "end": 2770,
+                "start": 2764,
               },
               "value": "String",
             },
@@ -3355,14 +4986,14 @@ Object {
       "interfaces": Array [],
       "kind": "ObjectTypeDefinition",
       "loc": Object {
-        "end": 1987,
-        "start": 1922,
+        "end": 2772,
+        "start": 2707,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 1946,
-          "start": 1927,
+          "end": 2731,
+          "start": 2712,
         },
         "value": "ModelPostConnection",
       },
@@ -3377,28 +5008,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2036,
-            "start": 2020,
+            "end": 2821,
+            "start": 2805,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2022,
-              "start": 2020,
+              "end": 2807,
+              "start": 2805,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2036,
-              "start": 2024,
+              "end": 2821,
+              "start": 2809,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2036,
-                "start": 2024,
+                "end": 2821,
+                "start": 2809,
               },
               "value": "ModelIDInput",
             },
@@ -3410,28 +5041,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2062,
-            "start": 2039,
+            "end": 2847,
+            "start": 2824,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2044,
-              "start": 2039,
+              "end": 2829,
+              "start": 2824,
             },
             "value": "title",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2062,
-              "start": 2046,
+              "end": 2847,
+              "start": 2831,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2062,
-                "start": 2046,
+                "end": 2847,
+                "start": 2831,
               },
               "value": "ModelStringInput",
             },
@@ -3443,34 +5074,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2092,
-            "start": 2065,
+            "end": 2877,
+            "start": 2850,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2068,
-              "start": 2065,
+              "end": 2853,
+              "start": 2850,
             },
             "value": "and",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 2092,
-              "start": 2070,
+              "end": 2877,
+              "start": 2855,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 2091,
-                "start": 2071,
+                "end": 2876,
+                "start": 2856,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2091,
-                  "start": 2071,
+                  "end": 2876,
+                  "start": 2856,
                 },
                 "value": "ModelPostFilterInput",
               },
@@ -3483,34 +5114,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2121,
-            "start": 2095,
+            "end": 2906,
+            "start": 2880,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2097,
-              "start": 2095,
+              "end": 2882,
+              "start": 2880,
             },
             "value": "or",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 2121,
-              "start": 2099,
+              "end": 2906,
+              "start": 2884,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 2120,
-                "start": 2100,
+                "end": 2905,
+                "start": 2885,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2120,
-                  "start": 2100,
+                  "end": 2905,
+                  "start": 2885,
                 },
                 "value": "ModelPostFilterInput",
               },
@@ -3523,28 +5154,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2149,
-            "start": 2124,
+            "end": 2934,
+            "start": 2909,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2127,
-              "start": 2124,
+              "end": 2912,
+              "start": 2909,
             },
             "value": "not",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2149,
-              "start": 2129,
+              "end": 2934,
+              "start": 2914,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2149,
-                "start": 2129,
+                "end": 2934,
+                "start": 2914,
               },
               "value": "ModelPostFilterInput",
             },
@@ -3553,14 +5184,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 2151,
-        "start": 1989,
+        "end": 2936,
+        "start": 2774,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 2015,
-          "start": 1995,
+          "end": 2800,
+          "start": 2780,
         },
         "value": "ModelPostFilterInput",
       },
@@ -3577,34 +5208,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2183,
-                "start": 2176,
+                "end": 2968,
+                "start": 2961,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2178,
-                  "start": 2176,
+                  "end": 2963,
+                  "start": 2961,
                 },
                 "value": "id",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 2183,
-                  "start": 2180,
+                  "end": 2968,
+                  "start": 2965,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 2182,
-                    "start": 2180,
+                    "end": 2967,
+                    "start": 2965,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 2182,
-                      "start": 2180,
+                      "end": 2967,
+                      "start": 2965,
                     },
                     "value": "ID",
                   },
@@ -3616,28 +5247,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 2190,
-            "start": 2168,
+            "end": 2975,
+            "start": 2953,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2175,
-              "start": 2168,
+              "end": 2960,
+              "start": 2953,
             },
             "value": "getPost",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2190,
-              "start": 2186,
+              "end": 2975,
+              "start": 2971,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2190,
-                "start": 2186,
+                "end": 2975,
+                "start": 2971,
               },
               "value": "Post",
             },
@@ -3651,28 +5282,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2231,
-                "start": 2203,
+                "end": 3016,
+                "start": 2988,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2209,
-                  "start": 2203,
+                  "end": 2994,
+                  "start": 2988,
                 },
                 "value": "filter",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2231,
-                  "start": 2211,
+                  "end": 3016,
+                  "start": 2996,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2231,
-                    "start": 2211,
+                    "end": 3016,
+                    "start": 2996,
                   },
                   "value": "ModelPostFilterInput",
                 },
@@ -3684,28 +5315,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2243,
-                "start": 2233,
+                "end": 3028,
+                "start": 3018,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2238,
-                  "start": 2233,
+                  "end": 3023,
+                  "start": 3018,
                 },
                 "value": "limit",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2243,
-                  "start": 2240,
+                  "end": 3028,
+                  "start": 3025,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2243,
-                    "start": 2240,
+                    "end": 3028,
+                    "start": 3025,
                   },
                   "value": "Int",
                 },
@@ -3717,28 +5348,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2262,
-                "start": 2245,
+                "end": 3047,
+                "start": 3030,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2254,
-                  "start": 2245,
+                  "end": 3039,
+                  "start": 3030,
                 },
                 "value": "nextToken",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2262,
-                  "start": 2256,
+                  "end": 3047,
+                  "start": 3041,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2262,
-                    "start": 2256,
+                    "end": 3047,
+                    "start": 3041,
                   },
                   "value": "String",
                 },
@@ -3749,28 +5380,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 2284,
-            "start": 2193,
+            "end": 3069,
+            "start": 2978,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2202,
-              "start": 2193,
+              "end": 2987,
+              "start": 2978,
             },
             "value": "listPosts",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2284,
-              "start": 2265,
+              "end": 3069,
+              "start": 3050,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2284,
-                "start": 2265,
+                "end": 3069,
+                "start": 3050,
               },
               "value": "ModelPostConnection",
             },
@@ -3784,34 +5415,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2302,
-                "start": 2295,
+                "end": 3087,
+                "start": 3080,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2297,
-                  "start": 2295,
+                  "end": 3082,
+                  "start": 3080,
                 },
                 "value": "id",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 2302,
-                  "start": 2299,
+                  "end": 3087,
+                  "start": 3084,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 2301,
-                    "start": 2299,
+                    "end": 3086,
+                    "start": 3084,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 2301,
-                      "start": 2299,
+                      "end": 3086,
+                      "start": 3084,
                     },
                     "value": "ID",
                   },
@@ -3823,28 +5454,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 2309,
-            "start": 2287,
+            "end": 3094,
+            "start": 3072,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2294,
-              "start": 2287,
+              "end": 3079,
+              "start": 3072,
             },
             "value": "getUser",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2309,
-              "start": 2305,
+              "end": 3094,
+              "start": 3090,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2309,
-                "start": 2305,
+                "end": 3094,
+                "start": 3090,
               },
               "value": "User",
             },
@@ -3858,28 +5489,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2350,
-                "start": 2322,
+                "end": 3135,
+                "start": 3107,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2328,
-                  "start": 2322,
+                  "end": 3113,
+                  "start": 3107,
                 },
                 "value": "filter",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2350,
-                  "start": 2330,
+                  "end": 3135,
+                  "start": 3115,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2350,
-                    "start": 2330,
+                    "end": 3135,
+                    "start": 3115,
                   },
                   "value": "ModelUserFilterInput",
                 },
@@ -3891,28 +5522,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2362,
-                "start": 2352,
+                "end": 3147,
+                "start": 3137,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2357,
-                  "start": 2352,
+                  "end": 3142,
+                  "start": 3137,
                 },
                 "value": "limit",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2362,
-                  "start": 2359,
+                  "end": 3147,
+                  "start": 3144,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2362,
-                    "start": 2359,
+                    "end": 3147,
+                    "start": 3144,
                   },
                   "value": "Int",
                 },
@@ -3924,28 +5555,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2381,
-                "start": 2364,
+                "end": 3166,
+                "start": 3149,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2373,
-                  "start": 2364,
+                  "end": 3158,
+                  "start": 3149,
                 },
                 "value": "nextToken",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2381,
-                  "start": 2375,
+                  "end": 3166,
+                  "start": 3160,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2381,
-                    "start": 2375,
+                    "end": 3166,
+                    "start": 3160,
                   },
                   "value": "String",
                 },
@@ -3956,28 +5587,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 2403,
-            "start": 2312,
+            "end": 3188,
+            "start": 3097,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2321,
-              "start": 2312,
+              "end": 3106,
+              "start": 3097,
             },
             "value": "listUsers",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2403,
-              "start": 2384,
+              "end": 3188,
+              "start": 3169,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2403,
-                "start": 2384,
+                "end": 3188,
+                "start": 3169,
               },
               "value": "ModelUserConnection",
             },
@@ -3987,14 +5618,14 @@ Object {
       "interfaces": Array [],
       "kind": "ObjectTypeDefinition",
       "loc": Object {
-        "end": 2405,
-        "start": 2153,
+        "end": 3190,
+        "start": 2938,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 2163,
-          "start": 2158,
+          "end": 2948,
+          "start": 2943,
         },
         "value": "Query",
       },
@@ -4009,28 +5640,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2464,
-            "start": 2441,
+            "end": 3249,
+            "start": 3226,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2446,
-              "start": 2441,
+              "end": 3231,
+              "start": 3226,
             },
             "value": "title",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2464,
-              "start": 2448,
+              "end": 3249,
+              "start": 3233,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2464,
-                "start": 2448,
+                "end": 3249,
+                "start": 3233,
               },
               "value": "ModelStringInput",
             },
@@ -4042,34 +5673,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2497,
-            "start": 2467,
+            "end": 3282,
+            "start": 3252,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2470,
-              "start": 2467,
+              "end": 3255,
+              "start": 3252,
             },
             "value": "and",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 2497,
-              "start": 2472,
+              "end": 3282,
+              "start": 3257,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 2496,
-                "start": 2473,
+                "end": 3281,
+                "start": 3258,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2496,
-                  "start": 2473,
+                  "end": 3281,
+                  "start": 3258,
                 },
                 "value": "ModelPostConditionInput",
               },
@@ -4082,34 +5713,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2529,
-            "start": 2500,
+            "end": 3314,
+            "start": 3285,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2502,
-              "start": 2500,
+              "end": 3287,
+              "start": 3285,
             },
             "value": "or",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 2529,
-              "start": 2504,
+              "end": 3314,
+              "start": 3289,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 2528,
-                "start": 2505,
+                "end": 3313,
+                "start": 3290,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2528,
-                  "start": 2505,
+                  "end": 3313,
+                  "start": 3290,
                 },
                 "value": "ModelPostConditionInput",
               },
@@ -4122,28 +5753,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2560,
-            "start": 2532,
+            "end": 3345,
+            "start": 3317,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2535,
-              "start": 2532,
+              "end": 3320,
+              "start": 3317,
             },
             "value": "not",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2560,
-              "start": 2537,
+              "end": 3345,
+              "start": 3322,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2560,
-                "start": 2537,
+                "end": 3345,
+                "start": 3322,
               },
               "value": "ModelPostConditionInput",
             },
@@ -4152,14 +5783,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 2562,
-        "start": 2407,
+        "end": 3347,
+        "start": 3192,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 2436,
-          "start": 2413,
+          "end": 3221,
+          "start": 3198,
         },
         "value": "ModelPostConditionInput",
       },
@@ -4174,28 +5805,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2596,
-            "start": 2590,
+            "end": 3381,
+            "start": 3375,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2592,
-              "start": 2590,
+              "end": 3377,
+              "start": 3375,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2596,
-              "start": 2594,
+              "end": 3381,
+              "start": 3379,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2596,
-                "start": 2594,
+                "end": 3381,
+                "start": 3379,
               },
               "value": "ID",
             },
@@ -4207,34 +5838,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2613,
-            "start": 2599,
+            "end": 3398,
+            "start": 3384,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2604,
-              "start": 2599,
+              "end": 3389,
+              "start": 3384,
             },
             "value": "title",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 2613,
-              "start": 2606,
+              "end": 3398,
+              "start": 3391,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 2612,
-                "start": 2606,
+                "end": 3397,
+                "start": 3391,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2612,
-                  "start": 2606,
+                  "end": 3397,
+                  "start": 3391,
                 },
                 "value": "String",
               },
@@ -4244,14 +5875,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 2615,
-        "start": 2564,
+        "end": 3400,
+        "start": 3349,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 2585,
-          "start": 2570,
+          "end": 3370,
+          "start": 3355,
         },
         "value": "CreatePostInput",
       },
@@ -4266,34 +5897,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2650,
-            "start": 2643,
+            "end": 3435,
+            "start": 3428,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2645,
-              "start": 2643,
+              "end": 3430,
+              "start": 3428,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 2650,
-              "start": 2647,
+              "end": 3435,
+              "start": 3432,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 2649,
-                "start": 2647,
+                "end": 3434,
+                "start": 3432,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2649,
-                  "start": 2647,
+                  "end": 3434,
+                  "start": 3432,
                 },
                 "value": "ID",
               },
@@ -4306,28 +5937,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2666,
-            "start": 2653,
+            "end": 3451,
+            "start": 3438,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2658,
-              "start": 2653,
+              "end": 3443,
+              "start": 3438,
             },
             "value": "title",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2666,
-              "start": 2660,
+              "end": 3451,
+              "start": 3445,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2666,
-                "start": 2660,
+                "end": 3451,
+                "start": 3445,
               },
               "value": "String",
             },
@@ -4336,14 +5967,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 2668,
-        "start": 2617,
+        "end": 3453,
+        "start": 3402,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 2638,
-          "start": 2623,
+          "end": 3423,
+          "start": 3408,
         },
         "value": "UpdatePostInput",
       },
@@ -4358,34 +5989,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 2703,
-            "start": 2696,
+            "end": 3488,
+            "start": 3481,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2698,
-              "start": 2696,
+              "end": 3483,
+              "start": 3481,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 2703,
-              "start": 2700,
+              "end": 3488,
+              "start": 3485,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 2702,
-                "start": 2700,
+                "end": 3487,
+                "start": 3485,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2702,
-                  "start": 2700,
+                  "end": 3487,
+                  "start": 3485,
                 },
                 "value": "ID",
               },
@@ -4395,14 +6026,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 2705,
-        "start": 2670,
+        "end": 3490,
+        "start": 3455,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 2691,
-          "start": 2676,
+          "end": 3476,
+          "start": 3461,
         },
         "value": "DeletePostInput",
       },
@@ -4419,34 +6050,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2759,
-                "start": 2736,
+                "end": 3544,
+                "start": 3521,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2741,
-                  "start": 2736,
+                  "end": 3526,
+                  "start": 3521,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 2759,
-                  "start": 2743,
+                  "end": 3544,
+                  "start": 3528,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 2758,
-                    "start": 2743,
+                    "end": 3543,
+                    "start": 3528,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 2758,
-                      "start": 2743,
+                      "end": 3543,
+                      "start": 3528,
                     },
                     "value": "CreatePostInput",
                   },
@@ -4459,28 +6090,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2795,
-                "start": 2761,
+                "end": 3580,
+                "start": 3546,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2770,
-                  "start": 2761,
+                  "end": 3555,
+                  "start": 3546,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2795,
-                  "start": 2772,
+                  "end": 3580,
+                  "start": 3557,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2795,
-                    "start": 2772,
+                    "end": 3580,
+                    "start": 3557,
                   },
                   "value": "ModelPostConditionInput",
                 },
@@ -4491,28 +6122,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 2802,
-            "start": 2725,
+            "end": 3587,
+            "start": 3510,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2735,
-              "start": 2725,
+              "end": 3520,
+              "start": 3510,
             },
             "value": "createPost",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2802,
-              "start": 2798,
+              "end": 3587,
+              "start": 3583,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2802,
-                "start": 2798,
+                "end": 3587,
+                "start": 3583,
               },
               "value": "Post",
             },
@@ -4526,34 +6157,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2839,
-                "start": 2816,
+                "end": 3624,
+                "start": 3601,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2821,
-                  "start": 2816,
+                  "end": 3606,
+                  "start": 3601,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 2839,
-                  "start": 2823,
+                  "end": 3624,
+                  "start": 3608,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 2838,
-                    "start": 2823,
+                    "end": 3623,
+                    "start": 3608,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 2838,
-                      "start": 2823,
+                      "end": 3623,
+                      "start": 3608,
                     },
                     "value": "UpdatePostInput",
                   },
@@ -4566,28 +6197,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2875,
-                "start": 2841,
+                "end": 3660,
+                "start": 3626,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2850,
-                  "start": 2841,
+                  "end": 3635,
+                  "start": 3626,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2875,
-                  "start": 2852,
+                  "end": 3660,
+                  "start": 3637,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2875,
-                    "start": 2852,
+                    "end": 3660,
+                    "start": 3637,
                   },
                   "value": "ModelPostConditionInput",
                 },
@@ -4598,28 +6229,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 2882,
-            "start": 2805,
+            "end": 3667,
+            "start": 3590,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2815,
-              "start": 2805,
+              "end": 3600,
+              "start": 3590,
             },
             "value": "updatePost",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2882,
-              "start": 2878,
+              "end": 3667,
+              "start": 3663,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2882,
-                "start": 2878,
+                "end": 3667,
+                "start": 3663,
               },
               "value": "Post",
             },
@@ -4633,34 +6264,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2919,
-                "start": 2896,
+                "end": 3704,
+                "start": 3681,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2901,
-                  "start": 2896,
+                  "end": 3686,
+                  "start": 3681,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 2919,
-                  "start": 2903,
+                  "end": 3704,
+                  "start": 3688,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 2918,
-                    "start": 2903,
+                    "end": 3703,
+                    "start": 3688,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 2918,
-                      "start": 2903,
+                      "end": 3703,
+                      "start": 3688,
                     },
                     "value": "DeletePostInput",
                   },
@@ -4673,28 +6304,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 2955,
-                "start": 2921,
+                "end": 3740,
+                "start": 3706,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2930,
-                  "start": 2921,
+                  "end": 3715,
+                  "start": 3706,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 2955,
-                  "start": 2932,
+                  "end": 3740,
+                  "start": 3717,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 2955,
-                    "start": 2932,
+                    "end": 3740,
+                    "start": 3717,
                   },
                   "value": "ModelPostConditionInput",
                 },
@@ -4705,28 +6336,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 2962,
-            "start": 2885,
+            "end": 3747,
+            "start": 3670,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2895,
-              "start": 2885,
+              "end": 3680,
+              "start": 3670,
             },
             "value": "deletePost",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 2962,
-              "start": 2958,
+              "end": 3747,
+              "start": 3743,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 2962,
-                "start": 2958,
+                "end": 3747,
+                "start": 3743,
               },
               "value": "Post",
             },
@@ -4740,34 +6371,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3011,
-                "start": 2982,
+                "end": 3796,
+                "start": 3767,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 2987,
-                  "start": 2982,
+                  "end": 3772,
+                  "start": 3767,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 3011,
-                  "start": 2989,
+                  "end": 3796,
+                  "start": 3774,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 3010,
-                    "start": 2989,
+                    "end": 3795,
+                    "start": 3774,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3010,
-                      "start": 2989,
+                      "end": 3795,
+                      "start": 3774,
                     },
                     "value": "CreatePostEditorInput",
                   },
@@ -4780,28 +6411,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3053,
-                "start": 3013,
+                "end": 3838,
+                "start": 3798,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3022,
-                  "start": 3013,
+                  "end": 3807,
+                  "start": 3798,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 3053,
-                  "start": 3024,
+                  "end": 3838,
+                  "start": 3809,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 3053,
-                    "start": 3024,
+                    "end": 3838,
+                    "start": 3809,
                   },
                   "value": "ModelPostEditorConditionInput",
                 },
@@ -4812,28 +6443,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3066,
-            "start": 2965,
+            "end": 3851,
+            "start": 3750,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 2981,
-              "start": 2965,
+              "end": 3766,
+              "start": 3750,
             },
             "value": "createPostEditor",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3066,
-              "start": 3056,
+              "end": 3851,
+              "start": 3841,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3066,
-                "start": 3056,
+                "end": 3851,
+                "start": 3841,
               },
               "value": "PostEditor",
             },
@@ -4847,34 +6478,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3115,
-                "start": 3086,
+                "end": 3900,
+                "start": 3871,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3091,
-                  "start": 3086,
+                  "end": 3876,
+                  "start": 3871,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 3115,
-                  "start": 3093,
+                  "end": 3900,
+                  "start": 3878,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 3114,
-                    "start": 3093,
+                    "end": 3899,
+                    "start": 3878,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3114,
-                      "start": 3093,
+                      "end": 3899,
+                      "start": 3878,
                     },
                     "value": "UpdatePostEditorInput",
                   },
@@ -4887,28 +6518,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3157,
-                "start": 3117,
+                "end": 3942,
+                "start": 3902,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3126,
-                  "start": 3117,
+                  "end": 3911,
+                  "start": 3902,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 3157,
-                  "start": 3128,
+                  "end": 3942,
+                  "start": 3913,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 3157,
-                    "start": 3128,
+                    "end": 3942,
+                    "start": 3913,
                   },
                   "value": "ModelPostEditorConditionInput",
                 },
@@ -4919,28 +6550,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3170,
-            "start": 3069,
+            "end": 3955,
+            "start": 3854,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3085,
-              "start": 3069,
+              "end": 3870,
+              "start": 3854,
             },
             "value": "updatePostEditor",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3170,
-              "start": 3160,
+              "end": 3955,
+              "start": 3945,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3170,
-                "start": 3160,
+                "end": 3955,
+                "start": 3945,
               },
               "value": "PostEditor",
             },
@@ -4954,34 +6585,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3219,
-                "start": 3190,
+                "end": 4004,
+                "start": 3975,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3195,
-                  "start": 3190,
+                  "end": 3980,
+                  "start": 3975,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 3219,
-                  "start": 3197,
+                  "end": 4004,
+                  "start": 3982,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 3218,
-                    "start": 3197,
+                    "end": 4003,
+                    "start": 3982,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3218,
-                      "start": 3197,
+                      "end": 4003,
+                      "start": 3982,
                     },
                     "value": "DeletePostEditorInput",
                   },
@@ -4994,28 +6625,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3261,
-                "start": 3221,
+                "end": 4046,
+                "start": 4006,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3230,
-                  "start": 3221,
+                  "end": 4015,
+                  "start": 4006,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 3261,
-                  "start": 3232,
+                  "end": 4046,
+                  "start": 4017,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 3261,
-                    "start": 3232,
+                    "end": 4046,
+                    "start": 4017,
                   },
                   "value": "ModelPostEditorConditionInput",
                 },
@@ -5026,28 +6657,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3274,
-            "start": 3173,
+            "end": 4059,
+            "start": 3958,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3189,
-              "start": 3173,
+              "end": 3974,
+              "start": 3958,
             },
             "value": "deletePostEditor",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3274,
-              "start": 3264,
+              "end": 4059,
+              "start": 4049,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3274,
-                "start": 3264,
+                "end": 4059,
+                "start": 4049,
               },
               "value": "PostEditor",
             },
@@ -5061,34 +6692,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3311,
-                "start": 3288,
+                "end": 4096,
+                "start": 4073,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3293,
-                  "start": 3288,
+                  "end": 4078,
+                  "start": 4073,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 3311,
-                  "start": 3295,
+                  "end": 4096,
+                  "start": 4080,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 3310,
-                    "start": 3295,
+                    "end": 4095,
+                    "start": 4080,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3310,
-                      "start": 3295,
+                      "end": 4095,
+                      "start": 4080,
                     },
                     "value": "CreateUserInput",
                   },
@@ -5101,28 +6732,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3347,
-                "start": 3313,
+                "end": 4132,
+                "start": 4098,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3322,
-                  "start": 3313,
+                  "end": 4107,
+                  "start": 4098,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 3347,
-                  "start": 3324,
+                  "end": 4132,
+                  "start": 4109,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 3347,
-                    "start": 3324,
+                    "end": 4132,
+                    "start": 4109,
                   },
                   "value": "ModelUserConditionInput",
                 },
@@ -5133,28 +6764,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3354,
-            "start": 3277,
+            "end": 4139,
+            "start": 4062,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3287,
-              "start": 3277,
+              "end": 4072,
+              "start": 4062,
             },
             "value": "createUser",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3354,
-              "start": 3350,
+              "end": 4139,
+              "start": 4135,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3354,
-                "start": 3350,
+                "end": 4139,
+                "start": 4135,
               },
               "value": "User",
             },
@@ -5168,34 +6799,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3391,
-                "start": 3368,
+                "end": 4176,
+                "start": 4153,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3373,
-                  "start": 3368,
+                  "end": 4158,
+                  "start": 4153,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 3391,
-                  "start": 3375,
+                  "end": 4176,
+                  "start": 4160,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 3390,
-                    "start": 3375,
+                    "end": 4175,
+                    "start": 4160,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3390,
-                      "start": 3375,
+                      "end": 4175,
+                      "start": 4160,
                     },
                     "value": "UpdateUserInput",
                   },
@@ -5208,28 +6839,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3427,
-                "start": 3393,
+                "end": 4212,
+                "start": 4178,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3402,
-                  "start": 3393,
+                  "end": 4187,
+                  "start": 4178,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 3427,
-                  "start": 3404,
+                  "end": 4212,
+                  "start": 4189,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 3427,
-                    "start": 3404,
+                    "end": 4212,
+                    "start": 4189,
                   },
                   "value": "ModelUserConditionInput",
                 },
@@ -5240,28 +6871,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3434,
-            "start": 3357,
+            "end": 4219,
+            "start": 4142,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3367,
-              "start": 3357,
+              "end": 4152,
+              "start": 4142,
             },
             "value": "updateUser",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3434,
-              "start": 3430,
+              "end": 4219,
+              "start": 4215,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3434,
-                "start": 3430,
+                "end": 4219,
+                "start": 4215,
               },
               "value": "User",
             },
@@ -5275,34 +6906,34 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3471,
-                "start": 3448,
+                "end": 4256,
+                "start": 4233,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3453,
-                  "start": 3448,
+                  "end": 4238,
+                  "start": 4233,
                 },
                 "value": "input",
               },
               "type": Object {
                 "kind": "NonNullType",
                 "loc": Object {
-                  "end": 3471,
-                  "start": 3455,
+                  "end": 4256,
+                  "start": 4240,
                 },
                 "type": Object {
                   "kind": "NamedType",
                   "loc": Object {
-                    "end": 3470,
-                    "start": 3455,
+                    "end": 4255,
+                    "start": 4240,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3470,
-                      "start": 3455,
+                      "end": 4255,
+                      "start": 4240,
                     },
                     "value": "DeleteUserInput",
                   },
@@ -5315,28 +6946,28 @@ Object {
               "directives": Array [],
               "kind": "InputValueDefinition",
               "loc": Object {
-                "end": 3507,
-                "start": 3473,
+                "end": 4292,
+                "start": 4258,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3482,
-                  "start": 3473,
+                  "end": 4267,
+                  "start": 4258,
                 },
                 "value": "condition",
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 3507,
-                  "start": 3484,
+                  "end": 4292,
+                  "start": 4269,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 3507,
-                    "start": 3484,
+                    "end": 4292,
+                    "start": 4269,
                   },
                   "value": "ModelUserConditionInput",
                 },
@@ -5347,28 +6978,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3514,
-            "start": 3437,
+            "end": 4299,
+            "start": 4222,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3447,
-              "start": 3437,
+              "end": 4232,
+              "start": 4222,
             },
             "value": "deleteUser",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3514,
-              "start": 3510,
+              "end": 4299,
+              "start": 4295,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3514,
-                "start": 3510,
+                "end": 4299,
+                "start": 4295,
               },
               "value": "User",
             },
@@ -5378,14 +7009,14 @@ Object {
       "interfaces": Array [],
       "kind": "ObjectTypeDefinition",
       "loc": Object {
-        "end": 3516,
-        "start": 2707,
+        "end": 4301,
+        "start": 3492,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 2720,
-          "start": 2712,
+          "end": 3505,
+          "start": 3497,
         },
         "value": "Mutation",
       },
@@ -5395,7 +7026,206 @@ Object {
       "directives": Array [],
       "fields": Array [
         Object {
-          "arguments": Array [],
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 4374,
+            "start": 4346,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 4348,
+              "start": 4346,
+            },
+            "value": "id",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 4374,
+              "start": 4350,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 4374,
+                "start": 4350,
+              },
+              "value": "ModelSubscriptionIDInput",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 4412,
+            "start": 4377,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 4382,
+              "start": 4377,
+            },
+            "value": "title",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 4412,
+              "start": 4384,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 4412,
+                "start": 4384,
+              },
+              "value": "ModelSubscriptionStringInput",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 4454,
+            "start": 4415,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 4418,
+              "start": 4415,
+            },
+            "value": "and",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 4454,
+              "start": 4420,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 4453,
+                "start": 4421,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 4453,
+                  "start": 4421,
+                },
+                "value": "ModelSubscriptionPostFilterInput",
+              },
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 4495,
+            "start": 4457,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 4459,
+              "start": 4457,
+            },
+            "value": "or",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 4495,
+              "start": 4461,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 4494,
+                "start": 4462,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 4494,
+                  "start": 4462,
+                },
+                "value": "ModelSubscriptionPostFilterInput",
+              },
+            },
+          },
+        },
+      ],
+      "kind": "InputObjectTypeDefinition",
+      "loc": Object {
+        "end": 4497,
+        "start": 4303,
+      },
+      "name": Object {
+        "kind": "Name",
+        "loc": Object {
+          "end": 4341,
+          "start": 4309,
+        },
+        "value": "ModelSubscriptionPostFilterInput",
+      },
+    },
+    Object {
+      "description": undefined,
+      "directives": Array [],
+      "fields": Array [
+        Object {
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 4574,
+                "start": 4534,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 4540,
+                  "start": 4534,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 4574,
+                  "start": 4542,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 4574,
+                    "start": 4542,
+                  },
+                  "value": "ModelSubscriptionPostFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -5403,30 +7233,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 3599,
-                    "start": 3574,
+                    "end": 4622,
+                    "start": 4597,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3583,
-                      "start": 3574,
+                      "end": 4606,
+                      "start": 4597,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 3599,
-                      "start": 3585,
+                      "end": 4622,
+                      "start": 4608,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 3598,
-                          "start": 3586,
+                          "end": 4621,
+                          "start": 4609,
                         },
                         "value": "createPost",
                       },
@@ -5436,14 +7266,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 3600,
-                "start": 3559,
+                "end": 4623,
+                "start": 4582,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3573,
-                  "start": 3560,
+                  "end": 4596,
+                  "start": 4583,
                 },
                 "value": "aws_subscribe",
               },
@@ -5451,35 +7281,69 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3600,
-            "start": 3540,
+            "end": 4623,
+            "start": 4521,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3552,
-              "start": 3540,
+              "end": 4533,
+              "start": 4521,
             },
             "value": "onCreatePost",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3558,
-              "start": 3554,
+              "end": 4581,
+              "start": 4577,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3558,
-                "start": 3554,
+                "end": 4581,
+                "start": 4577,
               },
               "value": "Post",
             },
           },
         },
         Object {
-          "arguments": Array [],
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 4679,
+                "start": 4639,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 4645,
+                  "start": 4639,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 4679,
+                  "start": 4647,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 4679,
+                    "start": 4647,
+                  },
+                  "value": "ModelSubscriptionPostFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -5487,30 +7351,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 3662,
-                    "start": 3637,
+                    "end": 4727,
+                    "start": 4702,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3646,
-                      "start": 3637,
+                      "end": 4711,
+                      "start": 4702,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 3662,
-                      "start": 3648,
+                      "end": 4727,
+                      "start": 4713,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 3661,
-                          "start": 3649,
+                          "end": 4726,
+                          "start": 4714,
                         },
                         "value": "updatePost",
                       },
@@ -5520,14 +7384,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 3663,
-                "start": 3622,
+                "end": 4728,
+                "start": 4687,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3636,
-                  "start": 3623,
+                  "end": 4701,
+                  "start": 4688,
                 },
                 "value": "aws_subscribe",
               },
@@ -5535,35 +7399,69 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3663,
-            "start": 3603,
+            "end": 4728,
+            "start": 4626,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3615,
-              "start": 3603,
+              "end": 4638,
+              "start": 4626,
             },
             "value": "onUpdatePost",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3621,
-              "start": 3617,
+              "end": 4686,
+              "start": 4682,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3621,
-                "start": 3617,
+                "end": 4686,
+                "start": 4682,
               },
               "value": "Post",
             },
           },
         },
         Object {
-          "arguments": Array [],
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 4784,
+                "start": 4744,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 4750,
+                  "start": 4744,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 4784,
+                  "start": 4752,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 4784,
+                    "start": 4752,
+                  },
+                  "value": "ModelSubscriptionPostFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -5571,30 +7469,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 3725,
-                    "start": 3700,
+                    "end": 4832,
+                    "start": 4807,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3709,
-                      "start": 3700,
+                      "end": 4816,
+                      "start": 4807,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 3725,
-                      "start": 3711,
+                      "end": 4832,
+                      "start": 4818,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 3724,
-                          "start": 3712,
+                          "end": 4831,
+                          "start": 4819,
                         },
                         "value": "deletePost",
                       },
@@ -5604,14 +7502,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 3726,
-                "start": 3685,
+                "end": 4833,
+                "start": 4792,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3699,
-                  "start": 3686,
+                  "end": 4806,
+                  "start": 4793,
                 },
                 "value": "aws_subscribe",
               },
@@ -5619,35 +7517,69 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3726,
-            "start": 3666,
+            "end": 4833,
+            "start": 4731,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3678,
-              "start": 3666,
+              "end": 4743,
+              "start": 4731,
             },
             "value": "onDeletePost",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3684,
-              "start": 3680,
+              "end": 4791,
+              "start": 4787,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3684,
-                "start": 3680,
+                "end": 4791,
+                "start": 4787,
               },
               "value": "Post",
             },
           },
         },
         Object {
-          "arguments": Array [],
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 4901,
+                "start": 4855,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 4861,
+                  "start": 4855,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 4901,
+                  "start": 4863,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 4901,
+                    "start": 4863,
+                  },
+                  "value": "ModelSubscriptionPostEditorFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -5655,30 +7587,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 3806,
-                    "start": 3775,
+                    "end": 4961,
+                    "start": 4930,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3784,
-                      "start": 3775,
+                      "end": 4939,
+                      "start": 4930,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 3806,
-                      "start": 3786,
+                      "end": 4961,
+                      "start": 4941,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 3805,
-                          "start": 3787,
+                          "end": 4960,
+                          "start": 4942,
                         },
                         "value": "createPostEditor",
                       },
@@ -5688,14 +7620,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 3807,
-                "start": 3760,
+                "end": 4962,
+                "start": 4915,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3774,
-                  "start": 3761,
+                  "end": 4929,
+                  "start": 4916,
                 },
                 "value": "aws_subscribe",
               },
@@ -5703,35 +7635,69 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3807,
-            "start": 3729,
+            "end": 4962,
+            "start": 4836,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3747,
-              "start": 3729,
+              "end": 4854,
+              "start": 4836,
             },
             "value": "onCreatePostEditor",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3759,
-              "start": 3749,
+              "end": 4914,
+              "start": 4904,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3759,
-                "start": 3749,
+                "end": 4914,
+                "start": 4904,
               },
               "value": "PostEditor",
             },
           },
         },
         Object {
-          "arguments": Array [],
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 5030,
+                "start": 4984,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 4990,
+                  "start": 4984,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 5030,
+                  "start": 4992,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 5030,
+                    "start": 4992,
+                  },
+                  "value": "ModelSubscriptionPostEditorFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -5739,30 +7705,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 3887,
-                    "start": 3856,
+                    "end": 5090,
+                    "start": 5059,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3865,
-                      "start": 3856,
+                      "end": 5068,
+                      "start": 5059,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 3887,
-                      "start": 3867,
+                      "end": 5090,
+                      "start": 5070,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 3886,
-                          "start": 3868,
+                          "end": 5089,
+                          "start": 5071,
                         },
                         "value": "updatePostEditor",
                       },
@@ -5772,14 +7738,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 3888,
-                "start": 3841,
+                "end": 5091,
+                "start": 5044,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3855,
-                  "start": 3842,
+                  "end": 5058,
+                  "start": 5045,
                 },
                 "value": "aws_subscribe",
               },
@@ -5787,35 +7753,69 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3888,
-            "start": 3810,
+            "end": 5091,
+            "start": 4965,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3828,
-              "start": 3810,
+              "end": 4983,
+              "start": 4965,
             },
             "value": "onUpdatePostEditor",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3840,
-              "start": 3830,
+              "end": 5043,
+              "start": 5033,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3840,
-                "start": 3830,
+                "end": 5043,
+                "start": 5033,
               },
               "value": "PostEditor",
             },
           },
         },
         Object {
-          "arguments": Array [],
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 5159,
+                "start": 5113,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 5119,
+                  "start": 5113,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 5159,
+                  "start": 5121,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 5159,
+                    "start": 5121,
+                  },
+                  "value": "ModelSubscriptionPostEditorFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -5823,30 +7823,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 3968,
-                    "start": 3937,
+                    "end": 5219,
+                    "start": 5188,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 3946,
-                      "start": 3937,
+                      "end": 5197,
+                      "start": 5188,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 3968,
-                      "start": 3948,
+                      "end": 5219,
+                      "start": 5199,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 3967,
-                          "start": 3949,
+                          "end": 5218,
+                          "start": 5200,
                         },
                         "value": "deletePostEditor",
                       },
@@ -5856,14 +7856,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 3969,
-                "start": 3922,
+                "end": 5220,
+                "start": 5173,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 3936,
-                  "start": 3923,
+                  "end": 5187,
+                  "start": 5174,
                 },
                 "value": "aws_subscribe",
               },
@@ -5871,35 +7871,69 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 3969,
-            "start": 3891,
+            "end": 5220,
+            "start": 5094,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3909,
-              "start": 3891,
+              "end": 5112,
+              "start": 5094,
             },
             "value": "onDeletePostEditor",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3921,
-              "start": 3911,
+              "end": 5172,
+              "start": 5162,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3921,
-                "start": 3911,
+                "end": 5172,
+                "start": 5162,
               },
               "value": "PostEditor",
             },
           },
         },
         Object {
-          "arguments": Array [],
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 5276,
+                "start": 5236,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 5242,
+                  "start": 5236,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 5276,
+                  "start": 5244,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 5276,
+                    "start": 5244,
+                  },
+                  "value": "ModelSubscriptionUserFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -5907,30 +7941,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 4031,
-                    "start": 4006,
+                    "end": 5324,
+                    "start": 5299,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 4015,
-                      "start": 4006,
+                      "end": 5308,
+                      "start": 5299,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 4031,
-                      "start": 4017,
+                      "end": 5324,
+                      "start": 5310,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 4030,
-                          "start": 4018,
+                          "end": 5323,
+                          "start": 5311,
                         },
                         "value": "createUser",
                       },
@@ -5940,14 +7974,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 4032,
-                "start": 3991,
+                "end": 5325,
+                "start": 5284,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4005,
-                  "start": 3992,
+                  "end": 5298,
+                  "start": 5285,
                 },
                 "value": "aws_subscribe",
               },
@@ -5955,35 +7989,69 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4032,
-            "start": 3972,
+            "end": 5325,
+            "start": 5223,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 3984,
-              "start": 3972,
+              "end": 5235,
+              "start": 5223,
             },
             "value": "onCreateUser",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 3990,
-              "start": 3986,
+              "end": 5283,
+              "start": 5279,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 3990,
-                "start": 3986,
+                "end": 5283,
+                "start": 5279,
               },
               "value": "User",
             },
           },
         },
         Object {
-          "arguments": Array [],
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 5381,
+                "start": 5341,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 5347,
+                  "start": 5341,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 5381,
+                  "start": 5349,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 5381,
+                    "start": 5349,
+                  },
+                  "value": "ModelSubscriptionUserFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -5991,30 +8059,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 4094,
-                    "start": 4069,
+                    "end": 5429,
+                    "start": 5404,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 4078,
-                      "start": 4069,
+                      "end": 5413,
+                      "start": 5404,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 4094,
-                      "start": 4080,
+                      "end": 5429,
+                      "start": 5415,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 4093,
-                          "start": 4081,
+                          "end": 5428,
+                          "start": 5416,
                         },
                         "value": "updateUser",
                       },
@@ -6024,14 +8092,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 4095,
-                "start": 4054,
+                "end": 5430,
+                "start": 5389,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4068,
-                  "start": 4055,
+                  "end": 5403,
+                  "start": 5390,
                 },
                 "value": "aws_subscribe",
               },
@@ -6039,35 +8107,69 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4095,
-            "start": 4035,
+            "end": 5430,
+            "start": 5328,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4047,
-              "start": 4035,
+              "end": 5340,
+              "start": 5328,
             },
             "value": "onUpdateUser",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4053,
-              "start": 4049,
+              "end": 5388,
+              "start": 5384,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4053,
-                "start": 4049,
+                "end": 5388,
+                "start": 5384,
               },
               "value": "User",
             },
           },
         },
         Object {
-          "arguments": Array [],
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 5486,
+                "start": 5446,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 5452,
+                  "start": 5446,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 5486,
+                  "start": 5454,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 5486,
+                    "start": 5454,
+                  },
+                  "value": "ModelSubscriptionUserFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -6075,30 +8177,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 4157,
-                    "start": 4132,
+                    "end": 5534,
+                    "start": 5509,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 4141,
-                      "start": 4132,
+                      "end": 5518,
+                      "start": 5509,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 4157,
-                      "start": 4143,
+                      "end": 5534,
+                      "start": 5520,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 4156,
-                          "start": 4144,
+                          "end": 5533,
+                          "start": 5521,
                         },
                         "value": "deleteUser",
                       },
@@ -6108,14 +8210,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 4158,
-                "start": 4117,
+                "end": 5535,
+                "start": 5494,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4131,
-                  "start": 4118,
+                  "end": 5508,
+                  "start": 5495,
                 },
                 "value": "aws_subscribe",
               },
@@ -6123,28 +8225,28 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4158,
-            "start": 4098,
+            "end": 5535,
+            "start": 5433,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4110,
-              "start": 4098,
+              "end": 5445,
+              "start": 5433,
             },
             "value": "onDeleteUser",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4116,
-              "start": 4112,
+              "end": 5493,
+              "start": 5489,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4116,
-                "start": 4112,
+                "end": 5493,
+                "start": 5489,
               },
               "value": "User",
             },
@@ -6154,14 +8256,14 @@ Object {
       "interfaces": Array [],
       "kind": "ObjectTypeDefinition",
       "loc": Object {
-        "end": 4160,
-        "start": 3518,
+        "end": 5537,
+        "start": 4499,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 3535,
-          "start": 3523,
+          "end": 4516,
+          "start": 4504,
         },
         "value": "Subscription",
       },
@@ -6176,28 +8278,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4222,
-            "start": 4202,
+            "end": 5599,
+            "start": 5579,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4208,
-              "start": 4202,
+              "end": 5585,
+              "start": 5579,
             },
             "value": "postID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4222,
-              "start": 4210,
+              "end": 5599,
+              "start": 5587,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4222,
-                "start": 4210,
+                "end": 5599,
+                "start": 5587,
               },
               "value": "ModelIDInput",
             },
@@ -6209,28 +8311,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4247,
-            "start": 4225,
+            "end": 5624,
+            "start": 5602,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4233,
-              "start": 4225,
+              "end": 5610,
+              "start": 5602,
             },
             "value": "editorID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4247,
-              "start": 4235,
+              "end": 5624,
+              "start": 5612,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4247,
-                "start": 4235,
+                "end": 5624,
+                "start": 5612,
               },
               "value": "ModelIDInput",
             },
@@ -6242,34 +8344,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4286,
-            "start": 4250,
+            "end": 5663,
+            "start": 5627,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4253,
-              "start": 4250,
+              "end": 5630,
+              "start": 5627,
             },
             "value": "and",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 4286,
-              "start": 4255,
+              "end": 5663,
+              "start": 5632,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4285,
-                "start": 4256,
+                "end": 5662,
+                "start": 5633,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4285,
-                  "start": 4256,
+                  "end": 5662,
+                  "start": 5633,
                 },
                 "value": "ModelPostEditorConditionInput",
               },
@@ -6282,34 +8384,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4324,
-            "start": 4289,
+            "end": 5701,
+            "start": 5666,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4291,
-              "start": 4289,
+              "end": 5668,
+              "start": 5666,
             },
             "value": "or",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 4324,
-              "start": 4293,
+              "end": 5701,
+              "start": 5670,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4323,
-                "start": 4294,
+                "end": 5700,
+                "start": 5671,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4323,
-                  "start": 4294,
+                  "end": 5700,
+                  "start": 5671,
                 },
                 "value": "ModelPostEditorConditionInput",
               },
@@ -6322,28 +8424,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4361,
-            "start": 4327,
+            "end": 5738,
+            "start": 5704,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4330,
-              "start": 4327,
+              "end": 5707,
+              "start": 5704,
             },
             "value": "not",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4361,
-              "start": 4332,
+              "end": 5738,
+              "start": 5709,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4361,
-                "start": 4332,
+                "end": 5738,
+                "start": 5709,
               },
               "value": "ModelPostEditorConditionInput",
             },
@@ -6352,14 +8454,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 4363,
-        "start": 4162,
+        "end": 5740,
+        "start": 5539,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4197,
-          "start": 4168,
+          "end": 5574,
+          "start": 5545,
         },
         "value": "ModelPostEditorConditionInput",
       },
@@ -6374,28 +8476,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4403,
-            "start": 4397,
+            "end": 5780,
+            "start": 5774,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4399,
-              "start": 4397,
+              "end": 5776,
+              "start": 5774,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4403,
-              "start": 4401,
+              "end": 5780,
+              "start": 5778,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4403,
-                "start": 4401,
+                "end": 5780,
+                "start": 5778,
               },
               "value": "ID",
             },
@@ -6407,34 +8509,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4417,
-            "start": 4406,
+            "end": 5794,
+            "start": 5783,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4412,
-              "start": 4406,
+              "end": 5789,
+              "start": 5783,
             },
             "value": "postID",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 4417,
-              "start": 4414,
+              "end": 5794,
+              "start": 5791,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4416,
-                "start": 4414,
+                "end": 5793,
+                "start": 5791,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4416,
-                  "start": 4414,
+                  "end": 5793,
+                  "start": 5791,
                 },
                 "value": "ID",
               },
@@ -6447,34 +8549,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4433,
-            "start": 4420,
+            "end": 5810,
+            "start": 5797,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4428,
-              "start": 4420,
+              "end": 5805,
+              "start": 5797,
             },
             "value": "editorID",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 4433,
-              "start": 4430,
+              "end": 5810,
+              "start": 5807,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4432,
-                "start": 4430,
+                "end": 5809,
+                "start": 5807,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4432,
-                  "start": 4430,
+                  "end": 5809,
+                  "start": 5807,
                 },
                 "value": "ID",
               },
@@ -6484,14 +8586,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 4435,
-        "start": 4365,
+        "end": 5812,
+        "start": 5742,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4392,
-          "start": 4371,
+          "end": 5769,
+          "start": 5748,
         },
         "value": "CreatePostEditorInput",
       },
@@ -6506,34 +8608,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4476,
-            "start": 4469,
+            "end": 5853,
+            "start": 5846,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4471,
-              "start": 4469,
+              "end": 5848,
+              "start": 5846,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 4476,
-              "start": 4473,
+              "end": 5853,
+              "start": 5850,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4475,
-                "start": 4473,
+                "end": 5852,
+                "start": 5850,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4475,
-                  "start": 4473,
+                  "end": 5852,
+                  "start": 5850,
                 },
                 "value": "ID",
               },
@@ -6546,28 +8648,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4489,
-            "start": 4479,
+            "end": 5866,
+            "start": 5856,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4485,
-              "start": 4479,
+              "end": 5862,
+              "start": 5856,
             },
             "value": "postID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4489,
-              "start": 4487,
+              "end": 5866,
+              "start": 5864,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4489,
-                "start": 4487,
+                "end": 5866,
+                "start": 5864,
               },
               "value": "ID",
             },
@@ -6579,28 +8681,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4504,
-            "start": 4492,
+            "end": 5881,
+            "start": 5869,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4500,
-              "start": 4492,
+              "end": 5877,
+              "start": 5869,
             },
             "value": "editorID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4504,
-              "start": 4502,
+              "end": 5881,
+              "start": 5879,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4504,
-                "start": 4502,
+                "end": 5881,
+                "start": 5879,
               },
               "value": "ID",
             },
@@ -6609,14 +8711,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 4506,
-        "start": 4437,
+        "end": 5883,
+        "start": 5814,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4464,
-          "start": 4443,
+          "end": 5841,
+          "start": 5820,
         },
         "value": "UpdatePostEditorInput",
       },
@@ -6631,34 +8733,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4547,
-            "start": 4540,
+            "end": 5924,
+            "start": 5917,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4542,
-              "start": 4540,
+              "end": 5919,
+              "start": 5917,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 4547,
-              "start": 4544,
+              "end": 5924,
+              "start": 5921,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4546,
-                "start": 4544,
+                "end": 5923,
+                "start": 5921,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4546,
-                  "start": 4544,
+                  "end": 5923,
+                  "start": 5921,
                 },
                 "value": "ID",
               },
@@ -6668,16 +8770,214 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 4549,
-        "start": 4508,
+        "end": 5926,
+        "start": 5885,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4535,
-          "start": 4514,
+          "end": 5912,
+          "start": 5891,
         },
         "value": "DeletePostEditorInput",
+      },
+    },
+    Object {
+      "description": undefined,
+      "directives": Array [],
+      "fields": Array [
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6005,
+            "start": 5977,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 5979,
+              "start": 5977,
+            },
+            "value": "id",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 6005,
+              "start": 5981,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 6005,
+                "start": 5981,
+              },
+              "value": "ModelSubscriptionIDInput",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6040,
+            "start": 6008,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 6014,
+              "start": 6008,
+            },
+            "value": "postID",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 6040,
+              "start": 6016,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 6040,
+                "start": 6016,
+              },
+              "value": "ModelSubscriptionIDInput",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6077,
+            "start": 6043,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 6051,
+              "start": 6043,
+            },
+            "value": "editorID",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 6077,
+              "start": 6053,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 6077,
+                "start": 6053,
+              },
+              "value": "ModelSubscriptionIDInput",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6125,
+            "start": 6080,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 6083,
+              "start": 6080,
+            },
+            "value": "and",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 6125,
+              "start": 6085,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 6124,
+                "start": 6086,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 6124,
+                  "start": 6086,
+                },
+                "value": "ModelSubscriptionPostEditorFilterInput",
+              },
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6172,
+            "start": 6128,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 6130,
+              "start": 6128,
+            },
+            "value": "or",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 6172,
+              "start": 6132,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 6171,
+                "start": 6133,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 6171,
+                  "start": 6133,
+                },
+                "value": "ModelSubscriptionPostEditorFilterInput",
+              },
+            },
+          },
+        },
+      ],
+      "kind": "InputObjectTypeDefinition",
+      "loc": Object {
+        "end": 6174,
+        "start": 5928,
+      },
+      "name": Object {
+        "kind": "Name",
+        "loc": Object {
+          "end": 5972,
+          "start": 5934,
+        },
+        "value": "ModelSubscriptionPostEditorFilterInput",
       },
     },
     Object {
@@ -6690,40 +8990,40 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4594,
-            "start": 4580,
+            "end": 6219,
+            "start": 6205,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4585,
-              "start": 4580,
+              "end": 6210,
+              "start": 6205,
             },
             "value": "items",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 4594,
-              "start": 4587,
+              "end": 6219,
+              "start": 6212,
             },
             "type": Object {
               "kind": "ListType",
               "loc": Object {
-                "end": 4593,
-                "start": 4587,
+                "end": 6218,
+                "start": 6212,
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 4592,
-                  "start": 4588,
+                  "end": 6217,
+                  "start": 6213,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 4592,
-                    "start": 4588,
+                    "end": 6217,
+                    "start": 6213,
                   },
                   "value": "User",
                 },
@@ -6737,28 +9037,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4614,
-            "start": 4597,
+            "end": 6239,
+            "start": 6222,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4606,
-              "start": 4597,
+              "end": 6231,
+              "start": 6222,
             },
             "value": "nextToken",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4614,
-              "start": 4608,
+              "end": 6239,
+              "start": 6233,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4614,
-                "start": 4608,
+                "end": 6239,
+                "start": 6233,
               },
               "value": "String",
             },
@@ -6768,14 +9068,14 @@ Object {
       "interfaces": Array [],
       "kind": "ObjectTypeDefinition",
       "loc": Object {
-        "end": 4616,
-        "start": 4551,
+        "end": 6241,
+        "start": 6176,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4575,
-          "start": 4556,
+          "end": 6200,
+          "start": 6181,
         },
         "value": "ModelUserConnection",
       },
@@ -6790,28 +9090,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4665,
-            "start": 4649,
+            "end": 6290,
+            "start": 6274,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4651,
-              "start": 4649,
+              "end": 6276,
+              "start": 6274,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4665,
-              "start": 4653,
+              "end": 6290,
+              "start": 6278,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4665,
-                "start": 4653,
+                "end": 6290,
+                "start": 6278,
               },
               "value": "ModelIDInput",
             },
@@ -6823,28 +9123,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4694,
-            "start": 4668,
+            "end": 6319,
+            "start": 6293,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4676,
-              "start": 4668,
+              "end": 6301,
+              "start": 6293,
             },
             "value": "username",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4694,
-              "start": 4678,
+              "end": 6319,
+              "start": 6303,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4694,
-                "start": 4678,
+                "end": 6319,
+                "start": 6303,
               },
               "value": "ModelStringInput",
             },
@@ -6856,34 +9156,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4724,
-            "start": 4697,
+            "end": 6349,
+            "start": 6322,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4700,
-              "start": 4697,
+              "end": 6325,
+              "start": 6322,
             },
             "value": "and",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 4724,
-              "start": 4702,
+              "end": 6349,
+              "start": 6327,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4723,
-                "start": 4703,
+                "end": 6348,
+                "start": 6328,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4723,
-                  "start": 4703,
+                  "end": 6348,
+                  "start": 6328,
                 },
                 "value": "ModelUserFilterInput",
               },
@@ -6896,34 +9196,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4753,
-            "start": 4727,
+            "end": 6378,
+            "start": 6352,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4729,
-              "start": 4727,
+              "end": 6354,
+              "start": 6352,
             },
             "value": "or",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 4753,
-              "start": 4731,
+              "end": 6378,
+              "start": 6356,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4752,
-                "start": 4732,
+                "end": 6377,
+                "start": 6357,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4752,
-                  "start": 4732,
+                  "end": 6377,
+                  "start": 6357,
                 },
                 "value": "ModelUserFilterInput",
               },
@@ -6936,28 +9236,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4781,
-            "start": 4756,
+            "end": 6406,
+            "start": 6381,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4759,
-              "start": 4756,
+              "end": 6384,
+              "start": 6381,
             },
             "value": "not",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4781,
-              "start": 4761,
+              "end": 6406,
+              "start": 6386,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4781,
-                "start": 4761,
+                "end": 6406,
+                "start": 6386,
               },
               "value": "ModelUserFilterInput",
             },
@@ -6966,14 +9266,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 4783,
-        "start": 4618,
+        "end": 6408,
+        "start": 6243,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4644,
-          "start": 4624,
+          "end": 6269,
+          "start": 6249,
         },
         "value": "ModelUserFilterInput",
       },
@@ -6988,28 +9288,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4845,
-            "start": 4819,
+            "end": 6470,
+            "start": 6444,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4827,
-              "start": 4819,
+              "end": 6452,
+              "start": 6444,
             },
             "value": "username",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4845,
-              "start": 4829,
+              "end": 6470,
+              "start": 6454,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4845,
-                "start": 4829,
+                "end": 6470,
+                "start": 6454,
               },
               "value": "ModelStringInput",
             },
@@ -7021,34 +9321,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4878,
-            "start": 4848,
+            "end": 6503,
+            "start": 6473,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4851,
-              "start": 4848,
+              "end": 6476,
+              "start": 6473,
             },
             "value": "and",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 4878,
-              "start": 4853,
+              "end": 6503,
+              "start": 6478,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4877,
-                "start": 4854,
+                "end": 6502,
+                "start": 6479,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4877,
-                  "start": 4854,
+                  "end": 6502,
+                  "start": 6479,
                 },
                 "value": "ModelUserConditionInput",
               },
@@ -7061,34 +9361,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4910,
-            "start": 4881,
+            "end": 6535,
+            "start": 6506,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4883,
-              "start": 4881,
+              "end": 6508,
+              "start": 6506,
             },
             "value": "or",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 4910,
-              "start": 4885,
+              "end": 6535,
+              "start": 6510,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4909,
-                "start": 4886,
+                "end": 6534,
+                "start": 6511,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4909,
-                  "start": 4886,
+                  "end": 6534,
+                  "start": 6511,
                 },
                 "value": "ModelUserConditionInput",
               },
@@ -7101,28 +9401,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4941,
-            "start": 4913,
+            "end": 6566,
+            "start": 6538,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4916,
-              "start": 4913,
+              "end": 6541,
+              "start": 6538,
             },
             "value": "not",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4941,
-              "start": 4918,
+              "end": 6566,
+              "start": 6543,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4941,
-                "start": 4918,
+                "end": 6566,
+                "start": 6543,
               },
               "value": "ModelUserConditionInput",
             },
@@ -7131,14 +9431,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 4943,
-        "start": 4785,
+        "end": 6568,
+        "start": 6410,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4814,
-          "start": 4791,
+          "end": 6439,
+          "start": 6416,
         },
         "value": "ModelUserConditionInput",
       },
@@ -7153,28 +9453,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4977,
-            "start": 4971,
+            "end": 6602,
+            "start": 6596,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4973,
-              "start": 4971,
+              "end": 6598,
+              "start": 6596,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4977,
-              "start": 4975,
+              "end": 6602,
+              "start": 6600,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4977,
-                "start": 4975,
+                "end": 6602,
+                "start": 6600,
               },
               "value": "ID",
             },
@@ -7186,34 +9486,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 4997,
-            "start": 4980,
+            "end": 6622,
+            "start": 6605,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4988,
-              "start": 4980,
+              "end": 6613,
+              "start": 6605,
             },
             "value": "username",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 4997,
-              "start": 4990,
+              "end": 6622,
+              "start": 6615,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 4996,
-                "start": 4990,
+                "end": 6621,
+                "start": 6615,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4996,
-                  "start": 4990,
+                  "end": 6621,
+                  "start": 6615,
                 },
                 "value": "String",
               },
@@ -7223,14 +9523,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 4999,
-        "start": 4945,
+        "end": 6624,
+        "start": 6570,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4966,
-          "start": 4951,
+          "end": 6591,
+          "start": 6576,
         },
         "value": "CreateUserInput",
       },
@@ -7245,34 +9545,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5034,
-            "start": 5027,
+            "end": 6659,
+            "start": 6652,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5029,
-              "start": 5027,
+              "end": 6654,
+              "start": 6652,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 5034,
-              "start": 5031,
+              "end": 6659,
+              "start": 6656,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5033,
-                "start": 5031,
+                "end": 6658,
+                "start": 6656,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5033,
-                  "start": 5031,
+                  "end": 6658,
+                  "start": 6656,
                 },
                 "value": "ID",
               },
@@ -7285,28 +9585,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5053,
-            "start": 5037,
+            "end": 6678,
+            "start": 6662,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5045,
-              "start": 5037,
+              "end": 6670,
+              "start": 6662,
             },
             "value": "username",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5053,
-              "start": 5047,
+              "end": 6678,
+              "start": 6672,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5053,
-                "start": 5047,
+                "end": 6678,
+                "start": 6672,
               },
               "value": "String",
             },
@@ -7315,14 +9615,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5055,
-        "start": 5001,
+        "end": 6680,
+        "start": 6626,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5022,
-          "start": 5007,
+          "end": 6647,
+          "start": 6632,
         },
         "value": "UpdateUserInput",
       },
@@ -7337,34 +9637,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5090,
-            "start": 5083,
+            "end": 6715,
+            "start": 6708,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5085,
-              "start": 5083,
+              "end": 6710,
+              "start": 6708,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 5090,
-              "start": 5087,
+              "end": 6715,
+              "start": 6712,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5089,
-                "start": 5087,
+                "end": 6714,
+                "start": 6712,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5089,
-                  "start": 5087,
+                  "end": 6714,
+                  "start": 6712,
                 },
                 "value": "ID",
               },
@@ -7374,14 +9674,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5092,
-        "start": 5057,
+        "end": 6717,
+        "start": 6682,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5078,
-          "start": 5063,
+          "end": 6703,
+          "start": 6688,
         },
         "value": "DeleteUserInput",
       },
@@ -7396,28 +9696,193 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5135,
-            "start": 5129,
+            "end": 6790,
+            "start": 6762,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5131,
-              "start": 5129,
+              "end": 6764,
+              "start": 6762,
+            },
+            "value": "id",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 6790,
+              "start": 6766,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 6790,
+                "start": 6766,
+              },
+              "value": "ModelSubscriptionIDInput",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6831,
+            "start": 6793,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 6801,
+              "start": 6793,
+            },
+            "value": "username",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 6831,
+              "start": 6803,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 6831,
+                "start": 6803,
+              },
+              "value": "ModelSubscriptionStringInput",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6873,
+            "start": 6834,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 6837,
+              "start": 6834,
+            },
+            "value": "and",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 6873,
+              "start": 6839,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 6872,
+                "start": 6840,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 6872,
+                  "start": 6840,
+                },
+                "value": "ModelSubscriptionUserFilterInput",
+              },
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6914,
+            "start": 6876,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 6878,
+              "start": 6876,
+            },
+            "value": "or",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 6914,
+              "start": 6880,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 6913,
+                "start": 6881,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 6913,
+                  "start": 6881,
+                },
+                "value": "ModelSubscriptionUserFilterInput",
+              },
+            },
+          },
+        },
+      ],
+      "kind": "InputObjectTypeDefinition",
+      "loc": Object {
+        "end": 6916,
+        "start": 6719,
+      },
+      "name": Object {
+        "kind": "Name",
+        "loc": Object {
+          "end": 6757,
+          "start": 6725,
+        },
+        "value": "ModelSubscriptionUserFilterInput",
+      },
+    },
+    Object {
+      "description": undefined,
+      "directives": Array [],
+      "fields": Array [
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6959,
+            "start": 6953,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 6955,
+              "start": 6953,
             },
             "value": "eq",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5135,
-              "start": 5133,
+              "end": 6959,
+              "start": 6957,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5135,
-                "start": 5133,
+                "end": 6959,
+                "start": 6957,
               },
               "value": "ID",
             },
@@ -7429,28 +9894,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5144,
-            "start": 5138,
+            "end": 6968,
+            "start": 6962,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5140,
-              "start": 5138,
+              "end": 6964,
+              "start": 6962,
             },
             "value": "le",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5144,
-              "start": 5142,
+              "end": 6968,
+              "start": 6966,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5144,
-                "start": 5142,
+                "end": 6968,
+                "start": 6966,
               },
               "value": "ID",
             },
@@ -7462,28 +9927,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5153,
-            "start": 5147,
+            "end": 6977,
+            "start": 6971,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5149,
-              "start": 5147,
+              "end": 6973,
+              "start": 6971,
             },
             "value": "lt",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5153,
-              "start": 5151,
+              "end": 6977,
+              "start": 6975,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5153,
-                "start": 5151,
+                "end": 6977,
+                "start": 6975,
               },
               "value": "ID",
             },
@@ -7495,28 +9960,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5162,
-            "start": 5156,
+            "end": 6986,
+            "start": 6980,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5158,
-              "start": 5156,
+              "end": 6982,
+              "start": 6980,
             },
             "value": "ge",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5162,
-              "start": 5160,
+              "end": 6986,
+              "start": 6984,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5162,
-                "start": 5160,
+                "end": 6986,
+                "start": 6984,
               },
               "value": "ID",
             },
@@ -7528,28 +9993,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5171,
-            "start": 5165,
+            "end": 6995,
+            "start": 6989,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5167,
-              "start": 5165,
+              "end": 6991,
+              "start": 6989,
             },
             "value": "gt",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5171,
-              "start": 5169,
+              "end": 6995,
+              "start": 6993,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5171,
-                "start": 5169,
+                "end": 6995,
+                "start": 6993,
               },
               "value": "ID",
             },
@@ -7561,34 +10026,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5187,
-            "start": 5174,
+            "end": 7011,
+            "start": 6998,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5181,
-              "start": 5174,
+              "end": 7005,
+              "start": 6998,
             },
             "value": "between",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 5187,
-              "start": 5183,
+              "end": 7011,
+              "start": 7007,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5186,
-                "start": 5184,
+                "end": 7010,
+                "start": 7008,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5186,
-                  "start": 5184,
+                  "end": 7010,
+                  "start": 7008,
                 },
                 "value": "ID",
               },
@@ -7601,28 +10066,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5204,
-            "start": 5190,
+            "end": 7028,
+            "start": 7014,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5200,
-              "start": 5190,
+              "end": 7024,
+              "start": 7014,
             },
             "value": "beginsWith",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5204,
-              "start": 5202,
+              "end": 7028,
+              "start": 7026,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5204,
-                "start": 5202,
+                "end": 7028,
+                "start": 7026,
               },
               "value": "ID",
             },
@@ -7631,14 +10096,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5206,
-        "start": 5094,
+        "end": 7030,
+        "start": 6918,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5124,
-          "start": 5100,
+          "end": 6948,
+          "start": 6924,
         },
         "value": "ModelIDKeyConditionInput",
       },
@@ -7653,40 +10118,40 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 5263,
-            "start": 5243,
+            "end": 7087,
+            "start": 7067,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5248,
-              "start": 5243,
+              "end": 7072,
+              "start": 7067,
             },
             "value": "items",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 5263,
-              "start": 5250,
+              "end": 7087,
+              "start": 7074,
             },
             "type": Object {
               "kind": "ListType",
               "loc": Object {
-                "end": 5262,
-                "start": 5250,
+                "end": 7086,
+                "start": 7074,
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 5261,
-                  "start": 5251,
+                  "end": 7085,
+                  "start": 7075,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 5261,
-                    "start": 5251,
+                    "end": 7085,
+                    "start": 7075,
                   },
                   "value": "PostEditor",
                 },
@@ -7700,28 +10165,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 5283,
-            "start": 5266,
+            "end": 7107,
+            "start": 7090,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5275,
-              "start": 5266,
+              "end": 7099,
+              "start": 7090,
             },
             "value": "nextToken",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5283,
-              "start": 5277,
+              "end": 7107,
+              "start": 7101,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5283,
-                "start": 5277,
+                "end": 7107,
+                "start": 7101,
               },
               "value": "String",
             },
@@ -7731,14 +10196,14 @@ Object {
       "interfaces": Array [],
       "kind": "ObjectTypeDefinition",
       "loc": Object {
-        "end": 5285,
-        "start": 5208,
+        "end": 7109,
+        "start": 7032,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5238,
-          "start": 5213,
+          "end": 7062,
+          "start": 7037,
         },
         "value": "ModelPostEditorConnection",
       },
@@ -7753,28 +10218,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5340,
-            "start": 5324,
+            "end": 7164,
+            "start": 7148,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5326,
-              "start": 5324,
+              "end": 7150,
+              "start": 7148,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5340,
-              "start": 5328,
+              "end": 7164,
+              "start": 7152,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5340,
-                "start": 5328,
+                "end": 7164,
+                "start": 7152,
               },
               "value": "ModelIDInput",
             },
@@ -7786,28 +10251,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5363,
-            "start": 5343,
+            "end": 7187,
+            "start": 7167,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5349,
-              "start": 5343,
+              "end": 7173,
+              "start": 7167,
             },
             "value": "postID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5363,
-              "start": 5351,
+              "end": 7187,
+              "start": 7175,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5363,
-                "start": 5351,
+                "end": 7187,
+                "start": 7175,
               },
               "value": "ModelIDInput",
             },
@@ -7819,28 +10284,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5388,
-            "start": 5366,
+            "end": 7212,
+            "start": 7190,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5374,
-              "start": 5366,
+              "end": 7198,
+              "start": 7190,
             },
             "value": "editorID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5388,
-              "start": 5376,
+              "end": 7212,
+              "start": 7200,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5388,
-                "start": 5376,
+                "end": 7212,
+                "start": 7200,
               },
               "value": "ModelIDInput",
             },
@@ -7852,34 +10317,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5424,
-            "start": 5391,
+            "end": 7248,
+            "start": 7215,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5394,
-              "start": 5391,
+              "end": 7218,
+              "start": 7215,
             },
             "value": "and",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 5424,
-              "start": 5396,
+              "end": 7248,
+              "start": 7220,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5423,
-                "start": 5397,
+                "end": 7247,
+                "start": 7221,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5423,
-                  "start": 5397,
+                  "end": 7247,
+                  "start": 7221,
                 },
                 "value": "ModelPostEditorFilterInput",
               },
@@ -7892,34 +10357,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5459,
-            "start": 5427,
+            "end": 7283,
+            "start": 7251,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5429,
-              "start": 5427,
+              "end": 7253,
+              "start": 7251,
             },
             "value": "or",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 5459,
-              "start": 5431,
+              "end": 7283,
+              "start": 7255,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5458,
-                "start": 5432,
+                "end": 7282,
+                "start": 7256,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5458,
-                  "start": 5432,
+                  "end": 7282,
+                  "start": 7256,
                 },
                 "value": "ModelPostEditorFilterInput",
               },
@@ -7932,28 +10397,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5493,
-            "start": 5462,
+            "end": 7317,
+            "start": 7286,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5465,
-              "start": 5462,
+              "end": 7289,
+              "start": 7286,
             },
             "value": "not",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5493,
-              "start": 5467,
+              "end": 7317,
+              "start": 7291,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5493,
-                "start": 5467,
+                "end": 7317,
+                "start": 7291,
               },
               "value": "ModelPostEditorFilterInput",
             },
@@ -7962,14 +10427,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5495,
-        "start": 5287,
+        "end": 7319,
+        "start": 7111,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5319,
-          "start": 5293,
+          "end": 7143,
+          "start": 7117,
         },
         "value": "ModelPostEditorFilterInput",
       },
@@ -7977,7 +10442,7 @@ Object {
   ],
   "kind": "Document",
   "loc": Object {
-    "end": 5497,
+    "end": 7321,
     "start": 0,
   },
 }
@@ -12467,6 +14932,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateChild.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreateFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12482,6 +14950,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateFriendship.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreateParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12497,6 +14968,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateParent.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12512,6 +14986,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreatePostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12527,6 +15004,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreatePostAuthor.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreatePostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12542,6 +15022,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreatePostModel.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12557,6 +15040,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateUser.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreateUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12572,6 +15058,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateUserModel.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12587,6 +15076,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteChild.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12602,6 +15094,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteFriendship.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12617,6 +15112,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteParent.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12632,6 +15130,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeletePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeletePostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12647,6 +15148,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeletePostAuthor.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeletePostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12662,6 +15166,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeletePostModel.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12677,6 +15184,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteUser.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12692,6 +15202,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteUserModel.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12707,6 +15220,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateChild.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12722,6 +15238,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateFriendship.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12737,6 +15256,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateParent.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12752,6 +15274,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdatePostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12767,6 +15292,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdatePostAuthor.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdatePostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12782,6 +15310,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdatePostModel.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12797,6 +15328,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateUser.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -12812,6 +15346,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateUserModel.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "User.friendships.req.vtl": "#if( $ctx.source.deniedField )

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
@@ -93,6 +93,65 @@ input ModelIDInput {
   size: ModelSizeInput
 }
 
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
 enum ModelAttributeTypes {
   binary
   binarySet
@@ -176,16 +235,23 @@ type Mutation {
   deleteModelAModelB(input: DeleteModelAModelBInput!, condition: ModelModelAModelBConditionInput): ModelAModelB
 }
 
+input ModelSubscriptionModelAFilterInput {
+  id: ModelSubscriptionIDInput
+  sortId: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelAFilterInput]
+  or: [ModelSubscriptionModelAFilterInput]
+}
+
 type Subscription {
-  onCreateModelA: ModelA @aws_subscribe(mutations: [\\"createModelA\\"])
-  onUpdateModelA: ModelA @aws_subscribe(mutations: [\\"updateModelA\\"])
-  onDeleteModelA: ModelA @aws_subscribe(mutations: [\\"deleteModelA\\"])
-  onCreateModelB: ModelB @aws_subscribe(mutations: [\\"createModelB\\"])
-  onUpdateModelB: ModelB @aws_subscribe(mutations: [\\"updateModelB\\"])
-  onDeleteModelB: ModelB @aws_subscribe(mutations: [\\"deleteModelB\\"])
-  onCreateModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"createModelAModelB\\"])
-  onUpdateModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"updateModelAModelB\\"])
-  onDeleteModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"deleteModelAModelB\\"])
+  onCreateModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"createModelA\\"])
+  onUpdateModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"updateModelA\\"])
+  onDeleteModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"deleteModelA\\"])
+  onCreateModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"createModelB\\"])
+  onUpdateModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"updateModelB\\"])
+  onDeleteModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"deleteModelB\\"])
+  onCreateModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"createModelAModelB\\"])
+  onUpdateModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"updateModelAModelB\\"])
+  onDeleteModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"deleteModelAModelB\\"])
 }
 
 type ModelModelBConnection {
@@ -220,6 +286,13 @@ input UpdateModelBInput {
 input DeleteModelBInput {
   id: ID!
   sortId: ID!
+}
+
+input ModelSubscriptionModelBFilterInput {
+  id: ModelSubscriptionIDInput
+  sortId: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelBFilterInput]
+  or: [ModelSubscriptionModelBFilterInput]
 }
 
 type ModelModelAModelBConnection {
@@ -266,6 +339,16 @@ input UpdateModelAModelBInput {
 
 input DeleteModelAModelBInput {
   id: ID!
+}
+
+input ModelSubscriptionModelAModelBFilterInput {
+  id: ModelSubscriptionIDInput
+  modelAID: ModelSubscriptionIDInput
+  modelAsortId: ModelSubscriptionIDInput
+  modelBID: ModelSubscriptionIDInput
+  modelBsortId: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelAModelBFilterInput]
+  or: [ModelSubscriptionModelAModelBFilterInput]
 }
 
 input ModelIDKeyConditionInput {
@@ -2031,6 +2114,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateModelA.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreateModelAModelB.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2046,6 +2132,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateModelAModelB.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreateModelB.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2061,6 +2150,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateModelB.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteModelA.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2076,6 +2168,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteModelA.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteModelAModelB.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2091,6 +2186,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteModelAModelB.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteModelB.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2106,6 +2204,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteModelB.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateModelA.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2121,6 +2222,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateModelA.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateModelAModelB.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2136,6 +2240,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateModelAModelB.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateModelB.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2151,6 +2258,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateModelB.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -3243,6 +3353,65 @@ input ModelIDInput {
   size: ModelSizeInput
 }
 
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
 enum ModelAttributeTypes {
   binary
   binarySet
@@ -3330,16 +3499,24 @@ type Mutation {
   deleteModelAModelB(input: DeleteModelAModelBInput!, condition: ModelModelAModelBConditionInput): ModelAModelB
 }
 
+input ModelSubscriptionModelAFilterInput {
+  id: ModelSubscriptionIDInput
+  sortId: ModelSubscriptionIDInput
+  secondSortId: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelAFilterInput]
+  or: [ModelSubscriptionModelAFilterInput]
+}
+
 type Subscription {
-  onCreateModelA: ModelA @aws_subscribe(mutations: [\\"createModelA\\"])
-  onUpdateModelA: ModelA @aws_subscribe(mutations: [\\"updateModelA\\"])
-  onDeleteModelA: ModelA @aws_subscribe(mutations: [\\"deleteModelA\\"])
-  onCreateModelB: ModelB @aws_subscribe(mutations: [\\"createModelB\\"])
-  onUpdateModelB: ModelB @aws_subscribe(mutations: [\\"updateModelB\\"])
-  onDeleteModelB: ModelB @aws_subscribe(mutations: [\\"deleteModelB\\"])
-  onCreateModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"createModelAModelB\\"])
-  onUpdateModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"updateModelAModelB\\"])
-  onDeleteModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"deleteModelAModelB\\"])
+  onCreateModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"createModelA\\"])
+  onUpdateModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"updateModelA\\"])
+  onDeleteModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"deleteModelA\\"])
+  onCreateModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"createModelB\\"])
+  onUpdateModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"updateModelB\\"])
+  onDeleteModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"deleteModelB\\"])
+  onCreateModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"createModelAModelB\\"])
+  onUpdateModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"updateModelAModelB\\"])
+  onDeleteModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"deleteModelAModelB\\"])
 }
 
 type ModelModelBConnection {
@@ -3374,6 +3551,13 @@ input UpdateModelBInput {
 input DeleteModelBInput {
   id: ID!
   sortId: ID!
+}
+
+input ModelSubscriptionModelBFilterInput {
+  id: ModelSubscriptionIDInput
+  sortId: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelBFilterInput]
+  or: [ModelSubscriptionModelBFilterInput]
 }
 
 type ModelModelAModelBConnection {
@@ -3424,6 +3608,17 @@ input UpdateModelAModelBInput {
 
 input DeleteModelAModelBInput {
   id: ID!
+}
+
+input ModelSubscriptionModelAModelBFilterInput {
+  id: ModelSubscriptionIDInput
+  modelAID: ModelSubscriptionIDInput
+  modelAsortId: ModelSubscriptionIDInput
+  modelAsecondSortId: ModelSubscriptionIDInput
+  modelBID: ModelSubscriptionIDInput
+  modelBsortId: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelAModelBFilterInput]
+  or: [ModelSubscriptionModelAModelBFilterInput]
 }
 
 input ModelModelAPrimaryCompositeKeyConditionInput {
@@ -3560,6 +3755,65 @@ input ModelIDInput {
   size: ModelSizeInput
 }
 
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
 enum ModelAttributeTypes {
   binary
   binarySet
@@ -3643,16 +3897,23 @@ type Mutation {
   deleteModelAModelB(input: DeleteModelAModelBInput!, condition: ModelModelAModelBConditionInput): ModelAModelB
 }
 
+input ModelSubscriptionModelAFilterInput {
+  id: ModelSubscriptionIDInput
+  sortId: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelAFilterInput]
+  or: [ModelSubscriptionModelAFilterInput]
+}
+
 type Subscription {
-  onCreateModelA: ModelA @aws_subscribe(mutations: [\\"createModelA\\"])
-  onUpdateModelA: ModelA @aws_subscribe(mutations: [\\"updateModelA\\"])
-  onDeleteModelA: ModelA @aws_subscribe(mutations: [\\"deleteModelA\\"])
-  onCreateModelB: ModelB @aws_subscribe(mutations: [\\"createModelB\\"])
-  onUpdateModelB: ModelB @aws_subscribe(mutations: [\\"updateModelB\\"])
-  onDeleteModelB: ModelB @aws_subscribe(mutations: [\\"deleteModelB\\"])
-  onCreateModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"createModelAModelB\\"])
-  onUpdateModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"updateModelAModelB\\"])
-  onDeleteModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"deleteModelAModelB\\"])
+  onCreateModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"createModelA\\"])
+  onUpdateModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"updateModelA\\"])
+  onDeleteModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"deleteModelA\\"])
+  onCreateModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"createModelB\\"])
+  onUpdateModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"updateModelB\\"])
+  onDeleteModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"deleteModelB\\"])
+  onCreateModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"createModelAModelB\\"])
+  onUpdateModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"updateModelAModelB\\"])
+  onDeleteModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"deleteModelAModelB\\"])
 }
 
 type ModelModelBConnection {
@@ -3683,6 +3944,12 @@ input UpdateModelBInput {
 
 input DeleteModelBInput {
   id: ID!
+}
+
+input ModelSubscriptionModelBFilterInput {
+  id: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelBFilterInput]
+  or: [ModelSubscriptionModelBFilterInput]
 }
 
 type ModelModelAModelBConnection {
@@ -3725,6 +3992,15 @@ input UpdateModelAModelBInput {
 
 input DeleteModelAModelBInput {
   id: ID!
+}
+
+input ModelSubscriptionModelAModelBFilterInput {
+  id: ModelSubscriptionIDInput
+  modelAID: ModelSubscriptionIDInput
+  modelAsortId: ModelSubscriptionIDInput
+  modelBID: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelAModelBFilterInput]
+  or: [ModelSubscriptionModelAModelBFilterInput]
 }
 
 input ModelIDKeyConditionInput {
@@ -3829,6 +4105,65 @@ input ModelIDInput {
   size: ModelSizeInput
 }
 
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
 enum ModelAttributeTypes {
   binary
   binarySet
@@ -3908,16 +4243,22 @@ type Mutation {
   deleteFooBar(input: DeleteFooBarInput!, condition: ModelFooBarConditionInput): FooBar
 }
 
+input ModelSubscriptionFooFilterInput {
+  id: ModelSubscriptionIDInput
+  and: [ModelSubscriptionFooFilterInput]
+  or: [ModelSubscriptionFooFilterInput]
+}
+
 type Subscription {
-  onCreateFoo: Foo @aws_subscribe(mutations: [\\"createFoo\\"])
-  onUpdateFoo: Foo @aws_subscribe(mutations: [\\"updateFoo\\"])
-  onDeleteFoo: Foo @aws_subscribe(mutations: [\\"deleteFoo\\"])
-  onCreateBar: Bar @aws_subscribe(mutations: [\\"createBar\\"])
-  onUpdateBar: Bar @aws_subscribe(mutations: [\\"updateBar\\"])
-  onDeleteBar: Bar @aws_subscribe(mutations: [\\"deleteBar\\"])
-  onCreateFooBar: FooBar @aws_subscribe(mutations: [\\"createFooBar\\"])
-  onUpdateFooBar: FooBar @aws_subscribe(mutations: [\\"updateFooBar\\"])
-  onDeleteFooBar: FooBar @aws_subscribe(mutations: [\\"deleteFooBar\\"])
+  onCreateFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"createFoo\\"])
+  onUpdateFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"updateFoo\\"])
+  onDeleteFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"deleteFoo\\"])
+  onCreateBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"createBar\\"])
+  onUpdateBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"updateBar\\"])
+  onDeleteBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"deleteBar\\"])
+  onCreateFooBar(filter: ModelSubscriptionFooBarFilterInput): FooBar @aws_subscribe(mutations: [\\"createFooBar\\"])
+  onUpdateFooBar(filter: ModelSubscriptionFooBarFilterInput): FooBar @aws_subscribe(mutations: [\\"updateFooBar\\"])
+  onDeleteFooBar(filter: ModelSubscriptionFooBarFilterInput): FooBar @aws_subscribe(mutations: [\\"deleteFooBar\\"])
 }
 
 type ModelBarConnection {
@@ -3948,6 +4289,12 @@ input UpdateBarInput {
 
 input DeleteBarInput {
   id: ID!
+}
+
+input ModelSubscriptionBarFilterInput {
+  id: ModelSubscriptionIDInput
+  and: [ModelSubscriptionBarFilterInput]
+  or: [ModelSubscriptionBarFilterInput]
 }
 
 type ModelFooBarConnection {
@@ -3986,6 +4333,14 @@ input UpdateFooBarInput {
 
 input DeleteFooBarInput {
   id: ID!
+}
+
+input ModelSubscriptionFooBarFilterInput {
+  id: ModelSubscriptionIDInput
+  fooID: ModelSubscriptionIDInput
+  barID: ModelSubscriptionIDInput
+  and: [ModelSubscriptionFooBarFilterInput]
+  or: [ModelSubscriptionFooBarFilterInput]
 }
 
 "
@@ -5525,6 +5880,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateBar.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreateFoo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5540,6 +5898,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateFoo.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreateFooBar.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5555,6 +5916,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateFooBar.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteBar.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5570,6 +5934,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteBar.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteFoo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5585,6 +5952,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteFoo.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteFooBar.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5600,6 +5970,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteFooBar.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateBar.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5615,6 +5988,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateBar.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateFoo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5630,6 +6006,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateFoo.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateFooBar.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5645,6 +6024,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateFooBar.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
@@ -112,6 +112,65 @@ input ModelIDInput {
   size: ModelSizeInput
 }
 
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
 enum ModelAttributeTypes {
   binary
   binarySet
@@ -193,10 +252,19 @@ type Mutation {
   deleteEmployee(input: DeleteEmployeeInput!, condition: ModelEmployeeConditionInput): Employee
 }
 
+input ModelSubscriptionEmployeeFilterInput {
+  id: ModelSubscriptionIDInput
+  firstName: ModelSubscriptionStringInput
+  lastName: ModelSubscriptionStringInput
+  type: ModelSubscriptionStringInput
+  and: [ModelSubscriptionEmployeeFilterInput]
+  or: [ModelSubscriptionEmployeeFilterInput]
+}
+
 type Subscription {
-  onCreateEmployee: Employee @aws_subscribe(mutations: [\\"createEmployee\\"])
-  onUpdateEmployee: Employee @aws_subscribe(mutations: [\\"updateEmployee\\"])
-  onDeleteEmployee: Employee @aws_subscribe(mutations: [\\"deleteEmployee\\"])
+  onCreateEmployee(filter: ModelSubscriptionEmployeeFilterInput): Employee @aws_subscribe(mutations: [\\"createEmployee\\"])
+  onUpdateEmployee(filter: ModelSubscriptionEmployeeFilterInput): Employee @aws_subscribe(mutations: [\\"updateEmployee\\"])
+  onDeleteEmployee(filter: ModelSubscriptionEmployeeFilterInput): Employee @aws_subscribe(mutations: [\\"deleteEmployee\\"])
 }
 
 input SearchableStringFilterInput {
@@ -419,6 +487,65 @@ input ModelIDInput {
   size: ModelSizeInput
 }
 
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
 enum ModelAttributeTypes {
   binary
   binarySet
@@ -495,10 +622,19 @@ type Mutation {
   deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionStringInput
+  updatedAt: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
 }
 
 input SearchableStringFilterInput {
@@ -1191,6 +1327,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1206,6 +1345,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeletePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1221,6 +1363,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -1486,6 +1631,65 @@ input ModelIDInput {
   size: ModelSizeInput
 }
 
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
 enum ModelAttributeTypes {
   binary
   binarySet
@@ -1565,13 +1769,22 @@ type Mutation {
   deleteUser(input: DeleteUserInput!, condition: ModelUserConditionInput): User
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionStringInput
+  updatedAt: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
-  onCreateUser: User @aws_subscribe(mutations: [\\"createUser\\"])
-  onUpdateUser: User @aws_subscribe(mutations: [\\"updateUser\\"])
-  onDeleteUser: User @aws_subscribe(mutations: [\\"deleteUser\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreateUser(filter: ModelSubscriptionUserFilterInput): User @aws_subscribe(mutations: [\\"createUser\\"])
+  onUpdateUser(filter: ModelSubscriptionUserFilterInput): User @aws_subscribe(mutations: [\\"updateUser\\"])
+  onDeleteUser(filter: ModelSubscriptionUserFilterInput): User @aws_subscribe(mutations: [\\"deleteUser\\"])
 }
 
 type ModelUserConnection {
@@ -1606,6 +1819,13 @@ input UpdateUserInput {
 
 input DeleteUserInput {
   id: ID!
+}
+
+input ModelSubscriptionUserFilterInput {
+  id: ModelSubscriptionIDInput
+  name: ModelSubscriptionStringInput
+  and: [ModelSubscriptionUserFilterInput]
+  or: [ModelSubscriptionUserFilterInput]
 }
 
 input SearchableStringFilterInput {
@@ -1858,6 +2078,65 @@ input ModelIDInput {
   size: ModelSizeInput
 }
 
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
 enum ModelAttributeTypes {
   binary
   binarySet
@@ -1921,8 +2200,17 @@ type Mutation {
   customCreatePost(input: CreatePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionStringInput
+  updatedAt: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"customCreatePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"customCreatePost\\"])
 }
 
 input SearchableStringFilterInput {
@@ -2140,6 +2428,65 @@ input ModelIDInput {
   size: ModelSizeInput
 }
 
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
 enum ModelAttributeTypes {
   binary
   binarySet
@@ -2216,10 +2563,19 @@ type Mutation {
   deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionStringInput
+  updatedAt: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
 }
 
 input SearchableStringFilterInput {
@@ -2437,6 +2793,65 @@ input ModelIDInput {
   size: ModelSizeInput
 }
 
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
 enum ModelAttributeTypes {
   binary
   binarySet
@@ -2513,10 +2928,19 @@ type Mutation {
   deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionStringInput
+  updatedAt: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
 }
 
 input SearchableStringFilterInput {

--- a/packages/graphql-transformer-common/src/ModelResourceIDs.ts
+++ b/packages/graphql-transformer-common/src/ModelResourceIDs.ts
@@ -31,12 +31,12 @@ export class ModelResourceIDs {
     }
     return `Model${name}FilterInput`;
   }
-  static ModelFilterScalarInputTypeName(name: string, includeFilter: Boolean): string {
+  static ModelFilterScalarInputTypeName(name: string, includeFilter: Boolean, isSubscriptionFilter:boolean = false): string {
     const nameOverride = DEFAULT_SCALARS[name];
     if (nameOverride) {
-      return `Model${nameOverride}${includeFilter ? 'Filter' : ''}Input`;
+      return `Model${isSubscriptionFilter ? 'Subscription' : ''}${nameOverride}${includeFilter ? 'Filter' : ''}Input`;
     }
-    return `Model${name}${includeFilter ? 'Filter' : ''}Input`;
+    return `Model${isSubscriptionFilter ? 'Subscription' : ''}${name}${includeFilter ? 'Filter' : ''}Input`;
   }
   static ModelConditionInputTypeName(name: string): string {
     const nameOverride = DEFAULT_SCALARS[name];
@@ -67,12 +67,12 @@ export class ModelResourceIDs {
   static ModelCompositeKeyInputTypeName(modelName: string, keyName: string): string {
     return `Model${modelName}${keyName}CompositeKeyInput`;
   }
-  static ModelFilterListInputTypeName(name: string, includeFilter: Boolean): string {
+  static ModelFilterListInputTypeName(name: string, includeFilter: Boolean, isSubscriptionFilter: boolean = false): string {
     const nameOverride = DEFAULT_SCALARS[name];
     if (nameOverride) {
-      return `Model${nameOverride}List${includeFilter ? 'Filter' : ''}Input`;
+      return `Model${isSubscriptionFilter ? 'Subscription' : ''}${nameOverride}List${includeFilter ? 'Filter' : ''}Input`;
     }
-    return `Model${name}List${includeFilter ? 'Filter' : ''}Input`;
+    return `Model${isSubscriptionFilter ? 'Subscription' : ''}${name}List${includeFilter ? 'Filter' : ''}Input`;
   }
 
   static ModelScalarFilterInputTypeName(name: string, includeFilter: Boolean): string {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts
@@ -1,0 +1,705 @@
+import { GRAPHQL_AUTH_MODE } from '@aws-amplify/api';
+import { AWS } from '@aws-amplify/core';
+import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
+import { API, Auth } from 'aws-amplify';
+import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
+import { CognitoIdentity, CognitoIdentityServiceProvider as CognitoClient, S3 } from 'aws-sdk';
+import { Output } from 'aws-sdk/clients/cloudformation';
+import gql from 'graphql-tag';
+import { ResourceConstants } from 'graphql-transformer-common';
+import 'isomorphic-fetch';
+import { default as moment } from 'moment';
+import * as Observable from 'zen-observable';
+import { CloudFormationClient } from '../CloudFormationClient';
+import {
+  addUserToGroup, authenticateUser, configureAmplify, createGroup, createIdentityPool, createUserPool,
+  createUserPoolClient, signupUser
+} from '../cognitoUtils';
+import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
+import { IAMHelper } from '../IAMHelper';
+import { withTimeOut } from '../promiseWithTimeout';
+import { S3Client } from '../S3Client';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+// to deal with subscriptions in node env
+(global as any).WebSocket = require('ws');
+
+// To overcome of the way of how AmplifyJS picks up currentUserCredentials
+const anyAWS = AWS as any;
+if (anyAWS && anyAWS.config && anyAWS.config.credentials) {
+  delete anyAWS.config.credentials;
+}
+
+// delay times
+const SUBSCRIPTION_DELAY = 10000;
+const PROPAGATION_DELAY = 5000;
+const JEST_TIMEOUT = 2000000;
+const SUBSCRIPTION_TIMEOUT = 10000;
+
+jest.setTimeout(JEST_TIMEOUT);
+
+function outputValueSelector(key: string) {
+  return (outputs: Output[]) => {
+    const output = outputs.find((o: Output) => o.OutputKey === key);
+    return output ? output.OutputValue : null;
+  };
+}
+
+const AWS_REGION = 'us-west-2';
+const cf = new CloudFormationClient(AWS_REGION);
+const customS3Client = new S3Client(AWS_REGION);
+const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: AWS_REGION });
+const identityClient = new CognitoIdentity({ apiVersion: '2014-06-30', region: AWS_REGION });
+const iamHelper = new IAMHelper(AWS_REGION);
+const awsS3Client = new S3({ region: AWS_REGION });
+
+// stack info
+const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
+const STACK_NAME = `SubscriptionRTFTests-${BUILD_TIMESTAMP}`;
+const BUCKET_NAME = `subscription-rtf-tests-bucket-${BUILD_TIMESTAMP}`;
+const LOCAL_FS_BUILD_DIR = '/tmp/subscription_rtf_tests/';
+const S3_ROOT_DIR_KEY = 'deployments';
+const AUTH_ROLE_NAME = `${STACK_NAME}-authRole`;
+const UNAUTH_ROLE_NAME = `${STACK_NAME}-unauthRole`;
+let USER_POOL_ID: string;
+let IDENTITY_POOL_ID: string;
+let GRAPHQL_ENDPOINT: string;
+let API_KEY: string;
+
+/**
+ * Client 1 is logged in and is a member of the Admin group.
+ */
+let GRAPHQL_CLIENT_1: AWSAppSyncClient<any> = undefined;
+
+/**
+ * Client 2 is logged in and is a member of the Devs group.
+ */
+let GRAPHQL_CLIENT_2: AWSAppSyncClient<any> = undefined;
+
+/**
+ * Auth IAM Client
+ */
+let GRAPHQL_IAM_AUTH_CLIENT: AWSAppSyncClient<any> = undefined;
+
+const USERNAME1 = 'user1@test.com';
+const USERNAME2 = 'user2@test.com';
+const USERNAME3 = 'user3@test.com';
+const TMP_PASSWORD = 'Password123!';
+const REAL_PASSWORD = 'Password1234!';
+
+const INSTRUCTOR_GROUP_NAME = 'Instructor';
+const MEMBER_GROUP_NAME = 'Member';
+const ADMIN_GROUP_NAME = 'Admin';
+
+// interface inputs
+interface CreateTaskInput {
+  id?: string;
+  title?: string,
+  description?: string,
+  priority?: number,
+  severity?: number,
+  owner?: string
+  readOwners?: string[]
+}
+
+interface UpdateTaskInput {
+  id?: string;
+  title?: string,
+  description?: string,
+  priority?: number,
+  severity?: number,
+  owner?: string
+  readOwners?: string[]
+}
+
+interface DeleteTaskInput {
+  id?: string;
+  title?: string,
+  description?: string,
+  priority?: number,
+  severity?: number,
+  owner?: string
+  readOwners?: string[]
+}
+
+beforeEach(async () => {
+  try {
+    await Auth.signOut();
+  } catch (ex) {
+    // don't need to fail tests on this error
+  }
+});
+
+beforeAll(async () => {
+  const validSchema = `
+  type Task @model
+  @auth(rules: [
+      {allow: owner, ownerField: "owner", identityClaim: "username"}
+      {allow: owner, ownerField: "readOwners", operations: [read], identityClaim: "username"}
+  ]) {
+      id: String,
+      title: String,
+      description: String,
+      priority: Int,
+      severity: Int,
+      owner: String
+      readOwners: [String]
+  }`;
+  const transformer = new GraphQLTransform({
+    authConfig: {
+      defaultAuthentication: {
+        authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+      },
+      additionalAuthenticationProviders: [
+        {
+          authenticationType: 'API_KEY',
+          apiKeyConfig: {
+            description: 'E2E Test API Key',
+            apiKeyExpirationDays: 300,
+          },
+        },
+        {
+          authenticationType: 'AWS_IAM',
+        },
+      ],
+    },
+    transformers: [new ModelTransformer(), new AuthTransformer()],
+    featureFlags: {
+      getBoolean: (value: string, defaultValue?: boolean) => {
+        if (value === 'useSubUsernameForDefaultIdentityClaim') {
+          return false;
+        }
+        return defaultValue;
+      },
+      getString: jest.fn(),
+      getNumber: jest.fn(),
+      getObject: jest.fn(),
+    },
+  });
+
+  try {
+    await awsS3Client.createBucket({ Bucket: BUCKET_NAME }).promise();
+  } catch (e) {
+    console.error(`Failed to create bucket: ${e}`);
+  }
+
+  // create userpool
+  const userPoolResponse = await createUserPool(cognitoClient, `UserPool${STACK_NAME}`);
+  USER_POOL_ID = userPoolResponse.UserPool.Id;
+  const userPoolClientResponse = await createUserPoolClient(cognitoClient, USER_POOL_ID, `UserPool${STACK_NAME}`);
+  const userPoolClientId = userPoolClientResponse.UserPoolClient.ClientId;
+  // create auth and unauthroles
+  const { authRole, unauthRole } = await iamHelper.createRoles(AUTH_ROLE_NAME, UNAUTH_ROLE_NAME);
+  // create identitypool
+  IDENTITY_POOL_ID = await createIdentityPool(identityClient, `IdentityPool${STACK_NAME}`, {
+    authRoleArn: authRole.Arn,
+    unauthRoleArn: unauthRole.Arn,
+    providerName: `cognito-idp.${AWS_REGION}.amazonaws.com/${USER_POOL_ID}`,
+    clientId: userPoolClientId,
+  });
+  const out = transformer.transform(validSchema);
+  const finishedStack = await deploy(
+    customS3Client,
+    cf,
+    STACK_NAME,
+    out,
+    { AuthCognitoUserPoolId: USER_POOL_ID, authRoleName: authRole.RoleName, unauthRoleName: unauthRole.RoleName },
+    LOCAL_FS_BUILD_DIR,
+    BUCKET_NAME,
+    S3_ROOT_DIR_KEY,
+    BUILD_TIMESTAMP,
+  );
+
+  expect(finishedStack).toBeDefined();
+  const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput);
+  const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput);
+  GRAPHQL_ENDPOINT = getApiEndpoint(finishedStack.Outputs);
+
+  API_KEY = getApiKey(finishedStack.Outputs);
+  expect(API_KEY).toBeTruthy();
+
+  // Verify we have all the details
+  expect(GRAPHQL_ENDPOINT).toBeTruthy();
+  expect(USER_POOL_ID).toBeTruthy();
+  expect(userPoolClientId).toBeTruthy();
+
+  // Configure Amplify, create users, and sign in
+  configureAmplify(USER_POOL_ID, userPoolClientId, IDENTITY_POOL_ID);
+
+  await signupUser(USER_POOL_ID, USERNAME1, TMP_PASSWORD);
+  await signupUser(USER_POOL_ID, USERNAME2, TMP_PASSWORD);
+  await signupUser(USER_POOL_ID, USERNAME3, TMP_PASSWORD);
+
+  await createGroup(USER_POOL_ID, INSTRUCTOR_GROUP_NAME);
+  await createGroup(USER_POOL_ID, MEMBER_GROUP_NAME);
+  await createGroup(USER_POOL_ID, ADMIN_GROUP_NAME);
+  await addUserToGroup(ADMIN_GROUP_NAME, USERNAME1, USER_POOL_ID);
+  await addUserToGroup(MEMBER_GROUP_NAME, USERNAME2, USER_POOL_ID);
+  await addUserToGroup(INSTRUCTOR_GROUP_NAME, USERNAME1, USER_POOL_ID);
+  await addUserToGroup(INSTRUCTOR_GROUP_NAME, USERNAME2, USER_POOL_ID);
+
+  // authenticate user3 we'll use amplify api for subscription calls
+  await authenticateUser(USERNAME3, TMP_PASSWORD, REAL_PASSWORD);
+
+  const authResAfterGroup: any = await authenticateUser(USERNAME1, TMP_PASSWORD, REAL_PASSWORD);
+  const idToken = authResAfterGroup.getIdToken().getJwtToken();
+  GRAPHQL_CLIENT_1 = new AWSAppSyncClient({
+    url: GRAPHQL_ENDPOINT,
+    region: AWS_REGION,
+    disableOffline: true,
+    auth: {
+      type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
+      jwtToken: idToken,
+    },
+  });
+  const authRes2AfterGroup: any = await authenticateUser(USERNAME2, TMP_PASSWORD, REAL_PASSWORD);
+  const idToken2 = authRes2AfterGroup.getIdToken().getJwtToken();
+  GRAPHQL_CLIENT_2 = new AWSAppSyncClient({
+    url: GRAPHQL_ENDPOINT,
+    region: AWS_REGION,
+    disableOffline: true,
+    auth: {
+      type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
+      jwtToken: idToken2,
+    },
+  });
+
+  await Auth.signIn(USERNAME1, REAL_PASSWORD);
+  const authCreds = await Auth.currentCredentials();
+  GRAPHQL_IAM_AUTH_CLIENT = new AWSAppSyncClient({
+    url: GRAPHQL_ENDPOINT,
+    region: AWS_REGION,
+    disableOffline: true,
+    auth: {
+      type: AUTH_TYPE.AWS_IAM,
+      credentials: authCreds,
+    },
+  });
+  // Wait for any propagation to avoid random
+  // "The security token included in the request is invalid" errors
+  await new Promise(res => setTimeout(res, PROPAGATION_DELAY));
+});
+
+afterAll(async () => {
+  await cleanupStackAfterTest(
+    BUCKET_NAME,
+    STACK_NAME,
+    cf,
+    { cognitoClient, userPoolId: USER_POOL_ID },
+    { identityClient, identityPoolId: IDENTITY_POOL_ID },
+  );
+  await iamHelper.deleteRole(AUTH_ROLE_NAME);
+  await iamHelper.deleteRole(UNAUTH_ROLE_NAME);
+});
+
+/**
+ * Tests
+ */
+
+/**
+ * Subscriptions with runtime filtering basic use case
+ * User1 is running the mutation and subscription
+ */
+test('Basic runtime filtering with subscriptions work', async () => {
+  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
+  await Auth.signIn(USERNAME1, REAL_PASSWORD);
+  const observer = API.graphql({
+    // @ts-ignore
+    query: gql`
+      subscription OnCreateTask {
+        onCreateTask(filter: {
+          and: [
+            { priority: { eq: 8 } }
+            { severity: { gt: 5 } }
+          ]
+        }) {
+          id
+          title
+          description
+          priority
+          severity
+          owner
+          readOwners
+        }
+      }
+    `,
+    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
+  }) as unknown as Observable<any>;
+  let subscription: ZenObservable.Subscription;
+  const subscriptionPromise = new Promise((resolve, _) => {
+    subscription = observer.subscribe((event: any) => {
+      const task = event.value.data.onCreateTask;
+      subscription.unsubscribe();
+      expect(task.title).toEqual('task2');
+      expect(task.description).toEqual('description2');
+      expect(task.priority).toEqual(8);
+      expect(task.severity).toEqual(7);
+      resolve(undefined);
+    });
+  });
+
+  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
+
+  await createTask(GRAPHQL_CLIENT_1, {
+    title: 'task1',
+    description: 'description1',
+    priority: 5,
+    severity: 5,
+  });
+
+  await createTask(GRAPHQL_CLIENT_1, {
+    title: 'task2',
+    description: 'description2',
+    priority: 8,
+    severity: 7,
+  });
+
+  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateTask Subscription timed out', () => {
+    subscription?.unsubscribe();
+  });
+});
+
+/**
+ * Runtime filtering supports multiple owners auth
+ * User1 is running the subscription and User2 is running the mutations
+ */
+test('Multiple owners auth is supported for subscriptions', async () => {
+  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
+  await Auth.signIn(USERNAME1, REAL_PASSWORD);
+  const observer = API.graphql({
+    // @ts-ignore
+    query: gql`
+      subscription OnCreateTask {
+        onCreateTask {
+          id
+          title
+          description
+          priority
+          severity
+          owner
+          readOwners
+        }
+      }
+    `,
+    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
+  }) as unknown as Observable<any>;
+  let subscription: ZenObservable.Subscription;
+  const subscriptionPromise = new Promise((resolve, _) => {
+    subscription = observer.subscribe((event: any) => {
+      const task = event.value.data.onCreateTask;
+      subscription.unsubscribe();
+      expect(task.title).toEqual('task3');
+      expect(task.description).toEqual('description3');
+      expect(task.priority).toEqual(1);
+      expect(task.severity).toEqual(2);
+      resolve(undefined);
+    });
+  });
+
+  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
+
+  await createTask(GRAPHQL_CLIENT_2, {
+    title: 'task3',
+    description: 'description3',
+    priority: 1,
+    severity: 2,
+    readOwners: [USERNAME1],
+  });
+
+  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateTask Subscription timed out', () => {
+    subscription?.unsubscribe();
+  });
+});
+
+/**
+ * Runtime filtering supports multiple owners auth and filter argument
+ * User1 is running the subscription and User2 is running the mutations
+ */
+test('Basic runtime filtering with subscriptions and multiple owners auth work', async () => {
+  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
+  await Auth.signIn(USERNAME1, REAL_PASSWORD);
+  const observer = API.graphql({
+    // @ts-ignore
+    query: gql`
+      subscription OnCreateTask {
+        onCreateTask(filter: {
+          or: [
+            { priority: { gt: 5 } }
+            { severity: { gt: 5 } }
+          ]
+        }) {
+          id
+          title
+          description
+          priority
+          severity
+          owner
+          readOwners
+        }
+      }
+    `,
+    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
+  }) as unknown as Observable<any>;
+  let subscription: ZenObservable.Subscription;
+  const subscriptionPromise = new Promise((resolve, _) => {
+    subscription = observer.subscribe((event: any) => {
+      const task = event.value.data.onCreateTask;
+      subscription.unsubscribe();
+      expect(task.title).toEqual('task5');
+      expect(task.description).toEqual('description5');
+      expect(task.priority).toEqual(1);
+      expect(task.severity).toEqual(6);
+      resolve(undefined);
+    });
+  });
+
+  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
+
+  await createTask(GRAPHQL_CLIENT_2, {
+    title: 'task4',
+    description: 'description4',
+    priority: 4,
+    severity: 4,
+  });
+
+  await createTask(GRAPHQL_CLIENT_2, {
+    title: 'task5',
+    description: 'description5',
+    priority: 1,
+    severity: 6,
+    readOwners: [USERNAME1],
+  });
+
+  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateTask Subscription timed out', () => {
+    subscription?.unsubscribe();
+  });
+});
+
+/**
+ * Runtime filtering on update mutation
+ * User1 is running the subscription and User2 is running the mutations
+ */
+test('Runtime filtering works with update mutation and multiple owners auth', async () => {
+  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
+  await Auth.signIn(USERNAME1, REAL_PASSWORD);
+  const observer = API.graphql({
+    // @ts-ignore
+    query: gql`
+      subscription OnUpdateTask {
+        onUpdateTask(filter: {
+          or: [
+            { priority: { lt: 5 } }
+            { severity: { lt: 5 } }
+          ]
+        }) {
+          id
+          title
+          description
+          priority
+          severity
+          owner
+          readOwners
+        }
+      }
+    `,
+    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
+  }) as unknown as Observable<any>;
+  let subscription: ZenObservable.Subscription;
+  const subscriptionPromise = new Promise((resolve, _) => {
+    subscription = observer.subscribe((event: any) => {
+      const task = event.value.data.onUpdateTask;
+      subscription.unsubscribe();
+      expect(task.title).toEqual('task7');
+      expect(task.description).toEqual('description7');
+      expect(task.priority).toEqual(2);
+      expect(task.severity).toEqual(3);
+      resolve(undefined);
+    });
+  });
+
+  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
+
+  await createTask(GRAPHQL_CLIENT_2, {
+    id: 'task-06',
+    title: 'task6',
+    description: 'description6',
+    priority: 6,
+    severity: 6,
+    readOwners: [USERNAME1],
+  });
+
+  await createTask(GRAPHQL_CLIENT_2, {
+    id: 'task-07',
+    title: 'task7',
+    description: 'description7',
+    priority: 2,
+    severity: 3,
+    readOwners: [USERNAME1],
+  });
+
+  await updateTask(GRAPHQL_CLIENT_2, {
+    id: 'task-06',
+    title: 'task6',
+    description: 'description6',
+    priority: 6,
+    severity: 6,
+    readOwners: [USERNAME1],
+  });
+
+  await updateTask(GRAPHQL_CLIENT_2, {
+    id: 'task-07',
+    title: 'task7',
+    description: 'description7',
+    priority: 2,
+    severity: 3,
+    readOwners: [USERNAME1],
+  });
+
+  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateTask Subscription timed out', () => {
+    subscription?.unsubscribe();
+  });
+});
+
+/**
+ * Runtime filtering on delete mutation
+ * User1 is running the subscription and User2 is running the mutations
+ */
+test('Runtime filtering works with delete mutation and multiple owners auth', async () => {
+  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
+  await Auth.signIn(USERNAME1, REAL_PASSWORD);
+  const observer = API.graphql({
+    // @ts-ignore
+    query: gql`
+      subscription OnDeleteTask {
+        onDeleteTask(filter: {
+          severity: { eq: 10 }
+        }) {
+          id
+          title
+          description
+          priority
+          severity
+          owner
+          readOwners
+        }
+      }
+    `,
+    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
+  }) as unknown as Observable<any>;
+  let subscription: ZenObservable.Subscription;
+  const subscriptionPromise = new Promise((resolve, _) => {
+    subscription = observer.subscribe((event: any) => {
+      const task = event.value.data.onDeleteTask;
+      subscription.unsubscribe();
+      expect(task.title).toEqual('task9');
+      expect(task.description).toEqual('description9');
+      expect(task.priority).toEqual(3);
+      expect(task.severity).toEqual(10);
+      resolve(undefined);
+    });
+  });
+
+  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
+
+  await createTask(GRAPHQL_CLIENT_2, {
+    id: 'task-08',
+    title: 'task8',
+    description: 'description8',
+    priority: 8,
+    severity: 8,
+    readOwners: [USERNAME1],
+  });
+
+  await createTask(GRAPHQL_CLIENT_2, {
+    id: 'task-09',
+    title: 'task9',
+    description: 'description9',
+    priority: 3,
+    severity: 10,
+    readOwners: [USERNAME1],
+  });
+
+  await deleteTask(GRAPHQL_CLIENT_2, {
+    id: 'task-08',
+  });
+
+  await deleteTask(GRAPHQL_CLIENT_2, {
+    id: 'task-09',
+  });
+
+  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateTask Subscription timed out', () => {
+    subscription?.unsubscribe();
+  });
+});
+
+const reconfigureAmplifyAPI = (appSyncAuthType: string, apiKey?: string):void => {
+  if (appSyncAuthType === 'API_KEY') {
+    API.configure({
+      aws_appsync_graphqlEndpoint: GRAPHQL_ENDPOINT,
+      aws_appsync_region: AWS_REGION,
+      aws_appsync_authenticationType: appSyncAuthType,
+      aws_appsync_apiKey: apiKey,
+    });
+  } else {
+    API.configure({
+      aws_appsync_graphqlEndpoint: GRAPHQL_ENDPOINT,
+      aws_appsync_region: AWS_REGION,
+      aws_appsync_authenticationType: appSyncAuthType,
+    });
+  }
+};
+
+// mutations
+const createTask = async (client: AWSAppSyncClient<any>, input: CreateTaskInput): Promise<any> => {
+  const request = gql`
+    mutation CreateTask($input: CreateTaskInput!) {
+      createTask(input: $input) {
+        id
+        title
+        description
+        priority
+        severity
+        owner
+        readOwners
+      }
+    }
+  `;
+  return client.mutate<any>({ mutation: request, variables: { input } });
+};
+
+const updateTask = async (client: AWSAppSyncClient<any>, input: UpdateTaskInput): Promise<any> => {
+  const request = gql`
+    mutation UpdateTask($input: UpdateTaskInput!) {
+      updateTask(input: $input) {
+        id
+        title
+        description
+        priority
+        severity
+        owner
+        readOwners
+      }
+    }
+  `;
+  return client.mutate<any>({ mutation: request, variables: { input } });
+};
+
+const deleteTask = async (client: AWSAppSyncClient<any>, input: DeleteTaskInput): Promise<any> => {
+  const request = gql`
+    mutation DeleteTask($input: DeleteTaskInput!) {
+      deleteTask(input: $input) {
+        id
+        title
+        description
+        priority
+        severity
+        owner
+        readOwners
+      }
+    }
+  `;
+  return client.mutate<any>({ mutation: request, variables: { input } });
+};

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts
@@ -213,10 +213,11 @@ beforeAll(async () => {
         {allow: owner}
         {allow: groups, groups: ["Instructor"]}
     ]) {
-        id: String,
-        name: String,
-        email: AWSEmail,
+        id: String
+        name: String
+        email: AWSEmail
         ssn: String @auth(rules: [{allow: owner}])
+        owner: String
     }
 
     type Member @model
@@ -686,51 +687,6 @@ test('Test that only authorized members are allowed to view subscriptions', asyn
   });
 });
 
-test('Test that an user not in the group is not allowed to view the subscription', async () => {
-  // subscribe to create students as user 3
-  // const observer = onCreateStudent(GRAPHQL_CLIENT_3)
-  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
-  await Auth.signIn(USERNAME3, REAL_PASSWORD);
-  const observer = API.graphql({
-    // @ts-ignore
-    query: gql`
-      subscription OnCreateStudent {
-        onCreateStudent {
-          id
-          name
-          email
-          ssn
-          owner
-        }
-      }
-    `,
-    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
-  }) as unknown as Observable<any>;
-  let subscription: ZenObservable.Subscription;
-  const subscriptionPromise = new Promise((resolve, _) => {
-    subscription = observer.subscribe({
-      error: (err: any) => {
-        expect(err.error.errors[0].message).toEqual(
-          'Connection failed: {"errors":[{"errorType":"Unauthorized","message":"Not Authorized to access onCreateStudent on type Subscription"}]}',
-        );
-        resolve(undefined);
-      },
-    });
-  });
-
-  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
-
-  await createStudent(GRAPHQL_CLIENT_1, {
-    name: 'student2',
-    email: 'student2@domain.com',
-    ssn: 'BBB-00-SNSN',
-  });
-
-  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'Subscription timed out', () => {
-    subscription?.unsubscribe();
-  });
-});
-
 test('Test a subscription on update', async () => {
   // subscribe to update students as user 2
   reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
@@ -1034,14 +990,14 @@ test('Test subscription onCreatePost with ownerField', async () => {
   });
 });
 
-test('Test onCreatePost with optional argument', async () => {
+test('Test onCreatePost with incorrect owner argument should throw an error', async () => {
   reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
   await Auth.signIn(USERNAME1, REAL_PASSWORD);
   const failedObserver = API.graphql({
     // @ts-ignore
     query: gql`
       subscription OnCreatePost {
-        onCreatePost {
+        onCreatePost(postOwner: "${USERNAME2}") {
           id
           title
           postOwner
@@ -1056,7 +1012,7 @@ test('Test onCreatePost with optional argument', async () => {
       event => {},
       err => {
         expect(err.error.errors[0].message).toEqual(
-          'Connection failed: {"errors":[{"errorType":"Unauthorized","message":"Not Authorized to access onCreatePost on type Subscription"}]}',
+          'Connection failed: {"errors":[{"errorType":"Unauthorized","message":"Not Authorized to access onCreatePost on type Post"}]}',
         );
         resolve(undefined);
       },

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts
@@ -1012,7 +1012,7 @@ test('Test onCreatePost with incorrect owner argument should throw an error', as
       event => {},
       err => {
         expect(err.error.errors[0].message).toEqual(
-          'Connection failed: {"errors":[{"errorType":"Unauthorized","message":"Not Authorized to access onCreatePost on type Post"}]}',
+          'Connection failed: {"errors":[{"errorType":"Unauthorized","message":"Not Authorized to access onCreatePost on type Subscription"}]}',
         );
         resolve(undefined);
       },

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts
@@ -400,51 +400,6 @@ test('Test that only authorized members are allowed to view subscriptions', asyn
   });
 });
 
-test('Test that an user not in the group is not allowed to view the subscription', async () => {
-  // subscribe to create students as user 3
-  // const observer = onCreateStudent(GRAPHQL_CLIENT_3)
-  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
-  await Auth.signIn(USERNAME3, REAL_PASSWORD);
-  const observer = API.graphql({
-    // @ts-ignore
-    query: gql`
-      subscription OnCreateStudent {
-        onCreateStudent {
-          id
-          name
-          email
-          ssn
-          owner
-        }
-      }
-    `,
-    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
-  }) as unknown as Observable<any>;
-  let subscription: ZenObservable.Subscription;
-  const subscriptionPromise = new Promise((resolve, _) => {
-    subscription = observer.subscribe({
-      error: (err: any) => {
-        expect(err.error.errors[0].message).toEqual(
-          'Connection failed: {"errors":[{"errorType":"Unauthorized","message":"Not Authorized to access onCreateStudent on type Student"}]}',
-        );
-        resolve(undefined);
-      },
-    });
-  });
-
-  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
-
-  await createStudent(GRAPHQL_CLIENT_1, {
-    name: 'student2',
-    email: 'student2@domain.com',
-    ssn: 'BBB-00-SNSN',
-  });
-
-  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'Subscription timed out', () => {
-    subscription?.unsubscribe();
-  });
-});
-
 test('Test a subscription on update', async () => {
   // subscribe to update students as user 2
   reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
@@ -748,14 +703,14 @@ test('Test subscription onCreatePost with ownerField', async () => {
   });
 });
 
-test('Test onCreatePost with optional argument', async () => {
+test('Test onCreatePost with incorrect owner argument should throw an error', async () => {
   reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
   await Auth.signIn(USERNAME1, REAL_PASSWORD);
   const failedObserver = API.graphql({
     // @ts-ignore
     query: gql`
       subscription OnCreatePost {
-        onCreatePost {
+        onCreatePost(postOwner: "${USERNAME2}") {
           id
           title
           postOwner

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2WithFF.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2WithFF.e2e.test.ts
@@ -400,51 +400,6 @@ test('Test that only authorized members are allowed to view subscriptions', asyn
   });
 });
 
-test('Test that an user not in the group is not allowed to view the subscription', async () => {
-  // subscribe to create students as user 3
-  // const observer = onCreateStudent(GRAPHQL_CLIENT_3)
-  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
-  await Auth.signIn(USERNAME3, REAL_PASSWORD);
-  const observer = API.graphql({
-    // @ts-ignore
-    query: gql`
-      subscription OnCreateStudent {
-        onCreateStudent {
-          id
-          name
-          email
-          ssn
-          owner
-        }
-      }
-    `,
-    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
-  }) as unknown as Observable<any>;
-  let subscription: ZenObservable.Subscription;
-  const subscriptionPromise = new Promise((resolve, _) => {
-    subscription = observer.subscribe({
-      error: (err: any) => {
-        expect(err.error.errors[0].message).toEqual(
-          'Connection failed: {"errors":[{"errorType":"Unauthorized","message":"Not Authorized to access onCreateStudent on type Student"}]}',
-        );
-        resolve(undefined);
-      },
-    });
-  });
-
-  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
-
-  await createStudent(GRAPHQL_CLIENT_1, {
-    name: 'student2',
-    email: 'student2@domain.com',
-    ssn: 'BBB-00-SNSN',
-  });
-
-  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'Subscription timed out', () => {
-    subscription?.unsubscribe();
-  });
-});
-
 test('Test a subscription on update', async () => {
   // subscribe to update students as user 2
   reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
@@ -748,14 +703,14 @@ test('Test subscription onCreatePost with ownerField', async () => {
   });
 });
 
-test('Test onCreatePost with optional argument', async () => {
+test('Test onCreatePost with incorrect owner argument should throw an error', async () => {
   reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
   await Auth.signIn(USERNAME1, REAL_PASSWORD);
   const failedObserver = API.graphql({
     // @ts-ignore
     query: gql`
       subscription OnCreatePost {
-        onCreatePost {
+        onCreatePost(postOwner: "${USERNAME2}") {
           id
           title
           postOwner


### PR DESCRIPTION
#### Description of changes
This PR adds support for subscriptions runtime filtering. 

List of changes:
- Adds new filter subscription input type for each model type.
- Adds a new argument `filter` for the generated subscriptions.
- Uses AppSync enhanced filtering to support server side runtime filtering.
- Adds @auth subscriptions support for multiple owners field (`owners: [String]`)

#### Issue #, if available

Fixes https://github.com/aws-amplify/amplify-category-api/issues/372

#### Description of how you validated changes
- Manual test
- Unit test
- e2e test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
