### PR TITLE
chore: add support for warning on owner who can reassign owner field

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -103,7 +103,7 @@ import {
   getAuthDirectiveRules,
   READ_MODEL_OPERATIONS,
 } from './utils';
-import { showDefaultIdentityClaimWarning } from './utils/warnings';
+import { showDefaultIdentityClaimWarning, showOwnerCanReassignWarning } from './utils/warnings';
 
 // @ auth
 // changing the schema
@@ -193,6 +193,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
 
   after = (context: TransformerContextProvider): void => {
     showDefaultIdentityClaimWarning(context, this.rules);
+    showOwnerCanReassignWarning(this.authModelConfig);
   };
 
   field = (

--- a/packages/amplify-graphql-auth-transformer/src/utils/warnings.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/warnings.ts
@@ -1,6 +1,7 @@
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { printer } from 'amplify-prompts';
 import { AuthRule } from '.';
+import { AccessControlMatrix } from '../accesscontrol';
 
 /**
  * Displays a warning when a default owner field is used and the feature flag is
@@ -8,7 +9,7 @@ import { AuthRule } from '.';
  */
 export const showDefaultIdentityClaimWarning = (context: TransformerContextProvider, optionRules?: AuthRule[]): void => {
   const rules = optionRules || [];
-  const usesDefaultIdentityClaim = rules.some(rule => rule.allow === 'owner' && rule.identityClaim === undefined);
+  const usesDefaultIdentityClaim = rules.some((rule) => rule.allow === 'owner' && rule.identityClaim === undefined);
 
   if (usesDefaultIdentityClaim) {
     const hasFeatureFlagEnabled = context.featureFlags?.getBoolean('useSubUsernameForDefaultIdentityClaim');
@@ -21,5 +22,47 @@ export const showDefaultIdentityClaimWarning = (context: TransformerContextProvi
         + '\'owner\' rules on your schema. The default will be officially switched with v9.0.0. To read '
         + 'more: https://docs.amplify.aws/cli/migration/identity-claim-changes/',
     );
+  }
+};
+
+/**
+ * Display a warning when an 'owner' has access to update their own owner field.
+ * @param authModelConfig The model to ACM map we generate for the given ruleset.
+ */
+export const showOwnerCanReassignWarning = (
+  authModelConfig: Map<string, AccessControlMatrix>,
+): void => {
+  try {
+    const ownerFieldRegExp = /(oidc|userPools):owner:(.*?):/;
+    const modelsWithOwnersWhoCanEditOwnFields: Record<string, string[]> = Object.fromEntries([...authModelConfig.entries()]
+      .map(([model, acm]) => {
+        const ownersWhoCanEditOwnValues = [...acm.getAcmPerRole().entries()]
+          .map(([role, acmMap]) => {
+            const match = ownerFieldRegExp.exec(role);
+            const ownerFieldOrNull = match && match.length === 3 ? match[2] : null; // captured owner group will be the final returned value
+            const canUpdateOwnOwnerField = ownerFieldOrNull && acmMap[ownerFieldOrNull] && acmMap[ownerFieldOrNull].update;
+            const isImputedOwnerField = ownerFieldOrNull === 'owner' && !acmMap[ownerFieldOrNull];
+            // ACM map doesn't appear to include generated fields, so if field is 'owner' and not in ACM map, assume full permissions
+            return [ownerFieldOrNull, canUpdateOwnOwnerField || isImputedOwnerField];
+          }).filter(([_, canUpdateOwnOwnerField]) => canUpdateOwnOwnerField)
+          .map(([role]) => role);
+
+        return [model, ownersWhoCanEditOwnValues];
+      }).filter(([_, ownersWhoCanEditOwnValues]) => ownersWhoCanEditOwnValues.length > 0));
+
+    if (Object.keys(modelsWithOwnersWhoCanEditOwnFields).length === 0) return;
+
+    const perModelWarning = Object.entries(modelsWithOwnersWhoCanEditOwnFields)
+      .map(([model, roles]) => `${model}: [${roles.join(', ')}]`)
+      .join(', ');
+
+    printer.warn(
+      `WARNING: owners may reassign ownership for the following model(s) and role(s): ${perModelWarning}. `
+        + 'If this is not intentional, you may want to apply field-level authorization rules to these fields. '
+        + 'To read more: https://docs.amplify.aws/cli/graphql/authorization-rules/#per-user--owner-based-data-access.',
+    );
+  } catch (e) {
+    // Error messaging should be best effort, and not impede actual functionality.
+    printer.debug(`Error caught while checking whether owners have reassign permissions: ${JSON.stringify(e)}`);
   }
 };


### PR DESCRIPTION
#### Description of changes
Show a warning on gql-compile when an `owner` has permissions to `update` their referenced owner field. This will apply to userPools and oidc providers, and should work regardless of whether the user is using a generated owner field, provided one, or list of owners.

As a followup I'll be adding a metric to this as well, so we can determine how many customers are encountering this condition, and whether or not we should consider changing the default behavior of ownership.

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit tests, ran `setup-dev` target and verified against a few schemas that I was seeing/not seeing this warning when expected.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
