### PR TITLE
Avoid scan on base table when sync expression is specified on index field

### DIFF
--- a/packages/amplify-e2e-tests/schemas/schema_with_index.graphql
+++ b/packages/amplify-e2e-tests/schemas/schema_with_index.graphql
@@ -1,0 +1,9 @@
+input AMPLIFY {
+  globalAuthRule: AuthRule = { allow: public }
+}
+
+type Song @model {
+    id: ID!
+    name: String!
+    genre: String! @index(name : "byGenre", queryField: "songInfoByGenre")
+}

--- a/packages/amplify-e2e-tests/src/__tests__/graphql-v2/sync_query_datastore.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/graphql-v2/sync_query_datastore.test.ts
@@ -1,0 +1,211 @@
+import {
+    initJSProjectWithProfile,
+    deleteProject,
+    amplifyPush,
+} from 'amplify-category-api-e2e-core';
+import { addApiWithBlankSchemaAndConflictDetection, updateApiSchema, getProjectMeta } from 'amplify-category-api-e2e-core';
+import { createNewProjectDir, deleteProjectDir } from 'amplify-category-api-e2e-core';
+import gql from 'graphql-tag';
+import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
+(global as any).fetch = require('node-fetch');
+
+const projectName = 'syncquerytest';
+describe('Sync query V2 resolver tests', () => {
+    let projRoot: string;
+    let appSyncClient = undefined;
+  
+    beforeEach(async () => {
+      projRoot = await createNewProjectDir(projectName);
+      await initJSProjectWithProfile(projRoot, {
+        name: projectName,
+      });
+      // await addAuthWithDefault(projRoot, {});
+    });
+  
+    afterEach(async () => {
+      await deleteProject(projRoot);
+      deleteProjectDir(projRoot);
+    });
+  
+    it('Able to sync latest updates with and without lastSync', async () => {
+        const v2Schema = 'schema_with_index.graphql';
+        await addApiWithBlankSchemaAndConflictDetection(projRoot, { transformerVersion: 2 });
+        await updateApiSchema(projRoot, projectName, v2Schema);
+        await amplifyPush(projRoot);
+    
+        appSyncClient = getAppSyncClientFromProj(projRoot);
+        
+        const createResult = await createSong('song1', 'rock');
+
+        expect(createResult.data).not.toBeNull();
+        expect(createResult.errors).toBeUndefined();
+        expect(createResult.data.createSong).not.toBeNull();
+        expect(createResult.data.createSong.id).toBeDefined();
+        expect(createResult.data.createSong.name).toEqual('song1');
+        expect(createResult.data.createSong.genre).toEqual('rock');
+        expect(createResult.data.createSong._version).toEqual(1);
+        expect(createResult.data.createSong._lastChangedAt).toBeDefined();
+        expect(createResult.data.createSong._deleted).toBeNull();
+
+        const songId = createResult.data.createSong.id;
+        const songCreatedAt = createResult.data.createSong._lastChangedAt;
+
+        // able to sync songs without lastSync specified. This will do a query on base table.
+        const syncResult = await syncSongs();
+        expect(syncResult.data).not.toBeNull();
+        expect(syncResult.errors).toBeUndefined();
+        expect(syncResult.data.syncSongs).not.toBeNull();
+        expect(syncResult.data.syncSongs.items?.length).toEqual(1);
+        const songAfterFirstSync = syncResult.data.syncSongs.items[0];
+        expect(songAfterFirstSync.id).toEqual(songId);
+        expect(songAfterFirstSync.name).toEqual('song1');
+        expect(songAfterFirstSync.genre).toEqual('rock');
+        expect(songAfterFirstSync._version).toEqual(1);
+        expect(songAfterFirstSync._lastChangedAt).toEqual(songCreatedAt);
+        // sync is started with the sync query post record creation
+        expect(syncResult.data.syncSongs.startedAt).toBeGreaterThan(songCreatedAt);
+
+        const syncStartedAt = syncResult.data.syncSongs.startedAt;
+
+        // now update the song record post sync
+        const updateResult = await updateSong(songId, 'song2', 'country', 1);
+        expect(updateResult.data).not.toBeNull();
+        expect(updateResult.errors).toBeUndefined();
+        expect(updateResult.data.updateSong).not.toBeNull();
+        expect(updateResult.data.updateSong.id).toEqual(songId);
+        expect(updateResult.data.updateSong.name).toEqual('song2');
+        expect(updateResult.data.updateSong.genre).toEqual('country');
+        // the record version should be updated
+        expect(updateResult.data.updateSong._version).toEqual(2);
+        expect(updateResult.data.updateSong._lastChangedAt).toBeGreaterThan(syncStartedAt);
+        expect(updateResult.data.updateSong._deleted).toBeNull();
+
+        // performing a sync with lastSync set, should fetch the updated song
+        const syncResultAfterUpdate = await syncSongs(syncStartedAt);
+        expect(syncResultAfterUpdate.data).not.toBeNull();
+        expect(syncResultAfterUpdate.errors).toBeUndefined();
+        expect(syncResultAfterUpdate.data.syncSongs).not.toBeNull();
+        expect(syncResultAfterUpdate.data.syncSongs.items?.length).toEqual(1);
+        const songAfterSecondSync = syncResultAfterUpdate.data.syncSongs.items[0];
+        expect(songAfterSecondSync.id).toEqual(songId);
+        expect(songAfterSecondSync.name).toEqual('song2');
+        expect(songAfterSecondSync.genre).toEqual('country');
+        expect(songAfterSecondSync._version).toEqual(2);
+        expect(songAfterSecondSync._lastChangedAt).toEqual(updateResult.data.updateSong._lastChangedAt);
+        // sync is re-started with the sync query
+        expect(syncResultAfterUpdate.data.syncSongs.startedAt).toBeGreaterThan(syncStartedAt);
+    });
+  
+    const getAppSyncClientFromProj = (projRoot: string) => {
+      const meta = getProjectMeta(projRoot);
+      const region = meta['providers']['awscloudformation']['Region'] as string;
+      const { output } = meta.api[projectName];
+      const url = output.GraphQLAPIEndpointOutput as string;
+      const apiKey = output.GraphQLAPIKeyOutput as string;
+  
+      return new AWSAppSyncClient({
+        url,
+        region,
+        disableOffline: true,
+        auth: {
+          type: AUTH_TYPE.API_KEY,
+          apiKey,
+        },
+      });
+    };
+
+    const createSong = async (
+        name: string, genre: string
+    ): Promise<any> => {
+        const createMutation = /* GraphQL */ `
+            mutation CreateSong($input: CreateSongInput!, $condition: ModelSongConditionInput) {
+                createSong(input: $input, condition: $condition) {
+                    id
+                    name
+                    genre
+                    _lastChangedAt
+                    _version
+                    _deleted
+                }
+            }
+        `;
+
+        const createInput = {
+            input: {
+                name: name,
+                genre: genre
+            },
+        };
+
+        const result: any = await appSyncClient.mutate({
+            mutation: gql(createMutation),
+            fetchPolicy: 'no-cache',
+            variables: createInput,
+        });
+        return result;
+    };
+
+    const updateSong = async (
+        id: string, name: string, genre: string, version: number
+    ): Promise<any> => {
+        const updateMutation = /* GraphQL */ `
+            mutation UpdateSong($input: UpdateSongInput!, $condition: ModelSongConditionInput) {
+                updateSong(input: $input, condition: $condition) {
+                    id
+                    name
+                    genre
+                    _lastChangedAt
+                    _version
+                    _deleted
+                }
+            }
+        `;
+
+        const updateInput = {
+            input: {
+                id: id,
+                name: name,
+                genre: genre,
+                _version: version
+            },
+        };
+
+        const result: any = await appSyncClient.mutate({
+            mutation: gql(updateMutation),
+            fetchPolicy: 'no-cache',
+            variables: updateInput,
+        });
+        return result;
+    };
+
+    const syncSongs = async (lastSync?: number): Promise<any> => {
+        const syncQuery = /* GraphQL */ `
+            query SyncSongs($limit: Int, $lastSync: AWSTimestamp) {
+                syncSongs(limit: $limit, lastSync: $lastSync) {
+                    items {
+                        id
+                        name
+                        genre
+                        _version
+                        _lastChangedAt
+                    }
+                    startedAt
+                }
+            }
+        `;
+
+        const syncQueryInput = {
+            input: {
+                limit: 10,
+                lastSync: lastSync ? lastSync : null
+            },
+        };
+
+        const result: any = await appSyncClient.query({
+            query: gql(syncQuery),
+            fetchPolicy: 'no-cache',
+            variables: syncQueryInput,
+        });
+        return result;
+    };
+});

--- a/packages/amplify-graphql-index-transformer/package.json
+++ b/packages/amplify-graphql-index-transformer/package.json
@@ -40,6 +40,9 @@
   "devDependencies": {
     "@aws-cdk/assert": "~1.124.0"
   },
+  "peerDependencies": {
+    "amplify-cli-core": "^2.9.0"
+  },
   "jest": {
     "transform": {
       "^.+\\.(ts|tsx)?$": "ts-jest"

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
@@ -3593,7 +3593,12 @@ $util.qr($PkMap.put('createdAt' , 'ByCreatedAt'))
 ## [End] Set query expression for @key **
 ## [Start] Set query expression for @key **
 #set( $filterArgsMap = $ctx.args.filter.get(\\"and\\") )
-#if( !$util.isNullOrEmpty($filterArgsMap) && ($util.isNull($ctx.args.lastSync) || $ctx.args.lastSync == 0) )
+#set( $isLastSyncInDeltaTTLWindow = false )
+#set( $minLastSync = $util.time.nowEpochMilliSeconds() - 1800000 )
+#if( !$util.isNull($ctx.args.lastSync) && $ctx.args.lastSync != 0 && $minLastSync <= $ctx.args.lastSync )
+  #set( $isLastSyncInDeltaTTLWindow = true )
+#end
+#if( !$util.isNullOrEmpty($filterArgsMap) && !$isLastSyncInDeltaTTLWindow )
   #set( $json = $filterArgsMap )
   #foreach( $item in $json )
     #set( $ind = $foreach.index )
@@ -3676,6 +3681,7 @@ $util.qr($PkMap.put('createdAt' , 'ByCreatedAt'))
   \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"Sync\\",
   \\"limit\\": $limit,
+  \\"lastSync\\": $util.toJson($util.defaultIfNull($ctx.args.lastSync, null)),
   \\"query\\": $modelQueryExpression
 } )
   #if( !$util.isNull($ctx.args.sortDirection)
@@ -3722,7 +3728,12 @@ $util.qr($PkMap.put('orderId' , 'dbTable'))
 ## [End] Set query expression for @key **
 ## [Start] Set query expression for @key **
 #set( $filterArgsMap = $ctx.args.filter.get(\\"and\\") )
-#if( !$util.isNullOrEmpty($filterArgsMap) && ($util.isNull($ctx.args.lastSync) || $ctx.args.lastSync == 0) )
+#set( $isLastSyncInDeltaTTLWindow = false )
+#set( $minLastSync = $util.time.nowEpochMilliSeconds() - 1800000 )
+#if( !$util.isNull($ctx.args.lastSync) && $ctx.args.lastSync != 0 && $minLastSync <= $ctx.args.lastSync )
+  #set( $isLastSyncInDeltaTTLWindow = true )
+#end
+#if( !$util.isNullOrEmpty($filterArgsMap) && !$isLastSyncInDeltaTTLWindow )
   #set( $json = $filterArgsMap )
   #foreach( $item in $json )
     #set( $ind = $foreach.index )
@@ -3805,6 +3816,7 @@ $util.qr($PkMap.put('orderId' , 'dbTable'))
   \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"Sync\\",
   \\"limit\\": $limit,
+  \\"lastSync\\": $util.toJson($util.defaultIfNull($ctx.args.lastSync, null)),
   \\"query\\": $modelQueryExpression
 } )
   #if( !$util.isNull($ctx.args.sortDirection)

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
@@ -4645,9 +4645,6 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateSong.res.vtl": "## [Start] Subscription Response template. **
-#if( !$util.isNullOrEmpty($ctx.args.filter) )
-$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
-#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -4663,9 +4660,6 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteSong.res.vtl": "## [Start] Subscription Response template. **
-#if( !$util.isNullOrEmpty($ctx.args.filter) )
-$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
-#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -4681,9 +4675,6 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateSong.res.vtl": "## [Start] Subscription Response template. **
-#if( !$util.isNullOrEmpty($ctx.args.filter) )
-$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
-#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -5394,9 +5385,6 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateSong.res.vtl": "## [Start] Subscription Response template. **
-#if( !$util.isNullOrEmpty($ctx.args.filter) )
-$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
-#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5412,9 +5400,6 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteSong.res.vtl": "## [Start] Subscription Response template. **
-#if( !$util.isNullOrEmpty($ctx.args.filter) )
-$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
-#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5430,9 +5415,6 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateSong.res.vtl": "## [Start] Subscription Response template. **
-#if( !$util.isNullOrEmpty($ctx.args.filter) )
-$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
-#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
@@ -3940,6 +3940,1504 @@ $util.toJson(null)
 }
 `;
 
+exports[`sync query resolver renders with deltaSyncTableTTL override 1`] = `
+Object {
+  "Mutation.createSong.init.1.req.vtl": "## [Start] Initialization default values. **
+$util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
+#set( $createdAt = $util.time.nowISO8601() )
+$util.qr($ctx.stash.defaultValues.put(\\"id\\", $util.autoId()))
+$util.qr($ctx.stash.defaultValues.put(\\"createdAt\\", $createdAt))
+$util.qr($ctx.stash.defaultValues.put(\\"updatedAt\\", $createdAt))
+$util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": {}
+})
+## [End] Initialization default values. **",
+  "Mutation.createSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Mutation.createSong.req.vtl": "## [Start] Create Request template. **
+#set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+## Set the default values to put request **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+## copy the values from input **
+$util.qr($mergedValues.putAll($util.defaultIfNull($args.input, {})))
+## set the typename **
+$util.qr($mergedValues.put(\\"__typename\\", \\"Song\\"))
+#set( $nullIndexFields = [] )
+#set( $indexFields = [\\"genre\\"] )
+#foreach( $entry in $util.map.copyAndRetainAllKeys($mergedValues, $indexFields).entrySet() )
+  #if( $util.isNull($entry.value) )
+    $util.qr($nullIndexFields.add($entry.key))
+  #end
+#end
+#set( $mergedValues = $util.map.copyAndRemoveAllKeys($mergedValues, $nullIndexFields) )
+#set( $PutObject = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"PutItem\\",
+  \\"attributeValues\\":   $util.dynamodb.toMapValues($mergedValues),
+  \\"condition\\": $condition
+} )
+#if( $args.condition )
+  $util.qr($ctx.stash.conditions.add($args.condition))
+#end
+## Begin - key condition **
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $keyConditionExpr = {} )
+  #set( $keyConditionExprNames = {} )
+  #foreach( $entry in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    $util.qr($keyConditionExpr.put(\\"keyCondition$velocityCount\\", {
+  \\"attributeExists\\": false
+}))
+    $util.qr($keyConditionExprNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+  $util.qr($ctx.stash.conditions.add($keyConditionExpr))
+#else
+  $util.qr($ctx.stash.conditions.add({
+  \\"id\\": {
+      \\"attributeExists\\": false
+  }
+}))
+#end
+## End - key condition **
+## Start condition block **
+#if( $ctx.stash.conditions && $ctx.stash.conditions.size() != 0 )
+  #set( $mergedConditions = {
+  \\"and\\": $ctx.stash.conditions
+} )
+  #set( $Conditions = $util.parseJson($util.transform.toDynamoDBConditionExpression($mergedConditions)) )
+  #if( $Conditions.expressionValues && $Conditions.expressionValues.size() == 0 )
+    #set( $Conditions = {
+  \\"expression\\": $Conditions.expression,
+  \\"expressionNames\\": $Conditions.expressionNames
+} )
+  #end
+  ## End condition block **
+#end
+#if( $Conditions )
+  #if( $keyConditionExprNames )
+    $util.qr($Conditions.expressionNames.putAll($keyConditionExprNames))
+  #end
+  $util.qr($PutObject.put(\\"condition\\", $Conditions))
+#end
+#if( $ctx.stash.metadata.modelObjectKey )
+  $util.qr($PutObject.put(\\"key\\", $ctx.stash.metadata.modelObjectKey))
+#else
+  #set( $Key = {
+  \\"id\\":   $util.dynamodb.toDynamoDB($mergedValues.id)
+} )
+  $util.qr($PutObject.put(\\"key\\", $Key))
+#end
+$util.toJson($PutObject)
+## [End] Create Request template. **",
+  "Mutation.createSong.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#else
+  $util.toJson($ctx.result)
+#end
+## [End] ResponseTemplate. **",
+  "Mutation.deleteSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Mutation.deleteSong.req.vtl": "## [Start] Delete Request template. **
+#set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+#set( $DeleteRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"DeleteItem\\"
+} )
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $Key = $ctx.stash.metadata.modelObjectKey )
+#else
+  #set( $Key = {
+  \\"id\\":   $util.dynamodb.toDynamoDB($args.input.id)
+} )
+#end
+$util.qr($DeleteRequest.put(\\"key\\", $Key))
+## Begin - key condition **
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $keyConditionExpr = {} )
+  #set( $keyConditionExprNames = {} )
+  #foreach( $entry in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    $util.qr($keyConditionExpr.put(\\"keyCondition$velocityCount\\", {
+  \\"attributeExists\\": true
+}))
+    $util.qr($keyConditionExprNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+  $util.qr($ctx.stash.conditions.add($keyConditionExpr))
+#else
+  $util.qr($ctx.stash.conditions.add({
+  \\"id\\": {
+      \\"attributeExists\\": true
+  }
+}))
+#end
+## End - key condition **
+#if( $args.condition )
+  $util.qr($ctx.stash.conditions.add($args.condition))
+#end
+## Start condition block **
+#if( $ctx.stash.conditions && $ctx.stash.conditions.size() != 0 )
+  #set( $mergedConditions = {
+  \\"and\\": $ctx.stash.conditions
+} )
+  #set( $Conditions = $util.parseJson($util.transform.toDynamoDBConditionExpression($mergedConditions)) )
+  #if( $Conditions.expressionValues && $Conditions.expressionValues.size() == 0 )
+    #set( $Conditions = {
+  \\"expression\\": $Conditions.expression,
+  \\"expressionNames\\": $Conditions.expressionNames
+} )
+  #end
+  ## End condition block **
+#end
+#if( $Conditions )
+  #if( $keyConditionExprNames )
+    $util.qr($Conditions.expressionNames.putAll($keyConditionExprNames))
+  #end
+  $util.qr($DeleteRequest.put(\\"condition\\", $Conditions))
+#end
+$util.qr($DeleteRequest.put(\\"_version\\", $util.defaultIfNull($args.input[\\"_version\\"], 0)))
+$util.toJson($DeleteRequest)
+## [End] Delete Request template. **",
+  "Mutation.deleteSong.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#else
+  $util.toJson($ctx.result)
+#end
+## [End] ResponseTemplate. **",
+  "Mutation.updateSong.init.1.req.vtl": "## [Start] Initialization default values. **
+$util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
+#set( $updatedAt = $util.time.nowISO8601() )
+$util.qr($ctx.stash.defaultValues.put(\\"updatedAt\\", $updatedAt))
+$util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": {}
+})
+## [End] Initialization default values. **",
+  "Mutation.updateSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Mutation.updateSong.req.vtl": "## [Start] Mutation Update resolver. **
+#set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+## Set the default values to put request **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+## copy the values from input **
+$util.qr($mergedValues.putAll($util.defaultIfNull($args.input, {})))
+## set the typename **
+## Initialize the vars for creating ddb expression **
+#set( $expNames = {} )
+#set( $expValues = {} )
+#set( $expSet = {} )
+#set( $expAdd = {} )
+#set( $expRemove = [] )
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $Key = $ctx.stash.metadata.modelObjectKey )
+#else
+  #set( $Key = {
+  \\"id\\":   $util.dynamodb.toDynamoDB($args.input.id)
+} )
+#end
+## Model key **
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $keyFields = [\\"_version\\", \\"_deleted\\", \\"_lastChangedAt\\"] )
+  #foreach( $entry in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    $util.qr($keyFields.add(\\"$entry.key\\"))
+  #end
+#else
+  #set( $keyFields = [\\"id\\", \\"_version\\", \\"_deleted\\", \\"_lastChangedAt\\"] )
+#end
+#foreach( $entry in $util.map.copyAndRemoveAllKeys($mergedValues, $keyFields).entrySet() )
+  #if( !$util.isNull($ctx.stash.metadata.dynamodbNameOverrideMap) && $ctx.stash.metadata.dynamodbNameOverrideMap.containsKey(\\"$entry.key\\") )
+    #set( $entryKeyAttributeName = $ctx.stash.metadata.dynamodbNameOverrideMap.get(\\"$entry.key\\") )
+  #else
+    #set( $entryKeyAttributeName = $entry.key )
+  #end
+  #if( $util.isNull($entry.value) )
+    #set( $discard = $expRemove.add(\\"#$entryKeyAttributeName\\") )
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+  #else
+    $util.qr($expSet.put(\\"#$entryKeyAttributeName\\", \\":$entryKeyAttributeName\\"))
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+    $util.qr($expValues.put(\\":$entryKeyAttributeName\\", $util.dynamodb.toDynamoDB($entry.value)))
+  #end
+#end
+#set( $expression = \\"\\" )
+#if( !$expSet.isEmpty() )
+  #set( $expression = \\"SET\\" )
+  #foreach( $entry in $expSet.entrySet() )
+    #set( $expression = \\"$expression $entry.key = $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expAdd.isEmpty() )
+  #set( $expression = \\"$expression ADD\\" )
+  #foreach( $entry in $expAdd.entrySet() )
+    #set( $expression = \\"$expression $entry.key $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expRemove.isEmpty() )
+  #set( $expression = \\"$expression REMOVE\\" )
+  #foreach( $entry in $expRemove )
+    #set( $expression = \\"$expression $entry\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#set( $update = {} )
+$util.qr($update.put(\\"expression\\", \\"$expression\\"))
+#if( !$expNames.isEmpty() )
+  $util.qr($update.put(\\"expressionNames\\", $expNames))
+#end
+#if( !$expValues.isEmpty() )
+  $util.qr($update.put(\\"expressionValues\\", $expValues))
+#end
+## Begin - key condition **
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $keyConditionExpr = {} )
+  #set( $keyConditionExprNames = {} )
+  #foreach( $entry in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    $util.qr($keyConditionExpr.put(\\"keyCondition$velocityCount\\", {
+  \\"attributeExists\\": true
+}))
+    $util.qr($keyConditionExprNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+  $util.qr($ctx.stash.conditions.add($keyConditionExpr))
+#else
+  $util.qr($ctx.stash.conditions.add({
+  \\"id\\": {
+      \\"attributeExists\\": true
+  }
+}))
+#end
+## End - key condition **
+#if( $args.condition )
+  $util.qr($ctx.stash.conditions.add($args.condition))
+#end
+## Start condition block **
+#if( $ctx.stash.conditions && $ctx.stash.conditions.size() != 0 )
+  #set( $mergedConditions = {
+  \\"and\\": $ctx.stash.conditions
+} )
+  #set( $Conditions = $util.parseJson($util.transform.toDynamoDBConditionExpression($mergedConditions)) )
+  #if( $Conditions.expressionValues && $Conditions.expressionValues.size() == 0 )
+    #set( $Conditions = {
+  \\"expression\\": $Conditions.expression,
+  \\"expressionNames\\": $Conditions.expressionNames
+} )
+  #end
+  ## End condition block **
+#end
+#set( $UpdateItem = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"UpdateItem\\",
+  \\"key\\": $Key,
+  \\"update\\": $update,
+  \\"_version\\": $util.defaultIfNull($args.input[\\"_version\\"], 0)
+} )
+#if( $Conditions )
+  #if( $keyConditionExprNames )
+    $util.qr($Conditions.expressionNames.putAll($keyConditionExprNames))
+  #end
+  $util.qr($UpdateItem.put(\\"condition\\", $Conditions))
+#end
+$util.toJson($UpdateItem)
+## [End] Mutation Update resolver. **",
+  "Mutation.updateSong.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#else
+  $util.toJson($ctx.result)
+#end
+## [End] ResponseTemplate. **",
+  "Query.getSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Query.getSong.req.vtl": "## [Start] Get Request template. **
+#set( $GetRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\"
+} )
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionNames = {} )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression#keyCount$velocityCount = :valueCount$velocityCount AND \\" )
+    $util.qr($expressionNames.put(\\"#keyCount$velocityCount\\", $item.key))
+    $util.qr($expressionValues.put(\\":valueCount$velocityCount\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionNames\\": $expressionNames,
+  \\"expressionValues\\": $expressionValues
+} )
+#else
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
+  }
+} )
+#end
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
+#end
+$util.toJson($GetRequest)
+## [End] Get Request template. **",
+  "Query.getSong.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#end
+#if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
+#else
+  #if( $ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized()
+  #end
+  $util.toJson(null)
+#end
+## [End] Get Response template. **",
+  "Query.listSongs.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Query.listSongs.req.vtl": "## [Start] List Request. **
+#set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+#set( $limit = $util.defaultIfNull($args.limit, 100) )
+#set( $ListRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"limit\\": $limit
+} )
+#if( $args.nextToken )
+  #set( $ListRequest.nextToken = $args.nextToken )
+#end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($args.filter) )
+    #set( $filter = {
+  \\"and\\":   [$filter, $args.filter]
+} )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($args.filter) )
+    #set( $filter = $args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( $util.isNullOrEmpty($filterExpression) )
+    $util.error(\\"Unable to process the filter expression\\", \\"Unrecognized Filter\\")
+  #end
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterExpression.expressionValues.size() == 0 )
+      $util.qr($filterExpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $ListRequest.filter = $filterExpression )
+  #end
+#end
+#if( !$util.isNull($ctx.stash.modelQueryExpression) && !$util.isNullOrEmpty($ctx.stash.modelQueryExpression.expression) )
+  $util.qr($ListRequest.put(\\"operation\\", \\"Query\\"))
+  $util.qr($ListRequest.put(\\"query\\", $ctx.stash.modelQueryExpression))
+  #if( !$util.isNull($args.sortDirection) && $args.sortDirection == \\"DESC\\" )
+    #set( $ListRequest.scanIndexForward = false )
+  #else
+    #set( $ListRequest.scanIndexForward = true )
+  #end
+#else
+  $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
+#end
+#if( !$util.isNull($ctx.stash.metadata.index) )
+  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+#end
+$util.toJson($ListRequest)
+## [End] List Request. **",
+  "Query.listSongs.res.vtl": "## [Start] ResponseTemplate. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#else
+  $util.toJson($ctx.result)
+#end
+## [End] ResponseTemplate. **",
+  "Query.songInfoByGenre.postAuth.1.res.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Query.songInfoByGenre.req.vtl": "## [Start] Set query expression for key **
+#if( !$util.isNull($ctx.args.sortDirection) )
+  $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
+#end
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($ctx.args.genre) )
+  #set( $modelQueryExpression.expression = \\"#genre = :genre\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#genre\\": \\"genre\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":genre\\": {
+      \\"S\\": \\"$ctx.args.genre\\"
+  }
+} )
+#end
+## [End] Set query expression for key **
+#set( $limit = $util.defaultIfNull($context.args.limit, 100) )
+#set( $QueryRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\",
+  \\"limit\\": $limit,
+  \\"query\\": $modelQueryExpression,
+  \\"index\\": \\"byGenre\\"
+} )
+#if( !$util.isNull($ctx.args.sortDirection)
+                      && $ctx.args.sortDirection == \\"DESC\\" )
+  #set( $QueryRequest.scanIndexForward = false )
+#else
+  #set( $QueryRequest.scanIndexForward = true )
+#end
+#if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = {
+  \\"and\\":   [$filter, $ctx.args.filter]
+} )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterExpression.expressionValues.size() == 0 )
+      $util.qr($filterExpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
+$util.toJson($QueryRequest)",
+  "Query.songInfoByGenre.res.vtl": "#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
+$util.toJson($ctx.result)",
+  "Query.syncSongs.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Query.syncSongs.preAuth.1.req.vtl": "## [Start] Set map initialization for @key **
+#set( $index = \\"\\" )
+#set( $scan = true )
+#set( $filterMap = {} )
+#set( $QueryMap = {} )
+#set( $PkMap = {} )
+#set( $filterArgsMap = {} )
+## [End] Set map initialization for @key **
+## [Start] Set query expression for @key **
+$util.qr($QueryMap.put('genre' , 'byGenre'))
+$util.qr($PkMap.put('genre' , 'byGenre'))
+## [End] Set query expression for @key **
+## [Start] Set query expression for @key **
+#set( $filterArgsMap = $ctx.args.filter.get(\\"and\\") )
+#set( $isLastSyncInDeltaTTLWindow = false )
+#set( $minLastSync = $util.time.nowEpochMilliSeconds() - 900000 )
+#if( !$util.isNull($ctx.args.lastSync) && $ctx.args.lastSync != 0 && $minLastSync <= $ctx.args.lastSync )
+  #set( $isLastSyncInDeltaTTLWindow = true )
+#end
+#if( !$util.isNullOrEmpty($filterArgsMap) && !$isLastSyncInDeltaTTLWindow )
+  #set( $json = $filterArgsMap )
+  #foreach( $item in $json )
+    #set( $ind = $foreach.index )
+    #foreach( $entry in $item.entrySet() )
+      #if( $ind == 0 && !$util.isNullOrEmpty($entry.value.eq) && !$util.isNullOrEmpty($PkMap.get($entry.key)) )
+        #set( $pk = $entry.key )
+        #set( $scan = false )
+        $util.qr($ctx.args.put($pk,$entry.value.eq))
+        #set( $index = $PkMap.get($pk) )
+      #end
+      #if( $ind == 1 && !$util.isNullOrEmpty($pk) && !$util.isNullOrEmpty($QueryMap.get(\\"\${pk}+$entry.key\\")) )
+        #set( $sk = $entry.key )
+        $util.qr($ctx.args.put($sk,$entry.value))
+        #set( $index = $QueryMap.get(\\"\${pk}+$sk\\") )
+      #else
+        #if( $ind > 0 )
+          $util.qr($filterMap.put($entry.key,$entry.value))
+        #end
+      #end
+    #end
+  #end
+#else
+  #set( $filterMap = $ctx.args.filter )
+#end
+## [End] Set query expression for @key **
+## [Start] Set Primary Key initialization @key **
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($pk) )
+  #set( $modelQueryExpression.expression = \\"#pk = :pk\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#pk\\": \\"$pk\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":pk\\": $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($pk)))
+} )
+#end
+## [End] Set Primary Key initialization @key **
+## [Start] Applying Key Condition **
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).beginsWith) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND begins_with(#sortKey, :sortKey)\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).beginsWith))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).between) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey BETWEEN :sortKey0 AND :sortKey1\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).between[0]))))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).between[1]))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).eq) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey = :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).eq))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).lt) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey < :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).lt))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).le) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey <= :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).le))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).gt) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey > :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).gt))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).ge) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey >= :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).ge))))
+#end
+## [End] Applying Key Condition **
+## [Start]  Set query expression for @key **
+#if( !$scan )
+  #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
+  #set( $QueryRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Sync\\",
+  \\"limit\\": $limit,
+  \\"lastSync\\": $util.toJson($util.defaultIfNull($ctx.args.lastSync, null)),
+  \\"query\\": $modelQueryExpression
+} )
+  #if( !$util.isNull($ctx.args.sortDirection)
+                    && $ctx.args.sortDirection == \\"DESC\\" )
+    #set( $QueryRequest.scanIndexForward = false )
+  #else
+    #set( $QueryRequest.scanIndexForward = true )
+  #end
+#if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
+  #if( !$util.isNullOrEmpty($filterMap) )
+    #set( $QueryRequest.filter = $util.parseJson($util.transform.toDynamoDBFilterExpression($filterMap)) )
+  #end
+  #if( $index != \\"dbTable\\" )
+    #set( $QueryRequest.index = $index )
+  #end
+  $util.toJson($QueryRequest)
+#else
+{
+      \\"version\\": \\"2018-05-29\\",
+      \\"operation\\": \\"Sync\\",
+      \\"limit\\": $util.defaultIfNull($ctx.args.limit, 100),
+      \\"nextToken\\": $util.toJson($util.defaultIfNull($ctx.args.nextToken, null)),
+      \\"lastSync\\": $util.toJson($util.defaultIfNull($ctx.args.lastSync, null)),
+      \\"filter\\":     #if( !$util.isNullOrEmpty($ctx.args.filter) )
+$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
+    #else
+null
+    #end
+  }
+#end
+## [End]  Set query expression for @key **
+",
+  "Query.syncSongs.req.vtl": "## [Start] Sync Request template. **
+#set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($args.filter) )
+    #set( $filter = {
+  \\"and\\":   [$filter, $args.filter]
+} )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($args.filter) )
+    #set( $filter = $args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterExpression.expressionValues.size() == 0 )
+      $util.qr($filterExpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $filter = $filterExpression )
+  #end
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Sync\\",
+  \\"filter\\":   #if( $filter )
+$util.toJson($filter)
+  #else
+null
+  #end,
+  \\"limit\\": $util.defaultIfNull($args.limit, 100),
+  \\"lastSync\\": $util.toJson($util.defaultIfNull($args.lastSync, null)),
+  \\"nextToken\\": $util.toJson($util.defaultIfNull($args.nextToken, null))
+}
+## [End] Sync Request template. **",
+  "Query.syncSongs.res.vtl": "## [Start] ResponseTemplate. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#else
+  $util.toJson($ctx.result)
+#end
+## [End] ResponseTemplate. **",
+  "Subscription.onCreateSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Subscription.onCreateSong.req.vtl": "## [Start] Subscription Request template. **
+$util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": {}
+})
+## [End] Subscription Request template. **",
+  "Subscription.onCreateSong.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
+$util.toJson(null)
+## [End] Subscription Response template. **",
+  "Subscription.onDeleteSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Subscription.onDeleteSong.req.vtl": "## [Start] Subscription Request template. **
+$util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": {}
+})
+## [End] Subscription Request template. **",
+  "Subscription.onDeleteSong.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
+$util.toJson(null)
+## [End] Subscription Response template. **",
+  "Subscription.onUpdateSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Subscription.onUpdateSong.req.vtl": "## [Start] Subscription Request template. **
+$util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": {}
+})
+## [End] Subscription Request template. **",
+  "Subscription.onUpdateSong.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
+$util.toJson(null)
+## [End] Subscription Response template. **",
+}
+`;
+
+exports[`sync query resolver renders without overrides 1`] = `
+Object {
+  "Mutation.createSong.init.1.req.vtl": "## [Start] Initialization default values. **
+$util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
+#set( $createdAt = $util.time.nowISO8601() )
+$util.qr($ctx.stash.defaultValues.put(\\"id\\", $util.autoId()))
+$util.qr($ctx.stash.defaultValues.put(\\"createdAt\\", $createdAt))
+$util.qr($ctx.stash.defaultValues.put(\\"updatedAt\\", $createdAt))
+$util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": {}
+})
+## [End] Initialization default values. **",
+  "Mutation.createSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Mutation.createSong.req.vtl": "## [Start] Create Request template. **
+#set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+## Set the default values to put request **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+## copy the values from input **
+$util.qr($mergedValues.putAll($util.defaultIfNull($args.input, {})))
+## set the typename **
+$util.qr($mergedValues.put(\\"__typename\\", \\"Song\\"))
+#set( $nullIndexFields = [] )
+#set( $indexFields = [\\"genre\\"] )
+#foreach( $entry in $util.map.copyAndRetainAllKeys($mergedValues, $indexFields).entrySet() )
+  #if( $util.isNull($entry.value) )
+    $util.qr($nullIndexFields.add($entry.key))
+  #end
+#end
+#set( $mergedValues = $util.map.copyAndRemoveAllKeys($mergedValues, $nullIndexFields) )
+#set( $PutObject = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"PutItem\\",
+  \\"attributeValues\\":   $util.dynamodb.toMapValues($mergedValues),
+  \\"condition\\": $condition
+} )
+#if( $args.condition )
+  $util.qr($ctx.stash.conditions.add($args.condition))
+#end
+## Begin - key condition **
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $keyConditionExpr = {} )
+  #set( $keyConditionExprNames = {} )
+  #foreach( $entry in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    $util.qr($keyConditionExpr.put(\\"keyCondition$velocityCount\\", {
+  \\"attributeExists\\": false
+}))
+    $util.qr($keyConditionExprNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+  $util.qr($ctx.stash.conditions.add($keyConditionExpr))
+#else
+  $util.qr($ctx.stash.conditions.add({
+  \\"id\\": {
+      \\"attributeExists\\": false
+  }
+}))
+#end
+## End - key condition **
+## Start condition block **
+#if( $ctx.stash.conditions && $ctx.stash.conditions.size() != 0 )
+  #set( $mergedConditions = {
+  \\"and\\": $ctx.stash.conditions
+} )
+  #set( $Conditions = $util.parseJson($util.transform.toDynamoDBConditionExpression($mergedConditions)) )
+  #if( $Conditions.expressionValues && $Conditions.expressionValues.size() == 0 )
+    #set( $Conditions = {
+  \\"expression\\": $Conditions.expression,
+  \\"expressionNames\\": $Conditions.expressionNames
+} )
+  #end
+  ## End condition block **
+#end
+#if( $Conditions )
+  #if( $keyConditionExprNames )
+    $util.qr($Conditions.expressionNames.putAll($keyConditionExprNames))
+  #end
+  $util.qr($PutObject.put(\\"condition\\", $Conditions))
+#end
+#if( $ctx.stash.metadata.modelObjectKey )
+  $util.qr($PutObject.put(\\"key\\", $ctx.stash.metadata.modelObjectKey))
+#else
+  #set( $Key = {
+  \\"id\\":   $util.dynamodb.toDynamoDB($mergedValues.id)
+} )
+  $util.qr($PutObject.put(\\"key\\", $Key))
+#end
+$util.toJson($PutObject)
+## [End] Create Request template. **",
+  "Mutation.createSong.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#else
+  $util.toJson($ctx.result)
+#end
+## [End] ResponseTemplate. **",
+  "Mutation.deleteSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Mutation.deleteSong.req.vtl": "## [Start] Delete Request template. **
+#set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+#set( $DeleteRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"DeleteItem\\"
+} )
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $Key = $ctx.stash.metadata.modelObjectKey )
+#else
+  #set( $Key = {
+  \\"id\\":   $util.dynamodb.toDynamoDB($args.input.id)
+} )
+#end
+$util.qr($DeleteRequest.put(\\"key\\", $Key))
+## Begin - key condition **
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $keyConditionExpr = {} )
+  #set( $keyConditionExprNames = {} )
+  #foreach( $entry in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    $util.qr($keyConditionExpr.put(\\"keyCondition$velocityCount\\", {
+  \\"attributeExists\\": true
+}))
+    $util.qr($keyConditionExprNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+  $util.qr($ctx.stash.conditions.add($keyConditionExpr))
+#else
+  $util.qr($ctx.stash.conditions.add({
+  \\"id\\": {
+      \\"attributeExists\\": true
+  }
+}))
+#end
+## End - key condition **
+#if( $args.condition )
+  $util.qr($ctx.stash.conditions.add($args.condition))
+#end
+## Start condition block **
+#if( $ctx.stash.conditions && $ctx.stash.conditions.size() != 0 )
+  #set( $mergedConditions = {
+  \\"and\\": $ctx.stash.conditions
+} )
+  #set( $Conditions = $util.parseJson($util.transform.toDynamoDBConditionExpression($mergedConditions)) )
+  #if( $Conditions.expressionValues && $Conditions.expressionValues.size() == 0 )
+    #set( $Conditions = {
+  \\"expression\\": $Conditions.expression,
+  \\"expressionNames\\": $Conditions.expressionNames
+} )
+  #end
+  ## End condition block **
+#end
+#if( $Conditions )
+  #if( $keyConditionExprNames )
+    $util.qr($Conditions.expressionNames.putAll($keyConditionExprNames))
+  #end
+  $util.qr($DeleteRequest.put(\\"condition\\", $Conditions))
+#end
+$util.qr($DeleteRequest.put(\\"_version\\", $util.defaultIfNull($args.input[\\"_version\\"], 0)))
+$util.toJson($DeleteRequest)
+## [End] Delete Request template. **",
+  "Mutation.deleteSong.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#else
+  $util.toJson($ctx.result)
+#end
+## [End] ResponseTemplate. **",
+  "Mutation.updateSong.init.1.req.vtl": "## [Start] Initialization default values. **
+$util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
+#set( $updatedAt = $util.time.nowISO8601() )
+$util.qr($ctx.stash.defaultValues.put(\\"updatedAt\\", $updatedAt))
+$util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": {}
+})
+## [End] Initialization default values. **",
+  "Mutation.updateSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Mutation.updateSong.req.vtl": "## [Start] Mutation Update resolver. **
+#set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+## Set the default values to put request **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+## copy the values from input **
+$util.qr($mergedValues.putAll($util.defaultIfNull($args.input, {})))
+## set the typename **
+## Initialize the vars for creating ddb expression **
+#set( $expNames = {} )
+#set( $expValues = {} )
+#set( $expSet = {} )
+#set( $expAdd = {} )
+#set( $expRemove = [] )
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $Key = $ctx.stash.metadata.modelObjectKey )
+#else
+  #set( $Key = {
+  \\"id\\":   $util.dynamodb.toDynamoDB($args.input.id)
+} )
+#end
+## Model key **
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $keyFields = [\\"_version\\", \\"_deleted\\", \\"_lastChangedAt\\"] )
+  #foreach( $entry in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    $util.qr($keyFields.add(\\"$entry.key\\"))
+  #end
+#else
+  #set( $keyFields = [\\"id\\", \\"_version\\", \\"_deleted\\", \\"_lastChangedAt\\"] )
+#end
+#foreach( $entry in $util.map.copyAndRemoveAllKeys($mergedValues, $keyFields).entrySet() )
+  #if( !$util.isNull($ctx.stash.metadata.dynamodbNameOverrideMap) && $ctx.stash.metadata.dynamodbNameOverrideMap.containsKey(\\"$entry.key\\") )
+    #set( $entryKeyAttributeName = $ctx.stash.metadata.dynamodbNameOverrideMap.get(\\"$entry.key\\") )
+  #else
+    #set( $entryKeyAttributeName = $entry.key )
+  #end
+  #if( $util.isNull($entry.value) )
+    #set( $discard = $expRemove.add(\\"#$entryKeyAttributeName\\") )
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+  #else
+    $util.qr($expSet.put(\\"#$entryKeyAttributeName\\", \\":$entryKeyAttributeName\\"))
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+    $util.qr($expValues.put(\\":$entryKeyAttributeName\\", $util.dynamodb.toDynamoDB($entry.value)))
+  #end
+#end
+#set( $expression = \\"\\" )
+#if( !$expSet.isEmpty() )
+  #set( $expression = \\"SET\\" )
+  #foreach( $entry in $expSet.entrySet() )
+    #set( $expression = \\"$expression $entry.key = $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expAdd.isEmpty() )
+  #set( $expression = \\"$expression ADD\\" )
+  #foreach( $entry in $expAdd.entrySet() )
+    #set( $expression = \\"$expression $entry.key $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expRemove.isEmpty() )
+  #set( $expression = \\"$expression REMOVE\\" )
+  #foreach( $entry in $expRemove )
+    #set( $expression = \\"$expression $entry\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#set( $update = {} )
+$util.qr($update.put(\\"expression\\", \\"$expression\\"))
+#if( !$expNames.isEmpty() )
+  $util.qr($update.put(\\"expressionNames\\", $expNames))
+#end
+#if( !$expValues.isEmpty() )
+  $util.qr($update.put(\\"expressionValues\\", $expValues))
+#end
+## Begin - key condition **
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $keyConditionExpr = {} )
+  #set( $keyConditionExprNames = {} )
+  #foreach( $entry in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    $util.qr($keyConditionExpr.put(\\"keyCondition$velocityCount\\", {
+  \\"attributeExists\\": true
+}))
+    $util.qr($keyConditionExprNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+  $util.qr($ctx.stash.conditions.add($keyConditionExpr))
+#else
+  $util.qr($ctx.stash.conditions.add({
+  \\"id\\": {
+      \\"attributeExists\\": true
+  }
+}))
+#end
+## End - key condition **
+#if( $args.condition )
+  $util.qr($ctx.stash.conditions.add($args.condition))
+#end
+## Start condition block **
+#if( $ctx.stash.conditions && $ctx.stash.conditions.size() != 0 )
+  #set( $mergedConditions = {
+  \\"and\\": $ctx.stash.conditions
+} )
+  #set( $Conditions = $util.parseJson($util.transform.toDynamoDBConditionExpression($mergedConditions)) )
+  #if( $Conditions.expressionValues && $Conditions.expressionValues.size() == 0 )
+    #set( $Conditions = {
+  \\"expression\\": $Conditions.expression,
+  \\"expressionNames\\": $Conditions.expressionNames
+} )
+  #end
+  ## End condition block **
+#end
+#set( $UpdateItem = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"UpdateItem\\",
+  \\"key\\": $Key,
+  \\"update\\": $update,
+  \\"_version\\": $util.defaultIfNull($args.input[\\"_version\\"], 0)
+} )
+#if( $Conditions )
+  #if( $keyConditionExprNames )
+    $util.qr($Conditions.expressionNames.putAll($keyConditionExprNames))
+  #end
+  $util.qr($UpdateItem.put(\\"condition\\", $Conditions))
+#end
+$util.toJson($UpdateItem)
+## [End] Mutation Update resolver. **",
+  "Mutation.updateSong.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#else
+  $util.toJson($ctx.result)
+#end
+## [End] ResponseTemplate. **",
+  "Query.getSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Query.getSong.req.vtl": "## [Start] Get Request template. **
+#set( $GetRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\"
+} )
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionNames = {} )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression#keyCount$velocityCount = :valueCount$velocityCount AND \\" )
+    $util.qr($expressionNames.put(\\"#keyCount$velocityCount\\", $item.key))
+    $util.qr($expressionValues.put(\\":valueCount$velocityCount\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionNames\\": $expressionNames,
+  \\"expressionValues\\": $expressionValues
+} )
+#else
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
+  }
+} )
+#end
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
+#end
+$util.toJson($GetRequest)
+## [End] Get Request template. **",
+  "Query.getSong.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#end
+#if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
+#else
+  #if( $ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized()
+  #end
+  $util.toJson(null)
+#end
+## [End] Get Response template. **",
+  "Query.listSongs.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Query.listSongs.req.vtl": "## [Start] List Request. **
+#set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+#set( $limit = $util.defaultIfNull($args.limit, 100) )
+#set( $ListRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"limit\\": $limit
+} )
+#if( $args.nextToken )
+  #set( $ListRequest.nextToken = $args.nextToken )
+#end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($args.filter) )
+    #set( $filter = {
+  \\"and\\":   [$filter, $args.filter]
+} )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($args.filter) )
+    #set( $filter = $args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( $util.isNullOrEmpty($filterExpression) )
+    $util.error(\\"Unable to process the filter expression\\", \\"Unrecognized Filter\\")
+  #end
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterExpression.expressionValues.size() == 0 )
+      $util.qr($filterExpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $ListRequest.filter = $filterExpression )
+  #end
+#end
+#if( !$util.isNull($ctx.stash.modelQueryExpression) && !$util.isNullOrEmpty($ctx.stash.modelQueryExpression.expression) )
+  $util.qr($ListRequest.put(\\"operation\\", \\"Query\\"))
+  $util.qr($ListRequest.put(\\"query\\", $ctx.stash.modelQueryExpression))
+  #if( !$util.isNull($args.sortDirection) && $args.sortDirection == \\"DESC\\" )
+    #set( $ListRequest.scanIndexForward = false )
+  #else
+    #set( $ListRequest.scanIndexForward = true )
+  #end
+#else
+  $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
+#end
+#if( !$util.isNull($ctx.stash.metadata.index) )
+  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+#end
+$util.toJson($ListRequest)
+## [End] List Request. **",
+  "Query.listSongs.res.vtl": "## [Start] ResponseTemplate. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#else
+  $util.toJson($ctx.result)
+#end
+## [End] ResponseTemplate. **",
+  "Query.songInfoByGenre.postAuth.1.res.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Query.songInfoByGenre.req.vtl": "## [Start] Set query expression for key **
+#if( !$util.isNull($ctx.args.sortDirection) )
+  $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
+#end
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($ctx.args.genre) )
+  #set( $modelQueryExpression.expression = \\"#genre = :genre\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#genre\\": \\"genre\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":genre\\": {
+      \\"S\\": \\"$ctx.args.genre\\"
+  }
+} )
+#end
+## [End] Set query expression for key **
+#set( $limit = $util.defaultIfNull($context.args.limit, 100) )
+#set( $QueryRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\",
+  \\"limit\\": $limit,
+  \\"query\\": $modelQueryExpression,
+  \\"index\\": \\"byGenre\\"
+} )
+#if( !$util.isNull($ctx.args.sortDirection)
+                      && $ctx.args.sortDirection == \\"DESC\\" )
+  #set( $QueryRequest.scanIndexForward = false )
+#else
+  #set( $QueryRequest.scanIndexForward = true )
+#end
+#if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = {
+  \\"and\\":   [$filter, $ctx.args.filter]
+} )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filter = $ctx.args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterExpression.expressionValues.size() == 0 )
+      $util.qr($filterExpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $QueryRequest.filter = $filterExpression )
+  #end
+#end
+$util.toJson($QueryRequest)",
+  "Query.songInfoByGenre.res.vtl": "#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
+$util.toJson($ctx.result)",
+  "Query.syncSongs.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Query.syncSongs.preAuth.1.req.vtl": "## [Start] Set map initialization for @key **
+#set( $index = \\"\\" )
+#set( $scan = true )
+#set( $filterMap = {} )
+#set( $QueryMap = {} )
+#set( $PkMap = {} )
+#set( $filterArgsMap = {} )
+## [End] Set map initialization for @key **
+## [Start] Set query expression for @key **
+$util.qr($QueryMap.put('genre' , 'byGenre'))
+$util.qr($PkMap.put('genre' , 'byGenre'))
+## [End] Set query expression for @key **
+## [Start] Set query expression for @key **
+#set( $filterArgsMap = $ctx.args.filter.get(\\"and\\") )
+#set( $isLastSyncInDeltaTTLWindow = false )
+#set( $minLastSync = $util.time.nowEpochMilliSeconds() - 1800000 )
+#if( !$util.isNull($ctx.args.lastSync) && $ctx.args.lastSync != 0 && $minLastSync <= $ctx.args.lastSync )
+  #set( $isLastSyncInDeltaTTLWindow = true )
+#end
+#if( !$util.isNullOrEmpty($filterArgsMap) && !$isLastSyncInDeltaTTLWindow )
+  #set( $json = $filterArgsMap )
+  #foreach( $item in $json )
+    #set( $ind = $foreach.index )
+    #foreach( $entry in $item.entrySet() )
+      #if( $ind == 0 && !$util.isNullOrEmpty($entry.value.eq) && !$util.isNullOrEmpty($PkMap.get($entry.key)) )
+        #set( $pk = $entry.key )
+        #set( $scan = false )
+        $util.qr($ctx.args.put($pk,$entry.value.eq))
+        #set( $index = $PkMap.get($pk) )
+      #end
+      #if( $ind == 1 && !$util.isNullOrEmpty($pk) && !$util.isNullOrEmpty($QueryMap.get(\\"\${pk}+$entry.key\\")) )
+        #set( $sk = $entry.key )
+        $util.qr($ctx.args.put($sk,$entry.value))
+        #set( $index = $QueryMap.get(\\"\${pk}+$sk\\") )
+      #else
+        #if( $ind > 0 )
+          $util.qr($filterMap.put($entry.key,$entry.value))
+        #end
+      #end
+    #end
+  #end
+#else
+  #set( $filterMap = $ctx.args.filter )
+#end
+## [End] Set query expression for @key **
+## [Start] Set Primary Key initialization @key **
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($pk) )
+  #set( $modelQueryExpression.expression = \\"#pk = :pk\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#pk\\": \\"$pk\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":pk\\": $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($pk)))
+} )
+#end
+## [End] Set Primary Key initialization @key **
+## [Start] Applying Key Condition **
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).beginsWith) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND begins_with(#sortKey, :sortKey)\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).beginsWith))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).between) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey BETWEEN :sortKey0 AND :sortKey1\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).between[0]))))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).between[1]))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).eq) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey = :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).eq))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).lt) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey < :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).lt))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).le) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey <= :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).le))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).gt) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey > :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).gt))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).ge) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey >= :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).ge))))
+#end
+## [End] Applying Key Condition **
+## [Start]  Set query expression for @key **
+#if( !$scan )
+  #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
+  #set( $QueryRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Sync\\",
+  \\"limit\\": $limit,
+  \\"lastSync\\": $util.toJson($util.defaultIfNull($ctx.args.lastSync, null)),
+  \\"query\\": $modelQueryExpression
+} )
+  #if( !$util.isNull($ctx.args.sortDirection)
+                    && $ctx.args.sortDirection == \\"DESC\\" )
+    #set( $QueryRequest.scanIndexForward = false )
+  #else
+    #set( $QueryRequest.scanIndexForward = true )
+  #end
+#if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
+  #if( !$util.isNullOrEmpty($filterMap) )
+    #set( $QueryRequest.filter = $util.parseJson($util.transform.toDynamoDBFilterExpression($filterMap)) )
+  #end
+  #if( $index != \\"dbTable\\" )
+    #set( $QueryRequest.index = $index )
+  #end
+  $util.toJson($QueryRequest)
+#else
+{
+      \\"version\\": \\"2018-05-29\\",
+      \\"operation\\": \\"Sync\\",
+      \\"limit\\": $util.defaultIfNull($ctx.args.limit, 100),
+      \\"nextToken\\": $util.toJson($util.defaultIfNull($ctx.args.nextToken, null)),
+      \\"lastSync\\": $util.toJson($util.defaultIfNull($ctx.args.lastSync, null)),
+      \\"filter\\":     #if( !$util.isNullOrEmpty($ctx.args.filter) )
+$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
+    #else
+null
+    #end
+  }
+#end
+## [End]  Set query expression for @key **
+",
+  "Query.syncSongs.req.vtl": "## [Start] Sync Request template. **
+#set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($args.filter) )
+    #set( $filter = {
+  \\"and\\":   [$filter, $args.filter]
+} )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($args.filter) )
+    #set( $filter = $args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterExpression.expressionValues.size() == 0 )
+      $util.qr($filterExpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $filter = $filterExpression )
+  #end
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Sync\\",
+  \\"filter\\":   #if( $filter )
+$util.toJson($filter)
+  #else
+null
+  #end,
+  \\"limit\\": $util.defaultIfNull($args.limit, 100),
+  \\"lastSync\\": $util.toJson($util.defaultIfNull($args.lastSync, null)),
+  \\"nextToken\\": $util.toJson($util.defaultIfNull($args.nextToken, null))
+}
+## [End] Sync Request template. **",
+  "Query.syncSongs.res.vtl": "## [Start] ResponseTemplate. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#else
+  $util.toJson($ctx.result)
+#end
+## [End] ResponseTemplate. **",
+  "Subscription.onCreateSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Subscription.onCreateSong.req.vtl": "## [Start] Subscription Request template. **
+$util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": {}
+})
+## [End] Subscription Request template. **",
+  "Subscription.onCreateSong.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
+$util.toJson(null)
+## [End] Subscription Response template. **",
+  "Subscription.onDeleteSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Subscription.onDeleteSong.req.vtl": "## [Start] Subscription Request template. **
+$util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": {}
+})
+## [End] Subscription Request template. **",
+  "Subscription.onDeleteSong.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
+$util.toJson(null)
+## [End] Subscription Response template. **",
+  "Subscription.onUpdateSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Subscription.onUpdateSong.req.vtl": "## [Start] Subscription Request template. **
+$util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": {}
+})
+## [End] Subscription Request template. **",
+  "Subscription.onUpdateSong.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
+$util.toJson(null)
+## [End] Subscription Response template. **",
+}
+`;
+
 exports[`validate resolver code 1`] = `
 Object {
   "Mutation.createItem.init.1.req.vtl": "## [Start] Initialization default values. **

--- a/packages/amplify-graphql-index-transformer/src/graphql-primary-key-transformer.ts
+++ b/packages/amplify-graphql-index-transformer/src/graphql-primary-key-transformer.ts
@@ -14,7 +14,13 @@ import {
   ObjectTypeDefinitionNode,
 } from 'graphql';
 import { isListType, isNonNullType, isScalarOrEnum } from 'graphql-transformer-common';
-import { constructSyncVTL, replaceDdbPrimaryKey, updateResolvers } from './resolvers';
+import { 
+  constructSyncVTL, 
+  replaceDdbPrimaryKey, 
+  updateResolvers,
+  getResourceOverrides,
+  getDeltaSyncTableTtl
+} from './resolvers';
 import {
   addKeyConditionInputs,
   removeAutoCreatedPrimaryKey,
@@ -70,10 +76,12 @@ export class PrimaryKeyTransformer extends TransformerPluginBase {
   public after = (ctx: TransformerContextProvider): void => {
     if (!ctx.isProjectUsingDataStore()) return;
 
+    const overriddenResources = getResourceOverrides([this], ctx?.stackManager);
     // construct sync VTL code
     this.resolverMap.forEach((syncVTLContent, resource) => {
       if (syncVTLContent) {
-        constructSyncVTL(syncVTLContent, resource);
+        const deltaSyncTableTtl = getDeltaSyncTableTtl(overriddenResources, resource);
+        constructSyncVTL(syncVTLContent, resource, deltaSyncTableTtl);
       }
     });
   };

--- a/packages/amplify-graphql-index-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers.ts
@@ -639,7 +639,7 @@ function setSyncQueryFilterSnippet() {
       set(ref('filterArgsMap'), ref('ctx.args.filter.get("and")')),
       generateDeltaTableTTLCheck(
         'isLastSyncInDeltaTTLWindow', 
-        SyncUtils.syncDataSourceConfig()?.DeltaSyncTableTTL, 
+        SyncUtils.syncDataSourceConfig().DeltaSyncTableTTL, 
         'ctx.args.lastSync'
       ),
       ifElse(

--- a/packages/amplify-graphql-transformer-core/src/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/index.ts
@@ -32,7 +32,7 @@ export {
   TransformerPluginBase,
   TransformerAuthBase,
 } from './transformation/transformer-plugin-base';
-export { TransformerResolver } from './transformer-context';
+export { TransformerResolver, StackManager } from './transformer-context';
 /**
  * Returns the extra set of directives that are supported by AppSync service
  */
@@ -48,3 +48,5 @@ export {
   InputObjectDefinitionWrapper,
   ObjectDefinitionWrapper,
 } from './wrappers/object-definition-wrapper';
+
+export { AmplifyApiGraphQlResourceStackTemplate } from './types/amplify-api-resource-stack-types';

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -57,6 +57,7 @@ import {
 import { validateAuthModes, validateModelSchema } from './validation';
 import { DocumentNode } from 'graphql/language';
 import { TransformerPreProcessContext } from '../transformer-context/pre-process-context';
+import { AmplifyApiGraphQlResourceStackTemplate } from '../types/amplify-api-resource-stack-types';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 function isFunction(obj: any): obj is Function {
@@ -305,7 +306,7 @@ export class GraphQLTransform {
     return this.synthesize(context);
   }
 
-  private applyOverride = (stackManager: StackManager) => {
+  public applyOverride = (stackManager: StackManager): AmplifyApiGraphQlResourceStackTemplate  => {
     const stacks: string[] = [];
     const amplifyApiObj: any = {};
     stackManager.rootStack.node.findAll().forEach(node => {
@@ -368,6 +369,7 @@ export class GraphQLTransform {
         throw error;
       }
     }
+    return appsyncResourceObj;
   };
 
   protected generateGraphQlApi(stackManager: StackManager, output: TransformerOutput): GraphQLApi {

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
@@ -20,6 +20,7 @@ import { TransformerResourceHelper } from './resource-helper';
 import { StackManager } from './stack-manager';
 
 export { TransformerResolver } from './resolver';
+export { StackManager } from './stack-manager';
 export class TransformerContextMetadata implements TransformerContextMetadataProvider {
   /**
    * Used by transformers to pass information between one another.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds a check to identify if the current query operation falls outside the delta table TTL window.
Avoids scanning the entire base table but query it when `syncExpression` returns a predicate that maps to a query expression. Relevant [doc](https://docs.amplify.aws/lib/datastore/sync/q/platform/js/#advanced-use-case---query-instead-of-scan).
This improves the performance of the query significantly as called out in the above doc section.

The Delta Sync Table TTL is set to 30 mins by Amplify CLI when conflict detection is enabled by the developer.
Developers however can override this value following the guide [here](https://docs.amplify.aws/cli/graphql/override/#customize-amplify-generated-resources-for-model-directive).
If the delta sync table TTL is overridden, we will use the overridden value in the Sync Query resolver function.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-category-api/issues/672

#### Description of how you validated changes
[Successful e2e test run](https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api/784/workflows/c4d07ec6-0dbb-49eb-a1ad-97db3552189a)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
