### PR TITLE
test(graphql): fix failing datastore modelgen tests

### DIFF
--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -80,6 +80,7 @@
     "@aws-cdk/region-info": "~1.124.0",
     "@graphql-tools/merge": "^6.0.18",
     "@octokit/rest": "^18.0.9",
+    "amplify-app": "4.2.35",
     "chalk": "^4.1.1",
     "cloudform": "^4.2.0",
     "cloudform-types": "^4.2.0",

--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -80,7 +80,6 @@
     "@aws-cdk/region-info": "~1.124.0",
     "@graphql-tools/merge": "^6.0.18",
     "@octokit/rest": "^18.0.9",
-    "amplify-app": "4.2.35",
     "chalk": "^4.1.1",
     "cloudform": "^4.2.0",
     "cloudform-types": "^4.2.0",

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -27,6 +27,7 @@
     "@aws-amplify/graphql-transformer-core": "0.17.5",
     "amplify-category-api-e2e-core": "4.0.1",
     "aws-amplify": "^4.2.8",
+    "amplify-app": "4.2.35",
     "aws-appsync": "^4.1.1",
     "aws-sdk": "^2.1113.0",
     "circleci-api": "^4.1.4",

--- a/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-setup.ts
+++ b/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-setup.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 
 const npm = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
-const amplifyAppBinPath = path.join(__dirname, '..', '..', '..', 'amplify-app', 'bin', 'amplify-app');
+const amplifyAppBinPath = path.join(__dirname, '..', '..', '..', '..', 'node_modules', 'amplify-app', 'bin', 'amplify-app');
 const spawnCommand = isCI() ? 'amplify-app' : amplifyAppBinPath;
 
 function amplifyAppAndroid(projRoot: string): Promise<void> {

--- a/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-setup.ts
+++ b/packages/amplify-e2e-tests/src/amplify-app-helpers/amplify-app-setup.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 
 const npm = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
-const amplifyAppBinPath = path.join(__dirname, '..', '..', '..', '..', 'node_modules', 'amplify-app', 'bin', 'amplify-app');
+const amplifyAppBinPath = path.join(__dirname, '..', '..', 'node_modules', '.bin', 'amplify-app');
 const spawnCommand = isCI() ? 'amplify-app' : amplifyAppBinPath;
 
 function amplifyAppAndroid(projRoot: string): Promise<void> {


### PR DESCRIPTION
#### Description of changes

Fix failing datastore modelgen e2e tests.
- datastore-modelgen.test.ts
- amplify-app.test.ts