### PR TITLE
fix: Enable Custom Lambda Conflict Handler support in GQLv2-enabled Applications

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -28,6 +28,7 @@ module.exports = {
     '<rootDir>/packages/amplify-graphql-relational-transformer',
     '<rootDir>/packages/amplify-graphql-searchable-transformer',
     '<rootDir>/packages/amplify-graphql-transformer-migrator',
+    '<rootDir>/packages/amplify-graphql-transformer-core',
     '<rootDir>/packages/graphql-auth-transformer',
     '<rootDir>/packages/graphql-connection-transformer',
     '<rootDir>/packages/graphql-dynamodb-transformer',

--- a/packages/amplify-e2e-tests/src/__tests__/graphql-v2/lambda-conflict-handler.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/graphql-v2/lambda-conflict-handler.test.ts
@@ -1,0 +1,96 @@
+import {
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  getAppSyncApi,
+  getProjectMeta,
+  initJSProjectWithProfile,
+  updateApiSchema,
+  amplifyPush,
+  addApiWithBlankSchemaAndConflictDetection,
+  updateApiConflictHandlerType,
+} from 'amplify-category-api-e2e-core';
+import { ConflictHandlerType } from '@aws-amplify/graphql-transformer-core';
+
+const verifyApiExists = async (meta: any, projName: string): Promise<void> => {
+  const region = meta.providers.awscloudformation.Region;
+  const { output } = meta.api[projName];
+  const { GraphQLAPIIdOutput, GraphQLAPIEndpointOutput, GraphQLAPIKeyOutput } = output;
+  const { graphqlApi } = await getAppSyncApi(GraphQLAPIIdOutput, region);
+
+  expect(GraphQLAPIIdOutput).toBeDefined();
+  expect(GraphQLAPIEndpointOutput).toBeDefined();
+  expect(GraphQLAPIKeyOutput).toBeDefined();
+  expect(graphqlApi).toBeDefined();
+  expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
+  expect(GraphQLAPIIdOutput).toBeDefined();
+  expect(GraphQLAPIEndpointOutput).toBeDefined();
+  expect(GraphQLAPIKeyOutput).toBeDefined();
+  expect(graphqlApi).toBeDefined();
+  expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
+};
+
+const verifyFunctionDefined = (meta: any): void => {
+  expect(meta.function).toBeDefined();
+  expect(Object.keys(meta.function).length).toBeGreaterThanOrEqual(1);
+  for (const key of Object.keys(meta.function)) {
+    const {
+      service,
+      build,
+      lastBuildTimeStamp,
+      lastPackageTimeStamp,
+      distZipFilename,
+      lastPushTimeStamp,
+      lastPushDirHash,
+    } = meta.function[key];
+    expect(service).toBe('Lambda');
+    expect(build).toBeTruthy();
+    expect(lastBuildTimeStamp).toBeDefined();
+    expect(lastPackageTimeStamp).toBeDefined();
+    expect(distZipFilename).toBeDefined();
+    expect(lastPushTimeStamp).toBeDefined();
+    expect(lastPushDirHash).toBeDefined();
+  }
+};
+
+describe('amplify api (GraphQL) - Customer Lambda Conflict Handler', () => {
+  let projRoot: string;
+
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir('lambda-conflict-handler');
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('amplify add api (GraphQL) - Custom Lambda Conflict Handler', async () => {
+    const envName = 'test';
+    const projName = 'addlambdahandler';
+    await initJSProjectWithProfile(projRoot, { name: projName, envName });
+    await addApiWithBlankSchemaAndConflictDetection(projRoot, { conflictHandlerType: ConflictHandlerType.LAMBDA });
+    await updateApiSchema(projRoot, projName, 'simple_model.graphql');
+    await amplifyPush(projRoot);
+
+    const meta = getProjectMeta(projRoot);
+
+    await verifyApiExists(meta, projName);
+    verifyFunctionDefined(meta);
+  });
+
+  it('amplify update api (GraphQL) - Custom Lambda Conflict Resolver', async () => {
+    const envName = 'test';
+    const projName = 'updatelambdahandler';
+    await initJSProjectWithProfile(projRoot, { name: projName, envName });
+    await addApiWithBlankSchemaAndConflictDetection(projRoot);
+    await updateApiSchema(projRoot, projName, 'simple_model.graphql');
+    await updateApiConflictHandlerType(projRoot, { conflictHandlerType: ConflictHandlerType.LAMBDA });
+    await amplifyPush(projRoot);
+
+    const meta = getProjectMeta(projRoot);
+
+    await verifyApiExists(meta, projName);
+    verifyFunctionDefined(meta);
+  });
+});

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -1340,7 +1340,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     const syncConfig = SyncUtils.getSyncConfig(context, def!.name.value);
     if (syncConfig && SyncUtils.isLambdaSyncConfig(syncConfig)) {
       role.attachInlinePolicy(
-        SyncUtils.createSyncLambdaIAMPolicy(stack, syncConfig.LambdaConflictHandler.name, syncConfig.LambdaConflictHandler.region),
+        SyncUtils.createSyncLambdaIAMPolicy(context, stack, syncConfig.LambdaConflictHandler.name, syncConfig.LambdaConflictHandler.region),
       );
     }
 

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transformation/sync-utils.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transformation/sync-utils.test.ts
@@ -1,0 +1,122 @@
+import { TransformerTransformSchemaStepContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { CfnParameter } from '@aws-cdk/core';
+import { ConflictHandlerType, SyncConfigLambda, ResolverConfig } from '../../config/transformer-config';
+import { getSyncConfig } from '../../transformation/sync-utils';
+
+describe('getSyncConfig', () => {
+  const createMockContext = (resolverConfig: ResolverConfig): TransformerTransformSchemaStepContextProvider => ({
+    getResolverConfig: () => resolverConfig,
+    stackManager: {
+      getParameter: (_: string) => jest.fn() as unknown as CfnParameter,
+    },
+  } as unknown as TransformerTransformSchemaStepContextProvider);
+
+  describe('lambda sync handler', () => {
+    test('handles explicit arn passed in for project-level config', () => {
+      const resolverConfig: ResolverConfig = {
+        project: {
+          ConflictDetection: 'NONE',
+          ConflictHandler: ConflictHandlerType.LAMBDA,
+          LambdaConflictHandler: {
+            name: 'myFunctionName',
+            region: 'myFunctionRegion',
+            lambdaArn: 'myFunctionARN',
+          },
+        },
+      };
+
+      const syncConfig = getSyncConfig(createMockContext(resolverConfig), '') as SyncConfigLambda;
+
+      expect(syncConfig).toBeDefined();
+      expect(syncConfig?.ConflictHandler).toEqual(ConflictHandlerType.LAMBDA);
+      expect(syncConfig?.LambdaConflictHandler.name).toEqual('myFunctionName');
+      expect(syncConfig?.LambdaConflictHandler.region).toEqual('myFunctionRegion');
+      expect(syncConfig?.LambdaConflictHandler.lambdaArn).toEqual('myFunctionARN');
+    });
+
+    test('handles explicit arn passed in for model-level config', () => {
+      const resolverConfig: ResolverConfig = {
+        models: {
+          Blog: {
+            ConflictDetection: 'NONE',
+            ConflictHandler: ConflictHandlerType.LAMBDA,
+            LambdaConflictHandler: {
+              name: 'myFunctionNameBlog',
+              region: 'myFunctionRegionBlog',
+              lambdaArn: 'myFunctionARNBlog',
+            },
+          },
+          Author: {
+            ConflictDetection: 'NONE',
+            ConflictHandler: ConflictHandlerType.LAMBDA,
+            LambdaConflictHandler: {
+              name: 'myFunctionNameAuthor',
+              region: 'myFunctionRegionAuthor',
+              lambdaArn: 'myFunctionARNAuthor',
+            },
+          },
+        },
+      };
+
+      const blogSyncConfig = getSyncConfig(createMockContext(resolverConfig), 'Blog') as SyncConfigLambda;
+
+      expect(blogSyncConfig).toBeDefined();
+      expect(blogSyncConfig?.ConflictHandler).toEqual(ConflictHandlerType.LAMBDA);
+      expect(blogSyncConfig?.LambdaConflictHandler.name).toEqual('myFunctionNameBlog');
+      expect(blogSyncConfig?.LambdaConflictHandler.region).toEqual('myFunctionRegionBlog');
+      expect(blogSyncConfig?.LambdaConflictHandler.lambdaArn).toEqual('myFunctionARNBlog');
+
+      const authorSyncConfig = getSyncConfig(createMockContext(resolverConfig), 'Author') as SyncConfigLambda;
+
+      expect(authorSyncConfig).toBeDefined();
+      expect(authorSyncConfig?.ConflictHandler).toEqual(ConflictHandlerType.LAMBDA);
+      expect(authorSyncConfig?.LambdaConflictHandler.name).toEqual('myFunctionNameAuthor');
+      expect(authorSyncConfig?.LambdaConflictHandler.region).toEqual('myFunctionRegionAuthor');
+      expect(authorSyncConfig?.LambdaConflictHandler.lambdaArn).toEqual('myFunctionARNAuthor');
+    });
+
+    test('generates arn reference if not provided for project-level config', () => {
+      const resolverConfig: ResolverConfig = {
+        project: {
+          ConflictDetection: 'NONE',
+          ConflictHandler: ConflictHandlerType.LAMBDA,
+          LambdaConflictHandler: {
+            // eslint-disable-next-line no-template-curly-in-string
+            name: 'myFunctionName-${env}',
+          },
+        },
+      };
+
+      const syncConfig = getSyncConfig(createMockContext(resolverConfig), '') as SyncConfigLambda;
+
+      expect(syncConfig).toBeDefined();
+      expect(syncConfig?.ConflictHandler).toEqual(ConflictHandlerType.LAMBDA);
+      // eslint-disable-next-line no-template-curly-in-string
+      expect(syncConfig?.LambdaConflictHandler.name).toEqual('myFunctionName-${env}');
+      expect(syncConfig?.LambdaConflictHandler.lambdaArn).toBeDefined();
+    });
+
+    test('generates arn reference if not provided for model-level config', () => {
+      const resolverConfig: ResolverConfig = {
+        models: {
+          Todo: {
+            ConflictDetection: 'NONE',
+            ConflictHandler: ConflictHandlerType.LAMBDA,
+            LambdaConflictHandler: {
+              // eslint-disable-next-line no-template-curly-in-string
+              name: 'myFunctionName-${env}',
+            },
+          },
+        },
+      };
+
+      const syncConfig = getSyncConfig(createMockContext(resolverConfig), 'Todo') as SyncConfigLambda;
+
+      expect(syncConfig).toBeDefined();
+      expect(syncConfig?.ConflictHandler).toEqual(ConflictHandlerType.LAMBDA);
+      // eslint-disable-next-line no-template-curly-in-string
+      expect(syncConfig?.LambdaConflictHandler.name).toEqual('myFunctionName-${env}');
+      expect(syncConfig?.LambdaConflictHandler.lambdaArn).toBeDefined();
+    });
+  });
+});

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
@@ -64,6 +64,7 @@ export type TransformerValidationStepContextProvider = Pick<
   | 'sandboxModeEnabled'
   | 'resourceHelper'
   | 'resolvers'
+  | 'stackManager'
 >;
 export type TransformerPrepareStepContextProvider = TransformerValidationStepContextProvider;
 export type TransformerTransformSchemaStepContextProvider = TransformerValidationStepContextProvider;


### PR DESCRIPTION
#### Description of changes
- fix: update api should allow setting NEW lambda conflict resolver
- fix: set cfn values correctly when applying lambda-based conflict resolution

#### Issue #, if available
https://github.com/aws-amplify/amplify-category-api/issues/628

#### Description of how you validated changes
Unit tests, deployed app locally w/ these changes, and additional e2e tests to cover this use case.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
