### PR TITLE
chore: manually bump major version

### DIFF
--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/amplify-category-api",
-  "version": "3.1.10",
+  "version": "4.0.0",
   "description": "Amplify CLI API category plugin",
   "repository": {
     "type": "git",
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@aws-amplify/graphql-auth-transformer": "0.12.7",
+    "@aws-amplify/graphql-auth-transformer": "1.0.0",
     "@aws-amplify/graphql-default-value-transformer": "0.6.5",
     "@aws-amplify/graphql-function-transformer": "0.7.26",
     "@aws-amplify/graphql-http-transformer": "0.8.26",

--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/graphql-auth-transformer",
-  "version": "0.12.7",
+  "version": "1.0.0",
   "description": "Amplify GraphQL @auth transformer",
   "repository": {
     "type": "git",

--- a/packages/amplify-graphql-migration-tests/package.json
+++ b/packages/amplify-graphql-migration-tests/package.json
@@ -37,7 +37,7 @@
     ]
   },
   "devDependencies": {
-    "@aws-amplify/graphql-auth-transformer": "0.12.7",
+    "@aws-amplify/graphql-auth-transformer": "1.0.0",
     "@aws-amplify/graphql-default-value-transformer": "0.6.5",
     "@aws-amplify/graphql-function-transformer": "0.7.26",
     "@aws-amplify/graphql-http-transformer": "0.8.26",

--- a/packages/amplify-graphql-schema-test-library/package.json
+++ b/packages/amplify-graphql-schema-test-library/package.json
@@ -28,7 +28,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-auth-transformer": "0.12.7",
+    "@aws-amplify/graphql-auth-transformer": "1.0.0",
     "@aws-amplify/graphql-default-value-transformer": "0.6.5",
     "@aws-amplify/graphql-function-transformer": "0.7.26",
     "@aws-amplify/graphql-http-transformer": "0.8.26",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -51,7 +51,7 @@
     "amplify-cli-core": "^2.9.0"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-auth-transformer": "0.12.7",
+    "@aws-amplify/graphql-auth-transformer": "1.0.0",
     "@aws-amplify/graphql-function-transformer": "0.7.26",
     "@aws-amplify/graphql-index-transformer": "0.13.5",
     "@aws-amplify/graphql-maps-to-transformer": "1.1.27",

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -22,7 +22,7 @@
     "build-tests": "yarn tsc --build tsconfig.tests.json"
   },
   "dependencies": {
-    "@aws-amplify/graphql-auth-transformer": "0.12.7",
+    "@aws-amplify/graphql-auth-transformer": "1.0.0",
     "@aws-amplify/graphql-relational-transformer": "0.11.6",
     "axios": "^0.26.0",
     "cloudform-types": "^4.2.0",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Manually bump the major version for Auth V2 transformer and API plugin. This is because of an [existing bug in lerna](https://github.com/lerna/lerna/issues/2668) that fails to detect the conventional commit for breaking changes.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
