### PR TITLE
Fix: detect when sort key added to primary key

### DIFF
--- a/packages/amplify-e2e-tests/schemas/iterative-push/add-sort-to-primary-key/final-schema.graphql
+++ b/packages/amplify-e2e-tests/schemas/iterative-push/add-sort-to-primary-key/final-schema.graphql
@@ -1,0 +1,5 @@
+type Blog @model {
+  id: ID! @primaryKey(sortKeyFields: ["name"]
+  name: String!
+  posts: [Post] @connection(keyName: "byBlog1", fields: ["id"])
+}

--- a/packages/amplify-e2e-tests/schemas/iterative-push/add-sort-to-primary-key/final-schema.graphql
+++ b/packages/amplify-e2e-tests/schemas/iterative-push/add-sort-to-primary-key/final-schema.graphql
@@ -1,5 +1,4 @@
 type Blog @model {
-  id: ID! @primaryKey(sortKeyFields: ["name"]
+  id: ID! @primaryKey(sortKeyFields: ["name"])
   name: String!
-  posts: [Post] @connection(keyName: "byBlog1", fields: ["id"])
 }

--- a/packages/amplify-e2e-tests/schemas/iterative-push/add-sort-to-primary-key/initial-schema.graphql
+++ b/packages/amplify-e2e-tests/schemas/iterative-push/add-sort-to-primary-key/initial-schema.graphql
@@ -1,0 +1,5 @@
+type Blog @model {
+  id: ID! @primaryKey
+  name: String!
+  posts: [Post] @connection(keyName: "byBlog1", fields: ["id"])
+}

--- a/packages/amplify-e2e-tests/schemas/iterative-push/add-sort-to-primary-key/initial-schema.graphql
+++ b/packages/amplify-e2e-tests/schemas/iterative-push/add-sort-to-primary-key/initial-schema.graphql
@@ -1,5 +1,4 @@
 type Blog @model {
   id: ID! @primaryKey
   name: String!
-  posts: [Post] @connection(keyName: "byBlog1", fields: ["id"])
 }

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-5.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-5.test.ts
@@ -30,7 +30,7 @@ describe('Schema iterative update - add sort key to primary key', () => {
     const apiName = 'iterativetest1';
 
     const initialSchema = path.join('iterative-push', 'add-sort-to-primary-key', 'initial-schema.graphql');
-    await addApiWithoutSchema(projectDir, { apiKeyExpirationDays: 7, transformerVersion: 1 });
+    await addApiWithoutSchema(projectDir, { apiKeyExpirationDays: 7, transformerVersion: 2 });
     await updateApiSchema(projectDir, apiName, initialSchema);
     await amplifyPush(projectDir);
 

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-5.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-5.test.ts
@@ -1,0 +1,41 @@
+import * as path from 'path';
+import {
+  createNewProjectDir,
+  initJSProjectWithProfile,
+  deleteProject,
+  deleteProjectDir,
+  addApiWithoutSchema,
+  addFeatureFlag,
+  amplifyPush,
+  updateApiSchema,
+  amplifyPushUpdate,
+} from 'amplify-category-api-e2e-core';
+
+describe('Schema iterative update - add sort key to primary key', () => {
+  let projectDir: string;
+
+  beforeAll(async () => {
+    projectDir = await createNewProjectDir('schemaIterative');
+    await initJSProjectWithProfile(projectDir, {
+      name: 'iterativetest1',
+    });
+
+    addFeatureFlag(projectDir, 'graphqltransformer', 'enableiterativegsiupdates', true);
+  });
+  afterAll(async () => {
+    await deleteProject(projectDir);
+    deleteProjectDir(projectDir);
+  });
+  it('should error out when pushed without allowing destructive updates', async () => {
+    const apiName = 'iterativetest1';
+
+    const initialSchema = path.join('iterative-push', 'add-sort-to-primary-key', 'initial-schema.graphql');
+    await addApiWithoutSchema(projectDir, { apiKeyExpirationDays: 7, transformerVersion: 1 });
+    await updateApiSchema(projectDir, apiName, initialSchema);
+    await amplifyPush(projectDir);
+
+    const finalSchema = path.join('iterative-push', 'add-sort-to-primary-key', 'final-schema.graphql');
+    await updateApiSchema(projectDir, apiName, finalSchema);
+    await expect(amplifyPushUpdate(projectDir)).resolves.toThrowError();
+  });
+});

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-5.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-5.test.ts
@@ -36,6 +36,6 @@ describe('Schema iterative update - add sort key to primary key', () => {
 
     const finalSchema = path.join('iterative-push', 'add-sort-to-primary-key', 'final-schema.graphql');
     await updateApiSchema(projectDir, apiName, finalSchema);
-    await expect(amplifyPushUpdate(projectDir)).resolves.toThrowError();
+    await expect(amplifyPushUpdate(projectDir)).rejects.toBeTruthy();
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-5.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-5.test.ts
@@ -11,13 +11,13 @@ import {
   amplifyPushUpdate,
 } from 'amplify-category-api-e2e-core';
 
-describe('Schema iterative update - add sort key to primary key', () => {
+describe('Schema iterative update - sort key modifications', () => {
   let projectDir: string;
 
   beforeAll(async () => {
     projectDir = await createNewProjectDir('schemaIterative');
     await initJSProjectWithProfile(projectDir, {
-      name: 'iterativetest1',
+      name: 'iterativetest5',
     });
 
     addFeatureFlag(projectDir, 'graphqltransformer', 'enableiterativegsiupdates', true);
@@ -26,8 +26,9 @@ describe('Schema iterative update - add sort key to primary key', () => {
     await deleteProject(projectDir);
     deleteProjectDir(projectDir);
   });
-  it('should error out when pushed without allowing destructive updates', async () => {
-    const apiName = 'iterativetest1';
+
+  it('should error out when sort key addition pushed without allowing destructive updates', async () => {
+    const apiName = 'iterativetest5';
 
     const initialSchema = path.join('iterative-push', 'add-sort-to-primary-key', 'initial-schema.graphql');
     await addApiWithoutSchema(projectDir, { apiKeyExpirationDays: 7, transformerVersion: 2 });
@@ -35,6 +36,19 @@ describe('Schema iterative update - add sort key to primary key', () => {
     await amplifyPush(projectDir);
 
     const finalSchema = path.join('iterative-push', 'add-sort-to-primary-key', 'final-schema.graphql');
+    await updateApiSchema(projectDir, apiName, finalSchema);
+    await expect(amplifyPushUpdate(projectDir)).rejects.toBeTruthy();
+  });
+
+  it('should error out when sort key removal pushed without allowing destructive updates', async () => {
+    const apiName = 'iterativetest5';
+
+    const initialSchema = path.join('iterative-push', 'add-sort-to-primary-key', 'final-schema.graphql');
+    await addApiWithoutSchema(projectDir, { apiKeyExpirationDays: 7, transformerVersion: 2 });
+    await updateApiSchema(projectDir, apiName, initialSchema);
+    await amplifyPush(projectDir);
+
+    const finalSchema = path.join('iterative-push', 'add-sort-to-primary-key', 'initial-schema.graphql');
     await updateApiSchema(projectDir, apiName, finalSchema);
     await expect(amplifyPushUpdate(projectDir)).rejects.toBeTruthy();
   });

--- a/packages/graphql-transformer-core/src/util/sanity-check.ts
+++ b/packages/graphql-transformer-core/src/util/sanity-check.ts
@@ -75,10 +75,9 @@ export const sanityCheckDiffs = (
  */
 export const getCantEditKeySchemaRule = (iterativeUpdatesEnabled = false) => {
   const cantEditKeySchemaRule = (diff: Diff): void => {
-    const sortKeyAdded = diff.kind === 'A' && diff.path.length === 6 && diff.path[5] === 'KeySchema' && diff.index === 1;
-    const sortKeyRemoved = diff.kind === 'D' && diff.path.length === 6 && diff.path[5] === 'KeySchema' && diff.index === 1;
+    const sortKeyAddedOrRemoved = diff.kind === 'A' && diff.path.length === 6 && diff.path[5] === 'KeySchema' && diff.index === 1;
     const keySchemaModified = diff.kind === 'E' && diff.path.length === 8 && diff.path[5] === 'KeySchema';
-    if (sortKeyAdded || sortKeyRemoved || keySchemaModified) {
+    if (sortKeyAddedOrRemoved || keySchemaModified) {
       // diff.path = [ "stacks", "Todo.json", "Resources", "TodoTable", "Properties", "KeySchema", 0, "AttributeName"]
       const stackName = path.basename(diff.path[1], '.json');
       const tableName = diff.path[3];

--- a/packages/graphql-transformer-core/src/util/sanity-check.ts
+++ b/packages/graphql-transformer-core/src/util/sanity-check.ts
@@ -76,8 +76,9 @@ export const sanityCheckDiffs = (
 export const getCantEditKeySchemaRule = (iterativeUpdatesEnabled = false) => {
   const cantEditKeySchemaRule = (diff: Diff): void => {
     const sortKeyAdded = diff.kind === 'A' && diff.path.length === 6 && diff.path[5] === 'KeySchema' && diff.index === 1;
+    const sortKeyRemoved = diff.kind === 'D' && diff.path.length === 6 && diff.path[5] === 'KeySchema' && diff.index === 1;
     const keySchemaModified = diff.kind === 'E' && diff.path.length === 8 && diff.path[5] === 'KeySchema';
-    if (sortKeyAdded || keySchemaModified) {
+    if (sortKeyAdded || sortKeyRemoved || keySchemaModified) {
       // diff.path = [ "stacks", "Todo.json", "Resources", "TodoTable", "Properties", "KeySchema", 0, "AttributeName"]
       const stackName = path.basename(diff.path[1], '.json');
       const tableName = diff.path[3];

--- a/packages/graphql-transformer-core/src/util/sanity-check.ts
+++ b/packages/graphql-transformer-core/src/util/sanity-check.ts
@@ -75,7 +75,9 @@ export const sanityCheckDiffs = (
  */
 export const getCantEditKeySchemaRule = (iterativeUpdatesEnabled = false) => {
   const cantEditKeySchemaRule = (diff: Diff): void => {
-    if (diff.kind === 'E' && diff.path.length === 8 && diff.path[5] === 'KeySchema') {
+    const sortKeyAdded = diff.kind === 'A' && diff.path.length === 6 && diff.path[5] === 'KeySchema' && diff.index === 1;
+    const keySchemaModified = diff.kind === 'E' && diff.path.length === 8 && diff.path[5] === 'KeySchema';
+    if (sortKeyAdded || keySchemaModified) {
       // diff.path = [ "stacks", "Todo.json", "Resources", "TodoTable", "Properties", "KeySchema", 0, "AttributeName"]
       const stackName = path.basename(diff.path[1], '.json');
       const tableName = diff.path[3];


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
We aren't currently detecting and warning users that a GraphQL schema change which adds a sort key to a primary key is a destructive update, or even performing the destructive update.

This adds the sanity check warning, and should go with a amplify-cli PR to actually perform the destructive update when `--allow-destructive-graphql-schema-updates` is provided

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
N/A

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Debugged to see what a sort key addition looks like, ran `amplify-dev` against a project with a sort key change and without the change

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
