### PR TITLE
Feat: Single Source Read

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "rm-dev-link": "rimraf -f \"$(yarn global bin)/amplify-dev\"",
     "setup-dev": "(yarn && lerna run build) && yarn add-cli-no-save && (yarn hoist-cli && yarn rm-dev-link && yarn link-dev)",
     "link-win": "node ./scripts/link-bin.js node_modules/amplify-cli-internal/bin/amplify amplify-dev",
+    "link-aa-win": "node ./scripts/link-bin.js packages/amplify-app/bin/amplify-app amplify-app-dev",
     "setup-dev-win": "(yarn && lerna run build) && yarn add-cli-no-save && (yarn hoist-cli-win && yarn rm-dev-link && yarn link-win)",
     "split-e2e-tests": "yarn ts-node ./scripts/split-e2e-tests.ts && git add .circleci/config.yml",
     "verify-commit": "yarn ts-node ./scripts/verify-commit.ts",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "rm-dev-link": "rimraf -f \"$(yarn global bin)/amplify-dev\"",
     "setup-dev": "(yarn && lerna run build) && yarn add-cli-no-save && (yarn hoist-cli && yarn rm-dev-link && yarn link-dev)",
     "link-win": "node ./scripts/link-bin.js node_modules/amplify-cli-internal/bin/amplify amplify-dev",
-    "link-aa-win": "node ./scripts/link-bin.js packages/amplify-app/bin/amplify-app amplify-app-dev",
     "setup-dev-win": "(yarn && lerna run build) && yarn add-cli-no-save && (yarn hoist-cli-win && yarn rm-dev-link && yarn link-win)",
     "split-e2e-tests": "yarn ts-node ./scripts/split-e2e-tests.ts && git add .circleci/config.yml",
     "verify-commit": "yarn ts-node ./scripts/verify-commit.ts",

--- a/packages/amplify-category-api/src/category-utils/context-util.ts
+++ b/packages/amplify-category-api/src/category-utils/context-util.ts
@@ -1,0 +1,55 @@
+import {
+  $TSAny,
+  $TSContext,
+  AmplifyCategories,
+  pathManager,
+} from 'amplify-cli-core';
+import path from 'path';
+import { PROVIDER_NAME } from '../graphql-transformer/constants';
+
+/**
+ * ContextUtil
+ * Some values are calculated on the basis of the context and options that come
+ * from the Amplify CLI, this class/singleton help calculate and cache those values
+ * for reference
+ */
+export class ContextUtil {
+  private resourceDir: string;
+
+  /**
+   * Get the resource directory as used by the API category for GraphQL
+   * @param context the context from the CLI
+   * @param options the options from the CLI
+   */
+  getResourceDir = async (
+    context: $TSContext,
+    options: $TSAny,
+  ): Promise<string> => {
+    if (this.resourceDir) {
+      return this.resourceDir;
+    }
+    let { resourceDir } = options;
+    const backEndDir = pathManager.getBackendDirPath();
+    const { resourcesToBeCreated, resourcesToBeUpdated } = await context.amplify.getResourceStatus(AmplifyCategories.API);
+    const resources = resourcesToBeCreated.concat(resourcesToBeUpdated);
+    if (!resourceDir) {
+      // There can only be one appsync resource
+      if (resources.length > 0) {
+        const resource = resources[0];
+        if (resource.providerPlugin !== PROVIDER_NAME) {
+          return undefined;
+        }
+        const { category } = resource;
+        const { resourceName } = resource;
+        resourceDir = path.normalize(path.join(backEndDir, category, resourceName));
+      } else {
+        // No appsync resource to update/add
+        return undefined;
+      }
+    }
+    this.resourceDir = resourceDir;
+    return resourceDir;
+  }
+}
+
+export const contextUtil = new ContextUtil();

--- a/packages/amplify-category-api/src/category-utils/context-util.ts
+++ b/packages/amplify-category-api/src/category-utils/context-util.ts
@@ -34,6 +34,10 @@ export class ContextUtil {
     const resources = resourcesToBeCreated.concat(resourcesToBeUpdated);
     if (!resourceDir) {
       // There can only be one appsync resource
+      if (!resources.length) {
+        // No appsync resource to update/add
+        return undefined;
+      }
       if (resources.length > 0) {
         const resource = resources[0];
         if (resource.providerPlugin !== PROVIDER_NAME) {
@@ -42,9 +46,6 @@ export class ContextUtil {
         const { category } = resource;
         const { resourceName } = resource;
         resourceDir = path.normalize(path.join(backEndDir, category, resourceName));
-      } else {
-        // No appsync resource to update/add
-        return undefined;
       }
     }
     this.resourceDir = resourceDir;

--- a/packages/amplify-category-api/src/category-utils/schema-reader.ts
+++ b/packages/amplify-category-api/src/category-utils/schema-reader.ts
@@ -81,12 +81,10 @@ export class SchemaReader {
       this.schemaDocument = parse(fullSchema);
     }
 
-    if (preProcessSchema) {
-      if (!this.preProcessedSchemaDocument) {
-        const transformerOptions = await generateTransformerOptions(context, options);
-        const transform = await buildGraphQLTransformV2(transformerOptions);
-        this.preProcessedSchemaDocument = transform.preProcessSchema(this.schemaDocument);
-      }
+    if (preProcessSchema && !this.preProcessedSchemaDocument) {
+      const transformerOptions = await generateTransformerOptions(context, options);
+      const transform = await buildGraphQLTransformV2(transformerOptions);
+      this.preProcessedSchemaDocument = transform.preProcessSchema(this.schemaDocument);
     }
 
     return preProcessSchema ? this.preProcessedSchemaDocument : this.schemaDocument;

--- a/packages/amplify-category-api/src/category-utils/schema-reader.ts
+++ b/packages/amplify-category-api/src/category-utils/schema-reader.ts
@@ -1,0 +1,96 @@
+import * as fs from 'fs-extra';
+import path from 'path';
+import {
+  DocumentNode,
+  parse,
+} from 'graphql';
+import {
+  $TSAny,
+  $TSContext,
+  ApiCategoryFacade,
+} from 'amplify-cli-core';
+import { buildGraphQLTransformV2 } from '../graphql-transformer/transformer-factory';
+import {
+  SCHEMA_DIR_NAME,
+  SCHEMA_FILENAME,
+} from '../graphql-transformer/constants';
+import { generateTransformerOptions } from '../graphql-transformer/transformer-options-v2';
+import {
+  contextUtil,
+} from './context-util';
+
+/**
+ * SchemaReader is a utility point to consolidate and abstract GraphQL Schema reading
+ * The readSchema method provides a flag to read the un-processed (original) schema
+ * if desired, but by default the intent of the SchemaReader is to use the preProcess
+ * utility of the V2 transformer
+ */
+export class SchemaReader {
+  private schemaPath: string;
+  private schemaDocument: DocumentNode;
+  private preProcessedSchemaDocument: DocumentNode;
+
+  getSchemaPath = async (
+    context: $TSContext,
+    options: $TSAny,
+  ): Promise<string> => {
+    if (this.schemaPath) {
+      return this.schemaPath;
+    }
+    const resourceDir = await contextUtil.getResourceDir(context, options);
+    const schemaFilePath = path.normalize(path.join(resourceDir, SCHEMA_FILENAME));
+    const schemaDirPath = path.normalize(path.join(resourceDir, SCHEMA_DIR_NAME));
+
+    if (fs.pathExistsSync(schemaFilePath)) {
+      this.schemaPath = schemaFilePath;
+    } else if (fs.pathExistsSync(schemaDirPath)) {
+      this.schemaPath = schemaDirPath;
+    } else {
+      this.schemaPath = null;
+    }
+    return this.schemaPath;
+  };
+
+  invalidateCachedSchema = (): void => {
+    this.schemaPath = null;
+    this.schemaDocument = null;
+    this.preProcessedSchemaDocument = null;
+  };
+
+  readSchema = async (
+    context: $TSContext,
+    options: $TSAny,
+    usePreProcessing = true,
+  ): Promise<DocumentNode> => {
+    const preProcessSchema = usePreProcessing && (await ApiCategoryFacade.getTransformerVersion(context) === 2);
+    if (!this.schemaDocument) {
+      const fileContentsList = new Array<Promise<Buffer>>();
+      const schemaPath = await this.getSchemaPath(context, options);
+
+      const stats = fs.statSync(schemaPath);
+      if (stats.isDirectory()) {
+        fs.readdirSync(schemaPath).forEach(fileName => {
+          fileContentsList.push(fs.readFile(path.join(schemaPath, fileName)));
+        });
+      } else {
+        fileContentsList.push(fs.readFile(schemaPath));
+      }
+
+      const bufferList = await Promise.all(fileContentsList);
+      const fullSchema = bufferList.map(buff => buff.toString()).join('\n');
+      this.schemaDocument = parse(fullSchema);
+    }
+
+    if (preProcessSchema) {
+      if (!this.preProcessedSchemaDocument) {
+        const transformerOptions = await generateTransformerOptions(context, options);
+        const transform = await buildGraphQLTransformV2(transformerOptions);
+        this.preProcessedSchemaDocument = transform.preProcessSchema(this.schemaDocument);
+      }
+    }
+
+    return preProcessSchema ? this.preProcessedSchemaDocument : this.schemaDocument;
+  };
+}
+
+export const schemaReader = new SchemaReader();

--- a/packages/amplify-category-api/src/category-utils/schema-reader.ts
+++ b/packages/amplify-category-api/src/category-utils/schema-reader.ts
@@ -42,7 +42,7 @@ export class SchemaReader {
     } else if (fs.pathExistsSync(schemaDirPath)) {
       this.schemaPath = schemaDirPath;
     } else {
-      this.schemaPath = null;
+      throw new Error(`No schema found, your graphql schema should be in either ${schemaFilePath} or ${schemaDirPath}`);
     }
     return this.schemaPath;
   };

--- a/packages/amplify-category-api/src/category-utils/schema-reader.ts
+++ b/packages/amplify-category-api/src/category-utils/schema-reader.ts
@@ -15,9 +15,7 @@ import {
   SCHEMA_FILENAME,
 } from '../graphql-transformer/constants';
 import { generateTransformerOptions } from '../graphql-transformer/transformer-options-v2';
-import {
-  contextUtil,
-} from './context-util';
+import { contextUtil } from './context-util';
 
 /**
  * SchemaReader is a utility point to consolidate and abstract GraphQL Schema reading
@@ -31,13 +29,11 @@ export class SchemaReader {
   private preProcessedSchemaDocument: DocumentNode;
 
   getSchemaPath = async (
-    context: $TSContext,
-    options: $TSAny,
+    resourceDir: string,
   ): Promise<string> => {
     if (this.schemaPath) {
       return this.schemaPath;
     }
-    const resourceDir = await contextUtil.getResourceDir(context, options);
     const schemaFilePath = path.normalize(path.join(resourceDir, SCHEMA_FILENAME));
     const schemaDirPath = path.normalize(path.join(resourceDir, SCHEMA_DIR_NAME));
 
@@ -65,11 +61,12 @@ export class SchemaReader {
     const preProcessSchema = usePreProcessing && (await ApiCategoryFacade.getTransformerVersion(context) === 2);
     if (!this.schemaDocument) {
       const fileContentsList = new Array<Promise<Buffer>>();
-      const schemaPath = await this.getSchemaPath(context, options);
+      const resourceDir = await contextUtil.getResourceDir(context, options);
+      const schemaPath = await this.getSchemaPath(resourceDir);
 
       const stats = fs.statSync(schemaPath);
       if (stats.isDirectory()) {
-        fs.readdirSync(schemaPath).forEach(fileName => {
+        fs.readdirSync(schemaPath).forEach((fileName) => {
           fileContentsList.push(fs.readFile(path.join(schemaPath, fileName)));
         });
       } else {
@@ -77,7 +74,7 @@ export class SchemaReader {
       }
 
       const bufferList = await Promise.all(fileContentsList);
-      const fullSchema = bufferList.map(buff => buff.toString()).join('\n');
+      const fullSchema = bufferList.map((buff) => buff.toString()).join('\n');
       this.schemaDocument = parse(fullSchema);
     }
 

--- a/packages/amplify-category-api/src/graphql-transformer/constants.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/constants.ts
@@ -1,0 +1,6 @@
+export const DESTRUCTIVE_UPDATES_FLAG = 'allow-destructive-graphql-schema-updates';
+export const PROVIDER_NAME = 'awscloudformation';
+export const PARAMETERS_FILENAME = 'parameters.json';
+export const ROOT_APPSYNC_S3_KEY = 'amplify-appsync-files';
+export const SCHEMA_FILENAME = 'schema.graphql';
+export const SCHEMA_DIR_NAME = 'schema';

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -2,34 +2,23 @@ import {
   collectDirectivesByTypeNames,
   DeploymentResources,
   GraphQLTransform,
-  ResolverConfig,
-  TransformerProjectConfig,
 } from '@aws-amplify/graphql-transformer-core';
-import { Template } from '@aws-amplify/graphql-transformer-core/lib/config/project-config';
-import { OverrideConfig } from '@aws-amplify/graphql-transformer-core/lib/transformation/types';
-import { AppSyncAuthConfiguration, TransformerPluginProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-interfaces';
 import {
-  $TSAny,
   $TSContext,
-  $TSMeta,
   $TSObject,
   AmplifyCategories,
   AmplifySupportedService,
   ApiCategoryFacade,
-  CloudformationProviderFacade,
   getGraphQLTransformerAuthDocLink,
   JSONUtilities,
   pathManager,
-  stateManager,
 } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import fs from 'fs-extra';
 import { ResourceConstants } from 'graphql-transformer-common';
 import {
-  DiffRule,
-  getSanityCheckRules,
   loadProject,
-  ProjectRule,
   sanityCheckProject,
 } from 'graphql-transformer-core';
 import _ from 'lodash';
@@ -38,24 +27,29 @@ import path from 'path';
 import { searchablePushChecks } from './api-utils';
 import { AmplifyCLIFeatureFlagAdapter } from './amplify-cli-feature-flag-adapter';
 import { isAuthModeUpdated } from './auth-mode-compare';
-import { schemaHasSandboxModeEnabled, showGlobalSandboxModeWarning, showSandboxModePrompts } from './sandbox-mode-helpers';
+import {
+  schemaHasSandboxModeEnabled,
+  showGlobalSandboxModeWarning,
+  showSandboxModePrompts,
+} from './sandbox-mode-helpers';
 import { parseUserDefinedSlots } from './user-defined-slots';
 import {
-  getAdminRoles, getIdentityPoolId, mergeUserConfigWithTransformOutput, writeDeploymentToDisk,
+  mergeUserConfigWithTransformOutput,
+  writeDeploymentToDisk,
 } from './utils';
-import { getTransformerFactory } from './transformer-factory';
-
-const PARAMETERS_FILENAME = 'parameters.json';
-const SCHEMA_FILENAME = 'schema.graphql';
-const SCHEMA_DIR_NAME = 'schema';
-const ROOT_APPSYNC_S3_KEY = 'amplify-appsync-files';
-const DESTRUCTIVE_UPDATES_FLAG = 'allow-destructive-graphql-schema-updates';
-const PROVIDER_NAME = 'awscloudformation';
-
-type SanityCheckRules = {
-  diffRules: DiffRule[];
-  projectRules: ProjectRule[];
-};
+import {
+  generateTransformerOptions,
+} from './transformer-options-v2';
+import {
+  PARAMETERS_FILENAME,
+  SCHEMA_DIR_NAME,
+  SCHEMA_FILENAME,
+} from './constants';
+import {
+  TransformerFactoryArgs,
+  TransformerProjectOptions,
+} from './transformer-options-types';
+import { contextUtil } from '../category-utils/context-util';
 
 const warnOnAuth = (map: $TSObject, docLink: string): void => {
   const unAuthModelTypes = Object.keys(map).filter(type => !map[type].includes('auth') && map[type].includes('model'));
@@ -74,15 +68,18 @@ const warnOnAuth = (map: $TSObject, docLink: string): void => {
  * Transform GraphQL Schema
  */
 export const transformGraphQLSchemaV2 = async (context: $TSContext, options): Promise<DeploymentResources | undefined> => {
-  let resourceName: string;
   const backEndDir = pathManager.getBackendDirPath();
   const flags = context.parameters.options;
   if (flags['no-gql-override']) {
     return undefined;
   }
 
-  let { resourceDir, parameters } = options;
+  let { parameters } = options;
   const { forceCompile } = options;
+  const resourceDir = await contextUtil.getResourceDir(context, options);
+  if (!resourceDir) {
+    return undefined;
+  }
 
   // Compilation during the push step
   const { resourcesToBeCreated, resourcesToBeUpdated, allResources } = await context.amplify.getResourceStatus(AmplifyCategories.API);
@@ -104,38 +101,6 @@ export const transformGraphQLSchemaV2 = async (context: $TSContext, options): Pr
     resources = resources.concat(allResources);
   }
   resources = resources.filter(resource => resource.service === 'AppSync');
-
-  if (!resourceDir) {
-    // There can only be one appsync resource
-    if (resources.length > 0) {
-      const resource = resources[0];
-      if (resource.providerPlugin !== PROVIDER_NAME) {
-        return undefined;
-      }
-      const { category } = resource;
-      ({ resourceName } = resource);
-      resourceDir = path.normalize(path.join(backEndDir, category, resourceName));
-    } else {
-      // No appsync resource to update/add
-      return undefined;
-    }
-  }
-
-  let previouslyDeployedBackendDir = options.cloudBackendDirectory;
-  if (!previouslyDeployedBackendDir) {
-    if (resources.length > 0) {
-      const resource = resources[0];
-      if (resource.providerPlugin !== PROVIDER_NAME) {
-        return undefined;
-      }
-      const { category } = resource;
-      resourceName = resource.resourceName;
-      const cloudBackendRootDir = pathManager.getCurrentCloudBackendDirPath();
-      /* eslint-disable */
-      previouslyDeployedBackendDir = path.normalize(path.join(cloudBackendRootDir, category, resourceName));
-      /* eslint-enable */
-    }
-  }
 
   const parametersFilePath = path.join(resourceDir, PARAMETERS_FILENAME);
 
@@ -183,29 +148,9 @@ export const transformGraphQLSchemaV2 = async (context: $TSContext, options): Pr
     }
   }
 
-  // for auth transformer we get any admin roles and a cognito identity pool to check for
-  // potential authenticated roles outside of the provided authRole
-  const adminRoles = await getAdminRoles(context, resourceName);
-  const identityPoolId = await getIdentityPoolId(context);
-
-  // for the predictions directive get storage config
-  const s3Resource = s3ResourceAlreadyExists();
-  const storageConfig = s3Resource ? getBucketName(s3Resource) : undefined;
-
   const buildDir = path.normalize(path.join(resourceDir, 'build'));
   const schemaFilePath = path.normalize(path.join(resourceDir, SCHEMA_FILENAME));
   const schemaDirPath = path.normalize(path.join(resourceDir, SCHEMA_DIR_NAME));
-  let deploymentRootKey = await getPreviousDeploymentRootKey(previouslyDeployedBackendDir);
-  if (!deploymentRootKey) {
-    const deploymentSubKey = await CloudformationProviderFacade.hashDirectory(context, resourceDir);
-    deploymentRootKey = `${ROOT_APPSYNC_S3_KEY}/${deploymentSubKey}`;
-  }
-  const projectBucket = options.dryRun ? 'fake-bucket' : getProjectBucket();
-  const buildParameters = {
-    ...parameters,
-    S3DeploymentBucket: projectBucket,
-    S3DeploymentRootKey: deploymentRootKey,
-  };
 
   // If it is a dry run, don't create the build folder as it could make a follow-up command
   // to not to trigger a build, hence a corrupt deployment.
@@ -215,9 +160,6 @@ export const transformGraphQLSchemaV2 = async (context: $TSContext, options): Pr
 
   const project = await loadProject(resourceDir);
 
-  const lastDeployedProjectConfig = fs.existsSync(previouslyDeployedBackendDir)
-    ? await loadProject(previouslyDeployedBackendDir)
-    : undefined;
   const transformerVersion = await ApiCategoryFacade.getTransformerVersion(context);
   const docLink = getGraphQLTransformerAuthDocLink(transformerVersion);
   const sandboxModeEnabled = schemaHasSandboxModeEnabled(project.schema, docLink);
@@ -234,65 +176,15 @@ export const transformGraphQLSchemaV2 = async (context: $TSContext, options): Pr
 
   searchablePushChecks(context, directiveMap.types, parameters[ResourceConstants.PARAMETERS.AppSyncApiName]);
 
-  const transformerListFactory = await getTransformerFactory(context, resourceDir);
-
   if (sandboxModeEnabled && options.promptApiKeyCreation) {
     const apiKeyConfig = await showSandboxModePrompts(context);
     if (apiKeyConfig) authConfig.additionalAuthenticationProviders.push(apiKeyConfig);
   }
 
-  let searchableTransformerFlag = false;
-
-  if (directiveMap.directives.includes('searchable')) {
-    searchableTransformerFlag = true;
+  const buildConfig = await generateTransformerOptions(context, options);
+  if (!buildConfig) {
+    return undefined;
   }
-
-  // construct sanityCheckRules
-  const ff = new AmplifyCLIFeatureFlagAdapter();
-  const isNewAppSyncAPI: boolean = resourcesToBeCreated.some(resource => resource.service === 'AppSync');
-  const allowDestructiveUpdates = context?.input?.options?.[DESTRUCTIVE_UPDATES_FLAG] || context?.input?.options?.force;
-  const sanityCheckRules = getSanityCheckRules(isNewAppSyncAPI, ff, allowDestructiveUpdates);
-  let resolverConfig = {};
-  if (!_.isEmpty(resources)) {
-    resolverConfig = await context.amplify.invokePluginMethod(
-      context,
-      AmplifyCategories.API,
-      AmplifySupportedService.APPSYNC,
-      'getResolverConfig',
-      [context, resources[0].resourceName],
-    );
-  }
-
-  /**
-   * if Auth is not migrated , we need to fetch resolver Config from transformer.conf.json
-   * since above function will return empty object
-   */
-  if (_.isEmpty(resolverConfig)) {
-    resolverConfig = project.config.ResolverConfig;
-  }
-
-  const buildConfig: ProjectOptions<TransformerFactoryArgs> = {
-    ...options,
-    buildParameters,
-    projectDirectory: resourceDir,
-    transformersFactory: transformerListFactory,
-    transformersFactoryArgs: {
-      addSearchableTransformer: searchableTransformerFlag,
-      storageConfig,
-      authConfig,
-      adminRoles,
-      identityPoolId,
-    },
-    rootStackFileName: 'cloudformation-template.json',
-    currentCloudBackendDirectory: previouslyDeployedBackendDir,
-    minify: options.minify,
-    projectConfig: project,
-    lastDeployedProjectConfig,
-    authConfig,
-    sandboxModeEnabled,
-    sanityCheckRules,
-    resolverConfig,
-  };
 
   const transformerOutput = await buildAPIProject(context, buildConfig);
 
@@ -309,109 +201,12 @@ place .graphql files in a directory at ${schemaDirPath}`);
   return transformerOutput;
 };
 
-const getProjectBucket = (): string => {
-  const meta: $TSMeta = stateManager.getMeta(undefined, { throwIfNotExist: false });
-  const projectBucket = meta?.providers ? meta.providers[PROVIDER_NAME].DeploymentBucketName : '';
-  return projectBucket;
-};
-
-const getPreviousDeploymentRootKey = async (previouslyDeployedBackendDir: string): Promise<string|undefined> => {
-  // this is the function
-  let parameters;
-  try {
-    const parametersPath = path.join(previouslyDeployedBackendDir, `build/${PARAMETERS_FILENAME}`);
-    const parametersExists = fs.existsSync(parametersPath);
-    if (parametersExists) {
-      const parametersString = await fs.readFile(parametersPath);
-      parameters = JSON.parse(parametersString.toString());
-    }
-    return parameters.S3DeploymentRootKey;
-  } catch (err) {
-    return undefined;
-  }
-};
-
-/**
- * Check if storage exists in the project if not return undefined
- */
-const s3ResourceAlreadyExists = (): string | undefined => {
-  try {
-    let resourceName: string;
-    const amplifyMeta: $TSMeta = stateManager.getMeta(undefined, { throwIfNotExist: false });
-    if (amplifyMeta?.[AmplifyCategories.STORAGE]) {
-      const categoryResources = amplifyMeta[AmplifyCategories.STORAGE];
-      Object.keys(categoryResources).forEach(resource => {
-        if (categoryResources[resource].service === AmplifySupportedService.S3) {
-          resourceName = resource;
-        }
-      });
-    }
-    return resourceName;
-  } catch (error) {
-    if (error.name === 'UndeterminedEnvironmentError') {
-      return undefined;
-    }
-    throw error;
-  }
-};
-
-const getBucketName = (s3ResourceName: string): { bucketName: string } => {
-  const amplifyMeta = stateManager.getMeta();
-  const stackName = amplifyMeta.providers.awscloudformation.StackName;
-  const s3ResourcePath = pathManager.getResourceDirectoryPath(undefined, AmplifyCategories.STORAGE, s3ResourceName);
-  const cliInputsPath = path.join(s3ResourcePath, 'cli-inputs.json');
-  let bucketParameters: $TSObject;
-  // get bucketParameters 1st from cli-inputs , if not present, then parameters.json
-  if (fs.existsSync(cliInputsPath)) {
-    bucketParameters = JSONUtilities.readJson(cliInputsPath);
-  } else {
-    bucketParameters = stateManager.getResourceParametersJson(undefined, AmplifyCategories.STORAGE, s3ResourceName);
-  }
-  const bucketName = stackName.startsWith('amplify-')
-    ? `${bucketParameters.bucketName}\${hash}-\${env}`
-    : `${bucketParameters.bucketName}${s3ResourceName}-\${env}`;
-  return { bucketName };
-};
-
-type TransformerFactoryArgs = {
-  addSearchableTransformer: boolean;
-  authConfig: $TSAny;
-  storageConfig?: $TSAny;
-  adminRoles?: Array<string>;
-  identityPoolId?: string;
-};
-
-/**
- * ProjectOptions Type Definition
- */
-type ProjectOptions<T> = {
-  buildParameters: {
-    S3DeploymentBucket: string;
-    S3DeploymentRootKey: string;
-  };
-  projectDirectory: string;
-  transformersFactory: (options: T) => Promise<TransformerPluginProvider[]>;
-  transformersFactoryArgs: T;
-  rootStackFileName: 'cloudformation-template.json';
-  currentCloudBackendDirectory?: string;
-  minify: boolean;
-  lastDeployedProjectConfig?: TransformerProjectConfig;
-  projectConfig: TransformerProjectConfig;
-  resolverConfig?: ResolverConfig;
-  dryRun?: boolean;
-  authConfig?: AppSyncAuthConfiguration;
-  stacks: Record<string, Template>;
-  sandboxModeEnabled?: boolean;
-  sanityCheckRules: SanityCheckRules;
-  overrideConfig: OverrideConfig;
-};
-
 /**
  * buildAPIProject
  */
 const buildAPIProject = async (
   context: $TSContext,
-  opts: ProjectOptions<TransformerFactoryArgs>,
+  opts: TransformerProjectOptions<TransformerFactoryArgs>,
 ): Promise<DeploymentResources|undefined> => {
   const schema = opts.projectConfig.schema.toString();
   // Skip building the project if the schema is blank
@@ -441,7 +236,7 @@ const buildAPIProject = async (
   return builtProject;
 };
 
-const _buildProject = async (opts: ProjectOptions<TransformerFactoryArgs>): Promise<DeploymentResources> => {
+const _buildProject = async (opts: TransformerProjectOptions<TransformerFactoryArgs>): Promise<DeploymentResources> => {
   const userProjectConfig = opts.projectConfig;
   const stackMapping = userProjectConfig.config.StackMapping;
   const userDefinedSlots = {

--- a/packages/amplify-category-api/src/graphql-transformer/transformer-options-types.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transformer-options-types.ts
@@ -1,0 +1,60 @@
+/**
+ * ProjectOptions Type Definition
+ */
+import {
+  AppSyncAuthConfiguration,
+  TransformerPluginProvider,
+} from '@aws-amplify/graphql-transformer-interfaces';
+import {
+  OverrideConfig,
+  ResolverConfig,
+  TransformerProjectConfig,
+} from '@aws-amplify/graphql-transformer-core';
+import Template from '@aws-amplify/graphql-transformer-core/lib/transformation/types';
+import {
+  DiffRule,
+  ProjectRule,
+} from 'graphql-transformer-core';
+import { $TSAny } from 'amplify-cli-core';
+
+/**
+ * Transformer Options used to create a GraphQL Transform and compile a GQL API
+ */
+export type TransformerProjectOptions<T> = {
+  buildParameters: {
+    S3DeploymentBucket: string;
+    S3DeploymentRootKey: string;
+  };
+  projectDirectory: string;
+  transformersFactory: (options: T) => Promise<TransformerPluginProvider[]>;
+  transformersFactoryArgs: T;
+  rootStackFileName: 'cloudformation-template.json';
+  currentCloudBackendDirectory?: string;
+  minify: boolean;
+  lastDeployedProjectConfig?: TransformerProjectConfig;
+  projectConfig: TransformerProjectConfig;
+  resolverConfig?: ResolverConfig;
+  dryRun?: boolean;
+  authConfig?: AppSyncAuthConfiguration;
+  stacks: Record<string, Template>;
+  sandboxModeEnabled?: boolean;
+  sanityCheckRules: SanityCheckRules;
+  overrideConfig: OverrideConfig;
+};
+
+type SanityCheckRules = {
+  diffRules: DiffRule[];
+  projectRules: ProjectRule[];
+};
+
+/**
+ * Arguments passed into a TransformerFactory
+ * Used to determine how to create a new GraphQLTransform
+ */
+export type TransformerFactoryArgs = {
+  addSearchableTransformer: boolean;
+  authConfig: $TSAny;
+  storageConfig?: $TSAny;
+  adminRoles?: Array<string>;
+  identityPoolId?: string;
+};

--- a/packages/amplify-category-api/src/graphql-transformer/transformer-options-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transformer-options-v2.ts
@@ -1,0 +1,300 @@
+import {
+  $TSAny,
+  $TSContext, $TSMeta, $TSObject,
+  AmplifyCategories,
+  AmplifySupportedService, ApiCategoryFacade,
+  CloudformationProviderFacade, getGraphQLTransformerAuthDocLink,
+  JSONUtilities,
+  pathManager,
+  stateManager,
+} from 'amplify-cli-core';
+import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-interfaces';
+import {
+  collectDirectivesByTypeNames,
+} from '@aws-amplify/graphql-transformer-core';
+import {
+  getSanityCheckRules,
+  loadProject,
+} from 'graphql-transformer-core';
+import path from 'path';
+import fs from 'fs-extra';
+import { ResourceConstants } from 'graphql-transformer-common';
+import _ from 'lodash';
+import { getAdminRoles, getIdentityPoolId } from './utils';
+import { schemaHasSandboxModeEnabled, showSandboxModePrompts } from './sandbox-mode-helpers';
+import { getTransformerFactory } from './transformer-factory';
+import { AmplifyCLIFeatureFlagAdapter } from './amplify-cli-feature-flag-adapter';
+import {
+  DESTRUCTIVE_UPDATES_FLAG,
+  PARAMETERS_FILENAME,
+  PROVIDER_NAME,
+  ROOT_APPSYNC_S3_KEY,
+} from './constants';
+import {
+  TransformerFactoryArgs,
+  TransformerProjectOptions,
+} from './transformer-options-types';
+import { contextUtil } from '../category-utils/context-util';
+
+/**
+ * Use current context to generate the Transformer options for generating
+ * a GraphQL Transformer V2 object
+ * @param context The $TSContext from the Amplify CLI
+ * @param options The $TSAny options config coming from the Amplify CLI
+ */
+export const generateTransformerOptions = async (
+  context: $TSContext,
+  options: $TSAny,
+): Promise<TransformerProjectOptions<TransformerFactoryArgs>> => {
+  let resourceName: string;
+  const backEndDir = pathManager.getBackendDirPath();
+  const flags = context.parameters.options;
+  if (flags['no-gql-override']) {
+    return undefined;
+  }
+
+  let { parameters } = options;
+  const { forceCompile } = options;
+
+  // Compilation during the push step
+  const { resourcesToBeCreated, resourcesToBeUpdated, allResources } = await context.amplify.getResourceStatus(AmplifyCategories.API);
+  let resources = resourcesToBeCreated.concat(resourcesToBeUpdated);
+
+  // When build folder is missing include the API
+  // to be compiled without the backend/api/<api-name>/build
+  // cloud formation push will fail even if there is no changes in the GraphQL API
+  // https://github.com/aws-amplify/amplify-console/issues/10
+  const resourceNeedCompile = allResources
+    .filter(r => !resources.includes(r))
+    .filter(r => {
+      const buildDir = path.normalize(path.join(backEndDir, AmplifyCategories.API, r.resourceName, 'build'));
+      return !fs.existsSync(buildDir);
+    });
+  resources = resources.concat(resourceNeedCompile);
+
+  if (forceCompile) {
+    resources = resources.concat(allResources);
+  }
+  resources = resources.filter(resource => resource.service === 'AppSync');
+
+  const resourceDir = await contextUtil.getResourceDir(context, options);
+
+  let previouslyDeployedBackendDir = options.cloudBackendDirectory;
+  if (!previouslyDeployedBackendDir) {
+    if (resources.length > 0) {
+      const resource = resources[0];
+      if (resource.providerPlugin !== PROVIDER_NAME) {
+        return undefined;
+      }
+      const { category } = resource;
+      resourceName = resource.resourceName;
+      const cloudBackendRootDir = pathManager.getCurrentCloudBackendDirPath();
+      /* eslint-disable */
+      previouslyDeployedBackendDir = path.normalize(path.join(cloudBackendRootDir, category, resourceName));
+      /* eslint-enable */
+    }
+  }
+
+  const parametersFilePath = path.join(resourceDir, PARAMETERS_FILENAME);
+
+  if (!parameters && fs.existsSync(parametersFilePath)) {
+    try {
+      parameters = JSONUtilities.readJson(parametersFilePath);
+
+      // OpenSearch Instance type support for x.y.search types
+      if (parameters[ResourceConstants.PARAMETERS.OpenSearchInstanceType]) {
+        parameters[ResourceConstants.PARAMETERS.OpenSearchInstanceType] = parameters[ResourceConstants.PARAMETERS.OpenSearchInstanceType]
+          .replace('.search', '.elasticsearch');
+      }
+    } catch (e) {
+      parameters = {};
+    }
+  }
+
+  let { authConfig }: { authConfig: AppSyncAuthConfiguration } = options;
+
+  if (_.isEmpty(authConfig) && !_.isEmpty(resources)) {
+    authConfig = await context.amplify.invokePluginMethod(
+      context,
+      AmplifyCategories.API,
+      AmplifySupportedService.APPSYNC,
+      'getAuthConfig',
+      [context, resources[0].resourceName],
+    );
+    // handle case where auth project is not migrated , if Auth not migrated above function will return empty Object
+    if (_.isEmpty(authConfig)) {
+      //
+      // If we don't have an authConfig from the caller, use it from the
+      // already read resources[0], which is an AppSync API.
+      //
+      if (resources[0].output.securityType) {
+        // Convert to multi-auth format if needed.
+        authConfig = {
+          defaultAuthentication: {
+            authenticationType: resources[0].output.securityType,
+          },
+          additionalAuthenticationProviders: [],
+        };
+      } else {
+        ({ authConfig } = resources[0].output);
+      }
+    }
+  }
+
+  // for auth transformer we get any admin roles and a cognito identity pool to check for
+  // potential authenticated roles outside of the provided authRole
+  const adminRoles = await getAdminRoles(context, resourceName);
+  const identityPoolId = await getIdentityPoolId(context);
+
+  // for the predictions directive get storage config
+  const s3Resource = s3ResourceAlreadyExists();
+  const storageConfig = s3Resource ? getBucketName(s3Resource) : undefined;
+
+  let deploymentRootKey = await getPreviousDeploymentRootKey(previouslyDeployedBackendDir);
+  if (!deploymentRootKey) {
+    const deploymentSubKey = await CloudformationProviderFacade.hashDirectory(context, resourceDir);
+    deploymentRootKey = `${ROOT_APPSYNC_S3_KEY}/${deploymentSubKey}`;
+  }
+  const projectBucket = options.dryRun ? 'fake-bucket' : getProjectBucket();
+  const buildParameters = {
+    ...parameters,
+    S3DeploymentBucket: projectBucket,
+    S3DeploymentRootKey: deploymentRootKey,
+  };
+
+  const project = await loadProject(resourceDir);
+
+  const lastDeployedProjectConfig = fs.existsSync(previouslyDeployedBackendDir)
+    ? await loadProject(previouslyDeployedBackendDir)
+    : undefined;
+  const transformerVersion = await ApiCategoryFacade.getTransformerVersion(context);
+  const docLink = getGraphQLTransformerAuthDocLink(transformerVersion);
+  const sandboxModeEnabled = schemaHasSandboxModeEnabled(project.schema, docLink);
+  const directiveMap = collectDirectivesByTypeNames(project.schema);
+
+  const transformerListFactory = await getTransformerFactory(context, resourceDir);
+
+  if (sandboxModeEnabled && options.promptApiKeyCreation) {
+    const apiKeyConfig = await showSandboxModePrompts(context);
+    if (apiKeyConfig) authConfig.additionalAuthenticationProviders.push(apiKeyConfig);
+  }
+
+  let searchableTransformerFlag = false;
+
+  if (directiveMap.directives.includes('searchable')) {
+    searchableTransformerFlag = true;
+  }
+
+  // construct sanityCheckRules
+  const ff = new AmplifyCLIFeatureFlagAdapter();
+  const isNewAppSyncAPI: boolean = resourcesToBeCreated.some(resource => resource.service === 'AppSync');
+  const allowDestructiveUpdates = context?.input?.options?.[DESTRUCTIVE_UPDATES_FLAG] || context?.input?.options?.force;
+  const sanityCheckRules = getSanityCheckRules(isNewAppSyncAPI, ff, allowDestructiveUpdates);
+  let resolverConfig = {};
+  if (!_.isEmpty(resources)) {
+    resolverConfig = await context.amplify.invokePluginMethod(
+      context,
+      AmplifyCategories.API,
+      AmplifySupportedService.APPSYNC,
+      'getResolverConfig',
+      [context, resources[0].resourceName],
+    );
+  }
+
+  /**
+   * if Auth is not migrated , we need to fetch resolver Config from transformer.conf.json
+   * since above function will return empty object
+   */
+  if (_.isEmpty(resolverConfig)) {
+    resolverConfig = project.config.ResolverConfig;
+  }
+
+  const buildConfig: TransformerProjectOptions<TransformerFactoryArgs> = {
+    ...options,
+    buildParameters,
+    projectDirectory: resourceDir,
+    transformersFactory: transformerListFactory,
+    transformersFactoryArgs: {
+      addSearchableTransformer: searchableTransformerFlag,
+      storageConfig,
+      authConfig,
+      adminRoles,
+      identityPoolId,
+    },
+    rootStackFileName: 'cloudformation-template.json',
+    currentCloudBackendDirectory: previouslyDeployedBackendDir,
+    minify: options.minify,
+    projectConfig: project,
+    lastDeployedProjectConfig,
+    authConfig,
+    sandboxModeEnabled,
+    sanityCheckRules,
+    resolverConfig,
+  };
+
+  return buildConfig;
+};
+
+const getBucketName = (s3ResourceName: string): { bucketName: string } => {
+  const amplifyMeta = stateManager.getMeta();
+  const stackName = amplifyMeta.providers.awscloudformation.StackName;
+  const s3ResourcePath = pathManager.getResourceDirectoryPath(undefined, AmplifyCategories.STORAGE, s3ResourceName);
+  const cliInputsPath = path.join(s3ResourcePath, 'cli-inputs.json');
+  let bucketParameters: $TSObject;
+  // get bucketParameters 1st from cli-inputs , if not present, then parameters.json
+  if (fs.existsSync(cliInputsPath)) {
+    bucketParameters = JSONUtilities.readJson(cliInputsPath);
+  } else {
+    bucketParameters = stateManager.getResourceParametersJson(undefined, AmplifyCategories.STORAGE, s3ResourceName);
+  }
+  const bucketName = stackName.startsWith('amplify-')
+    ? `${bucketParameters.bucketName}\${hash}-\${env}`
+    : `${bucketParameters.bucketName}${s3ResourceName}-\${env}`;
+  return { bucketName };
+};
+
+const getPreviousDeploymentRootKey = async (previouslyDeployedBackendDir: string): Promise<string|undefined> => {
+  // this is the function
+  let parameters;
+  try {
+    const parametersPath = path.join(previouslyDeployedBackendDir, `build/${PARAMETERS_FILENAME}`);
+    const parametersExists = fs.existsSync(parametersPath);
+    if (parametersExists) {
+      const parametersString = await fs.readFile(parametersPath);
+      parameters = JSON.parse(parametersString.toString());
+    }
+    return parameters.S3DeploymentRootKey;
+  } catch (err) {
+    return undefined;
+  }
+};
+
+const getProjectBucket = (): string => {
+  const meta: $TSMeta = stateManager.getMeta(undefined, { throwIfNotExist: false });
+  const projectBucket = meta?.providers ? meta.providers[PROVIDER_NAME].DeploymentBucketName : '';
+  return projectBucket;
+};
+
+/**
+ * Check if storage exists in the project if not return undefined
+ */
+const s3ResourceAlreadyExists = (): string | undefined => {
+  try {
+    let resourceName: string;
+    const amplifyMeta: $TSMeta = stateManager.getMeta(undefined, { throwIfNotExist: false });
+    if (amplifyMeta?.[AmplifyCategories.STORAGE]) {
+      const categoryResources = amplifyMeta[AmplifyCategories.STORAGE];
+      Object.keys(categoryResources).forEach(resource => {
+        if (categoryResources[resource].service === AmplifySupportedService.S3) {
+          resourceName = resource;
+        }
+      });
+    }
+    return resourceName;
+  } catch (error) {
+    if (error.name === 'UndeterminedEnvironmentError') {
+      return undefined;
+    }
+    throw error;
+  }
+};

--- a/packages/amplify-category-api/src/graphql-transformer/transformer-options-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transformer-options-v2.ts
@@ -36,6 +36,8 @@ import {
 } from './transformer-options-types';
 import { contextUtil } from '../category-utils/context-util';
 
+export const APPSYNC_RESOURCE_SERVICE = 'AppSync';
+
 /**
  * Use current context to generate the Transformer options for generating
  * a GraphQL Transformer V2 object
@@ -65,8 +67,8 @@ export const generateTransformerOptions = async (
   // cloud formation push will fail even if there is no changes in the GraphQL API
   // https://github.com/aws-amplify/amplify-console/issues/10
   const resourceNeedCompile = allResources
-    .filter(r => !resources.includes(r))
-    .filter(r => {
+    .filter((r) => !resources.includes(r))
+    .filter((r) => {
       const buildDir = path.normalize(path.join(backEndDir, AmplifyCategories.API, r.resourceName, 'build'));
       return !fs.existsSync(buildDir);
     });
@@ -75,7 +77,7 @@ export const generateTransformerOptions = async (
   if (forceCompile) {
     resources = resources.concat(allResources);
   }
-  resources = resources.filter(resource => resource.service === 'AppSync');
+  resources = resources.filter((resource) => resource.service === APPSYNC_RESOURCE_SERVICE);
 
   const resourceDir = await contextUtil.getResourceDir(context, options);
 

--- a/packages/amplify-graphql-transformer-core/src/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/index.ts
@@ -1,7 +1,13 @@
 import { print } from 'graphql';
 import { EXTRA_DIRECTIVES_DOCUMENT } from './transformation/validation';
+
 export { GraphQLTransform, GraphQLTransformOptions, SyncUtils } from './transformation';
-export { DeploymentResources, UserDefinedSlot, UserDefinedResolver } from './transformation/types';
+export {
+  DeploymentResources,
+  UserDefinedSlot,
+  UserDefinedResolver,
+  OverrideConfig,
+} from './transformation/types';
 export { validateModelSchema } from './transformation/validation';
 export {
   ConflictDetectionType,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This adds the capability for but does not enable single source reading on GraphQL schemas
This is intended for GraphQL Transformer V2 without support for V1
This also required pulling apart some of the logic in schema transformation so I can actually instantiate the transformer elsewhere

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
No validation yet, runtime change that hasn't been enabled. Running tests to make sure I haven't broken any existing functionality when refactoring the code

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
