### PR TITLE
Support credentials for lambda client

### DIFF
--- a/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py
+++ b/packages/graphql-elasticsearch-transformer/scripts/ddb_to_es.py
@@ -30,7 +30,13 @@ def main():
     args.ak = args.ak or credentials.access_key
     args.st = args.st or credentials.token
 
-  client = boto3.client('lambda', region_name=args.rn)
+  session = Session(
+    aws_access_key_id=args.ak,
+    aws_secret_access_key=args.sk,
+    aws_session_token=args.st,
+    region_name=args.rn,
+  )
+  client = session.client('lambda', region_name=args.rn)
   import_dynamodb_items_to_es(args.tn, args.sk, args.ak, args.st, args.rn, args.esarn, args.lf, scan_limit)
 
 def import_dynamodb_items_to_es(table_name, aws_secret, aws_access, aws_token, aws_region, event_source_arn, lambda_f, scan_limit):


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Support credentials for lambda client on backfill script `ddb_to_es.py`

Without this changes, the script fails when locally executing it with the arguments:
```bash
python3 ddb_to_es.py \
  --rn 'us-west-2' \
  --tn 'Post-XXXX-dev' \
  --lf 'arn:aws:lambda:us-west-2:123456789xxx:function:DdbToEsFn-<api__id>-dev' \
  --esarn 'arn:aws:dynamodb:us-west-2:123456789xxx:table/Post-<api__id>-dev/stream/2019-20-03T00:00:00.350' \
  --ak 'XXX' \
  --sk 'XXX' \
  --st 'XXX'
  ```

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Running the script against a dev environment (wasn't able to run `yarn test` since the dev setup `yarn setup-dev` was failing)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

####NOTES
This code has been moved from a different repository, here the link to the original PR https://github.com/aws-amplify/amplify-cli/pull/9658