### PR TITLE
chore: improve error messaging if an invalid boolean sort key is provided to @index

### DIFF
--- a/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
@@ -874,20 +874,7 @@ test('validate resolver code', () => {
     }`;
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
-    featureFlags: {
-      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
-        if (name === 'secondaryKeyAsGSI') {
-          return true;
-        }
-        if (name === 'useSubUsernameForDefaultIdentityClaim') {
-          return true;
-        }
-        return defaultValue;
-      }),
-      getNumber: jest.fn(),
-      getObject: jest.fn(),
-      getString: jest.fn(),
-    },
+    featureFlags: generateFeatureFlagWithBooleanOverrides({ secondaryKeyAsGSI: true, useSubUsernameForDefaultIdentityClaim: true }),
   });
   const out = transformer.transform(inputSchema);
   expect(out).toBeDefined();
@@ -916,17 +903,7 @@ it('@model mutation with user defined null args', () => {
     }`;
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
-    featureFlags: {
-      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
-        if (name === 'useSubUsernameForDefaultIdentityClaim') {
-          return true;
-        }
-        return defaultValue;
-      }),
-      getNumber: jest.fn(),
-      getObject: jest.fn(),
-      getString: jest.fn(),
-    },
+    featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
   });
   const out = transformer.transform(inputSchema);
   expect(out).toBeDefined();
@@ -960,17 +937,7 @@ it('@model mutation with user defined create args', () => {
     }`;
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
-    featureFlags: {
-      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
-        if (name === 'useSubUsernameForDefaultIdentityClaim') {
-          return true;
-        }
-        return defaultValue;
-      }),
-      getNumber: jest.fn(),
-      getObject: jest.fn(),
-      getString: jest.fn(),
-    },
+    featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
   });
   const out = transformer.transform(inputSchema);
   expect(out).toBeDefined();
@@ -1004,17 +971,7 @@ it('@model mutation with default', () => {
     }`;
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
-    featureFlags: {
-      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
-        if (name === 'useSubUsernameForDefaultIdentityClaim') {
-          return true;
-        }
-        return defaultValue;
-      }),
-      getNumber: jest.fn(),
-      getObject: jest.fn(),
-      getString: jest.fn(),
-    },
+    featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
   });
   const out = transformer.transform(inputSchema);
   expect(out).toBeDefined();
@@ -1056,17 +1013,7 @@ it('@model mutation with queries', () => {
     }`;
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
-    featureFlags: {
-      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
-        if (name === 'useSubUsernameForDefaultIdentityClaim') {
-          return true;
-        }
-        return defaultValue;
-      }),
-      getNumber: jest.fn(),
-      getObject: jest.fn(),
-      getString: jest.fn(),
-    },
+    featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
   });
   const out = transformer.transform(inputSchema);
   expect(out).toBeDefined();
@@ -1108,17 +1055,7 @@ it('id field should be optional in updateInputObjects when it is not a primary k
   `;
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
-    featureFlags: {
-      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
-        if (name === 'useSubUsernameForDefaultIdentityClaim') {
-          return true;
-        }
-        return defaultValue;
-      }),
-      getNumber: jest.fn(),
-      getObject: jest.fn(),
-      getString: jest.fn(),
-    },
+    featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
   });
   const out = transformer.transform(inputSchema);
   expect(out).toBeDefined();
@@ -1149,17 +1086,7 @@ test('GSI composite sort keys are wrapped in conditional to check presence in mu
   `;
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
-    featureFlags: {
-      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
-        if (name === 'useSubUsernameForDefaultIdentityClaim') {
-          return true;
-        }
-        return defaultValue;
-      }),
-      getNumber: jest.fn(),
-      getObject: jest.fn(),
-      getString: jest.fn(),
-    },
+    featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
   });
   const out = transformer.transform(inputSchema);
   expect(out).toBeDefined();
@@ -1193,17 +1120,7 @@ it('should support index/primary key with sync resolvers', () => {
     resolverConfig: {
       project: config,
     },
-    featureFlags: {
-      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
-        if (name === 'useSubUsernameForDefaultIdentityClaim') {
-          return true;
-        }
-        return defaultValue;
-      }),
-      getNumber: jest.fn(),
-      getObject: jest.fn(),
-      getString: jest.fn(),
-    },
+    featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
   });
 
   const out = transformer.transform(validSchema);
@@ -1225,23 +1142,30 @@ test('LSI creation regression test', () => {
 
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new IndexTransformer(), new PrimaryKeyTransformer()],
-    featureFlags: {
-      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
-        if (name === 'useSubUsernameForDefaultIdentityClaim') {
-          return true;
-        }
-        return defaultValue;
-      }),
-      getNumber: jest.fn(),
-      getObject: jest.fn(),
-      getString: jest.fn(),
-    },
+    featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
   });
 
   const out = transformer.transform(inputSchema);
   expect(out).toBeDefined();
   const schema = parse(out.schema);
   validateModelSchema(schema);
+});
+
+test('it throws an understandable error on boolean sort keys', () => {
+  const inputSchema = `
+  type Test @model {
+    taskID: ID! @index(sortKeyFields: ["completed"])
+    completed: Boolean!
+  }`;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new ModelTransformer(), new IndexTransformer(), new PrimaryKeyTransformer()],
+    featureFlags: generateFeatureFlagWithBooleanOverrides({ enableAutoIndexQueryNames: true }),
+  });
+
+  expect(() => {
+    transformer.transform(inputSchema);
+  }).toThrowErrorMatchingInlineSnapshot('"Sort Key Condition could not be constructed for field \'completed\'"');
 });
 
 describe('automatic name generation', () => {

--- a/packages/amplify-graphql-index-transformer/src/schema.ts
+++ b/packages/amplify-graphql-index-transformer/src/schema.ts
@@ -35,6 +35,7 @@ import {
 } from 'graphql-transformer-common';
 import { IndexDirectiveConfiguration, PrimaryKeyDirectiveConfiguration } from './types';
 import { lookupResolverName } from './utils';
+import { InvalidDirectiveError } from '@aws-amplify/graphql-transformer-core';
 
 export function addKeyConditionInputs(
   config: PrimaryKeyDirectiveConfiguration | IndexDirectiveConfiguration,
@@ -64,7 +65,9 @@ export function addKeyConditionInputs(
       return resolvedEnumType ? 'String' : undefined;
     };
     const sortKeyConditionInput = makeScalarKeyConditionForType(sortKeyField.type, typeResolver as (baseType: string) => string);
-    assert(sortKeyConditionInput);
+    if (sortKeyConditionInput === undefined) {
+      throw new InvalidDirectiveError(`Sort Key Condition could not be constructed for field '${sortKeyField.name.value}'`);
+    }
 
     if (!ctx.output.getType(sortKeyConditionInput.name.value)) {
       ctx.output.addInput(sortKeyConditionInput);


### PR DESCRIPTION
#### Description of changes
We have a bunch of bare `assert`s in our code, which can lead to poor UX for errors. This addresses one which we'd identified, but there are more, and we should instead be writing custom validation/error logic since assert doesn't play nicely once you have tests for failure, and they don't default to user-friendly messaging. I've created a backlog item to fix the rest of these occurrences.

#### Issue #, if available
https://github.com/aws-amplify/amplify-category-api/issues/498

#### Description of how you validated changes
Validated that I get a more readable error given the repro from Josef, and added a unit test to cover this case.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
