### PR TITLE
chore: change flag name for PK properties

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/relations-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/relations-auth.test.ts
@@ -7,7 +7,7 @@ import { AuthTransformer } from '../graphql-auth-transformer';
 
 const featureFlags: FeatureFlagProvider = {
   getBoolean: (value: string): boolean => {
-    if (value === 'useFieldNameForPrimaryKeyConnectionField') {
+    if (value === 'respectPrimaryKeyAttributesOnConnectionField') {
       return true;
     }
     return false;

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-relations-with-custom-primary-key.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-relations-with-custom-primary-key.test.ts
@@ -6,10 +6,10 @@ import { BelongsToTransformer, HasManyTransformer, HasOneTransformer } from '..'
 import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const mockFeatureFlags = (useFieldNameForPrimaryKeyConnectionField: boolean) => ({
+const mockFeatureFlags = (respectPrimaryKeyAttributesOnConnectionField: boolean) => ({
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
-    if (name === 'useFieldNameForPrimaryKeyConnectionField') {
-      return useFieldNameForPrimaryKeyConnectionField;
+    if (name === 'respectPrimaryKeyAttributesOnConnectionField') {
+      return respectPrimaryKeyAttributesOnConnectionField;
     }
     return defaultValue;
   }),

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/test-helpers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/test-helpers.ts
@@ -5,7 +5,7 @@ import { FeatureFlagProvider } from '@aws-amplify/graphql-transformer-interfaces
  */
 export const featureFlags: FeatureFlagProvider = {
   getBoolean: (value: string, defaultValue: boolean): boolean => {
-    if (value === 'useFieldNameForPrimaryKeyConnectionField') {
+    if (value === 'respectPrimaryKeyAttributesOnConnectionField') {
       return false;
     }
     if (value === 'useSubUsernameForDefaultIdentityClaim') {

--- a/packages/amplify-graphql-relational-transformer/src/schema.ts
+++ b/packages/amplify-graphql-relational-transformer/src/schema.ts
@@ -548,7 +548,7 @@ export const getSortKeyFieldsNoContext = (object: ObjectTypeDefinitionNode | Obj
 };
 
 const getPrimaryKeyConnectionFieldType = (ctx: TransformerContextProvider, primaryKeyField: FieldDefinitionNode): string => (
-  ctx.featureFlags.getBoolean('useFieldNameForPrimaryKeyConnectionField') ? getBaseType(primaryKeyField.type) : 'ID'
+  ctx.featureFlags.getBoolean('respectPrimaryKeyAttributesOnConnectionField') ? getBaseType(primaryKeyField.type) : 'ID'
 );
 
 const updateInputWithConnectionFields = (

--- a/packages/amplify-graphql-relational-transformer/src/utils.ts
+++ b/packages/amplify-graphql-relational-transformer/src/utils.ts
@@ -175,7 +175,7 @@ function getIndexName(directive: DirectiveNode): string | undefined {
 }
 
 export function getConnectionAttributeName(featureFlags: FeatureFlagProvider, type: string, field: string, relatedTypeField: string) {
-  const nameSuffix = featureFlags.getBoolean('useFieldNameForPrimaryKeyConnectionField') ? relatedTypeField : 'id';
+  const nameSuffix = featureFlags.getBoolean('respectPrimaryKeyAttributesOnConnectionField') ? relatedTypeField : 'id';
   return toCamelCase([type, field, nameSuffix]);
 }
 

--- a/packages/amplify-util-mock/src/__e2e_v2__/model-relational-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e_v2__/model-relational-transformer.e2e.test.ts
@@ -59,7 +59,7 @@ describe('@model with relational transformer', () => {
               return true;
             }
 
-            if (featureName === 'useFieldNameForPrimaryKeyConnectionField') {
+            if (featureName === 'respectPrimaryKeyAttributesOnConnectionField') {
               return false;
             }
 

--- a/packages/amplify-util-mock/src/__e2e_v2__/model-relational-with-key-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e_v2__/model-relational-with-key-transformer.e2e.test.ts
@@ -81,7 +81,7 @@ describe('@model with relational transformers', () => {
               return true;
             }
 
-            if (featureName === 'useFieldNameForPrimaryKeyConnectionField') {
+            if (featureName === 'respectPrimaryKeyAttributesOnConnectionField') {
               return false;
             }
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/BelongsToTransformerV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/BelongsToTransformerV2.e2e.test.ts
@@ -11,7 +11,7 @@ describe('@belongsTo transformer', () => {
   const transformerFactory = () => new GraphQLTransform({
     featureFlags: {
       getBoolean: (value: string, defaultValue: boolean): boolean => {
-        if (value === 'useFieldNameForPrimaryKeyConnectionField') {
+        if (value === 'respectPrimaryKeyAttributesOnConnectionField') {
           return false;
         }
         return defaultValue;

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MapsToTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MapsToTransformer.e2e.test.ts
@@ -10,7 +10,7 @@ describe('@mapsTo transformer', () => {
     new GraphQLTransform({
       featureFlags: {
         getBoolean: (value: string, defaultValue: boolean): boolean => {
-          if (value === 'useFieldNameForPrimaryKeyConnectionField') {
+          if (value === 'respectPrimaryKeyAttributesOnConnectionField') {
             return false;
           }
           return defaultValue;


### PR DESCRIPTION
#### Description of changes
- changing feature flag as it's controlling more than just the PK connection field name
- CLI related PR: https://github.com/aws-amplify/amplify-cli/pull/10617/files
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
