### PR TITLE
fix: remove `gqlSchemaPath` in cli-inputs.json

### DIFF
--- a/packages/amplify-category-api/resources/schemas/aPIGateway/APIGatewayCLIInputs.schema.json
+++ b/packages/amplify-category-api/resources/schemas/aPIGateway/APIGatewayCLIInputs.schema.json
@@ -5,7 +5,9 @@
     "version": {
       "description": "The schema version.",
       "type": "number",
-      "enum": [1]
+      "enum": [
+        1
+      ]
     },
     "paths": {
       "description": "map of paths in the REST API.",
@@ -25,14 +27,24 @@
               "auth": {
                 "type": "array",
                 "items": {
-                  "enum": ["create", "delete", "read", "update"],
+                  "enum": [
+                    "create",
+                    "delete",
+                    "read",
+                    "update"
+                  ],
                   "type": "string"
                 }
               },
               "guest": {
                 "type": "array",
                 "items": {
-                  "enum": ["create", "delete", "read", "update"],
+                  "enum": [
+                    "create",
+                    "delete",
+                    "read",
+                    "update"
+                  ],
                   "type": "string"
                 }
               },
@@ -41,23 +53,40 @@
                 "additionalProperties": {
                   "type": "array",
                   "items": {
-                    "enum": ["create", "delete", "read", "update"],
+                    "enum": [
+                      "create",
+                      "delete",
+                      "read",
+                      "update"
+                    ],
                     "type": "string"
                   }
                 }
               }
             },
-            "required": ["setting"]
+            "required": [
+              "setting"
+            ]
           }
         },
-        "required": ["lambdaFunction", "permissions"]
+        "required": [
+          "lambdaFunction",
+          "permissions"
+        ]
       }
     }
   },
-  "required": ["paths", "version"],
+  "required": [
+    "paths",
+    "version"
+  ],
   "definitions": {
     "PermissionSetting": {
-      "enum": ["open", "private", "protected"],
+      "enum": [
+        "open",
+        "private",
+        "protected"
+      ],
       "type": "string"
     }
   },

--- a/packages/amplify-category-api/resources/schemas/appsync/AppSyncCLIInputs.schema.json
+++ b/packages/amplify-category-api/resources/schemas/appsync/AppSyncCLIInputs.schema.json
@@ -5,14 +5,19 @@
     "version": {
       "description": "The schema version.",
       "type": "number",
-      "enum": [1]
+      "enum": [
+        1
+      ]
     },
     "serviceConfiguration": {
       "$ref": "#/definitions/AppSyncServiceConfig",
       "description": "The service configuration that will be interpreted by Amplify."
     }
   },
-  "required": ["serviceConfiguration", "version"],
+  "required": [
+    "serviceConfiguration",
+    "version"
+  ],
   "definitions": {
     "AppSyncServiceConfig": {
       "description": "Configuration exposed by AppSync. Currently this is the only API type supported by Amplify headless mode.",
@@ -21,14 +26,12 @@
         "serviceName": {
           "description": "The service name of the resource provider.",
           "type": "string",
-          "enum": ["AppSync"]
+          "enum": [
+            "AppSync"
+          ]
         },
         "apiName": {
           "description": "The name of the API that will be created.",
-          "type": "string"
-        },
-        "gqlSchemaPath": {
-          "description": "Path to GraphQL schema that defines the AppSync API.",
           "type": "string"
         },
         "defaultAuthType": {
@@ -79,7 +82,11 @@
           "description": "The strategy for resolving API write conflicts."
         }
       },
-      "required": ["apiName", "defaultAuthType", "gqlSchemaPath", "serviceName"]
+      "required": [
+        "apiName",
+        "defaultAuthType",
+        "serviceName"
+      ]
     },
     "AppSyncAPIKeyAuthType": {
       "description": "Specifies that the AppSync API should be secured using an API key.",
@@ -87,7 +94,9 @@
       "properties": {
         "mode": {
           "type": "string",
-          "enum": ["API_KEY"]
+          "enum": [
+            "API_KEY"
+          ]
         },
         "expirationTime": {
           "type": "number"
@@ -100,7 +109,9 @@
           "type": "string"
         }
       },
-      "required": ["mode"]
+      "required": [
+        "mode"
+      ]
     },
     "AppSyncAWSIAMAuthType": {
       "description": "Specifies that the AppSync API should be secured using AWS IAM.",
@@ -108,10 +119,14 @@
       "properties": {
         "mode": {
           "type": "string",
-          "enum": ["AWS_IAM"]
+          "enum": [
+            "AWS_IAM"
+          ]
         }
       },
-      "required": ["mode"]
+      "required": [
+        "mode"
+      ]
     },
     "AppSyncCognitoUserPoolsAuthType": {
       "description": "Specifies that the AppSync API should be secured using Cognito.",
@@ -119,14 +134,18 @@
       "properties": {
         "mode": {
           "type": "string",
-          "enum": ["AMAZON_COGNITO_USER_POOLS"]
+          "enum": [
+            "AMAZON_COGNITO_USER_POOLS"
+          ]
         },
         "cognitoUserPoolId": {
           "description": "The user pool that will be used to authenticate requests.",
           "type": "string"
         }
       },
-      "required": ["mode"]
+      "required": [
+        "mode"
+      ]
     },
     "AppSyncOpenIDConnectAuthType": {
       "description": "Specifies that the AppSync API should be secured using OpenID.",
@@ -134,7 +153,9 @@
       "properties": {
         "mode": {
           "type": "string",
-          "enum": ["OPENID_CONNECT"]
+          "enum": [
+            "OPENID_CONNECT"
+          ]
         },
         "openIDProviderName": {
           "type": "string"
@@ -152,7 +173,12 @@
           "type": "string"
         }
       },
-      "required": ["mode", "openIDClientID", "openIDIssuerURL", "openIDProviderName"]
+      "required": [
+        "mode",
+        "openIDClientID",
+        "openIDIssuerURL",
+        "openIDProviderName"
+      ]
     },
     "AppSyncLambdaAuthType": {
       "description": "Specifies that the AppSync API should be secured using Lambda.",
@@ -160,7 +186,9 @@
       "properties": {
         "mode": {
           "type": "string",
-          "enum": ["AWS_LAMBDA"]
+          "enum": [
+            "AWS_LAMBDA"
+          ]
         },
         "lambdaFunction": {
           "type": "string"
@@ -169,7 +197,10 @@
           "type": "string"
         }
       },
-      "required": ["lambdaFunction", "mode"]
+      "required": [
+        "lambdaFunction",
+        "mode"
+      ]
     },
     "ConflictResolution": {
       "description": "Defines a strategy for resolving API write conflicts.",
@@ -200,11 +231,17 @@
       "type": "object",
       "properties": {
         "type": {
-          "enum": ["AUTOMERGE", "NONE", "OPTIMISTIC_CONCURRENCY"],
+          "enum": [
+            "AUTOMERGE",
+            "NONE",
+            "OPTIMISTIC_CONCURRENCY"
+          ],
           "type": "string"
         }
       },
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "LambdaResolutionStrategy": {
       "description": "Resolution strategy using a custom lambda function.",
@@ -212,7 +249,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["LAMBDA"]
+          "enum": [
+            "LAMBDA"
+          ]
         },
         "resolver": {
           "description": "The lambda function used to resolve conflicts.",
@@ -226,7 +265,10 @@
           ]
         }
       },
-      "required": ["resolver", "type"]
+      "required": [
+        "resolver",
+        "type"
+      ]
     },
     "NewLambdaConflictResolver": {
       "description": "Defines a new lambda conflict resolver. Using this resolver type will create a new lambda function with boilerplate resolver logic.",
@@ -234,10 +276,14 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["NEW"]
+          "enum": [
+            "NEW"
+          ]
         }
       },
-      "required": ["type"]
+      "required": [
+        "type"
+      ]
     },
     "ExistingLambdaConflictResolver": {
       "description": "Defines an lambda conflict resolver that uses an existing lambda function.",
@@ -245,7 +291,9 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["EXISTING"]
+          "enum": [
+            "EXISTING"
+          ]
         },
         "name": {
           "description": "The name of the lambda function (this must be a lambda function that exists in the Amplify project).",
@@ -260,7 +308,10 @@
           "type": "string"
         }
       },
-      "required": ["name", "type"]
+      "required": [
+        "name",
+        "type"
+      ]
     },
     "PerModelResolutionstrategy": {
       "description": "Defines a resolution strategy for a single model.",
@@ -282,7 +333,10 @@
           "type": "string"
         }
       },
-      "required": ["entityName", "resolutionStrategy"]
+      "required": [
+        "entityName",
+        "resolutionStrategy"
+      ]
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#"

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/api-input-manager/appsync-api-input-state.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/api-input-manager/appsync-api-input-state.test.ts
@@ -18,7 +18,6 @@ jest.mock('amplify-cli-core', () => ({
         serviceConfiguration: {
           apiName: 'authv2migration1',
           serviceName: 'AppSync',
-          gqlSchemaPath: 'mock/schema.graphql',
           defaultAuthType: {
             mode: 'AWS_IAM',
           },

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cfn-api-artifact-handler.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cfn-api-artifact-handler.test.ts
@@ -143,7 +143,6 @@ describe('create artifacts', () => {
       serviceConfiguration: {
         apiName: 'testApiName',
         defaultAuthType: { expirationTime: 10, keyDescription: 'api key description', mode: 'API_KEY' },
-        gqlSchemaPath: 'backendDirPath/api/testApiName/schema.graphql',
         serviceName: 'AppSync',
       },
       version: 1,
@@ -250,7 +249,6 @@ describe('update artifacts', () => {
       serviceConfiguration: {
         apiName: 'testApiName',
         defaultAuthType: { expirationTime: 10, keyDescription: 'api key description', mode: 'API_KEY' },
-        gqlSchemaPath: 'backendDirPath/api/testApiName/schema.graphql',
         serviceName: 'AppSync',
       },
       version: 1,
@@ -266,7 +264,6 @@ describe('update artifacts', () => {
       serviceConfiguration: {
         apiName: 'testApiName',
         defaultAuthType: { expirationTime: 10, keyDescription: 'api key description', mode: 'API_KEY' },
-        gqlSchemaPath: 'backendDirPath/api/testApiName/schema.graphql',
         serviceName: 'AppSync',
       },
       version: 1,
@@ -284,7 +281,6 @@ describe('update artifacts', () => {
       serviceConfiguration: {
         apiName: 'testApiName',
         defaultAuthType: { expirationTime: 10, keyDescription: 'api key description', mode: 'API_KEY' },
-        gqlSchemaPath: 'backendDirPath/api/testApiName/schema.graphql',
         serviceName: 'AppSync',
       },
       version: 1,
@@ -295,7 +291,6 @@ describe('update artifacts', () => {
         additionalAuthTypes: [{ mode: 'AWS_IAM' }, { mode: 'API_KEY' }],
         apiName: 'testApiName',
         defaultAuthType: { expirationTime: 10, keyDescription: 'api key description', mode: 'API_KEY' },
-        gqlSchemaPath: 'backendDirPath/api/testApiName/schema.graphql',
         serviceName: 'AppSync',
       },
       version: 1,
@@ -308,7 +303,6 @@ describe('update artifacts', () => {
       serviceConfiguration: {
         apiName: 'testApiName',
         defaultAuthType: { expirationTime: 10, keyDescription: 'api key description', mode: 'API_KEY' },
-        gqlSchemaPath: 'backendDirPath/api/testApiName/schema.graphql',
         serviceName: 'AppSync',
       },
       version: 1,

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/get-appsync-auth-config.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/get-appsync-auth-config.test.ts
@@ -8,7 +8,6 @@ const getCLIInputPayload_mock = jest
     serviceConfiguration: {
       apiName: 'authv2migration1',
       serviceName: 'AppSync',
-      gqlSchemaPath: 'mock/schema.graphql',
       defaultAuthType: {
         mode: 'AWS_IAM',
       },
@@ -21,7 +20,6 @@ const getCLIInputPayload_mock = jest
     serviceConfiguration: {
       apiName: 'authv2migration1',
       serviceName: 'AppSync',
-      gqlSchemaPath: 'mock/schema.graphql',
       defaultAuthType: {
         mode: 'AWS_IAM',
       },

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/migrate-api-override-resource.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/migrate-api-override-resource.test.ts
@@ -72,7 +72,6 @@ test('migrate resource', async () => {
         },
       },
       apiName: 'apiunittests',
-      gqlSchemaPath: 'mockProjectPath/schema.graphql',
     },
   };
   expect(JSONUtilities.writeJson).toBeCalledWith(expectedPath, expectedPayload);

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthrough-types/appsync-user-input-types.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthrough-types/appsync-user-input-types.ts
@@ -25,10 +25,6 @@ export interface AppSyncServiceConfig {
    */
   apiName: string;
   /**
-   * Path to GraphQL schema that defines the AppSync API.
-   */
-  gqlSchemaPath: string;
-  /**
    * The auth type that will be used by default.
    */
   defaultAuthType: AppSyncAuthType;

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/migrate-api-override-resource.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/migrate-api-override-resource.ts
@@ -13,7 +13,6 @@ import { ResolverConfig } from 'graphql-transformer-core';
 import _ from 'lodash';
 import * as path from 'path';
 import { v4 as uuid } from 'uuid';
-import { gqlSchemaFilename } from '../aws-constants';
 import { AppSyncCLIInputs } from '../service-walkthrough-types/appsync-user-input-types';
 import { authConfigToAppSyncAuthType } from './auth-config-to-app-sync-auth-type-bi-di-mapper';
 import { resolverConfigToConflictResolution } from './resolver-config-to-conflict-resolution-bi-di-mapper';
@@ -58,7 +57,7 @@ export const migrateResourceToSupportOverride = async (resourceName: string) => 
       resourceName,
     };
     // convert parameters.json to cli-inputs.json
-    const cliInputs = generateCliInputs(parameters, apiresourceDirPath);
+    const cliInputs = generateCliInputs(parameters);
     const cliInputsPath = path.join(apiresourceDirPath, 'cli-inputs.json');
     JSONUtilities.writeJson(cliInputsPath, cliInputs);
     printer.debug('Migration is Successful');
@@ -102,7 +101,7 @@ function cleanUp(authresourcePath: string | undefined) {
   if (!!authresourcePath && fs.existsSync(authresourcePath)) fs.removeSync(authresourcePath);
 }
 
-const generateCliInputs = (parameters: ApiMetaData, apiResourceDir: string): AppSyncCLIInputs => {
+const generateCliInputs = (parameters: ApiMetaData): AppSyncCLIInputs => {
   return {
     version: 1,
     serviceConfiguration: {
@@ -114,7 +113,6 @@ const generateCliInputs = (parameters: ApiMetaData, apiResourceDir: string): App
           : undefined,
       conflictResolution: resolverConfigToConflictResolution(parameters.resolverConfig),
       apiName: parameters.resourceName,
-      gqlSchemaPath: path.join(apiResourceDir, gqlSchemaFilename),
     },
   };
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Since `gqlSchemaPath` doesn't be actually used for gql-compilation, we remove it entirely and use the path computed on-the-fly.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

fix #123

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- Unit Testing (`yarn test`)
- Manual Testing
  - `amplify-dev api add`
  - `amplify-dev api update`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
