### PR TITLE
fix: update api should allow setting NEW lambda conflict resolver

### DIFF
--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cfn-api-artifact-handler.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cfn-api-artifact-handler.test.ts
@@ -357,4 +357,36 @@ describe('update artifacts', () => {
       },
     ]);
   });
+
+  it('correctly updates the cli-inputs on an update that sets a NEW lambda for conflict resolution', async () =>{
+    jest.spyOn(AppsyncApiInputState.prototype, 'saveCLIInputPayload');
+    jest.spyOn(AppsyncApiInputState.prototype, 'cliInputFileExists').mockReturnValueOnce(true);
+
+    updateRequestStub.serviceModification.conflictResolution = {
+      defaultResolutionStrategy: {
+        type: 'LAMBDA',
+        resolver: {
+          type: 'NEW',
+        },
+      },
+    };
+
+    await cfnApiArtifactHandler.updateArtifacts(updateRequestStub);
+
+    const { objectContaining, stringContaining } = expect;
+
+    expect(AppsyncApiInputState.prototype.saveCLIInputPayload).toHaveBeenCalledWith(objectContaining({
+      serviceConfiguration: objectContaining({
+        conflictResolution: {
+          defaultResolutionStrategy: {
+            type: 'LAMBDA',
+            resolver: {
+              type: 'EXISTING',
+              name: stringContaining('syncConflictHandler'),
+            },
+          },
+        },
+      }),
+    }));
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,13 +54,13 @@
     ora "^4.0.3"
     uuid "^8.3.2"
 
-"@aws-amplify/analytics@5.2.12":
-  version "5.2.12"
-  resolved "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-5.2.12.tgz#32ccd0ee5c43c221d1ac9664966e3e6553a50d92"
-  integrity sha512-sA79p2+llnX6bwskcA2YUzZFh4oALpS0OfSTsHdyURKg7tn3UGwxKHCSp181YS0uRe1Pgf1qpLqzc6uM1PAG5g==
+"@aws-amplify/analytics@5.2.13":
+  version "5.2.13"
+  resolved "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-5.2.13.tgz#dd36a95a7193f1d8c4a89832c848cf874f1856f1"
+  integrity sha512-bnQOo3tdjZPT3Vq156YODmdjT+52mR8eX1fpJQaJjAeVKQxig1V7Oo9VDFQyUlyt585e5cAXKmYH8xrI8PeNqw==
   dependencies:
-    "@aws-amplify/cache" "4.0.47"
-    "@aws-amplify/core" "4.5.9"
+    "@aws-amplify/cache" "4.0.48"
+    "@aws-amplify/core" "4.5.10"
     "@aws-sdk/client-firehose" "3.6.1"
     "@aws-sdk/client-kinesis" "3.6.1"
     "@aws-sdk/client-personalize-events" "3.6.1"
@@ -69,40 +69,40 @@
     lodash "^4.17.20"
     uuid "^3.2.1"
 
-"@aws-amplify/api-graphql@2.3.9":
-  version "2.3.9"
-  resolved "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-2.3.9.tgz#6e2d0cd3a11002b105c8953ccfd3a2f10a0593a3"
-  integrity sha512-UK3NjTIDfH0SrD/lEQQaXZPo3i8cfbcDmNDIoal1cz7K2aAxTH82QAWqyB/YrDmx94sjlCB2PUZLqED0i/c8PA==
+"@aws-amplify/api-graphql@2.3.10":
+  version "2.3.10"
+  resolved "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-2.3.10.tgz#0fa136e95443c14f18dc26342082313fc10df9bc"
+  integrity sha512-4XePAjnKXCKch0pLKOTY8QbhaN3O6jDolMnwPqPHzqA+viJXTeWWVXdxiHvuphWGMjbhijRSIneax6WCs9msYw==
   dependencies:
-    "@aws-amplify/api-rest" "2.0.45"
-    "@aws-amplify/auth" "4.5.9"
-    "@aws-amplify/cache" "4.0.47"
-    "@aws-amplify/core" "4.5.9"
-    "@aws-amplify/pubsub" "4.4.6"
+    "@aws-amplify/api-rest" "2.0.46"
+    "@aws-amplify/auth" "4.5.10"
+    "@aws-amplify/cache" "4.0.48"
+    "@aws-amplify/core" "4.5.10"
+    "@aws-amplify/pubsub" "4.4.7"
     graphql "15.8.0"
     uuid "^3.2.1"
     zen-observable-ts "0.8.19"
 
-"@aws-amplify/api-rest@2.0.45":
-  version "2.0.45"
-  resolved "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-2.0.45.tgz#11f94b05021a5077570d966682da039ec0cf751f"
-  integrity sha512-Mw2Bn2YzKVrolNBWLHTyJlEWV6UpFLbA7d2xnZcEMX0LGEx1Qz7s4+52hnGJpF6yZZC3kNw6scQpSFsZXSd4JA==
+"@aws-amplify/api-rest@2.0.46":
+  version "2.0.46"
+  resolved "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-2.0.46.tgz#68a636c0629f22c0ded626d32969c270691909a2"
+  integrity sha512-+I4aGz71nwTjeeOJj9/rdTiFXIYqmRktYCijsaMDSeEuQsuC4xDFOCLFMntJeVeHSsPDvjyiCVyvEIefJwoT8Q==
   dependencies:
-    "@aws-amplify/core" "4.5.9"
+    "@aws-amplify/core" "4.5.10"
     axios "0.26.0"
 
-"@aws-amplify/api@4.0.45":
-  version "4.0.45"
-  resolved "https://registry.npmjs.org/@aws-amplify/api/-/api-4.0.45.tgz#f63fc1ba3b5ea6ada31b3cdecddc8b3bfcc6ab74"
-  integrity sha512-T8tiu1V2wwVjtkpGnntmAuAUJKdNCQYWNoa0tiZdb2VVrlfSLBhJrmJsZgb6Pg4f2umOdrSIBGrVLWgrYGNu6g==
+"@aws-amplify/api@4.0.46":
+  version "4.0.46"
+  resolved "https://registry.npmjs.org/@aws-amplify/api/-/api-4.0.46.tgz#5079ed0eec620bc157ba8b73c7852119830744e9"
+  integrity sha512-ajJFkveMt8/nkPt8hrU/VUUQ5DJywQkwWVdmEWKTZ/t9PVTCqUzQO/4MuqzM8WhtCG39mdcL978zyfycxjFHVQ==
   dependencies:
-    "@aws-amplify/api-graphql" "2.3.9"
-    "@aws-amplify/api-rest" "2.0.45"
+    "@aws-amplify/api-graphql" "2.3.10"
+    "@aws-amplify/api-rest" "2.0.46"
 
-"@aws-amplify/appsync-modelgen-plugin@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.0.1.tgz#b47832bf3fb96041b121ccb2c8a80db06a633854"
-  integrity sha512-TmZu6fbe/fNarUe5dQzxWb80Br/6dtXKNtwcUUbe++yHAV4psUJTYs2sjtq0GsNCeb9AJQ8IeDVFBWWEvFoE/g==
+"@aws-amplify/appsync-modelgen-plugin@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.0.2.tgz#342426b55aa2d266a0969dc0edf494c672c34cc6"
+  integrity sha512-e4hdKXjFhfrVsvBD4jyZ8B6IGsc2pTfpYycCBmiD7M3/7IezG5cbDk58dGwr+Z+E66APJKdpXrRWFsbQ6aUlUw==
   dependencies:
     "@graphql-codegen/plugin-helpers" "^1.18.8"
     "@graphql-codegen/visitor-plugin-common" "^1.22.0"
@@ -117,22 +117,22 @@
     strip-indent "^3.0.0"
     ts-dedent "^1.1.0"
 
-"@aws-amplify/auth@4.5.9":
-  version "4.5.9"
-  resolved "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.5.9.tgz#5ecf8a6ba239e2fec3c98d21550dedbd7798d8f0"
-  integrity sha512-XufqVR+nW5VG/hUSkOpgWne8L3iC9T+2ntA8oU5mj+DJi169tamQXWIlpfG3R1ncz8DB2kYM+AnZZUhSJDhrFQ==
+"@aws-amplify/auth@4.5.10":
+  version "4.5.10"
+  resolved "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.5.10.tgz#b8eb44ef2e557684b0c01e2271d42f51ab0919d4"
+  integrity sha512-G3p5nuFRZKoX4/5s9NSE+x3g0vmjkPhMjh3Gimzofvw8mn91YUUyQ1BfFvyfIKXUfAPZg22oIlm0V7N2fP8abA==
   dependencies:
-    "@aws-amplify/cache" "4.0.47"
-    "@aws-amplify/core" "4.5.9"
+    "@aws-amplify/cache" "4.0.48"
+    "@aws-amplify/core" "4.5.10"
     amazon-cognito-identity-js "5.2.10"
     crypto-js "^4.1.1"
 
-"@aws-amplify/cache@4.0.47":
-  version "4.0.47"
-  resolved "https://registry.npmjs.org/@aws-amplify/cache/-/cache-4.0.47.tgz#35fa68c77f488d73006633ecdc5016e5e117a0ec"
-  integrity sha512-XVHtZFIo9nkamCR8+mBY3K9N5fjM6aQwwycWxG6pUa3B9AWUhJbUrDE5LpW9BsDc8/wqQsHyM8P52BNK5AgQNg==
+"@aws-amplify/cache@4.0.48":
+  version "4.0.48"
+  resolved "https://registry.npmjs.org/@aws-amplify/cache/-/cache-4.0.48.tgz#8ec77458876da7a63d2e34afd081f6b811c1ae0a"
+  integrity sha512-WXW4K1rf3iBV6c6C+QutPj5ZuOH4osd3R7EIdK1/k8+KMlCsnp9DkhKpSH8OxOhVy6n/QgPsGhPEKHbix6E6Eg==
   dependencies:
-    "@aws-amplify/core" "4.5.9"
+    "@aws-amplify/core" "4.5.10"
 
 "@aws-amplify/cli-extensibility-helper@2.3.32":
   version "2.3.32"
@@ -152,10 +152,10 @@
     amplify-cli-core "2.11.0"
     amplify-prompts "2.2.0"
 
-"@aws-amplify/core@4.5.9":
-  version "4.5.9"
-  resolved "https://registry.npmjs.org/@aws-amplify/core/-/core-4.5.9.tgz#0c43abee404fe7b818b113691ae6f9eaab3fd5c8"
-  integrity sha512-MCVbhpHvxwSNL9FkdUfpeBzXR/x3RC2NbYfENgxEKx/dCxWjehr84podf3LRT5wSJXlPLHjpPK6Ob3rhlKk23Q==
+"@aws-amplify/core@4.5.10":
+  version "4.5.10"
+  resolved "https://registry.npmjs.org/@aws-amplify/core/-/core-4.5.10.tgz#219c6da8fa9326d98abc77e00e8e72ac9d8a0711"
+  integrity sha512-iXlNRsGWzDoRLx+e0JntiAJwQKMy7QmvIuaVPLe2vPGltuMXqvEHg5Re8yUnwB923OrAGctylCD7UDomco2w7w==
   dependencies:
     "@aws-crypto/sha256-js" "1.0.0-alpha.0"
     "@aws-sdk/client-cloudwatch-logs" "3.6.1"
@@ -175,15 +175,15 @@
     url "^0.11.0"
     zen-observable "^0.8.6"
 
-"@aws-amplify/datastore@3.12.2":
-  version "3.12.2"
-  resolved "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.12.2.tgz#991577f57dbf98547a75991cea7ea9820a226e8d"
-  integrity sha512-q9Rt//Hjde/9LWy2f7sMfauL64qwyU6GVKdaGvgVehpOp4L91XAp25xofxByCqPyyOhuiQ0mjrdp6pEpuMlHrQ==
+"@aws-amplify/datastore@3.12.3":
+  version "3.12.3"
+  resolved "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.12.3.tgz#9c01d6c8db01a353e6c3700093fa4f40d07ea9d8"
+  integrity sha512-wPMrbX0ojZHxhZG2QAgvC7ZZLsO4Daz9VjaMt5AzLmtpKntsaIpKu2eklaQtFYyKkDrEaqjO2wKs+ETWfSdF3A==
   dependencies:
-    "@aws-amplify/api" "4.0.45"
-    "@aws-amplify/auth" "4.5.9"
-    "@aws-amplify/core" "4.5.9"
-    "@aws-amplify/pubsub" "4.4.6"
+    "@aws-amplify/api" "4.0.46"
+    "@aws-amplify/auth" "4.5.10"
+    "@aws-amplify/core" "4.5.10"
+    "@aws-amplify/pubsub" "4.4.7"
     amazon-cognito-identity-js "5.2.10"
     idb "5.0.6"
     immer "9.0.6"
@@ -192,20 +192,20 @@
     zen-observable-ts "0.8.19"
     zen-push "0.2.1"
 
-"@aws-amplify/geo@1.3.8":
-  version "1.3.8"
-  resolved "https://registry.npmjs.org/@aws-amplify/geo/-/geo-1.3.8.tgz#a8f9e90b1c3015b9740a391145c3b09086d829e6"
-  integrity sha512-ENMA48j1KV2uckUqYx0oZIt+MVBvAqTbRelcMcdnAdOaJhy9GYl2s0fqU3VhlXPQmXFrZ4Pv5AKxMn4anT5v7w==
+"@aws-amplify/geo@1.3.9":
+  version "1.3.9"
+  resolved "https://registry.npmjs.org/@aws-amplify/geo/-/geo-1.3.9.tgz#ead3b9d2763368c9e76a5c1ea4607bb5d21fd4a0"
+  integrity sha512-tAVVlPdwzoy8w3iF/EX6DaGWTyC70XiX+hUpDeKKBDniDlpGfrsSAZsO+y2sBd/pLjISM+NvpcS1x5bWIF7qXQ==
   dependencies:
-    "@aws-amplify/core" "4.5.9"
+    "@aws-amplify/core" "4.5.10"
     "@aws-sdk/client-location" "3.48.0"
     "@turf/boolean-clockwise" "6.5.0"
     camelcase-keys "6.2.2"
 
-"@aws-amplify/graphql-docs-generator@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/@aws-amplify/graphql-docs-generator/-/graphql-docs-generator-3.0.1.tgz#0603cfe45900010ad6b60f0858f59a640c74ef8f"
-  integrity sha512-zlbjtbm/SmLqPfKDBwFYJJF8BA2+8IDzZMpCOcw8VnM8qOTu9IYSGEvAi26zOrCoHlmpInxWHDZhbG8gfd9fkA==
+"@aws-amplify/graphql-docs-generator@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/@aws-amplify/graphql-docs-generator/-/graphql-docs-generator-3.0.2.tgz#8784f11010faa83a65890631994fa7d7b43088c8"
+  integrity sha512-URvSlbUo5yiC6ZUe4S/ptCnfS9blfEZYwsAsNrHajC0fw9nFKMU5Ed8N1qGcvuclfMtzsp0pDFgvKpOEkPf78w==
   dependencies:
     graphql "^14.5.8"
     handlebars "4.7.7"
@@ -237,21 +237,21 @@
     source-map-support "^0.5.16"
     yargs "^15.1.0"
 
-"@aws-amplify/interactions@4.0.45":
-  version "4.0.45"
-  resolved "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-4.0.45.tgz#103d1fd76bf46aff834b39d7eaafb310aaceaae0"
-  integrity sha512-GamG1cXYzVtnDLzheodYelxS0kFp+1AKG1Dm7UrblI2sOyRQ8L31dZS5G9vZYM6ux+h7164I8vl2CkQ/2HebmQ==
+"@aws-amplify/interactions@4.0.46":
+  version "4.0.46"
+  resolved "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-4.0.46.tgz#2caf5e66cdc97e6c5a554634e550968a9217fb3d"
+  integrity sha512-rGO91+Nm+YkT0E5OzKGHkJEXRRWSCg69ahLaDFbIWEnTIO9LgguyHh50uadvyy0PJY2FGNVSZet4T8+kypbPNQ==
   dependencies:
-    "@aws-amplify/core" "4.5.9"
+    "@aws-amplify/core" "4.5.10"
     "@aws-sdk/client-lex-runtime-service" "3.6.1"
 
-"@aws-amplify/predictions@4.0.45":
-  version "4.0.45"
-  resolved "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-4.0.45.tgz#3239b1891c0bfdc47fd53941639958287bbf7909"
-  integrity sha512-iYLXVFcEuPWRBl6gywT+KUnMOfEWJb3El4/YsM7nzJUTxub2ErQYtEj2YQ8Ku/i/uKhxGatdHkTgFHNjW2tLRg==
+"@aws-amplify/predictions@4.0.46":
+  version "4.0.46"
+  resolved "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-4.0.46.tgz#72d4243fea9f329072641bccac088ca4aa56c9a9"
+  integrity sha512-KcYr2yR91IunKfNLsY6u9ZMfpkgqFjT5fLJjvCJTEoPJZjqMF5wgszltPwxO5j95PysNsTnfIFDln3a/yndLNQ==
   dependencies:
-    "@aws-amplify/core" "4.5.9"
-    "@aws-amplify/storage" "4.4.28"
+    "@aws-amplify/core" "4.5.10"
+    "@aws-amplify/storage" "4.4.29"
     "@aws-sdk/client-comprehend" "3.6.1"
     "@aws-sdk/client-polly" "3.6.1"
     "@aws-sdk/client-rekognition" "3.6.1"
@@ -261,25 +261,25 @@
     "@aws-sdk/util-utf8-node" "3.6.1"
     uuid "^3.2.1"
 
-"@aws-amplify/pubsub@4.4.6":
-  version "4.4.6"
-  resolved "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-4.4.6.tgz#03bef913b90493746b9e28bbcb2f7fe48a45f6b2"
-  integrity sha512-yWsEpB7o5g4vOgom+tblVxwTBkHnmY+UH1ZMdWfFYlUaWp3bPup/jnlSTaGXTdtsxyEBc8EMBjAhDsQI415zHw==
+"@aws-amplify/pubsub@4.4.7":
+  version "4.4.7"
+  resolved "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-4.4.7.tgz#e886bb9e5a5df084b377875b96826147dd7a59f6"
+  integrity sha512-iYreEOQdU3gmgbAsgQcuUDrbYfc6qLRBYA5adkEEe1XJli4pBT0FK4pkT76MzYHMyzXetgR3sN3Nz6YE0Cm4Kg==
   dependencies:
-    "@aws-amplify/auth" "4.5.9"
-    "@aws-amplify/cache" "4.0.47"
-    "@aws-amplify/core" "4.5.9"
+    "@aws-amplify/auth" "4.5.10"
+    "@aws-amplify/cache" "4.0.48"
+    "@aws-amplify/core" "4.5.10"
     graphql "15.8.0"
     paho-mqtt "^1.1.0"
     uuid "^3.2.1"
     zen-observable-ts "0.8.19"
 
-"@aws-amplify/storage@4.4.28":
-  version "4.4.28"
-  resolved "https://registry.npmjs.org/@aws-amplify/storage/-/storage-4.4.28.tgz#c1c99187519bb15179d17bf3553566deec68ab37"
-  integrity sha512-GohL1tFoKQdy748YQE9PMx1Lx6ecGr6B47RpptJ7V02Uc0fk9+b7c6+4ZIbvMsUi7g50dQzoORIl+IQB1E2fWA==
+"@aws-amplify/storage@4.4.29":
+  version "4.4.29"
+  resolved "https://registry.npmjs.org/@aws-amplify/storage/-/storage-4.4.29.tgz#94b93309f5c02315496b86517c437882481cce1d"
+  integrity sha512-WiYEZBaAV50jNJc/Q5/mSJhFSCpfE99gqpDfabBHBICwk6FzR8m7aIJYpzl80x7BkY4gQoqU8udM6ZgR4QlCTg==
   dependencies:
-    "@aws-amplify/core" "4.5.9"
+    "@aws-amplify/core" "4.5.10"
     "@aws-sdk/client-s3" "3.6.1"
     "@aws-sdk/s3-request-presigner" "3.6.1"
     "@aws-sdk/util-create-request" "3.6.1"
@@ -292,12 +292,12 @@
   resolved "https://registry.npmjs.org/@aws-amplify/ui/-/ui-2.0.5.tgz#0800938a0bf36ff51922637628b0889017da19f1"
   integrity sha512-atoc/zIJRhgpoSDDKgRxbTSD7D9S4wbOzHUHMqRlcEPRKqRrQPGvd6zCUVSBS0jqdrrw6+UTJbWj7ttWCfE4pQ==
 
-"@aws-amplify/xr@3.0.45":
-  version "3.0.45"
-  resolved "https://registry.npmjs.org/@aws-amplify/xr/-/xr-3.0.45.tgz#60904cb06a531ffc9b290f99d07d1ea2e2937c54"
-  integrity sha512-VspCF8IEvAu8WeVA7Xo90ey2yqkXkY/Z/Y5ORzJreP5R0Y7YI+wdOd4tELsT3r68QjIEtY+ei1c3jop7zZ+t4w==
+"@aws-amplify/xr@3.0.46":
+  version "3.0.46"
+  resolved "https://registry.npmjs.org/@aws-amplify/xr/-/xr-3.0.46.tgz#9e1d0d753303ea6f25ba1a52d2989ae8886b2660"
+  integrity sha512-AQ+vuUReq0/rzK01AiUNzqkxK4z/2cbWmXQMLc/4SwwVRVdpSvV6yBejaxUgHuIvu9/jr1vWB03NFEkYR617hQ==
   dependencies:
-    "@aws-amplify/core" "4.5.9"
+    "@aws-amplify/core" "4.5.10"
 
 "@aws-cdk/assert@~1.124.0":
   version "1.124.0"
@@ -1828,16 +1828,16 @@
     tslib "^2.0.0"
 
 "@aws-sdk/client-s3@^3.25.0":
-  version "3.131.0"
-  resolved "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.131.0.tgz#6a193cfef008877028de0018f7b218191997bf5e"
-  integrity sha512-ue6uzk04pRJCJIaU1xKAW7Fx4TJx5n5Dwtycm0H94msj5HpJOfDKPoO9+kbywZywWP7n+eNnzNl/6lMjCSfO4g==
+  version "3.137.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.137.0.tgz#1ff4ec3edcaeb488fc1f59d310228be65b19dff6"
+  integrity sha512-WFOBywwV7ECAOkSOLecpPOGbgmYV5NxHzXHTJEio6xR6s2KzoLegJa0/mq5ljh0Zl5t2h5bsKT1CxYRC0sfwWw==
   dependencies:
     "@aws-crypto/sha1-browser" "2.0.0"
     "@aws-crypto/sha256-browser" "2.0.0"
     "@aws-crypto/sha256-js" "2.0.0"
-    "@aws-sdk/client-sts" "3.131.0"
+    "@aws-sdk/client-sts" "3.137.0"
     "@aws-sdk/config-resolver" "3.130.0"
-    "@aws-sdk/credential-provider-node" "3.131.0"
+    "@aws-sdk/credential-provider-node" "3.137.0"
     "@aws-sdk/eventstream-serde-browser" "3.127.0"
     "@aws-sdk/eventstream-serde-config-resolver" "3.127.0"
     "@aws-sdk/eventstream-serde-node" "3.127.0"
@@ -1866,15 +1866,15 @@
     "@aws-sdk/node-http-handler" "3.127.0"
     "@aws-sdk/protocol-http" "3.127.0"
     "@aws-sdk/signature-v4-multi-region" "3.130.0"
-    "@aws-sdk/smithy-client" "3.127.0"
+    "@aws-sdk/smithy-client" "3.137.0"
     "@aws-sdk/types" "3.127.0"
     "@aws-sdk/url-parser" "3.127.0"
     "@aws-sdk/util-base64-browser" "3.109.0"
     "@aws-sdk/util-base64-node" "3.55.0"
     "@aws-sdk/util-body-length-browser" "3.55.0"
     "@aws-sdk/util-body-length-node" "3.55.0"
-    "@aws-sdk/util-defaults-mode-browser" "3.127.0"
-    "@aws-sdk/util-defaults-mode-node" "3.130.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.137.0"
+    "@aws-sdk/util-defaults-mode-node" "3.137.0"
     "@aws-sdk/util-stream-browser" "3.131.0"
     "@aws-sdk/util-stream-node" "3.129.0"
     "@aws-sdk/util-user-agent-browser" "3.127.0"
@@ -1887,10 +1887,10 @@
     fast-xml-parser "3.19.0"
     tslib "^2.3.1"
 
-"@aws-sdk/client-sso@3.131.0":
-  version "3.131.0"
-  resolved "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.131.0.tgz#2a1177854092a64e976720a7e69bbab0d72e0855"
-  integrity sha512-6fbjqLdVZF7mvGpHjWX5YsqBE/99MilNtGUFlwuf4/KnmYy49V16A6Dltnd43Hu6HVGxJ8caH9nCkIdNp3YZcQ==
+"@aws-sdk/client-sso@3.137.0":
+  version "3.137.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.137.0.tgz#cc1c35de209a28ddfdeccc6e3e4658c76a355f73"
+  integrity sha512-l9y9usMuXGI+o1c/VO2qMccN0Bm0T5bFmmbRljB6kIzbJYXD/wVqR8GMZwSnFnz52cnURQ4pgqM1ETg54FlBYQ==
   dependencies:
     "@aws-crypto/sha256-browser" "2.0.0"
     "@aws-crypto/sha256-js" "2.0.0"
@@ -1909,15 +1909,15 @@
     "@aws-sdk/node-config-provider" "3.127.0"
     "@aws-sdk/node-http-handler" "3.127.0"
     "@aws-sdk/protocol-http" "3.127.0"
-    "@aws-sdk/smithy-client" "3.127.0"
+    "@aws-sdk/smithy-client" "3.137.0"
     "@aws-sdk/types" "3.127.0"
     "@aws-sdk/url-parser" "3.127.0"
     "@aws-sdk/util-base64-browser" "3.109.0"
     "@aws-sdk/util-base64-node" "3.55.0"
     "@aws-sdk/util-body-length-browser" "3.55.0"
     "@aws-sdk/util-body-length-node" "3.55.0"
-    "@aws-sdk/util-defaults-mode-browser" "3.127.0"
-    "@aws-sdk/util-defaults-mode-node" "3.130.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.137.0"
+    "@aws-sdk/util-defaults-mode-node" "3.137.0"
     "@aws-sdk/util-user-agent-browser" "3.127.0"
     "@aws-sdk/util-user-agent-node" "3.127.0"
     "@aws-sdk/util-utf8-browser" "3.109.0"
@@ -1960,15 +1960,15 @@
     "@aws-sdk/util-utf8-node" "3.47.2"
     tslib "^2.3.0"
 
-"@aws-sdk/client-sts@3.131.0":
-  version "3.131.0"
-  resolved "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.131.0.tgz#5867be8c1e9cf71c9abad90e3a67c8d10a5aa89b"
-  integrity sha512-D9GAnF8n3VwFhaE+jxXH035ZZ24WxpY36DUxszCRwXbA7qFazY1BTs1WoKFr8tDH4/iUUqCXd8NuA1l4RiwnqQ==
+"@aws-sdk/client-sts@3.137.0":
+  version "3.137.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.137.0.tgz#71a4fe715b30943d599bd6654d26ccafed138545"
+  integrity sha512-yJqfkEq0DG9Ds+oif/sc02PX6vfSNcyRe3YcaW5P6ouMyhJRljSIVCnA6iPwJaTsmK9BE9PDgFD2v/GYM/XgOA==
   dependencies:
     "@aws-crypto/sha256-browser" "2.0.0"
     "@aws-crypto/sha256-js" "2.0.0"
     "@aws-sdk/config-resolver" "3.130.0"
-    "@aws-sdk/credential-provider-node" "3.131.0"
+    "@aws-sdk/credential-provider-node" "3.137.0"
     "@aws-sdk/fetch-http-handler" "3.131.0"
     "@aws-sdk/hash-node" "3.127.0"
     "@aws-sdk/invalid-dependency" "3.127.0"
@@ -1985,15 +1985,15 @@
     "@aws-sdk/node-config-provider" "3.127.0"
     "@aws-sdk/node-http-handler" "3.127.0"
     "@aws-sdk/protocol-http" "3.127.0"
-    "@aws-sdk/smithy-client" "3.127.0"
+    "@aws-sdk/smithy-client" "3.137.0"
     "@aws-sdk/types" "3.127.0"
     "@aws-sdk/url-parser" "3.127.0"
     "@aws-sdk/util-base64-browser" "3.109.0"
     "@aws-sdk/util-base64-node" "3.55.0"
     "@aws-sdk/util-body-length-browser" "3.55.0"
     "@aws-sdk/util-body-length-node" "3.55.0"
-    "@aws-sdk/util-defaults-mode-browser" "3.127.0"
-    "@aws-sdk/util-defaults-mode-node" "3.130.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.137.0"
+    "@aws-sdk/util-defaults-mode-node" "3.137.0"
     "@aws-sdk/util-user-agent-browser" "3.127.0"
     "@aws-sdk/util-user-agent-node" "3.127.0"
     "@aws-sdk/util-utf8-browser" "3.109.0"
@@ -2216,14 +2216,14 @@
     "@aws-sdk/types" "3.6.1"
     tslib "^1.8.0"
 
-"@aws-sdk/credential-provider-ini@3.131.0":
-  version "3.131.0"
-  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.131.0.tgz#fa22aebeb65804b8ec1c4a7167292a80ea7d8131"
-  integrity sha512-0hA2ZwRUDmG5Wp/1t5BLvju2kZft1T3b3KC068ZY3t1+t/O46R6R9vINKEodohKTbfmGddu+aGY58Ai+N7O5Xw==
+"@aws-sdk/credential-provider-ini@3.137.0":
+  version "3.137.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.137.0.tgz#ad7e35b61a38fa37db0f2dc8b3a2d56cad4e0e79"
+  integrity sha512-FNSYjHaW83b4sQac+EWh/C6p1taBdvPOXFAVml1mPH49Nlkv9/E4bbjaWwgxvlxjqjNCbkDMKzhb19DN3gVulA==
   dependencies:
     "@aws-sdk/credential-provider-env" "3.127.0"
     "@aws-sdk/credential-provider-imds" "3.127.0"
-    "@aws-sdk/credential-provider-sso" "3.131.0"
+    "@aws-sdk/credential-provider-sso" "3.137.0"
     "@aws-sdk/credential-provider-web-identity" "3.127.0"
     "@aws-sdk/property-provider" "3.127.0"
     "@aws-sdk/shared-ini-file-loader" "3.127.0"
@@ -2255,16 +2255,16 @@
     "@aws-sdk/types" "3.6.1"
     tslib "^1.8.0"
 
-"@aws-sdk/credential-provider-node@3.131.0":
-  version "3.131.0"
-  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.131.0.tgz#df76ef73c90320121a9d63d3c85e1579d58b9125"
-  integrity sha512-nVQ6P91nd7i/G+iEnKWVwRRsQZIdY0qfza2+v70fOphjv0vzgDN7Xbn1GiYQVbxBiuxMSjQqg1r/p9PdRmt6QA==
+"@aws-sdk/credential-provider-node@3.137.0":
+  version "3.137.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.137.0.tgz#ec0a95ae6696ed849b97feea53eb7826b5d79103"
+  integrity sha512-if4CzNSyPS3ZERLtDocNNC+l5ejK93d2hoOzNHP2qCmTppThEPWF2TH506ez0v0lbUzeI7qWgpYe9m4+BFLEwQ==
   dependencies:
     "@aws-sdk/credential-provider-env" "3.127.0"
     "@aws-sdk/credential-provider-imds" "3.127.0"
-    "@aws-sdk/credential-provider-ini" "3.131.0"
+    "@aws-sdk/credential-provider-ini" "3.137.0"
     "@aws-sdk/credential-provider-process" "3.127.0"
-    "@aws-sdk/credential-provider-sso" "3.131.0"
+    "@aws-sdk/credential-provider-sso" "3.137.0"
     "@aws-sdk/credential-provider-web-identity" "3.127.0"
     "@aws-sdk/property-provider" "3.127.0"
     "@aws-sdk/shared-ini-file-loader" "3.127.0"
@@ -2334,12 +2334,12 @@
     "@aws-sdk/types" "3.6.1"
     tslib "^1.8.0"
 
-"@aws-sdk/credential-provider-sso@3.131.0":
-  version "3.131.0"
-  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.131.0.tgz#263694373bb9ee87d622d32a3e79d4e0ff4e9787"
-  integrity sha512-3LVan87e6NqnwUrpmjM5dbx8LbZyGG7Gdzf68YL0tZFptCFh1mR/kTJCToGX/hm7Jf3SRU3wtUWJ6G72yP72Sw==
+"@aws-sdk/credential-provider-sso@3.137.0":
+  version "3.137.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.137.0.tgz#c1e573f5f934073596579d3f43da1c252713e9af"
+  integrity sha512-Up2Q3tWSo6Mv2icXMrHa8dGtnC9yQAeUnftrIlvLXi3P9RjxlOPZCSg1NF8FOS90RdEgORlj/7LPlIniHgGUmg==
   dependencies:
-    "@aws-sdk/client-sso" "3.131.0"
+    "@aws-sdk/client-sso" "3.137.0"
     "@aws-sdk/property-provider" "3.127.0"
     "@aws-sdk/shared-ini-file-loader" "3.127.0"
     "@aws-sdk/types" "3.127.0"
@@ -2609,11 +2609,11 @@
     tslib "^1.8.0"
 
 "@aws-sdk/lib-storage@^3.25.0":
-  version "3.131.0"
-  resolved "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.131.0.tgz#1ab3b124288810baf28d699beb95f02882b05468"
-  integrity sha512-oAcAZd/UwoXr4L8yMDeAbZLBs3HMR6yRrQp9K3joBOl3VCV03Hv01ducOcDDxcwwyOJyuRrc513URFKFMgdGeQ==
+  version "3.137.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.137.0.tgz#fcacc2abad5d00b62a95f5aa21df0c03db8cb150"
+  integrity sha512-xLs4AeXuuOvLo3fPSmKSIS6G3KPA5TaAKmk7sF99XCXKnkk+TEGfEBIdwp+O+AacLw44l8H+bpSV/hqIV7Fkzg==
   dependencies:
-    "@aws-sdk/smithy-client" "3.127.0"
+    "@aws-sdk/smithy-client" "3.137.0"
     buffer "5.6.0"
     events "3.3.0"
     stream-browserify "3.0.0"
@@ -3268,10 +3268,10 @@
     "@aws-sdk/util-uri-escape" "3.6.1"
     tslib "^1.8.0"
 
-"@aws-sdk/smithy-client@3.127.0":
-  version "3.127.0"
-  resolved "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.127.0.tgz#64bbdedc3f8ef8a9b908b109833c458f24f58a13"
-  integrity sha512-sfcAJ+7a41CJMtsv6HRIjA91155Yk013RvMUdG2EMSo3cpLq/QmTJ1EGw4ByDZs5HLpXAaRoLI+bA2ovriGQnQ==
+"@aws-sdk/smithy-client@3.137.0":
+  version "3.137.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.137.0.tgz#cf0b639330dd1b4eb9b350e8d0e216c399290bd4"
+  integrity sha512-YAuWiSzHJGV9jQCjmcBWxbWRoq/3INEpdtfAdpR+X+sEZaRJESDGPt4or7WbQ9Tmbd/uZ0uQLYIed/NDSyJLLQ==
   dependencies:
     "@aws-sdk/middleware-stack" "3.127.0"
     "@aws-sdk/types" "3.127.0"
@@ -3509,10 +3509,10 @@
     "@aws-sdk/shared-ini-file-loader" "3.47.1"
     tslib "^2.3.0"
 
-"@aws-sdk/util-defaults-mode-browser@3.127.0":
-  version "3.127.0"
-  resolved "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.127.0.tgz#4fa9fe802e4296c0ab2e63a6a3c7c787ac5286df"
-  integrity sha512-e/vBm+EYSJ0R79591EPiCPE3aR5RKk5CjOkQjNxZIX8UPnIlo7xohTcebfR/iugSTxNrpfrFv+o4H5GjzAuhLA==
+"@aws-sdk/util-defaults-mode-browser@3.137.0":
+  version "3.137.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.137.0.tgz#68fe89aae7504f10d69a52806768f129195d1c65"
+  integrity sha512-9f5045wqPAcGLKIAXzZKHE2n42ilGo/g4rLSS09OXx9CoFT4lVdqZPqBqh/prDUMrqXge9FK3EH2VId7L5GpEQ==
   dependencies:
     "@aws-sdk/property-provider" "3.127.0"
     "@aws-sdk/types" "3.127.0"
@@ -3529,10 +3529,10 @@
     bowser "^2.11.0"
     tslib "^2.3.0"
 
-"@aws-sdk/util-defaults-mode-node@3.130.0":
-  version "3.130.0"
-  resolved "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.130.0.tgz#4347aeabccf7b3d04aecd7545e904781ac9c0be1"
-  integrity sha512-0BWx7C6GhHBrjPUuSgMnRA4InxYisX6MIGs5yIHk2OArYkQLJMdeORYXXz1y40ahMihmtjD/Ap5xQGBm2vyffA==
+"@aws-sdk/util-defaults-mode-node@3.137.0":
+  version "3.137.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.137.0.tgz#e43340efebb88d9f5a214127c383345d0bbcfd00"
+  integrity sha512-CvMpemcsOkoMEz0iALamyQBt1rHx98NvF/cay019F8m+umD03I8CclDugy/13DqESWfsVxn91lZY/DOnO+si7A==
   dependencies:
     "@aws-sdk/config-resolver" "3.130.0"
     "@aws-sdk/credential-provider-imds" "3.127.0"
@@ -4341,7 +4341,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.18.3", "@babel/runtime@^7.5.5", "@babel/runtime@^7.9.6":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.18.9", "@babel/runtime@^7.5.5", "@babel/runtime@^7.9.6":
   version "7.18.9"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
   integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
@@ -5881,11 +5881,11 @@
   integrity sha512-93uGjlhUD+iNg1iWhUENAtJata6w5nE+V4urXOAlIXdco6xNZtUSfYY8dzp3Udy74aqO/B5UZL80x/YMa5PKRw==
 
 "@octokit/plugin-paginate-rest@^2.16.8":
-  version "2.21.2"
-  resolved "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.2.tgz#070be9bb18cb78e52b471ddc3551d28355e2d5e2"
-  integrity sha512-S24H0a6bBVreJtoTaRHT/gnVASbOHVTRMOVIqd9zrJBP3JozsxJB56TDuTUmd1xLI4/rAE2HNmThvVKtIdLLEw==
+  version "2.21.3"
+  resolved "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz#7f12532797775640dbb8224da577da7dc210c87e"
+  integrity sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==
   dependencies:
-    "@octokit/types" "^6.39.0"
+    "@octokit/types" "^6.40.0"
 
 "@octokit/plugin-request-log@^1.0.4":
   version "1.0.4"
@@ -5931,7 +5931,7 @@
     "@octokit/plugin-request-log" "^1.0.4"
     "@octokit/plugin-rest-endpoint-methods" "^5.12.0"
 
-"@octokit/types@^6.0.3", "@octokit/types@^6.16.1", "@octokit/types@^6.39.0":
+"@octokit/types@^6.0.3", "@octokit/types@^6.16.1", "@octokit/types@^6.39.0", "@octokit/types@^6.40.0":
   version "6.40.0"
   resolved "https://registry.npmjs.org/@octokit/types/-/types-6.40.0.tgz#f2e665196d419e19bb4265603cf904a820505d0e"
   integrity sha512-MFZOU5r8SwgJWDMhrLUSvyJPtVsqA6VnbVI3TNbsmw+Jnvrktzvq2fYES/6RiJA/5Ykdwq4mJmtlYUfW7CGjmw==
@@ -6179,9 +6179,9 @@
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
 "@types/node@*", "@types/node@>=12":
-  version "18.0.6"
-  resolved "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz#0ba49ac517ad69abe7a1508bc9b3a5483df9d5d7"
-  integrity sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==
+  version "18.6.1"
+  resolved "https://registry.npmjs.org/@types/node/-/node-18.6.1.tgz#828e4785ccca13f44e2fb6852ae0ef11e3e20ba5"
+  integrity sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==
 
 "@types/node@^10.17.60":
   version "10.17.60"
@@ -6224,9 +6224,9 @@
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
 
 "@types/prettier@^2.0.0":
-  version "2.6.3"
-  resolved "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz#68ada76827b0010d0db071f739314fa429943d0a"
-  integrity sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==
+  version "2.6.4"
+  resolved "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.4.tgz#ad899dad022bab6b5a9f0a0fe67c2f7a4a8950ed"
+  integrity sha512-fOwvpvQYStpb/zHMx0Cauwywu9yLDmzWiiQBC7gJyq5tYLUXFZvDG7VK1B7WBxxjBJNKFOZ0zLoOQn8vmATbhw==
 
 "@types/rimraf@^3.0.0":
   version "3.0.2"
@@ -6331,23 +6331,23 @@
     "@typescript-eslint/types" "4.33.0"
     "@typescript-eslint/visitor-keys" "4.33.0"
 
-"@typescript-eslint/scope-manager@5.30.6":
-  version "5.30.6"
-  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.30.6.tgz#ce1b49ff5ce47f55518d63dbe8fc9181ddbd1a33"
-  integrity sha512-Hkq5PhLgtVoW1obkqYH0i4iELctEKixkhWLPTYs55doGUKCASvkjOXOd/pisVeLdO24ZX9D6yymJ/twqpJiG3g==
+"@typescript-eslint/scope-manager@5.31.0":
+  version "5.31.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.31.0.tgz#f47a794ba84d9b818ab7f8f44fff55a61016c606"
+  integrity sha512-8jfEzBYDBG88rcXFxajdVavGxb5/XKXyvWgvD8Qix3EEJLCFIdVloJw+r9ww0wbyNLOTYyBsR+4ALNGdlalLLg==
   dependencies:
-    "@typescript-eslint/types" "5.30.6"
-    "@typescript-eslint/visitor-keys" "5.30.6"
+    "@typescript-eslint/types" "5.31.0"
+    "@typescript-eslint/visitor-keys" "5.31.0"
 
 "@typescript-eslint/types@4.33.0":
   version "4.33.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
   integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
 
-"@typescript-eslint/types@5.30.6":
-  version "5.30.6"
-  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.30.6.tgz#86369d0a7af8c67024115ac1da3e8fb2d38907e1"
-  integrity sha512-HdnP8HioL1F7CwVmT4RaaMX57RrfqsOMclZc08wGMiDYJBsLGBM7JwXM4cZJmbWLzIR/pXg1kkrBBVpxTOwfUg==
+"@typescript-eslint/types@5.31.0":
+  version "5.31.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.31.0.tgz#7aa389122b64b18e473c1672fb3b8310e5f07a9a"
+  integrity sha512-/f/rMaEseux+I4wmR6mfpM2wvtNZb1p9hAV77hWfuKc3pmaANp5dLAZSiE3/8oXTYTt3uV9KW5yZKJsMievp6g==
 
 "@typescript-eslint/typescript-estree@4.33.0":
   version "4.33.0"
@@ -6362,13 +6362,13 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/typescript-estree@5.30.6":
-  version "5.30.6"
-  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.6.tgz#a84a0d6a486f9b54042da1de3d671a2c9f14484e"
-  integrity sha512-Z7TgPoeYUm06smfEfYF0RBkpF8csMyVnqQbLYiGgmUSTaSXTP57bt8f0UFXstbGxKIreTwQCujtaH0LY9w9B+A==
+"@typescript-eslint/typescript-estree@5.31.0":
+  version "5.31.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.31.0.tgz#eb92970c9d6e3946690d50c346fb9b1d745ee882"
+  integrity sha512-3S625TMcARX71wBc2qubHaoUwMEn+l9TCsaIzYI/ET31Xm2c9YQ+zhGgpydjorwQO9pLfR/6peTzS/0G3J/hDw==
   dependencies:
-    "@typescript-eslint/types" "5.30.6"
-    "@typescript-eslint/visitor-keys" "5.30.6"
+    "@typescript-eslint/types" "5.31.0"
+    "@typescript-eslint/visitor-keys" "5.31.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -6376,14 +6376,14 @@
     tsutils "^3.21.0"
 
 "@typescript-eslint/utils@^5.10.0":
-  version "5.30.6"
-  resolved "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.30.6.tgz#1de2da14f678e7d187daa6f2e4cdb558ed0609dc"
-  integrity sha512-xFBLc/esUbLOJLk9jKv0E9gD/OH966M40aY9jJ8GiqpSkP2xOV908cokJqqhVd85WoIvHVHYXxSFE4cCSDzVvA==
+  version "5.31.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.31.0.tgz#e146fa00dca948bfe547d665b2138a2dc1b79acd"
+  integrity sha512-kcVPdQS6VIpVTQ7QnGNKMFtdJdvnStkqS5LeALr4rcwx11G6OWb2HB17NMPnlRHvaZP38hL9iK8DdE9Fne7NYg==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.30.6"
-    "@typescript-eslint/types" "5.30.6"
-    "@typescript-eslint/typescript-estree" "5.30.6"
+    "@typescript-eslint/scope-manager" "5.31.0"
+    "@typescript-eslint/types" "5.31.0"
+    "@typescript-eslint/typescript-estree" "5.31.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
@@ -6395,12 +6395,12 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@typescript-eslint/visitor-keys@5.30.6":
-  version "5.30.6"
-  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.6.tgz#94dd10bb481c8083378d24de1742a14b38a2678c"
-  integrity sha512-41OiCjdL2mCaSDi2SvYbzFLlqqlm5v1ZW9Ym55wXKL/Rx6OOB1IbuFGo71Fj6Xy90gJDFTlgOS+vbmtGHPTQQA==
+"@typescript-eslint/visitor-keys@5.31.0":
+  version "5.31.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.31.0.tgz#b0eca264df01ce85dceb76aebff3784629258f54"
+  integrity sha512-ZK0jVxSjS4gnPirpVjXHz7mgdOsZUHzNYSfTw2yPa3agfbt9YfqaBiBZFSSxeBWnpWkzCxTfUpnzA3Vily/CSg==
   dependencies:
-    "@typescript-eslint/types" "5.30.6"
+    "@typescript-eslint/types" "5.31.0"
     eslint-visitor-keys "^3.3.0"
 
 "@wry/equality@^0.1.2":
@@ -6473,9 +6473,9 @@ acorn@^7.1.1, acorn@^7.4.0:
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 acorn@^8.2.4, acorn@^8.4.1, acorn@^8.7.0:
-  version "8.7.1"
-  resolved "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
-  integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
+  version "8.8.0"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
+  integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -6712,18 +6712,18 @@ amplify-cli-shared-interfaces@1.1.0:
   integrity sha512-lN5Y4PfyY5SSCZLxRSfv3qhYYSEwEsFG9T+SbQIf05o6Yfim93Xy9f+1pAAlGc3f/HWjEqdegAH3HG496/BGeg==
 
 amplify-codegen@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/amplify-codegen/-/amplify-codegen-3.0.1.tgz#ac2390bc83a013ee28565f2dcbdf6e9615f10612"
-  integrity sha512-BYCyn8Eh/t/sfWqBh+kiKFEN3Yqhz7E2WBz/QGFBFJkXg4VMo8nIK6AsAmCUQkRqDQDna2iIi3gpjYbXF+2O7A==
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/amplify-codegen/-/amplify-codegen-3.0.2.tgz#59f3d22611e26d5e4d691d3d05ed642b4e9fe7b0"
+  integrity sha512-u80Hnawhz2GBjtUj/EPr4Dn+gQDRGL+AzPNQGaqy4SCQq79h+ILPoWEM5K+930Z+b/GECGXx6ncMfDNc1vEoXA==
   dependencies:
-    "@aws-amplify/appsync-modelgen-plugin" "2.0.1"
-    "@aws-amplify/graphql-docs-generator" "3.0.1"
+    "@aws-amplify/appsync-modelgen-plugin" "2.0.2"
+    "@aws-amplify/graphql-docs-generator" "3.0.2"
     "@aws-amplify/graphql-types-generator" "3.0.0"
     "@graphql-codegen/core" "1.8.3"
     chalk "^3.0.0"
     fs-extra "^8.1.0"
     glob-all "^3.1.0"
-    glob-parent "^5.1.1"
+    glob-parent "^6.0.2"
     graphql "^14.5.8"
     graphql-config "^2.2.1"
     inquirer "^7.3.3"
@@ -7424,23 +7424,23 @@ available-typed-arrays@^1.0.5:
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 aws-amplify@^4.2.8:
-  version "4.3.27"
-  resolved "https://registry.npmjs.org/aws-amplify/-/aws-amplify-4.3.27.tgz#05f77e1deef2a63262e6f23e912a090d890774d6"
-  integrity sha512-qwA3ElnBsilmqHJxrBTN0geDBq8jhpDR5/kEvIXWZ9rEBYCuWF/cUm9Dzc5KDV0dP1JR1mhzJQ6iZKL12+Acsg==
+  version "4.3.28"
+  resolved "https://registry.npmjs.org/aws-amplify/-/aws-amplify-4.3.28.tgz#39b3605a8092c40a16f673560e7d14dde37d8ec0"
+  integrity sha512-qioXWvsNm7c5oRfZp73wURyO0nXDjILujW89Elsd8zmyY1jxWDL/tpFQMvV5sjXS6VnWnIRlXVILY2qcyspLOA==
   dependencies:
-    "@aws-amplify/analytics" "5.2.12"
-    "@aws-amplify/api" "4.0.45"
-    "@aws-amplify/auth" "4.5.9"
-    "@aws-amplify/cache" "4.0.47"
-    "@aws-amplify/core" "4.5.9"
-    "@aws-amplify/datastore" "3.12.2"
-    "@aws-amplify/geo" "1.3.8"
-    "@aws-amplify/interactions" "4.0.45"
-    "@aws-amplify/predictions" "4.0.45"
-    "@aws-amplify/pubsub" "4.4.6"
-    "@aws-amplify/storage" "4.4.28"
+    "@aws-amplify/analytics" "5.2.13"
+    "@aws-amplify/api" "4.0.46"
+    "@aws-amplify/auth" "4.5.10"
+    "@aws-amplify/cache" "4.0.48"
+    "@aws-amplify/core" "4.5.10"
+    "@aws-amplify/datastore" "3.12.3"
+    "@aws-amplify/geo" "1.3.9"
+    "@aws-amplify/interactions" "4.0.46"
+    "@aws-amplify/predictions" "4.0.46"
+    "@aws-amplify/pubsub" "4.4.7"
+    "@aws-amplify/storage" "4.4.29"
     "@aws-amplify/ui" "2.0.5"
-    "@aws-amplify/xr" "3.0.45"
+    "@aws-amplify/xr" "3.0.46"
 
 aws-appsync-auth-link@^1.0.1:
   version "1.0.1"
@@ -7545,9 +7545,9 @@ aws-sdk-mock@^5.6.2:
     traverse "^0.6.6"
 
 aws-sdk@2.518.0, aws-sdk@^2.1113.0, aws-sdk@^2.1122.0, aws-sdk@^2.1141.0, aws-sdk@^2.518.0:
-  version "2.1176.0"
-  resolved "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1176.0.tgz#f3524433a60857a8fcd21722251f2b1f19d72008"
-  integrity sha512-jinSKjACYHIkkz0UlFwQXwz8HAHZIeJg5wOnZoMTKU3/WM6Vh26hZJJ6XkwDAfBmyWp3V9qFdQoSAiO8SeXKjw==
+  version "2.1182.0"
+  resolved "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1182.0.tgz#7364e3e104f62b61018a00f19f2ffc989b1780ed"
+  integrity sha512-iemVvLTc2iy0rz3xTp8zc/kD27gIfDF/mk6bxY8/35xMulKCVANWUkAH8jWRKReHh5F/gX4bp33dnfG63ny1Ww==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -7570,7 +7570,7 @@ aws4@^1.8.0:
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axe-core@^4.4.2:
+axe-core@^4.4.3:
   version "4.4.3"
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz#11c74d23d5013c0fa5d183796729bc3482bd2f6f"
   integrity sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==
@@ -8134,9 +8134,9 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001366:
-  version "1.0.30001367"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz#2b97fe472e8fa29c78c5970615d7cd2ee414108a"
-  integrity sha512-XDgbeOHfifWV3GEES2B8rtsrADx4Jf+juKX2SICJcaUhjYBO3bR96kvEIHa15VU6ohtOhBZuPGGYGbXMRn0NCw==
+  version "1.0.30001370"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001370.tgz#0a30d4f20d38b9e108cc5ae7cc62df9fe66cd5ba"
+  integrity sha512-3PDmaP56wz/qz7G508xzjx8C+MC2qEm4SYhSEzC9IBROo+dGXFWRuaXkWti0A9tuI00g+toiriVqxtWMgl350g==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -8334,9 +8334,9 @@ cli-cursor@^3.1.0:
     restore-cursor "^3.1.0"
 
 cli-spinners@^2.2.0:
-  version "2.6.1"
-  resolved "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz#adc954ebe281c37a6319bfa401e6dd2488ffb70d"
-  integrity sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==
+  version "2.7.0"
+  resolved "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz#f815fd30b5f9eaac02db604c7a231ed7cb2f797a"
+  integrity sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==
 
 cli-width@^2.0.0:
   version "2.2.1"
@@ -8613,9 +8613,9 @@ constant-case@^3.0.4:
     upper-case "^2.0.2"
 
 constructs@^3.3.125, constructs@^3.3.69:
-  version "3.4.42"
-  resolved "https://registry.npmjs.org/constructs/-/constructs-3.4.42.tgz#d17aac6e71c8277ed02ed6251cc93915f4de970e"
-  integrity sha512-IN9OBQpzL/hf1kIkW0bfVIDX6zW/4F2GXybWsK0JwmNz1tT+R2EggfMMY+RggvugKZq9Pi7sAMR/q5XAvulgow==
+  version "3.4.51"
+  resolved "https://registry.npmjs.org/constructs/-/constructs-3.4.51.tgz#0671c3ebf924ad57f19c2a90184d8ced2d56ba7b"
+  integrity sha512-wBTyaC6y4L0GKGb0RdLuAivlEJm3LsTIHZKVl/9TdV7WImwBBe0/6KsWmQeXwNDOt5yDQXxM18Y8WTeiF2Pkhg==
 
 content-disposition@0.5.4:
   version "0.5.4"
@@ -8761,9 +8761,9 @@ copyfiles@^2.2.0:
     yargs "^16.1.0"
 
 core-js-pure@^3.20.2:
-  version "3.23.5"
-  resolved "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.23.5.tgz#23daaa9af9230e50f10b0fa4b8e6b87402be4c33"
-  integrity sha512-8t78LdpKSuCq4pJYCYk8hl7XEkAX+BP16yRIwL3AanTksxuEf7CM83vRyctmiEL8NDZ3jpUcv56fk9/zG3aIuw==
+  version "3.24.0"
+  resolved "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.24.0.tgz#10eeb90dbf0d670a6b22b081aecc7deb2faec7e1"
+  integrity sha512-uzMmW8cRh7uYw4JQtzqvGWRyC2T5+4zipQLQdi2FmiRqP83k3d6F3stv2iAlNhOs6cXN401FCD5TL0vvleuHgA==
 
 core-js@^2.4.0:
   version "2.6.12"
@@ -8771,9 +8771,9 @@ core-js@^2.4.0:
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.6.4:
-  version "3.23.5"
-  resolved "https://registry.npmjs.org/core-js/-/core-js-3.23.5.tgz#1f82b0de5eece800827a2f59d597509c67650475"
-  integrity sha512-7Vh11tujtAZy82da4duVreQysIoO2EvVrur7y6IzZkH1IHPSekuDi8Vuw1+YKjkbfWLRD7Nc9ICQ/sIUDutcyg==
+  version "3.24.0"
+  resolved "https://registry.npmjs.org/core-js/-/core-js-3.24.0.tgz#4928d4e99c593a234eb1a1f9abd3122b04d3ac57"
+  integrity sha512-IeOyT8A6iK37Ep4kZDD423mpi6JfPRoPUdQwEWYiGolvn4o6j2diaRzNfDfpTdu3a5qMbrGUzKUpYpRY8jXCkQ==
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -9280,9 +9280,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.188:
-  version "1.4.192"
-  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.192.tgz#fac050058b3e0713b401a1088cc579e14c2ab165"
-  integrity sha512-8nCXyIQY9An88NXAp+PuPy5h3/w5ZY7Iu2lag65Q0XREprcat5F8gKhoHsBUnQcFuCRnmevpR8yEBYRU3d2HDw==
+  version "1.4.202"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.202.tgz#0c2ed733f42b02ec49a955c5badfcc65888c390b"
+  integrity sha512-JYsK2ex9lmQD27kj19fhXYxzFJ/phLAkLKHv49A5UY6kMRV2xED3qMMLg/voW/+0AR6wMiI+VxlmK9NDtdxlPA==
 
 emittery@^0.7.1:
   version "0.7.2"
@@ -9547,20 +9547,20 @@ eslint-plugin-jsdoc@^37.9.6:
     spdx-expression-parse "^3.0.1"
 
 eslint-plugin-jsx-a11y@^6.5.1:
-  version "6.6.0"
-  resolved "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.0.tgz#2c5ac12e013eb98337b9aa261c3b355275cc6415"
-  integrity sha512-kTeLuIzpNhXL2CwLlc8AHI0aFRwWHcg483yepO9VQiHzM9bZwJdzTkzBszbuPrbgGmq2rlX/FaT2fJQsjUSHsw==
+  version "6.6.1"
+  resolved "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.1.tgz#93736fc91b83fdc38cc8d115deedfc3091aef1ff"
+  integrity sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==
   dependencies:
-    "@babel/runtime" "^7.18.3"
+    "@babel/runtime" "^7.18.9"
     aria-query "^4.2.2"
     array-includes "^3.1.5"
     ast-types-flow "^0.0.7"
-    axe-core "^4.4.2"
+    axe-core "^4.4.3"
     axobject-query "^2.2.0"
     damerau-levenshtein "^1.0.8"
     emoji-regex "^9.2.2"
     has "^1.0.3"
-    jsx-ast-utils "^3.3.1"
+    jsx-ast-utils "^3.3.2"
     language-tags "^1.0.5"
     minimatch "^3.1.2"
     semver "^6.3.0"
@@ -10551,9 +10551,9 @@ globals@^11.1.0:
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^13.0.0, globals@^13.6.0, globals@^13.9.0:
-  version "13.16.0"
-  resolved "https://registry.npmjs.org/globals/-/globals-13.16.0.tgz#9be4aca28f311aaeb974ea54978ebbb5e35ce46a"
-  integrity sha512-A1lrQfpNF+McdPOnnFqY3kSN0AFTy485bTi1bkLk4mVPODIUEcSfhHgRqA+QdXPksrSTTztYXx37NFV+GpGk3Q==
+  version "13.17.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz#902eb1e680a41da93945adbdcb5a9f361ba69bd4"
+  integrity sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==
   dependencies:
     type-fest "^0.20.2"
 
@@ -12265,7 +12265,7 @@ jstreemap@^1.28.2:
   resolved "https://registry.npmjs.org/jstreemap/-/jstreemap-1.28.2.tgz#fe884994039e5ee23a157cf7ddd6c01c3a6d134d"
   integrity sha512-JYVDYwLat+OVXLpIXgUPy06wPSEkQafGOeotpGFodkM5+K8x3IrVPGaTw+Fd9MmZy092cLG/N+3q90oSBHZoQQ==
 
-"jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.3.1:
+"jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz#afe5efe4332cd3515c065072bd4d6b0aa22152bd"
   integrity sha512-4ZCADZHRkno244xlNnn4AOG6sRQ7iBZ5BbgZ4vW4y5IZw7cVUD1PPeblm1xx/nfmMxPdt/LHsXZW8z/j58+l9Q==
@@ -13924,7 +13924,7 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
-parse-path@^4.0.4, parse-path@^5.0.0:
+parse-path@^4.0.0, parse-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/parse-path/-/parse-path-5.0.0.tgz#f933152f3c6d34f4cf36cfc3d07b138ac113649d"
   integrity sha512-qOpH55/+ZJ4jUu/oLO+ifUKjFPNZGfnPJtzvGzKN/4oLMil5m9OH4VpOj6++9/ytJcfks4kzH2hhi87GL/OU9A==
@@ -13932,13 +13932,13 @@ parse-path@^4.0.4, parse-path@^5.0.0:
     protocols "^2.0.0"
 
 parse-url@^6.0.0:
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/parse-url/-/parse-url-6.0.2.tgz#4a30b057bfc452af64512dfb1a7755c103db3ea1"
-  integrity sha512-uCSjOvD3T+6B/sPWhR+QowAZcU/o4bjPrVBQBGFxcDF6J6FraCGIaDBsdoQawiaaAVdHvtqBe3w3vKlfBKySOQ==
+  version "6.0.5"
+  resolved "https://registry.npmjs.org/parse-url/-/parse-url-6.0.5.tgz#4acab8982cef1846a0f8675fa686cef24b2f6f9b"
+  integrity sha512-e35AeLTSIlkw/5GFq70IN7po8fmDUjpDPY1rIK+VubRfsUvBonjQ+PBZG+vWMACnQSmNlvl524IucoDmcioMxA==
   dependencies:
     is-ssh "^1.3.0"
     normalize-url "^6.1.0"
-    parse-path "^4.0.4"
+    parse-path "^4.0.0"
     protocols "^1.4.0"
 
 parse5@6.0.1:
@@ -16212,9 +16212,9 @@ ua-parser-js@^0.7.30:
   integrity sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==
 
 uglify-js@^3.1.4:
-  version "3.16.2"
-  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.2.tgz#0481e1dbeed343ad1c2ddf3c6d42e89b7a6d4def"
-  integrity sha512-AaQNokTNgExWrkEYA24BTNMSjyqEXPSfhqoS0AxmHkCJ4U+Dyy5AvbGV/sqxuxficEfGGoX3zWw9R7QpLFfEsg==
+  version "3.16.3"
+  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz#94c7a63337ee31227a18d03b8a3041c210fd1f1d"
+  integrity sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==
 
 uid-number@0.0.6:
   version "0.0.6"
@@ -16322,9 +16322,9 @@ upath@^2.0.1:
   integrity sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==
 
 update-browserslist-db@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.4.tgz#dbfc5a789caa26b1db8990796c2c8ebbce304824"
-  integrity sha512-jnmO2BEGUjsMOe/Fg9u0oczOe/ppIDZPebzccl1yDWGLFP16Pa1/RM5wEoKYPG2zstNcDuAStejyxsOuKINdGA==
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz#be06a5eedd62f107b7c19eb5bcefb194411abf38"
+  integrity sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==
   dependencies:
     escalade "^3.1.1"
     picocolors "^1.0.0"


### PR DESCRIPTION
#### Description of changes
* When a NEW lambda conflict resolver is set up, we're not appropriately reflecting the generated state of the lambda back to cli-inputs.json, leading to a push failure. This refactor allows us to correctly update state.

#### Issue #, if available
* https://github.com/aws-amplify/amplify-category-api/issues/628

#### Description of how you validated changes
Unit test for this use-case, and manually tested with an `amplify-dev update api` .

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
