### PR TITLE
Feature/data stream add aggregateSearch functionality, and tease out possible api a bit

### DIFF
--- a/projectdata/README.md
+++ b/projectdata/README.md
@@ -6,8 +6,9 @@ This is a CDK project which allows for quick reproduction of a test app which ca
 
 ### Pre-requisites
 
-1. CDK is installed.
+1. CDK is installed via `npm i -g aws-cdk`
 2. You have access to an aws account to deploy this stack into.
+3. This account has cdk enabled by running `cdk bootstrap` against the relevant account/region you plan to deploy into.
 
 ### Useful commands
 

--- a/projectdata/aggregate-poc/package.json
+++ b/projectdata/aggregate-poc/package.json
@@ -11,18 +11,18 @@
     "clean": "rimraf cdk.out node_modules package-lock.json"
   },
   "devDependencies": {
-    "rimraf": "^3.0.2",
     "@types/node": "10.17.27",
     "@types/prettier": "2.6.0",
     "aws-cdk": "2.28.1",
+    "rimraf": "^3.0.2",
     "ts-node": "^10.8.1",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.28.1",
     "@aws-cdk/aws-appsync-alpha": "^2.28.1-alpha.0",
+    "aws-cdk-lib": "2.28.1",
     "constructs": "^10.0.0",
-    "source-map-support": "^0.5.21",
-    "jszip": "^3.10.0"
+    "jszip": "^3.10.0",
+    "source-map-support": "^0.5.21"
   }
 }

--- a/projectdata/aggregate-poc/resources/lambda/benchmarkQueries/index.js
+++ b/projectdata/aggregate-poc/resources/lambda/benchmarkQueries/index.js
@@ -17,6 +17,10 @@ const AWS = require('aws-sdk');
 
 const docClient = new AWS.DynamoDB.DocumentClient();
 
+/**
+ * Example query which executes against the HashKey and SortKey for a given table.
+ * Only pulls COUNT.
+ */
 const queryItemCount = async ({
   year, letter1, letter2, LastKey,
 }) => {
@@ -47,17 +51,383 @@ const queryItemCount = async ({
 };
 
 /**
+ * Example query which executes against the HashKey and SortKey for a given table.
+ * Leverages a FilterExpression to additionally filter beyond the key space.
+ * Only pulls COUNT
+ */
+const queryItemCountWithFilter = async ({
+  year, letter1, letter2, minRunningTimeSecs, LastKey,
+}) => {
+  let count = 0;
+
+  const data = await docClient.query({
+    TableName: process.env.MOVIES_TABLE_NAME,
+    KeyConditionExpression: '#yr = :yyyy AND title between :letter1 and :letter2',
+    FilterExpression: 'info.running_time_secs >= :minRunningTimeSecs',
+    ExpressionAttributeNames: { '#yr': 'year' },
+    ExpressionAttributeValues: {
+      ':yyyy': year,
+      ':letter1': letter1,
+      ':letter2': letter2,
+      ':minRunningTimeSecs': minRunningTimeSecs,
+    },
+    Select: 'COUNT',
+    ...((LastKey !== 'undefined') ? { ExclusiveStartKey: LastKey } : {}),
+  }).promise();
+
+  count += data.Count ?? 0;
+
+  if (typeof data.LastEvaluatedKey !== 'undefined') {
+    count += await queryItemCountWithFilter({
+      year, letter1, letter2, minRunningTimeSecs, LastKey: data.LastEvaluatedKey,
+    });
+  }
+
+  return count;
+};
+
+/**
+ * Example query which executes against the HashKey and SortKey for a given table.
+ * Leverages a FilterExpression to additionally filter beyond the key space.
+ * Pulls COUNT, MIN, MAX, SUM for a fixed field.
+ */
+const queryItemAggregateMetadata = async ({
+  year, letter1, letter2, minRunningTimeSecs, fieldToAggregate, LastKey,
+}) => {
+  let count = 0;
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  let sum = 0;
+
+  const queryInput = {
+    TableName: process.env.MOVIES_TABLE_NAME,
+    KeyConditionExpression: '#yr = :yyyy AND title between :letter1 and :letter2',
+    FilterExpression: 'info.running_time_secs >= :minRunningTimeSecs',
+    ExpressionAttributeNames: { '#yr': 'year' },
+    ExpressionAttributeValues: {
+      ':yyyy': year,
+      ':letter1': letter1,
+      ':letter2': letter2,
+      ':minRunningTimeSecs': minRunningTimeSecs,
+    },
+    ProjectionExpression: fieldToAggregate,
+    Select: 'SPECIFIC_ATTRIBUTES',
+    ...((LastKey !== 'undefined') ? { ExclusiveStartKey: LastKey } : {}),
+  };
+
+  console.debug(`Generated Query: ${JSON.stringify(queryInput)}`);
+
+  const data = await docClient.query(queryInput).promise();
+
+  // TODO: Do this all in one pass.
+  // TODO: Parse out the field using `fieldToAggregate`
+  const runningTimes = data.Items.map(item => item.info.running_time_secs).filter(runtime => typeof runtime === 'number');
+  count += runningTimes.length;
+  sum += runningTimes.reduce((previousValue, currentValue) => previousValue + currentValue, 0);
+  min = Math.min(min, ...runningTimes);
+  max = Math.max(max, ...runningTimes);
+
+  if (typeof data.LastEvaluatedKey !== 'undefined') {
+    const recursiveResponse = await queryItemAggregateMetadata({
+      year, letter1, letter2, minRunningTimeSecs, fieldToAggregate, LastKey: data.LastEvaluatedKey,
+    });
+    count += recursiveResponse.count;
+    sum += recursiveResponse.sum;
+    min = Math.min(min, recursiveResponse.min);
+    max = Math.max(max, recursiveResponse.max);
+  }
+
+  return {
+    count, min, max, sum,
+  };
+};
+
+// TYPES
+// TODO: Support NOT, AND, OR, and NEQ for filterAttributes as well. https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Syntax
+// type ComparisonType = 'EQ' | 'LT' | 'LTE' | 'GT' | 'GTE' | 'BETWEEN' | 'BEGINS_WITH';
+
+// type PartitionKeyComparison = {
+//   fieldName: String,
+//   comparedValue: Number,
+// };
+
+// type Comparison = {
+//   fieldName: String,
+//   comparisonType: ComparisonType,
+//   comparedValue?: Number,
+//   rangeStart?: Number,
+//   rangeEnd?: Number,
+// };
+
+// type QueryProps = {
+//   tableName: String,
+//   partitionKeyComparison: PartitionKeyComparison,
+//   sortKeyComparison?: Comparison,
+//   filterComparisons?: Comparison[],
+//   aggregateField: String,
+//   lastKey: Any,
+// };
+
+/**
+ * Example query which executes against the HashKey and SortKey for a given table.
+ * Leverages a FilterExpression to additionally filter beyond the key space.
+ * Genericized Version of the previous implementation
+ * Pulls COUNT, MIN, MAX, SUM for a fixed field.
+ */
+// eslint-disable-next-line max-lines-per-function
+const queryItemAggregateMetadataGeneric = async ({
+  tableName: TableName,
+  partitionKeyComparison,
+  sortKeyComparison,
+  filterComparisons,
+  aggregateField: ProjectionExpression,
+  lastKey: LastKey,
+}) => {
+  let count = 0;
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  let sum = 0;
+
+  // TODO: This can be simplified into a map and between/all other cases.
+  // eslint-disable-next-line max-lines-per-function
+  const buildAliasedComparisonExpression = (comparisonAlias, comparison) => {
+    const {
+      fieldName, comparisonType, comparedValue, rangeStart, rangeEnd,
+    } = comparison;
+    if (comparisonType === 'BETWEEN') {
+      return {
+        expressionString: `#${comparisonAlias} BETWEEN :${comparisonAlias}Start AND :${comparisonAlias}End`,
+        expressionAttributeName: { [`#${comparisonAlias}`]: fieldName },
+        expressionAttributeValues: {
+          [`:${comparisonAlias}Start`]: rangeStart,
+          [`:${comparisonAlias}End`]: rangeEnd,
+        },
+      };
+    }
+
+    if (comparisonType === 'BEGINS_WITH') {
+      return {
+        expressionString: `begins_with( #${comparisonAlias}, :${comparisonAlias} )`,
+        expressionAttributeName: { [`#${comparisonAlias}`]: fieldName },
+        expressionAttributeValues: { [`:${comparisonAlias}`]: comparedValue },
+      };
+    }
+
+    const comparisonOperator = {
+      EQ: '=',
+      LT: '<',
+      LTE: '<=',
+      GT: '>',
+      GTE: '>=',
+    }[comparisonType];
+
+    if (fieldName.includes('.')) {
+      return {
+        expressionString: `${fieldName} ${comparisonOperator} :${comparisonAlias}`,
+        expressionAttributeName: {},
+        expressionAttributeValues: { [`:${comparisonAlias}`]: comparedValue },
+      };
+    }
+
+    return {
+      expressionString: `#${comparisonAlias} ${comparisonOperator} :${comparisonAlias}`,
+      expressionAttributeName: { [`#${comparisonAlias}`]: fieldName },
+      expressionAttributeValues: { [`:${comparisonAlias}`]: comparedValue },
+    };
+  };
+
+  const {
+    expressionString: pkExpressionString,
+    expressionAttributeName: pkExpressionAttributeName,
+    expressionAttributeValues: pkExpressionAttributeValues,
+  } = buildAliasedComparisonExpression('pk', { ...partitionKeyComparison, comparisonType: 'EQ' });
+  let KeyConditionExpression = pkExpressionString;
+  let ExpressionAttributeNames = { ...pkExpressionAttributeName };
+  let ExpressionAttributeValues = { ...pkExpressionAttributeValues };
+
+  if (sortKeyComparison) {
+    const { expressionString, expressionAttributeName, expressionAttributeValues } = buildAliasedComparisonExpression('sk', sortKeyComparison);
+    KeyConditionExpression = KeyConditionExpression.concat(` AND ${expressionString}`);
+    ExpressionAttributeNames = { ...ExpressionAttributeNames, ...expressionAttributeName };
+    ExpressionAttributeValues = { ...ExpressionAttributeValues, ...expressionAttributeValues };
+  }
+
+  let FilterExpression = null;
+  if (filterComparisons) {
+    FilterExpression = '';
+    filterComparisons.forEach((filterComparison, i) => {
+      const { expressionString, expressionAttributeName, expressionAttributeValues } = buildAliasedComparisonExpression(`filter${i}`, filterComparison);
+      if (FilterExpression === '') {
+        FilterExpression = expressionString;
+      } else {
+        FilterExpression = FilterExpression.concat(` AND ${expressionString}`);
+      }
+      ExpressionAttributeNames = { ...ExpressionAttributeNames, ...expressionAttributeName };
+      ExpressionAttributeValues = { ...ExpressionAttributeValues, ...expressionAttributeValues };
+    });
+  }
+
+  const queryInput = {
+    TableName,
+    KeyConditionExpression,
+    FilterExpression,
+    ExpressionAttributeNames,
+    ExpressionAttributeValues,
+    ProjectionExpression,
+    Select: 'SPECIFIC_ATTRIBUTES',
+    ...((LastKey !== 'undefined') ? { ExclusiveStartKey: LastKey } : {}),
+  };
+
+  console.debug(`Generated Query: ${JSON.stringify(queryInput)}`);
+
+  const data = await docClient.query(queryInput).promise();
+
+  // TODO: Support [] index based access https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.Attributes.html#Expressions.Attributes.NestedElements.DocumentPathExamples
+  const accessByDocumentPath = (item, path) => {
+    const pathParts = path.split('.');
+    let currentValue = item;
+    pathParts.forEach(pathPart => {
+      currentValue = currentValue[pathPart];
+    });
+    return currentValue;
+  };
+
+  // TODO: Do this all in one pass.
+  const aggregateValues = data.Items
+    .map(item => accessByDocumentPath(item, ProjectionExpression))
+    .filter(runtime => typeof runtime === 'number');
+  count += aggregateValues.length;
+  sum += aggregateValues.reduce((previousValue, currentValue) => previousValue + currentValue, 0);
+  min = Math.min(min, ...aggregateValues);
+  max = Math.max(max, ...aggregateValues);
+
+  if (typeof data.LastEvaluatedKey !== 'undefined') {
+    const recursiveResponse = await queryItemAggregateMetadata({
+      tableName: TableName,
+      partitionKeyComparison,
+      sortKeyComparison,
+      filterComparisons,
+      aggregateField: ProjectionExpression,
+      lastKey: data.LastEvaluatedKey,
+    });
+    count += recursiveResponse.count;
+    sum += recursiveResponse.sum;
+    min = Math.min(min, recursiveResponse.min);
+    max = Math.max(max, recursiveResponse.max);
+  }
+
+  return {
+    count, min, max, sum, average: sum / count,
+  };
+};
+
+const validateExpectedInputs = nameValPairs => {
+  nameValPairs.forEach(([name, val]) => {
+    if (!val) { throw new Error(`Expected ${name} to be provided in input`); }
+  });
+};
+
+/**
  * Entry point to the lambda function.
  */
+// eslint-disable-next-line max-lines-per-function
 exports.handler = async event => {
-  console.log(event);
+  console.debug(event);
 
-  const { year, letter1, letter2 } = event;
-  if (!year) { throw new Error('Expected year to be provided in input'); }
-  if (!letter1) { throw new Error('Expected letter1 to be provided in input'); }
-  if (!letter2) { throw new Error('Expected letter2 to be provided in input'); }
+  const { benchmarkType } = event;
 
-  const count = await queryItemCount({ year, letter1, letter2 });
-  console.log(`Got count ${count} for input: { year: ${year}, letter1: ${letter1}, letter2: ${letter2} }`);
-  return { count };
+  if (!benchmarkType) { throw new Error('Expected benchmarkType to be provided in input as either queryItemCount, queryItemCountWithFilter, queryItemAggregateMetadata, or queryItemAggregateMetadataGeneric'); }
+
+  if (benchmarkType === 'queryItemCount') {
+    const { year, letter1, letter2 } = event;
+    validateExpectedInputs([
+      ['year', year],
+      ['letter1', letter1],
+      ['letter2', letter2],
+    ]);
+    const count = await queryItemCount({ year, letter1, letter2 });
+    return { benchmarkType, ...event, count };
+  }
+
+  if (benchmarkType === 'queryItemCountWithFilter') {
+    const {
+      year, letter1, letter2, minRunningTimeSecs,
+    } = event;
+    validateExpectedInputs([
+      ['year', year],
+      ['letter1', letter1],
+      ['letter2', letter2],
+      ['minRunningTimeSecs', minRunningTimeSecs],
+    ]);
+    const count = await queryItemCountWithFilter({
+      year, letter1, letter2, minRunningTimeSecs,
+    });
+    return { benchmarkType, ...event, count };
+  }
+
+  if (benchmarkType === 'queryItemAggregateMetadata') {
+    const {
+      year, letter1, letter2, minRunningTimeSecs, fieldToAggregate,
+    } = event;
+    validateExpectedInputs([
+      ['year', year],
+      ['letter1', letter1],
+      ['letter2', letter2],
+      ['minRunningTimeSecs', minRunningTimeSecs],
+      ['fieldToAggregate', fieldToAggregate],
+    ]);
+    const aggregateMetadata = await queryItemAggregateMetadata({
+      year, letter1, letter2, minRunningTimeSecs, fieldToAggregate,
+    });
+    aggregateMetadata.average = aggregateMetadata.sum / aggregateMetadata.count;
+    return { benchmarkType, ...event, ...aggregateMetadata };
+  }
+
+  if (benchmarkType === 'queryItemAggregateMetadataGeneric') {
+    // TODO: Support Generic Input Mapping
+    const {
+      year, letter1, letter2, minRunningTimeSecs, fieldToAggregate,
+    } = event;
+    validateExpectedInputs([
+      ['year', year],
+      ['letter1', letter1],
+      ['letter2', letter2],
+      ['minRunningTimeSecs', minRunningTimeSecs],
+      ['fieldToAggregate', fieldToAggregate],
+    ]);
+    const aggregateMetadata = await queryItemAggregateMetadataGeneric({
+      year, letter1, letter2, minRunningTimeSecs, fieldToAggregate,
+    });
+    return { benchmarkType, ...event, ...aggregateMetadata };
+  }
+
+  if (benchmarkType === 'queryItemAggregateMetadataGenericFixedInput') {
+    const aggregateMetadata = await queryItemAggregateMetadataGeneric({
+      tableName: process.env.MOVIES_TABLE_NAME,
+      partitionKeyComparison: {
+        fieldName: 'year',
+        comparedValue: 2040,
+      },
+      sortKeyComparison: {
+        fieldName: 'title',
+        comparisonType: 'BETWEEN',
+        rangeStart: 'A',
+        rangeEnd: 'Z',
+      },
+      filterComparisons: [{
+        fieldName: 'info.running_time_secs',
+        comparisonType: 'GTE',
+        comparedValue: 5400,
+      }],
+      aggregateField: 'info.running_time_secs',
+    });
+    return { benchmarkType, ...event, ...aggregateMetadata };
+  }
+
+  throw new Error('Something went wrong');
 };
+
+// Gotchas so far, filter expressions with dots are kind of weird
+// it's not obvious yet how to generically support either names w/ a dot in them (which need) to go into a keyExpressionAlias,
+// or those which are nested, and need to be referenced directly. It may be a non-issue, since I'm not sure we support dot-names in gql.
+// Additionally, this only supports numbers today, not sure if that's something we need to break longer term.

--- a/projectdata/aggregate-poc/resources/lambda/eventBusDemo/index.js
+++ b/projectdata/aggregate-poc/resources/lambda/eventBusDemo/index.js
@@ -1,0 +1,39 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type, spellcheck/spell-checker */
+/* eslint-disable import/no-extraneous-dependencies, @typescript-eslint/no-var-requires, no-console */
+// const AWSXRay = require('aws-xray-sdk');
+// const AWS = AWSXRay.captureAWS(require('aws-sdk'));
+const AWS = require('aws-sdk');
+
+const EventBusName = process.env.EVENT_BUS_NAME;
+
+const eventBridge = new AWS.EventBridge();
+
+/**
+ * Triggers a bus event.
+ */
+exports.trigger = async event => {
+  console.debug(event);
+  const response = await eventBridge.putEvents({
+    Entries: [{
+      // Event envelope fields
+      Source: 'custom.myATMapp',
+      EventBusName,
+      DetailType: 'transaction',
+      Time: new Date(),
+
+      // Main event body
+      Detail: JSON.stringify({
+        message: event.arguments.message,
+      }),
+    }],
+  }).promise();
+  return response.Entries[0].EventId;
+};
+
+/**
+ * Responds to a matched bus event.
+ */
+exports.respond = event => {
+  console.debug(event);
+  return event;
+};

--- a/projectdata/aggregate-poc/resources/resolver/movieAggregateSearch.req.vtl
+++ b/projectdata/aggregate-poc/resources/resolver/movieAggregateSearch.req.vtl
@@ -1,0 +1,8 @@
+#set( $myMap = $util.map.copyAndRemoveAllKeys($context.arguments, []) )
+$util.qr( $myMap.put("tableName", "AggregateStack-MoviesTable0F76A3E4-1KWQ8OUBZCCL1") )
+
+{
+  "version" : "2017-02-28",
+  "operation": "Invoke",
+  "payload": $util.toJson($myMap)
+}

--- a/projectdata/aggregate-poc/resources/resolver/movieAggregateSearch.res.vtl
+++ b/projectdata/aggregate-poc/resources/resolver/movieAggregateSearch.res.vtl
@@ -1,0 +1,6 @@
+## Raise a GraphQL field error in case of a datasource invocation error
+#if($ctx.error)
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
+
+$util.toJson($context.result)

--- a/projectdata/aggregate-poc/resources/schema/schema.graphql
+++ b/projectdata/aggregate-poc/resources/schema/schema.graphql
@@ -13,6 +13,7 @@ type Movie {
 
 type Mutation {
 	putMovie(year: Int!, title: String!, info: String): Movie
+	triggerEvent(message: String!): String
 }
 
 type Query {

--- a/projectdata/aggregate-poc/resources/schema/schema.graphql
+++ b/projectdata/aggregate-poc/resources/schema/schema.graphql
@@ -1,8 +1,32 @@
 type Aggregate {
 	count: Int
-	min: Int
-	max: Int
-	sum: Int
+	min: Float
+	max: Float
+	sum: Float
+	average: Float
+}
+
+enum ComparisonType {
+	EQ
+	LT
+	LTE
+	GT
+	GTE
+	BETWEEN
+	BEGINS_WITH
+}
+
+input PartitionKeyComparison {
+	fieldName: String!
+	comparedValue: Int!
+}
+
+input Comparison {
+	fieldName: String!
+	comparisonType: ComparisonType!
+	comparedValue: Int
+	rangeStart: Int
+	rangeEnd: Int
 }
 
 type Movie {
@@ -19,6 +43,12 @@ type Mutation {
 type Query {
 	moviesByYearLetter(year: Int!, letter1: String!, letter2: String!): [Movie]
 	count_moviesByYearLetter(model: String!, queryExpression: String!): Aggregate
+	movieAggregateSearch(
+		aggregateField: String!,
+		partitionKeyComparison: PartitionKeyComparison!,
+		sortKeyComparison: Comparison,
+		filterComparisons: [Comparison]
+	): Aggregate
 }
 
 schema {

--- a/projectdata/aggregate-poc/src/stacks/aggregate-stack.ts
+++ b/projectdata/aggregate-poc/src/stacks/aggregate-stack.ts
@@ -63,6 +63,14 @@ export class AggregateStack extends Stack {
       tracing: lambda.Tracing.ACTIVE,
     });
 
+    const aggregateSearchFunction = new lambda.Function(this, 'AggregateSearch', {
+      runtime: lambda.Runtime.NODEJS_16_X,
+      code: getLambdaCode('aggregateSearch'),
+      handler: 'index.handler',
+      timeout: Duration.seconds(10),
+      tracing: lambda.Tracing.ACTIVE,
+    });
+
     // Generate Lambdas for populating and querying mock data
     const generateMockDataFunction = new lambda.Function(this, 'GenerateMockData', {
       runtime: lambda.Runtime.NODEJS_16_X,
@@ -127,6 +135,7 @@ export class AggregateStack extends Stack {
     const aggregatesDataSource = api.addDynamoDbDataSource('AggregatesDataSource', aggregatesTable);
     const computeAggregatesDataSource = api.addLambdaDataSource('ComputeAggregatesDataSource', computeAggregatesFunction);
     const triggerEventDataSource = api.addLambdaDataSource('TriggereEventDataSource', triggerEventBus);
+    const aggregateSearchDataSource = api.addLambdaDataSource('AggregateSearchDataSource', aggregateSearchFunction);
     
     moviesDataSource.createResolver({
       typeName: 'Query',
@@ -140,6 +149,13 @@ export class AggregateStack extends Stack {
       fieldName: 'count_moviesByYearLetter',
       requestMappingTemplate: getMappingTemplate('count_moviesByYearLetter.req.vtl'),
       responseMappingTemplate: getMappingTemplate('count_moviesByYearLetter.res.vtl'),
+    });
+
+    aggregateSearchDataSource.createResolver({
+      typeName: 'Query',
+      fieldName: 'movieAggregateSearch',
+      requestMappingTemplate: getMappingTemplate('movieAggregateSearch.req.vtl'),
+      responseMappingTemplate: getMappingTemplate('movieAggregateSearch.res.vtl'),
     });
 
     api.createResolver({
@@ -174,6 +190,7 @@ export class AggregateStack extends Stack {
     moviesTable.grantReadWriteData(moviesDataSource);
     moviesTable.grantWriteData(generateMockDataFunction);
     moviesTable.grantReadData(benchmarkQueriesFunction);
+    moviesTable.grantReadData(aggregateSearchFunction);
     aggregatesTable.grantReadWriteData(computeAggregatesFunction);
     aggregatesTable.grantReadWriteData(computeAggregatesDataSource);
     aggregatesTable.grantReadWriteData(aggregatesDataSource);

--- a/projectdata/aggregate-poc/src/stacks/aggregate-stack.ts
+++ b/projectdata/aggregate-poc/src/stacks/aggregate-stack.ts
@@ -1,10 +1,14 @@
 /* eslint-disable */
-import { Duration, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
+import { Duration, RemovalPolicy, Stack, StackProps, Token } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as appsync from '@aws-cdk/aws-appsync-alpha';
 import * as path from 'path';
+import * as eventbridge from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
+import { MappingTemplate } from '@aws-cdk/aws-appsync-alpha';
 
 /**
  * Helpers to compute resource files into cdk objects.
@@ -56,6 +60,7 @@ export class AggregateStack extends Stack {
         MOVIES_TABLE_NAME: moviesTable.tableName,
       },
       timeout: Duration.seconds(10),
+      tracing: lambda.Tracing.ACTIVE,
     });
 
     // Generate Lambdas for populating and querying mock data
@@ -67,6 +72,7 @@ export class AggregateStack extends Stack {
         MOVIES_TABLE_NAME: moviesTable.tableName,
       },
       timeout: Duration.minutes(15),
+      tracing: lambda.Tracing.ACTIVE,
     });
 
     const benchmarkQueriesFunction = new lambda.Function(this, 'BenchmarkQueries', {
@@ -77,12 +83,50 @@ export class AggregateStack extends Stack {
         MOVIES_TABLE_NAME: moviesTable.tableName,
       },
       timeout: Duration.seconds(10),
+      tracing: lambda.Tracing.ACTIVE,
+    });
+
+    // Generate EventBridge to connect things together
+    const eventBus = new eventbridge.EventBus(this, 'AggregateEventBus');
+    
+    const triggerEventBus = new lambda.Function(this, 'TriggerBusEvent', {
+      runtime: lambda.Runtime.NODEJS_16_X,
+      code: getLambdaCode('eventBusDemo'),
+      handler: 'index.trigger',
+      environment: {
+        EVENT_BUS_NAME: eventBus.eventBusName,
+      },
+      tracing: lambda.Tracing.ACTIVE,
+    });
+
+    eventBus.grantPutEventsTo(triggerEventBus);
+
+    const respondToEventBus = new lambda.Function(this, 'RespondToEventBus', {
+      runtime: lambda.Runtime.NODEJS_16_X,
+      code: getLambdaCode('eventBusDemo'),
+      handler: 'index.respond',
+      environment: {
+        EVENT_BUS_NAME: eventBus.eventBusName,
+      },
+      tracing: lambda.Tracing.ACTIVE,
+    });
+
+    const eventDlq = new sqs.Queue(this, 'RespondToEventBusDlq');
+
+    new eventbridge.Rule(this, 'TriggerLambda', {
+      eventPattern: { source: ['custom.myATMapp'] },
+      targets: [new targets.LambdaFunction(respondToEventBus, {
+        deadLetterQueue: eventDlq,
+        retryAttempts: 3,
+      })],
+      eventBus,
     });
 
     // Generate Resolvers and DataSources to configure the API
     const moviesDataSource = api.addDynamoDbDataSource('MoviesDataSource', moviesTable);
     const aggregatesDataSource = api.addDynamoDbDataSource('AggregatesDataSource', aggregatesTable);
     const computeAggregatesDataSource = api.addLambdaDataSource('ComputeAggregatesDataSource', computeAggregatesFunction);
+    const triggerEventDataSource = api.addLambdaDataSource('TriggereEventDataSource', triggerEventBus);
     
     moviesDataSource.createResolver({
       typeName: 'Query',
@@ -115,6 +159,13 @@ export class AggregateStack extends Stack {
       ],
       requestMappingTemplate: getMappingTemplate('putMovie.before.vtl'),
       responseMappingTemplate: getMappingTemplate('putMovie.after.vtl'),
+    });
+
+    triggerEventDataSource.createResolver({
+      typeName: 'Mutation',
+      fieldName: 'triggerEvent',
+      requestMappingTemplate: MappingTemplate.lambdaRequest(),
+      responseMappingTemplate: MappingTemplate.lambdaResult(),
     });
 
     // Grant Access between components


### PR DESCRIPTION
#### Description of changes
Adding a new lambda which can perform more generalized queries against a table, and produce aggregates for min/max/sum/count/avg

A few example queries made through appsync

```graphql
query SimpleQuery {
  movieAggregateSearch(
    aggregateField: "info.running_time_secs"
    partitionKeyComparison: {comparedValue: 2040, fieldName: "year"}
    filterComparisons: {comparedValue: 5400, comparisonType: GT, fieldName: "info.running_time_secs"}
  ) {
    count
    max
    min
    sum
    average
  }
}

query MidRatedMovies {
  movieAggregateSearch(
    aggregateField: "info.running_time_secs"
    partitionKeyComparison: {
      comparedValue: 2040
      fieldName: "year"
    }
    filterComparisons: [
      {
      	comparedValue: 5400
      	comparisonType: GT
      	fieldName: "info.running_time_secs"
    	}
      {
        rangeStart: 5
        rangeEnd: 7
      	comparisonType: BETWEEN
      	fieldName: "info.rating"
      }
    ]
  ) {
    count
    max
    min
    sum
    average
  }
}
```

#### Issue #, if available
N/A

#### Description of how you validated changes
Manually running queries, using `benchmarkQueries` lambda with different inputs to test out functionality.
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
