### PR TITLE
Remove unneeded FF prefix

### DIFF
--- a/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
@@ -1,6 +1,6 @@
 import { ArgumentNode, DirectiveNode, NameNode, valueFromASTUntyped, ValueNode, Location } from 'graphql';
 import _ from 'lodash';
-import { FeatureFlagProvider } from "@aws-amplify/graphql-transformer-interfaces";
+import { FeatureFlagProvider } from '@aws-amplify/graphql-transformer-interfaces';
 
 export class ArgumentWrapper {
   public readonly name: NameNode;
@@ -42,7 +42,7 @@ export class DirectiveWrapper {
       }),
       {},
     );
-    if (featureFlags.getBoolean('graphQLTransformer.shouldDeepMergeDirectiveConfigDefaults')) {
+    if (featureFlags.getBoolean('shouldDeepMergeDirectiveConfigDefaults')) {
       return _.merge(defaultValue, argValues);
     }
     return Object.assign(defaultValue, argValues);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Didn't show up from normal tests but the new feature flag was being accessed through the GQL FF provider, which doesn't need the GQL FF prefix. Caused errors in E2E

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
