### PR TITLE
Graphql auth transformer/dynamic groups

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/field-auth-argument.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/field-auth-argument.test.ts.snap
@@ -237,7 +237,14 @@ $util.unauthorized()
     #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), null)) )
     #if( !$util.isNull($ownerClaim0) )
 
-      #set( $ownerClaimsList0 = [] )
+      #set( $ownerClaimsList0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), [])) )
+      #if( $util.isString($ownerClaimsList0) )
+        #if( $util.isList($util.parseJson($ownerClaimsList0)) )
+          #set( $ownerClaimsList0 = $util.parseJson($ownerClaimsList0) )
+        #else
+          #set( $ownerClaimsList0 = [$ownerClaimsList0] )
+        #end
+      #end
       #if( $ownerEntity0 == $ownerClaim0 || $ownerClaimsList0.contains($ownerEntity0) )
         #set( $isAuthorized = true )
       #end
@@ -278,7 +285,14 @@ exports[`with identity claim feature flag disabled generates field resolver for 
     #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), null)) )
     #if( !$util.isNull($ownerClaim0) )
 
-      #set( $ownerClaimsList0 = [] )
+      #set( $ownerClaimsList0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), [])) )
+      #if( $util.isString($ownerClaimsList0) )
+        #if( $util.isList($util.parseJson($ownerClaimsList0)) )
+          #set( $ownerClaimsList0 = $util.parseJson($ownerClaimsList0) )
+        #else
+          #set( $ownerClaimsList0 = [$ownerClaimsList0] )
+        #end
+      #end
       #if( $ownerEntity0 == $ownerClaim0 || $ownerClaimsList0.contains($ownerEntity0) )
         #set( $isAuthorized = true )
       #end
@@ -373,7 +387,14 @@ exports[`with identity claim feature flag disabled subscription disabled and use
     #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), null)) )
     #if( !$util.isNull($ownerClaim0) )
 
-      #set( $ownerClaimsList0 = [] )
+      #set( $ownerClaimsList0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), [])) )
+      #if( $util.isString($ownerClaimsList0) )
+        #if( $util.isList($util.parseJson($ownerClaimsList0)) )
+          #set( $ownerClaimsList0 = $util.parseJson($ownerClaimsList0) )
+        #else
+          #set( $ownerClaimsList0 = [$ownerClaimsList0] )
+        #end
+      #end
       #if( $ownerEntity0 == $ownerClaim0 || $ownerClaimsList0.contains($ownerEntity0) )
         #set( $isAuthorized = true )
       #end
@@ -418,7 +439,14 @@ exports[`with identity claim feature flag disabled subscription disabled and use
     #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), null)) )
     #if( !$util.isNull($ownerClaim0) )
 
-      #set( $ownerClaimsList0 = [] )
+      #set( $ownerClaimsList0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), [])) )
+      #if( $util.isString($ownerClaimsList0) )
+        #if( $util.isList($util.parseJson($ownerClaimsList0)) )
+          #set( $ownerClaimsList0 = $util.parseJson($ownerClaimsList0) )
+        #else
+          #set( $ownerClaimsList0 = [$ownerClaimsList0] )
+        #end
+      #end
       #if( $ownerEntity0 == $ownerClaim0 || $ownerClaimsList0.contains($ownerEntity0) )
         #set( $isAuthorized = true )
       #end

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
@@ -178,7 +178,14 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
       $util.qr($ctx.args.input.put(\\"owner\\", $ownerClaim0))
     #end
     #if( !$isAuthorized )
-      #set( $ownerClaimsList0 = [] )
+      #set( $ownerClaimsList0 = $util.defaultIfNull($ctx.identity.claims.get(\\"custom:my_field\\"), []) )
+      #if( $util.isString($ownerClaimsList0) )
+        #if( $util.isList($util.parseJson($ownerClaimsList0)) )
+          #set( $ownerClaimsList0 = $util.parseJson($ownerClaimsList0) )
+        #else
+          #set( $ownerClaimsList0 = [$ownerClaimsList0] )
+        #end
+      #end
       #set( $ownerAllowedFields0 = [\\"id\\",\\"title\\",\\"createdAt\\",\\"updatedAt\\"] )
       #set( $isAuthorizedOnAllFields0 = true )
       #if( $ownerClaim0 == $ownerEntity0 || $ownerClaimsList0.contains($ownerEntity0) )
@@ -305,7 +312,14 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
   #set( $parentClaim = $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), null) )
   #if( !$util.isNull($parentClaim) )
 
-    #set( $ownerClaimsList0 = [] )
+    #set( $ownerClaimsList0 = $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), []) )
+    #if( $util.isString($ownerClaimsList0) )
+      #if( $util.isList($util.parseJson($ownerClaimsList0)) )
+        #set( $ownerClaimsList0 = $util.parseJson($ownerClaimsList0) )
+      #else
+        #set( $ownerClaimsList0 = [$ownerClaimsList0] )
+      #end
+    #end
     $util.qr($ownerClaimsList0.add($parentClaim))
     #if( !$util.isNull($ctx.args.parent) )
       #if( $util.isString($ctx.args.parent) )
@@ -335,7 +349,14 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
   #set( $childClaim = $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), null) )
   #if( !$util.isNull($childClaim) )
 
-    #set( $ownerClaimsList1 = [] )
+    #set( $ownerClaimsList1 = $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), []) )
+    #if( $util.isString($ownerClaimsList1) )
+      #if( $util.isList($util.parseJson($ownerClaimsList1)) )
+        #set( $ownerClaimsList1 = $util.parseJson($ownerClaimsList1) )
+      #else
+        #set( $ownerClaimsList1 = [$ownerClaimsList1] )
+      #end
+    #end
     $util.qr($ownerClaimsList1.add($childClaim))
     #if( !$util.isNull($ctx.args.child) )
       #if( $util.isString($ctx.args.child) )
@@ -601,7 +622,14 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
       $util.qr($ctx.args.input.put(\\"editors\\", [$ownerClaim0]))
     #end
     #if( !$isAuthorized )
-      #set( $ownerClaimsList0 = [] )
+      #set( $ownerClaimsList0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), [])) )
+      #if( $util.isString($ownerClaimsList0) )
+        #if( $util.isList($util.parseJson($ownerClaimsList0)) )
+          #set( $ownerClaimsList0 = $util.parseJson($ownerClaimsList0) )
+        #else
+          #set( $ownerClaimsList0 = [$ownerClaimsList0] )
+        #end
+      #end
       #set( $ownerAllowedFields0 = [\\"id\\",\\"title\\",\\"editors\\",\\"createdAt\\",\\"updatedAt\\"] )
       #set( $isAuthorizedOnAllFields0 = true )
       #foreach( $allowedOwner in $ownerEntity0 )
@@ -731,7 +759,14 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
   #set( $parentClaim = $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), null) )
   #if( !$util.isNull($parentClaim) )
 
-    #set( $ownerClaimsList0 = [] )
+    #set( $ownerClaimsList0 = $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), []) )
+    #if( $util.isString($ownerClaimsList0) )
+      #if( $util.isList($util.parseJson($ownerClaimsList0)) )
+        #set( $ownerClaimsList0 = $util.parseJson($ownerClaimsList0) )
+      #else
+        #set( $ownerClaimsList0 = [$ownerClaimsList0] )
+      #end
+    #end
     $util.qr($ownerClaimsList0.add($parentClaim))
     #if( !$util.isNull($ctx.args.parent) )
       #if( $util.isString($ctx.args.parent) )
@@ -761,7 +796,14 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
   #set( $childClaim = $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), null) )
   #if( !$util.isNull($childClaim) )
 
-    #set( $ownerClaimsList1 = [] )
+    #set( $ownerClaimsList1 = $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), []) )
+    #if( $util.isString($ownerClaimsList1) )
+      #if( $util.isList($util.parseJson($ownerClaimsList1)) )
+        #set( $ownerClaimsList1 = $util.parseJson($ownerClaimsList1) )
+      #else
+        #set( $ownerClaimsList1 = [$ownerClaimsList1] )
+      #end
+    #end
     $util.qr($ownerClaimsList1.add($childClaim))
     #if( !$util.isNull($ctx.args.child) )
       #if( $util.isString($ctx.args.child) )

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/field-auth-argument.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/field-auth-argument.test.ts
@@ -525,7 +525,14 @@ describe('with identity claim feature flag disabled', () => {
     #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get("username"), $util.defaultIfNull($ctx.identity.claims.get("cognito:username"), null)) )
     #if( !$util.isNull($ownerClaim0) )
 
-      #set( $ownerClaimsList0 = [] )
+      #set( $ownerClaimsList0 = $util.defaultIfNull($ctx.identity.claims.get("username"), $util.defaultIfNull($ctx.identity.claims.get("cognito:username"), [])) )
+      #if( $util.isString($ownerClaimsList0) )
+        #if( $util.isList($util.parseJson($ownerClaimsList0)) )
+          #set( $ownerClaimsList0 = $util.parseJson($ownerClaimsList0) )
+        #else
+          #set( $ownerClaimsList0 = [$ownerClaimsList0] )
+        #end
+      #end
       #if( $ownerEntity0 == $ownerClaim0 || $ownerClaimsList0.contains($ownerEntity0) )
         #set( $isAuthorized = true )
       #end
@@ -622,7 +629,14 @@ describe('with identity claim feature flag disabled', () => {
     #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get("username"), $util.defaultIfNull($ctx.identity.claims.get("cognito:username"), null)) )
     #if( !$util.isNull($ownerClaim0) )
 
-      #set( $ownerClaimsList0 = [] )
+      #set( $ownerClaimsList0 = $util.defaultIfNull($ctx.identity.claims.get("username"), $util.defaultIfNull($ctx.identity.claims.get("cognito:username"), [])) )
+      #if( $util.isString($ownerClaimsList0) )
+        #if( $util.isList($util.parseJson($ownerClaimsList0)) )
+          #set( $ownerClaimsList0 = $util.parseJson($ownerClaimsList0) )
+        #else
+          #set( $ownerClaimsList0 = [$ownerClaimsList0] )
+        #end
+      #end
       #if( $ownerEntity0 == $ownerClaim0 || $ownerClaimsList0.contains($ownerEntity0) )
         #set( $isAuthorized = true )
       #end

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/helpers.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/helpers.ts
@@ -21,7 +21,7 @@ import {
   and,
   parens,
   notEquals,
-  nul
+  nul,
 } from 'graphql-mapping-template';
 import {
   DEFAULT_COGNITO_IDENTITY_CLAIM,
@@ -31,7 +31,7 @@ import {
   LAMBDA_AUTH_TYPE,
   IAM_AUTH_TYPE,
   IDENTITY_CLAIM_DELIMITER,
-  ALLOWED_FIELDS
+  ALLOWED_FIELDS,
 } from '../utils';
 
 // note in the resolver that operation is protected by auth
@@ -80,11 +80,11 @@ export const iamCheck = (claim: string, exp: Expression, identityPoolId?: string
  * 1. custom
  * 2. none value
  */
-export const getOwnerClaim = (ownerClaim: string): Expression => {
+export const getOwnerClaim = (ownerClaim: string, defaultValueExp: Expression = nul()): Expression => {
   if (ownerClaim === 'username') {
-    return getIdentityClaimExp(str(ownerClaim), getIdentityClaimExp(str(DEFAULT_COGNITO_IDENTITY_CLAIM), nul()));
+    return getIdentityClaimExp(str(ownerClaim), getIdentityClaimExp(str(DEFAULT_COGNITO_IDENTITY_CLAIM), defaultValueExp));
   }
-  return getIdentityClaimExp(str(ownerClaim), nul());
+  return getIdentityClaimExp(str(ownerClaim), defaultValueExp);
 };
 
 /**
@@ -99,7 +99,7 @@ export const responseCheckForErrors = (): Expression => iff(ref('ctx.error'), me
  */
 export const generateStaticRoleExpression = (roles: Array<RoleDefinition>): Array<Expression> => {
   const staticRoleExpression: Array<Expression> = [];
-  const privateRoleIdx = roles.findIndex(r => r.strategy === 'private');
+  const privateRoleIdx = roles.findIndex((r) => r.strategy === 'private');
   if (privateRoleIdx > -1) {
     staticRoleExpression.push(set(ref(IS_AUTHORIZED_FLAG), bool(true)));
     roles.splice(privateRoleIdx, 1);
@@ -109,7 +109,7 @@ export const generateStaticRoleExpression = (roles: Array<RoleDefinition>): Arra
       iff(
         not(ref(IS_AUTHORIZED_FLAG)),
         compoundExpression([
-          set(ref('staticGroupRoles'), raw(JSON.stringify(roles.map(r => ({ claim: r.claim, entity: r.entity }))))),
+          set(ref('staticGroupRoles'), raw(JSON.stringify(roles.map((r) => ({ claim: r.claim, entity: r.entity }))))),
           forEach(ref('groupRole'), ref('staticGroupRoles'), [
             set(ref('groupsInToken'), getIdentityClaimExp(ref('groupRole.claim'), list([]))),
             iff(
@@ -156,7 +156,7 @@ export const iamExpression = (
     expression.push(iamAdminRoleCheckExpression(adminRoles, fieldName));
   }
   if (roles.length > 0) {
-    roles.forEach(role => {
+    roles.forEach((role) => {
       expression.push(iff(not(ref(IS_AUTHORIZED_FLAG)), iamCheck(role.claim!, set(ref(IS_AUTHORIZED_FLAG), bool(true)), identityPoolId)));
     });
   } else {
@@ -170,7 +170,7 @@ export const iamExpression = (
  */
 export const iamAdminRoleCheckExpression = (adminRoles: Array<string>, fieldName?: string, adminCheckExpression?: Expression): Expression => {
   const returnStatement = fieldName ? raw(`#return($context.source.${fieldName})`) : raw('#return($util.toJson({}))');
-  const fullReturnExpression = adminCheckExpression ? compoundExpression([ adminCheckExpression, returnStatement ]) : returnStatement;
+  const fullReturnExpression = adminCheckExpression ? compoundExpression([adminCheckExpression, returnStatement]) : returnStatement;
   return compoundExpression([
     set(ref('adminRoles'), raw(JSON.stringify(adminRoles))),
     forEach(/* for */ ref('adminRole'), /* in */ ref('adminRoles'), [
@@ -180,10 +180,10 @@ export const iamAdminRoleCheckExpression = (adminRoles: Array<string>, fieldName
           notEquals(ref('ctx.identity.userArn'), ref('ctx.stash.authRole')),
           notEquals(ref('ctx.identity.userArn'), ref('ctx.stash.unauthRole')),
         ]),
-        fullReturnExpression
+        fullReturnExpression,
       ),
     ]),
-  ])
+  ]);
 };
 
 /**
@@ -211,15 +211,24 @@ export const emptyPayload = toJson(raw(JSON.stringify({ version: '2018-05-29', p
  */
 export const generateOwnerClaimListExpression = (claim: string, refName: string): Expression => {
   const claims = claim.split(IDENTITY_CLAIM_DELIMITER);
-
-  if (claims.length <= 1) {
-    return set(ref(refName), list([]));
+  if (claims.length > 1) {
+    return compoundExpression([
+      set(ref(refName), list([])),
+      compoundExpression(
+        claims.map((c) => qref(methodCall(ref(`${refName}.add`), getOwnerClaim(c)))),
+      ),
+    ]);
   }
 
   return compoundExpression([
-    set(ref(refName), list([])),
-    compoundExpression(
-      claims.map(c => qref(methodCall(ref(`${refName}.add`), getOwnerClaim(c)))),
+    set(ref(refName), getOwnerClaim(claim, list([]))),
+    iff(
+      methodCall(ref('util.isString'), ref(refName)),
+      ifElse(
+        methodCall(ref('util.isList'), methodCall(ref('util.parseJson'), ref(refName))),
+        set(ref(refName), methodCall(ref('util.parseJson'), ref(refName))),
+        set(ref(refName), list([ref(refName)])),
+      ),
     ),
   ]);
 };
@@ -236,16 +245,16 @@ export const generateOwnerClaimExpression = (ownerClaim: string, refName: string
     identityClaims.forEach((claim, idx) => {
       expressions.push();
       if (idx === 0) {
-        expressions.push(set(ref(refName), getOwnerClaim(claim)));
+        expressions.push(set(ref(refName), getOwnerClaim(claim, list([]))));
       } else {
         expressions.push(
-          set(ref(`currentClaim${idx}`), getOwnerClaim(claim)),
+          set(ref(`currentClaim${idx}`), getOwnerClaim(claim, list([]))),
         );
       }
     });
   } else {
     expressions.push(
-      set(ref(refName), getOwnerClaim(ownerClaim)),
+      set(ref(refName), getOwnerClaim(ownerClaim, list([]))),
     );
   }
 
@@ -262,8 +271,8 @@ export const generateOwnerMultiClaimExpression = (ownerClaim: string, refName: s
   if (hasMultiIdentityClaims) {
     const additionalClaims = [...Array(identityClaims.length).keys()].splice(1).map((idx) => `$currentClaim${idx}`);
     return set(
-      ref(refName), 
-      raw(`"$${[refName, ...additionalClaims].join(IDENTITY_CLAIM_DELIMITER)}"`)
+      ref(refName),
+      raw(`"$${[refName, ...additionalClaims].join(IDENTITY_CLAIM_DELIMITER)}"`),
     );
   }
 };
@@ -288,14 +297,14 @@ export const generateInvalidClaimsCondition = (ownerClaim: string, refName: stri
  * Sets the value of owner field if the user is already Authorized
  */
 export const generatePopulateOwnerField = (
-   claimRef: string, 
-   ownerEntity: string, 
-   entityRef: string, 
-   entityIsList: boolean,
-   checkIfAuthorized: boolean,
-   allowedFieldsKey?: string,
-   allowedFieldsCondition?: string): Expression => {
-
+  claimRef: string,
+  ownerEntity: string,
+  entityRef: string,
+  entityIsList: boolean,
+  checkIfAuthorized: boolean,
+  allowedFieldsKey?: string,
+  allowedFieldsCondition?: string,
+): Expression => {
   const conditionsToCheck = new Array<Expression>();
   if (checkIfAuthorized) {
     conditionsToCheck.push(ref(IS_AUTHORIZED_FLAG));
@@ -309,15 +318,15 @@ export const generatePopulateOwnerField = (
       methodCall(
         ref('ctx.args.input.put'),
         str(ownerEntity),
-        entityIsList ? list([ref(claimRef)]) : ref(claimRef)
+        entityIsList ? list([ref(claimRef)]) : ref(claimRef),
       ),
-    )
+    ),
   );
   if (allowedFieldsKey && allowedFieldsCondition) {
     populateOwnerFieldExprs.push(addAllowedFieldsIfElse(allowedFieldsKey, allowedFieldsCondition));
   }
 
-  return(compoundExpression([iff(and(conditionsToCheck), compoundExpression(populateOwnerFieldExprs))]));
+  return (compoundExpression([iff(and(conditionsToCheck), compoundExpression(populateOwnerFieldExprs))]));
 };
 
 export const addAllowedFieldsIfElse = (allowedFieldsKey: string, condition: string, breakLoop = false): Expression => ifElse(

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -1237,6 +1237,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
       ...(context.isProjectUsingDataStore() ? { timeToLiveAttribute: '_ttl' } : undefined),
     });
     const cfnTable = table.node.defaultChild as CfnTable;
+    cfnTable.overrideLogicalId(tableLogicalName);
 
     cfnTable.provisionedThroughput = cdk.Fn.conditionIf(usePayPerRequestBilling.logicalId, cdk.Fn.ref('AWS::NoValue'), {
       ReadCapacityUnits: readIops,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8594,7 +8594,7 @@ async@^2.6.4:
 
 async@^3.2.0, async@^3.2.3:
   version "3.2.4"
-  resolved "https://registry.npmjs.org/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
   integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
 asynckit@^0.4.0:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

I moved the changes suggested in this PR over to the new repository: https://github.com/aws-amplify/amplify-cli/pull/9535. This adds support for dynamic groups when the custom claims are a stringified array (e.g. custom claims set through the Cognito pre-token-generation trigger).

cc @danielleadams this is the PR with the changes you suggested in this comment https://github.com/aws-amplify/amplify-cli/pull/9535#issuecomment-1169926914. Please take a look when you get the time and let me know if this looks alright to you. Thanks

#### Issue #, if available

https://github.com/aws-amplify/amplify-category-api/issues/132

#### Description of how you validated changes

I tested the changes both through automated tests and manually

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
