### PR TITLE
fix: use PK name in many to many link object

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/graphql-many-to-many-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-many-to-many-transformer.ts
@@ -36,7 +36,7 @@ import { IndexTransformer } from '@aws-amplify/graphql-index-transformer';
 import produce from 'immer';
 import { WritableDraft } from 'immer/dist/types/types-external';
 import { ManyToManyDirectiveConfiguration, ManyToManyPreProcessContext, ManyToManyRelation } from './types';
-import { registerManyToManyForeignKeyMappings, validateModelDirective } from './utils';
+import { getManyToManyConnectionAttributeName, getObjectPrimaryKey, registerManyToManyForeignKeyMappings, validateModelDirective } from './utils';
 import { makeQueryConnectionWithKeyResolver, updateTableForConnection } from './resolvers';
 import {
   ensureHasManyConnectionField,
@@ -165,9 +165,9 @@ export class ManyToManyTransformer extends TransformerPluginBase {
         const d2SortKeys = getSortKeyFieldsNoContext(manyToManyTwo.model);
         const d1IndexName = `by${d1origTypeName}`;
         const d2IndexName = `by${d2origTypeName}`;
-        const d1FieldNameId = `${d1FieldName}ID`;
+        const d1FieldNameId = getManyToManyConnectionAttributeName(context.featureFlags, d1FieldName, getObjectPrimaryKey(manyToManyOne.model as ObjectTypeDefinitionNode).name.value);
         const d1SortFieldNames = d1SortKeys.map(node => `${d1FieldNameOrig}${node.name.value}`);
-        const d2FieldNameId = `${d2FieldName}ID`;
+        const d2FieldNameId = getManyToManyConnectionAttributeName(context.featureFlags, d2FieldName, getObjectPrimaryKey(manyToManyTwo.model as ObjectTypeDefinitionNode).name.value);
         const d2SortFieldNames = d2SortKeys.map(node => `${d2FieldNameOrig}${node.name.value}`);
         const joinModelDirective = makeDirective('model', []);
         const d1IndexDirective = makeDirective('index', [
@@ -282,9 +282,9 @@ export class ManyToManyTransformer extends TransformerPluginBase {
       const d2SortKeys = getSortKeyFields(context, directive2.object);
       const d1IndexName = `by${d1origTypeName}`;
       const d2IndexName = `by${d2origTypeName}`;
-      const d1FieldNameId = `${d1FieldName}ID`;
+      const d1FieldNameId = getManyToManyConnectionAttributeName(ctx.featureFlags, d1FieldName, getObjectPrimaryKey(directive1.object).name.value);
       const d1SortFieldNames = d1SortKeys.map(node => `${d1FieldNameOrig}${node.name.value}`);
-      const d2FieldNameId = `${d2FieldName}ID`;
+      const d2FieldNameId = getManyToManyConnectionAttributeName(ctx.featureFlags, d2FieldName, getObjectPrimaryKey(directive2.object).name.value);
       const d1FieldNameIdOrig = `${d1FieldNameOrig}ID`;
       const d2FieldNameIdOrig = `${d2FieldNameOrig}ID`;
       const d2SortFieldNames = d2SortKeys.map(node => `${d2FieldNameOrig}${node.name.value}`);

--- a/packages/amplify-graphql-relational-transformer/src/utils.ts
+++ b/packages/amplify-graphql-relational-transformer/src/utils.ts
@@ -10,7 +10,7 @@ import {
 import {
   DirectiveNode, EnumTypeDefinitionNode, FieldDefinitionNode, Kind, ObjectTypeDefinitionNode, StringValueNode,
 } from 'graphql';
-import { getBaseType, isScalarOrEnum, makeField, makeNamedType, makeNonNullType, toCamelCase } from 'graphql-transformer-common';
+import { getBaseType, isScalarOrEnum, makeField, makeNamedType, makeNonNullType, toCamelCase, toPascalCase } from 'graphql-transformer-common';
 import {
   BelongsToDirectiveConfiguration,
   HasManyDirectiveConfiguration,
@@ -177,6 +177,11 @@ function getIndexName(directive: DirectiveNode): string | undefined {
 export function getConnectionAttributeName(featureFlags: FeatureFlagProvider, type: string, field: string, relatedTypeField: string) {
   const nameSuffix = featureFlags.getBoolean('respectPrimaryKeyAttributesOnConnectionField') ? relatedTypeField : 'id';
   return toCamelCase([type, field, nameSuffix]);
+}
+
+export function getManyToManyConnectionAttributeName(featureFlags: FeatureFlagProvider, field: string, relatedTypeField: string) {
+  const nameSuffix = featureFlags.getBoolean('respectPrimaryKeyAttributesOnConnectionField') ? toPascalCase([relatedTypeField]) : 'ID';
+  return `${toCamelCase([field])}${nameSuffix}`;
 }
 
 export function getSortKeyConnectionAttributeName(type: string, field: string, relatedTypeField: string) {


### PR DESCRIPTION
#### Description of changes
- uses PK name in connection field in the many to many middle object

#### Description of how you validated changes
- manual testing and `yarn test`

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
