### PR TITLE
feat(graphql-function-transformer): support cross-account lambda resolvers using @function (#499)

### DIFF
--- a/packages/amplify-graphql-function-transformer/README.md
+++ b/packages/amplify-graphql-function-transformer/README.md
@@ -10,5 +10,5 @@ resolvers within your AWS AppSync API.
 #### Definition
 
 ```graphql
-directive @function(name: String!, region: String) on FIELD_DEFINITION
+directive @function(name: String!, region: String, accountId: String) on FIELD_DEFINITION
 ```

--- a/packages/amplify-graphql-function-transformer/src/__tests__/__snapshots__/amplify-graphql-function-transformer.test.ts.snap
+++ b/packages/amplify-graphql-function-transformer/src/__tests__/__snapshots__/amplify-graphql-function-transformer.test.ts.snap
@@ -1,5 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`for @function with account ID, it generates the expected resources 1`] = `
+Object {
+  "InvokeEchofunction123123456456LambdaDataSource.req.vtl": "## [Start] Invoke AWS Lambda data source: Echofunction123123456456LambdaDataSource. **
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Invoke\\",
+  \\"payload\\": {
+      \\"typeName\\": $util.toJson($ctx.stash.get(\\"typeName\\")),
+      \\"fieldName\\": $util.toJson($ctx.stash.get(\\"fieldName\\")),
+      \\"arguments\\": $util.toJson($ctx.arguments),
+      \\"identity\\": $util.toJson($ctx.identity),
+      \\"source\\": $util.toJson($ctx.source),
+      \\"request\\": $util.toJson($ctx.request),
+      \\"prev\\": $util.toJson($ctx.prev)
+  }
+}
+## [End] Invoke AWS Lambda data source: Echofunction123123456456LambdaDataSource. **",
+  "InvokeEchofunction123123456456LambdaDataSource.res.vtl": "## [Start] Handle error or return result. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
+$util.toJson($ctx.result)
+## [End] Handle error or return result. **",
+  "Query.echo.res.vtl": "$util.toJson($ctx.prev.result)",
+}
+`;
+
+exports[`for @function with only name, it generates the expected resources 1`] = `
+Object {
+  "InvokeEchofunctionLambdaDataSource.req.vtl": "## [Start] Invoke AWS Lambda data source: EchofunctionLambdaDataSource. **
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Invoke\\",
+  \\"payload\\": {
+      \\"typeName\\": $util.toJson($ctx.stash.get(\\"typeName\\")),
+      \\"fieldName\\": $util.toJson($ctx.stash.get(\\"fieldName\\")),
+      \\"arguments\\": $util.toJson($ctx.arguments),
+      \\"identity\\": $util.toJson($ctx.identity),
+      \\"source\\": $util.toJson($ctx.source),
+      \\"request\\": $util.toJson($ctx.request),
+      \\"prev\\": $util.toJson($ctx.prev)
+  }
+}
+## [End] Invoke AWS Lambda data source: EchofunctionLambdaDataSource. **",
+  "InvokeEchofunctionLambdaDataSource.res.vtl": "## [Start] Handle error or return result. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
+$util.toJson($ctx.result)
+## [End] Handle error or return result. **",
+  "Query.echo.res.vtl": "$util.toJson($ctx.prev.result)",
+}
+`;
+
 exports[`it generates the expected resources 1`] = `
 Object {
   "InvokeEchofunctionLambdaDataSource.req.vtl": "## [Start] Invoke AWS Lambda data source: EchofunctionLambdaDataSource. **

--- a/packages/amplify-graphql-function-transformer/src/__tests__/amplify-graphql-function-transformer.test.ts
+++ b/packages/amplify-graphql-function-transformer/src/__tests__/amplify-graphql-function-transformer.test.ts
@@ -4,7 +4,7 @@ import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import { parse } from 'graphql';
 import { FunctionTransformer } from '..';
 
-test('it generates the expected resources', () => {
+test('for @function with only name, it generates the expected resources', () => {
   const validSchema = `
     type Query {
         echo(msg: String): String @function(name: "echofunction-\${env}")
@@ -117,6 +117,140 @@ test('it generates the expected resources', () => {
       },
       ResponseMappingTemplateS3Location: {
         'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/InvokeEchofunctionLambdaDataSource.res.vtl']],
+      },
+    }),
+  );
+  cdkExpect(stack).to(
+    haveResource('AWS::AppSync::Resolver', {
+      ApiId: { Ref: anything() },
+      FieldName: 'echo',
+      TypeName: 'Query',
+      Kind: 'PIPELINE',
+      PipelineConfig: {
+        Functions: [{ 'Fn::GetAtt': [anything(), 'FunctionId'] }],
+      },
+      RequestMappingTemplate: anything(),
+      ResponseMappingTemplateS3Location: {
+        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Query.echo.res.vtl']],
+      },
+    }),
+  );
+  expect(out.resolvers).toMatchSnapshot();
+});
+
+test('for @function with account ID, it generates the expected resources', () => {
+  const validSchema = `
+    type Query {
+        echo(msg: String): String @function(name: "echofunction", accountId: "123123456456")
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new FunctionTransformer()],
+  });
+
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  expect(out.stacks).toBeDefined();
+  parse(out.schema);
+  const stack = out.stacks.FunctionDirectiveStack;
+  expect(stack).toBeDefined();
+  cdkExpect(stack).to(countResources('AWS::IAM::Role', 1));
+  cdkExpect(stack).to(countResources('AWS::IAM::Policy', 1));
+  cdkExpect(stack).to(countResources('AWS::AppSync::DataSource', 1));
+  cdkExpect(stack).to(countResources('AWS::AppSync::FunctionConfiguration', 1));
+  cdkExpect(stack).to(countResources('AWS::AppSync::Resolver', 1));
+  cdkExpect(stack).to(
+    haveResource('AWS::IAM::Role', {
+      AssumeRolePolicyDocument: {
+        Statement: [
+          {
+            Action: 'sts:AssumeRole',
+            Effect: 'Allow',
+            Principal: {
+              Service: 'appsync.amazonaws.com',
+            },
+          },
+        ],
+        Version: '2012-10-17',
+      },
+    }),
+  );
+  cdkExpect(stack).to(
+    haveResource('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: [
+          {
+            Action: 'lambda:InvokeFunction',
+            Effect: 'Allow',
+            Resource: [
+              {
+                'Fn::If': [
+                  'HasEnvironmentParameter',
+                  {
+                    'Fn::Sub': ['arn:aws:lambda:${AWS::Region}:123123456456:function:echofunction', {}],
+                  },
+                  { 'Fn::Sub': 'arn:aws:lambda:${AWS::Region}:123123456456:function:echofunction' },
+                ],
+              },
+              {
+                'Fn::Join': [
+                  '',
+                  [
+                    {
+                      'Fn::If': [
+                        'HasEnvironmentParameter',
+                        {
+                          'Fn::Sub': ['arn:aws:lambda:${AWS::Region}:123123456456:function:echofunction', {}],
+                        },
+                        { 'Fn::Sub': 'arn:aws:lambda:${AWS::Region}:123123456456:function:echofunction' },
+                      ],
+                    },
+                    ':*',
+                  ],
+                ],
+              },
+            ],
+          },
+        ],
+        Version: '2012-10-17',
+      },
+      PolicyName: anything(),
+      Roles: [{ Ref: anything() }],
+    }),
+  );
+  cdkExpect(stack).to(
+    haveResource('AWS::AppSync::DataSource', {
+      ApiId: { Ref: anything() },
+      Name: 'Echofunction123123456456LambdaDataSource',
+      Type: 'AWS_LAMBDA',
+      LambdaConfig: {
+        LambdaFunctionArn: {
+          'Fn::If': [
+            'HasEnvironmentParameter',
+            {
+              'Fn::Sub': ['arn:aws:lambda:${AWS::Region}:123123456456:function:echofunction', {}],
+            },
+            { 'Fn::Sub': 'arn:aws:lambda:${AWS::Region}:123123456456:function:echofunction' },
+          ],
+        },
+      },
+      ServiceRoleArn: {
+        'Fn::GetAtt': ['Echofunction123123456456LambdaDataSourceServiceRole0B60B47E', 'Arn'],
+      },
+    }),
+  );
+  cdkExpect(stack).to(
+    haveResource('AWS::AppSync::FunctionConfiguration', {
+      ApiId: { Ref: anything() },
+      DataSourceName: { 'Fn::GetAtt': [anything(), 'Name'] },
+      FunctionVersion: '2018-05-29',
+      Name: 'InvokeEchofunction123123456456LambdaDataSource',
+      RequestMappingTemplateS3Location: {
+        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/InvokeEchofunction123123456456LambdaDataSource.req.vtl']],
+      },
+      ResponseMappingTemplateS3Location: {
+        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/InvokeEchofunction123123456456LambdaDataSource.res.vtl']],
       },
     }),
   );

--- a/packages/amplify-graphql-function-transformer/src/graphql-function-transformer.ts
+++ b/packages/amplify-graphql-function-transformer/src/graphql-function-transformer.ts
@@ -11,23 +11,21 @@ import * as lambda from '@aws-cdk/aws-lambda';
 import { AuthorizationType } from '@aws-cdk/aws-appsync';
 import * as cdk from '@aws-cdk/core';
 import { obj, str, ref, printBlock, compoundExpression, qref, raw, iff, Expression } from 'graphql-mapping-template';
-import { FunctionResourceIDs, ResolverResourceIDs, ResourceConstants } from 'graphql-transformer-common';
+import { FunctionDirectiveConfig, FunctionResourceIDs, ResolverResourceIDs, ResourceConstants } from 'graphql-transformer-common';
 import { DirectiveNode, ObjectTypeDefinitionNode, InterfaceTypeDefinitionNode, FieldDefinitionNode } from 'graphql';
 
-type FunctionDirectiveConfiguration = {
-  name: string;
-  region: string | undefined;
+interface FunctionDirectiveWithResolverConfig extends FunctionDirectiveConfig {
   resolverTypeName: string;
   resolverFieldName: string;
-};
+}
 
 const FUNCTION_DIRECTIVE_STACK = 'FunctionDirectiveStack';
 const directiveDefinition = /* GraphQL */ `
-  directive @function(name: String!, region: String) repeatable on FIELD_DEFINITION
+  directive @function(name: String!, region: String, accountId: String) repeatable on FIELD_DEFINITION
 `;
 
 export class FunctionTransformer extends TransformerPluginBase {
-  private resolverGroups: Map<FieldDefinitionNode, FunctionDirectiveConfiguration[]> = new Map();
+  private resolverGroups: Map<FieldDefinitionNode, FunctionDirectiveWithResolverConfig[]> = new Map();
 
   constructor() {
     super('amplify-function-transformer', directiveDefinition);
@@ -43,7 +41,7 @@ export class FunctionTransformer extends TransformerPluginBase {
     const args = directiveWrapped.getArguments({
       resolverTypeName: parent.name.value,
       resolverFieldName: definition.name.value,
-    } as FunctionDirectiveConfiguration, generateGetArgumentsInput(acc.featureFlags));
+    }, generateGetArgumentsInput(acc.featureFlags)) as FunctionDirectiveWithResolverConfig;
     let resolver = this.resolverGroups.get(definition);
 
     if (resolver === undefined) {
@@ -73,13 +71,13 @@ export class FunctionTransformer extends TransformerPluginBase {
     this.resolverGroups.forEach((resolverFns, fieldDefinition) => {
       resolverFns.forEach(config => {
         // Create data sources that register Lambdas and IAM roles.
-        const dataSourceId = FunctionResourceIDs.FunctionDataSourceID(config.name, config.region);
+        const dataSourceId = FunctionResourceIDs.FunctionDataSourceID(config);
 
         if (!createdResources.has(dataSourceId)) {
           const dataSource = context.api.host.addLambdaDataSource(
             dataSourceId,
             lambda.Function.fromFunctionAttributes(stack, `${dataSourceId}Function`, {
-              functionArn: lambdaArnResource(env, config.name, config.region),
+              functionArn: lambdaArnResource(env, config),
             }),
             {},
             stack,
@@ -88,7 +86,7 @@ export class FunctionTransformer extends TransformerPluginBase {
         }
 
         // Create AppSync functions.
-        const functionId = FunctionResourceIDs.FunctionAppSyncFunctionConfigurationID(config.name, config.region);
+        const functionId = FunctionResourceIDs.FunctionAppSyncFunctionConfigurationID(config);
         let func = createdResources.get(functionId);
 
         if (func === undefined) {
@@ -181,18 +179,21 @@ export class FunctionTransformer extends TransformerPluginBase {
   };
 }
 
-function lambdaArnResource(env: cdk.CfnParameter, name: string, region?: string): string {
+function lambdaArnResource(env: cdk.CfnParameter, fdConfig: FunctionDirectiveConfig): string {
   const substitutions: { [key: string]: string } = {};
-  if (name.includes('${env}')) {
+  if (fdConfig.name.includes('${env}')) {
     substitutions.env = env as unknown as string;
   }
   return cdk.Fn.conditionIf(
     ResourceConstants.CONDITIONS.HasEnvironmentParameter,
-    cdk.Fn.sub(lambdaArnKey(name, region), substitutions),
-    cdk.Fn.sub(lambdaArnKey(name.replace(/(-\${env})/, ''), region)),
+    cdk.Fn.sub(lambdaArnKey(fdConfig), substitutions),
+    cdk.Fn.sub(lambdaArnKey({
+      ...fdConfig,
+      name: fdConfig.name.replace(/(-\${env})/, ''),
+    })),
   ).toString();
 }
 
-function lambdaArnKey(name: string, region?: string): string {
-  return `arn:aws:lambda:${region ? region : '${AWS::Region}'}:\${AWS::AccountId}:function:${name}`;
+function lambdaArnKey({ name, region, accountId }: FunctionDirectiveConfig): string {
+  return `arn:aws:lambda:${region ?? '${AWS::Region}'}:${accountId ?? '${AWS::AccountId}'}:function:${name}`;
 }

--- a/packages/graphql-function-transformer/src/FunctionTransformer.ts
+++ b/packages/graphql-function-transformer/src/FunctionTransformer.ts
@@ -1,6 +1,12 @@
-import { Transformer, gql, TransformerContext, getDirectiveArguments, TransformerContractError } from 'graphql-transformer-core';
+import { Transformer, gql, TransformerContext } from 'graphql-transformer-core';
 import { obj, str, ref, printBlock, compoundExpression, qref, raw, iff } from 'graphql-mapping-template';
-import { ResolverResourceIDs, FunctionResourceIDs, ResourceConstants } from 'graphql-transformer-common';
+import {
+  ResolverResourceIDs,
+  FunctionResourceIDs,
+  ResourceConstants,
+  parseFunctionDirective,
+  FunctionDirectiveConfig,
+} from 'graphql-transformer-common';
 import { ObjectTypeDefinitionNode, FieldDefinitionNode, DirectiveNode } from 'graphql';
 import { AppSync, IAM, Fn } from 'cloudform-types';
 import { lambdaArnResource } from './lambdaArns';
@@ -14,7 +20,7 @@ export class FunctionTransformer extends Transformer {
     super(
       'FunctionTransformer',
       gql`
-        directive @function(name: String!, region: String) repeatable on FIELD_DEFINITION
+        directive @function(name: String!, region: String, accountId: String) repeatable on FIELD_DEFINITION
       `
     );
   }
@@ -23,29 +29,26 @@ export class FunctionTransformer extends Transformer {
    * Add the required resources to invoke a lambda function for this field.
    */
   field = (parent: ObjectTypeDefinitionNode, definition: FieldDefinitionNode, directive: DirectiveNode, ctx: TransformerContext) => {
-    const { name, region } = getDirectiveArguments(directive);
-    if (!name) {
-      throw new TransformerContractError(`Must supply a 'name' to @function.`);
-    }
+    const fdConfig = parseFunctionDirective(directive);
 
     // Add the iam role if it does not exist.
-    const iamRoleKey = FunctionResourceIDs.FunctionIAMRoleID(name, region);
+    const iamRoleKey = FunctionResourceIDs.FunctionIAMRoleID(fdConfig);
     if (!ctx.getResource(iamRoleKey)) {
-      ctx.setResource(iamRoleKey, this.role(name, region));
+      ctx.setResource(iamRoleKey, this.role(fdConfig));
       ctx.mapResourceToStack(FUNCTION_DIRECTIVE_STACK, iamRoleKey);
     }
 
     // Add the data source if it does not exist.
-    const lambdaDataSourceKey = FunctionResourceIDs.FunctionDataSourceID(name, region);
+    const lambdaDataSourceKey = FunctionResourceIDs.FunctionDataSourceID(fdConfig);
     if (!ctx.getResource(lambdaDataSourceKey)) {
-      ctx.setResource(lambdaDataSourceKey, this.datasource(name, region));
+      ctx.setResource(lambdaDataSourceKey, this.datasource(fdConfig));
       ctx.mapResourceToStack(FUNCTION_DIRECTIVE_STACK, lambdaDataSourceKey);
     }
 
     // Add function that invokes the lambda function
-    const functionConfigurationKey = FunctionResourceIDs.FunctionAppSyncFunctionConfigurationID(name, region);
+    const functionConfigurationKey = FunctionResourceIDs.FunctionAppSyncFunctionConfigurationID(fdConfig);
     if (!ctx.getResource(functionConfigurationKey)) {
-      ctx.setResource(functionConfigurationKey, this.function(name, region));
+      ctx.setResource(functionConfigurationKey, this.function(fdConfig));
       ctx.mapResourceToStack(FUNCTION_DIRECTIVE_STACK, functionConfigurationKey);
     }
 
@@ -55,12 +58,12 @@ export class FunctionTransformer extends Transformer {
     const resolverKey = ResolverResourceIDs.ResolverResourceID(typeName, fieldName);
     const resolver = ctx.getResource(resolverKey);
     if (!resolver) {
-      ctx.setResource(resolverKey, this.resolver(typeName, fieldName, name, region));
+      ctx.setResource(resolverKey, this.resolver(typeName, fieldName, fdConfig));
       ctx.mapResourceToStack(FUNCTION_DIRECTIVE_STACK, resolverKey);
     } else if (resolver.Properties.Kind === 'PIPELINE') {
       ctx.setResource(
         resolverKey,
-        this.appendFunctionToResolver(resolver, FunctionResourceIDs.FunctionAppSyncFunctionConfigurationID(name, region))
+        this.appendFunctionToResolver(resolver, FunctionResourceIDs.FunctionAppSyncFunctionConfigurationID(fdConfig))
       );
     }
   };
@@ -68,17 +71,17 @@ export class FunctionTransformer extends Transformer {
   /**
    * Create a role that allows our AppSync API to talk to our Lambda function.
    */
-  role = (name: string, region: string): any => {
+  role = (fdConfig: FunctionDirectiveConfig): any => {
     return new IAM.Role({
       RoleName: Fn.If(
         ResourceConstants.CONDITIONS.HasEnvironmentParameter,
         Fn.Join('-', [
-          FunctionResourceIDs.FunctionIAMRoleName(name, true), // max of 64. 64-10-26-28 = 0
+          FunctionResourceIDs.FunctionIAMRoleName(fdConfig.name, true), // max of 64. 64-10-26-28 = 0
           Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'), // 26
           Fn.Ref(ResourceConstants.PARAMETERS.Env), // 10
         ]),
         Fn.Join('-', [
-          FunctionResourceIDs.FunctionIAMRoleName(name, false), // max of 64. 64-26-38 = 0
+          FunctionResourceIDs.FunctionIAMRoleName(fdConfig.name, false), // max of 64. 64-26-38 = 0
           Fn.GetAtt(ResourceConstants.RESOURCES.GraphQLAPILogicalID, 'ApiId'), // 26
         ])
       ),
@@ -103,7 +106,7 @@ export class FunctionTransformer extends Transformer {
               {
                 Effect: 'Allow',
                 Action: ['lambda:InvokeFunction'],
-                Resource: lambdaArnResource(name, region),
+                Resource: lambdaArnResource(fdConfig),
               },
             ],
           },
@@ -115,28 +118,28 @@ export class FunctionTransformer extends Transformer {
   /**
    * Creates a lambda data source that registers the lambda function and associated role.
    */
-  datasource = (name: string, region: string): any => {
+  datasource = (fdConfig: FunctionDirectiveConfig): any => {
     return new AppSync.DataSource({
       ApiId: Fn.Ref(ResourceConstants.PARAMETERS.AppSyncApiId),
-      Name: FunctionResourceIDs.FunctionDataSourceID(name, region),
+      Name: FunctionResourceIDs.FunctionDataSourceID(fdConfig),
       Type: 'AWS_LAMBDA',
-      ServiceRoleArn: Fn.GetAtt(FunctionResourceIDs.FunctionIAMRoleID(name, region), 'Arn'),
+      ServiceRoleArn: Fn.GetAtt(FunctionResourceIDs.FunctionIAMRoleID(fdConfig), 'Arn'),
       LambdaConfig: {
-        LambdaFunctionArn: lambdaArnResource(name, region),
+        LambdaFunctionArn: lambdaArnResource(fdConfig),
       },
-    }).dependsOn(FunctionResourceIDs.FunctionIAMRoleID(name, region));
+    }).dependsOn(FunctionResourceIDs.FunctionIAMRoleID(fdConfig));
   };
 
   /**
    * Create a new pipeline function that calls out to the lambda function and returns the value.
    */
-  function = (name: string, region: string): any => {
+  function = (fdConfig: FunctionDirectiveConfig): any => {
     return new AppSync.FunctionConfiguration({
       ApiId: Fn.Ref(ResourceConstants.PARAMETERS.AppSyncApiId),
-      Name: FunctionResourceIDs.FunctionAppSyncFunctionConfigurationID(name, region),
-      DataSourceName: FunctionResourceIDs.FunctionDataSourceID(name, region),
+      Name: FunctionResourceIDs.FunctionAppSyncFunctionConfigurationID(fdConfig),
+      DataSourceName: FunctionResourceIDs.FunctionDataSourceID(fdConfig),
       FunctionVersion: '2018-05-29',
-      RequestMappingTemplate: printBlock(`Invoke AWS Lambda data source: ${FunctionResourceIDs.FunctionDataSourceID(name, region)}`)(
+      RequestMappingTemplate: printBlock(`Invoke AWS Lambda data source: ${FunctionResourceIDs.FunctionDataSourceID(fdConfig)}`)(
         obj({
           version: str('2018-05-29'),
           operation: str('Invoke'),
@@ -157,26 +160,26 @@ export class FunctionTransformer extends Transformer {
           raw('$util.toJson($ctx.result)'),
         ])
       ),
-    }).dependsOn(FunctionResourceIDs.FunctionDataSourceID(name, region));
+    }).dependsOn(FunctionResourceIDs.FunctionDataSourceID(fdConfig));
   };
 
   /**
    * Create a resolver of one that calls the "function" function.
    */
-  resolver = (type: string, field: string, name: string, region?: string): any => {
+  resolver = (type: string, field: string, fdConfig: FunctionDirectiveConfig): any => {
     return new AppSync.Resolver({
       ApiId: Fn.Ref(ResourceConstants.PARAMETERS.AppSyncApiId),
       TypeName: type,
       FieldName: field,
       Kind: 'PIPELINE',
       PipelineConfig: {
-        Functions: [Fn.GetAtt(FunctionResourceIDs.FunctionAppSyncFunctionConfigurationID(name, region), 'FunctionId')],
+        Functions: [Fn.GetAtt(FunctionResourceIDs.FunctionAppSyncFunctionConfigurationID(fdConfig), 'FunctionId')],
       },
       RequestMappingTemplate: printBlock('Stash resolver specific context.')(
         compoundExpression([qref(`$ctx.stash.put("typeName", "${type}")`), qref(`$ctx.stash.put("fieldName", "${field}")`), obj({})])
       ),
       ResponseMappingTemplate: '$util.toJson($ctx.prev.result)',
-    }).dependsOn(FunctionResourceIDs.FunctionAppSyncFunctionConfigurationID(name, region));
+    }).dependsOn(FunctionResourceIDs.FunctionAppSyncFunctionConfigurationID(fdConfig));
   };
 
   appendFunctionToResolver(resolver: any, functionId: string) {

--- a/packages/graphql-function-transformer/src/__tests__/FunctionTransformer.test.ts
+++ b/packages/graphql-function-transformer/src/__tests__/FunctionTransformer.test.ts
@@ -90,6 +90,45 @@ test('two @function directives for the same field should be valid', () => {
   );
 });
 
+test('@function directive referencing Lambda function in another AWS account', () => {
+  const validSchema = `
+    type Query {
+        echo(msg: String): String @function(name: "echofunction", accountId: "0123")
+    }
+    `;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new FunctionTransformer()],
+  });
+
+  const out = transformer.transform(validSchema);
+  expect(out).toBeDefined();
+  // EchofunctionLambdaDataSource, EchofunctionLambdaDataSourceRole, QueryEchoResolver, GraphQLSchema
+  expect(Object.keys(out.stacks.FunctionDirectiveStack.Resources).length).toEqual(4);
+
+  let expectedLambdaArn = 'arn:aws:lambda:${AWS::Region}:0123:function:echofunction';
+  // datasource
+  let datasourceResource = out.stacks.FunctionDirectiveStack.Resources.Echofunction0123LambdaDataSource;
+  expect(datasourceResource).toBeDefined();
+  expect(datasourceResource.Properties.LambdaConfig.LambdaFunctionArn['Fn::If'][1]['Fn::Sub'][0]).toEqual(expectedLambdaArn);
+
+  // IAM role
+  let iamRoleResource = out.stacks.FunctionDirectiveStack.Resources.Echofunction0123LambdaDataSourceRole;
+  expect(iamRoleResource).toBeDefined();
+  expect(iamRoleResource.Properties.AssumeRolePolicyDocument.Statement[0].Principal.Service).toEqual('appsync.amazonaws.com');
+  expect(iamRoleResource.Properties.AssumeRolePolicyDocument.Statement[0].Action).toEqual('sts:AssumeRole');
+  expect(iamRoleResource.Properties.Policies[0].PolicyDocument.Statement[0].Action[0]).toEqual('lambda:InvokeFunction');
+  expect(iamRoleResource.Properties.Policies[0].PolicyDocument.Statement[0].Resource['Fn::If'][1]['Fn::Sub'][0]).toEqual(expectedLambdaArn);
+
+  // Resolver
+  let resolverResource = out.stacks.FunctionDirectiveStack.Resources.QueryechoResolver;
+  expect(resolverResource).toBeDefined();
+  expect(resolverResource.Properties.FieldName).toEqual('echo');
+  expect(resolverResource.Properties.TypeName).toEqual('Query');
+  expect(resolverResource.Properties.Kind).toEqual('PIPELINE');
+  expect(resolverResource.Properties.PipelineConfig.Functions.length).toEqual(1);
+});
+
 test('@function directive applied to Object should throw Error', () => {
   const invalidSchema = `
     type Query @function(name: "echofunction-\${env}") {

--- a/packages/graphql-transformer-common/src/FunctionDirectiveConfig.ts
+++ b/packages/graphql-transformer-common/src/FunctionDirectiveConfig.ts
@@ -1,0 +1,5 @@
+export interface FunctionDirectiveConfig {
+  name: string;
+  region?: string;
+  accountId?: string;
+}

--- a/packages/graphql-transformer-common/src/FunctionResourceIDs.ts
+++ b/packages/graphql-transformer-common/src/FunctionResourceIDs.ts
@@ -1,13 +1,27 @@
 import { simplifyName } from './util';
 import md5 from 'md5';
+import { DirectiveNode } from 'graphql';
+import { getDirectiveArguments, TransformerContractError } from 'graphql-transformer-core';
 
-export class FunctionResourceIDs {
-  static FunctionDataSourceID(name: string, region?: string): string {
-    return `${simplifyName(name)}${simplifyName(region || '')}LambdaDataSource`;
+import { FunctionDirectiveConfig } from './FunctionDirectiveConfig';
+
+export function parseFunctionDirective(directive: DirectiveNode): FunctionDirectiveConfig {
+  const { name, region, accountId } = getDirectiveArguments(directive);
+
+  if (!name) {
+    throw new TransformerContractError(`Must supply a 'name' to @function.`);
   }
 
-  static FunctionIAMRoleID(name: string, region?: string): string {
-    return `${FunctionResourceIDs.FunctionDataSourceID(name, region)}Role`;
+  return { name, region, accountId };
+}
+
+export class FunctionResourceIDs {
+  static FunctionDataSourceID({ name, region, accountId }: FunctionDirectiveConfig): string {
+    return `${simplifyName(name)}${simplifyName(region || '')}${accountId || ''}LambdaDataSource`;
+  }
+
+  static FunctionIAMRoleID(fdConfig: FunctionDirectiveConfig): string {
+    return `${FunctionResourceIDs.FunctionDataSourceID(fdConfig)}Role`;
   }
 
   static FunctionIAMRoleName(name: string, withEnv: boolean = false): string {
@@ -17,7 +31,7 @@ export class FunctionResourceIDs {
     return `${simplifyName(name).slice(0, 32)}${md5(name).slice(0, 4)}`;
   }
 
-  static FunctionAppSyncFunctionConfigurationID(name: string, region?: string): string {
-    return `Invoke${FunctionResourceIDs.FunctionDataSourceID(name, region)}`;
+  static FunctionAppSyncFunctionConfigurationID(fdConfig: FunctionDirectiveConfig): string {
+    return `Invoke${FunctionResourceIDs.FunctionDataSourceID(fdConfig)}`;
   }
 }

--- a/packages/graphql-transformer-common/src/index.ts
+++ b/packages/graphql-transformer-common/src/index.ts
@@ -6,6 +6,7 @@ export * from './ModelResourceIDs';
 export * from './SearchableResourceIDs';
 export * from './nodeUtils';
 export * from './HttpResourceIDs';
+export * from './FunctionDirectiveConfig';
 export * from './FunctionResourceIDs';
 export * from './connectionUtils';
 export * from './dynamodbUtils';


### PR DESCRIPTION
This change does not come with E2E tests because I don't know whether the
existing CI infra has access to multiple AWS accounts.

However, I tested this in my own two AWS accounts.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Adds support for `accountId: XYZ` attribute on `@function` directive, to allow data sources
to be Lambda functions in a different AWS account than the AppSync instance.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

#499 
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

1. Unit tests
2. Deployed an Amplify application to my AWS account *A* with a function referencing AWS account *B*. Created the function in *B*, issued a GraphQL query against my instance, and verified that the function in *B* gets invoked.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
