### PR TITLE
Fix broken method call from CLI if FF provider not given

### DIFF
--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -2,11 +2,11 @@ import {
   collectDirectivesByTypeNames,
   DeploymentResources,
   GraphQLTransform,
+  OverrideConfig,
   ResolverConfig,
+  Template,
   TransformerProjectConfig,
 } from '@aws-amplify/graphql-transformer-core';
-import { Template } from '@aws-amplify/graphql-transformer-core/lib/config/project-config';
-import { OverrideConfig } from '@aws-amplify/graphql-transformer-core/lib/transformation/types';
 import { AppSyncAuthConfiguration, TransformerPluginProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import {
   $TSAny,

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -170,7 +170,9 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     if (context.metadata.has('joinTypeList')) {
       isJoinType = context.metadata.get<Array<string>>('joinTypeList')!.includes(typeName);
     }
-    this.rules = getAuthDirectiveRules(new DirectiveWrapper(directive), context.featureFlags);
+    this.rules = getAuthDirectiveRules(new DirectiveWrapper(directive), false, {
+      deepMergeArguments: context.featureFlags.getBoolean('shouldDeepMergeDirectiveConfigDefaults'),
+    });
 
     // validate rules
     validateRules(this.rules, this.configuredAuthProviders, def.name.value);
@@ -225,7 +227,9 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     const modelDirective = parent.directives?.find(dir => dir.name.value === 'model');
     const typeName = parent.name.value;
     const fieldName = field.name.value;
-    const rules: AuthRule[] = getAuthDirectiveRules(new DirectiveWrapper(directive), context.featureFlags, true);
+    const rules: AuthRule[] = getAuthDirectiveRules(new DirectiveWrapper(directive), true, {
+      deepMergeArguments: context.featureFlags.getBoolean('shouldDeepMergeDirectiveConfigDefaults'),
+    });
     validateFieldRules(new DirectiveWrapper(directive), isParentTypeBuiltinType, modelDirective !== undefined, field.name.value, context.featureFlags);
     validateRules(rules, this.configuredAuthProviders, field.name.value);
 

--- a/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
@@ -1,4 +1,5 @@
 import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-interfaces';
+import { GetArgumentsOptions } from '@aws-amplify/graphql-transformer-core/lib/utils/directive-wrapper';
 
 /**
  * AuthStrategy
@@ -29,6 +30,8 @@ export interface SearchableConfig {
     search: string;
   };
 }
+
+export type GetAuthRulesOptions = GetArgumentsOptions;
 
 /**
  * AuthTransformerConfig

--- a/packages/amplify-graphql-auth-transformer/src/utils/index.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/index.ts
@@ -35,7 +35,7 @@ export const splitRoles = (roles: Array<RoleDefinition>): RolesByProvider => ({
 /**
  * returns @auth directive rules
  */
-export const getAuthDirectiveRules = (authDir: DirectiveWrapper, isField = false, featureFlags: FeatureFlagProvider = null): AuthRule[] => {
+export const getAuthDirectiveRules = (authDir: DirectiveWrapper, featureFlags?: FeatureFlagProvider, isField = false): AuthRule[] => {
   const splitReadOperation = (rule: AuthRule): void => {
     const operations: (ModelOperation | 'read')[] = rule.operations ?? [];
     const indexOfRead = operations.indexOf('read', 0);

--- a/packages/amplify-graphql-auth-transformer/src/utils/index.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/index.ts
@@ -35,7 +35,7 @@ export const splitRoles = (roles: Array<RoleDefinition>): RolesByProvider => ({
 /**
  * returns @auth directive rules
  */
-export const getAuthDirectiveRules = (authDir: DirectiveWrapper, featureFlags: FeatureFlagProvider, isField = false): AuthRule[] => {
+export const getAuthDirectiveRules = (authDir: DirectiveWrapper, isField = false, featureFlags: FeatureFlagProvider = null): AuthRule[] => {
   const splitReadOperation = (rule: AuthRule): void => {
     const operations: (ModelOperation | 'read')[] = rule.operations ?? [];
     const indexOfRead = operations.indexOf('read', 0);

--- a/packages/amplify-graphql-auth-transformer/src/utils/index.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/index.ts
@@ -7,7 +7,7 @@ import {
   AuthProvider,
   AuthRule,
   AuthTransformerConfig,
-  ConfiguredAuthProviders,
+  ConfiguredAuthProviders, GetAuthRulesOptions,
   ModelOperation,
   RoleDefinition,
   RolesByProvider,
@@ -35,7 +35,7 @@ export const splitRoles = (roles: Array<RoleDefinition>): RolesByProvider => ({
 /**
  * returns @auth directive rules
  */
-export const getAuthDirectiveRules = (authDir: DirectiveWrapper, featureFlags?: FeatureFlagProvider, isField = false): AuthRule[] => {
+export const getAuthDirectiveRules = (authDir: DirectiveWrapper, isField = false, options: GetAuthRulesOptions = {}): AuthRule[] => {
   const splitReadOperation = (rule: AuthRule): void => {
     const operations: (ModelOperation | 'read')[] = rule.operations ?? [];
     const indexOfRead = operations.indexOf('read', 0);
@@ -51,7 +51,7 @@ export const getAuthDirectiveRules = (authDir: DirectiveWrapper, featureFlags?: 
     }
   };
 
-  const { rules } = authDir.getArguments<{ rules: Array<AuthRule> }>({ rules: [] }, featureFlags);
+  const { rules } = authDir.getArguments<{ rules: Array<AuthRule> }>({ rules: [] }, null, options);
   rules.forEach(rule => {
     const operations: (ModelOperation | 'read')[] = rule.operations ?? MODEL_OPERATIONS;
 

--- a/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
@@ -1,8 +1,11 @@
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import {
-  ConflictHandlerType, GraphQLTransform, SyncConfig, validateModelSchema,
+  ConflictHandlerType,
+  GraphQLTransform,
+  SyncConfig,
+  validateModelSchema,
+  Template,
 } from '@aws-amplify/graphql-transformer-core';
-import Template from '@aws-amplify/graphql-transformer-core/lib/transformation/types';
 import { FeatureFlagProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { expect as cdkExpect, haveResourceLike } from '@aws-cdk/assert';
 import { DocumentNode, parse } from 'graphql';

--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -63,7 +63,6 @@
     "vm2": "^3.9.8"
   },
   "peerDependencies": {
-    "amplify-cli-core": "^2.9.0",
     "amplify-prompts": "^2.0.1"
   },
   "devDependencies": {

--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -27,7 +27,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "amplify-cli-core": "^2.9.0",
     "@aws-amplify/graphql-transformer-interfaces": "1.14.7",
     "@aws-cdk/aws-applicationautoscaling": "~1.124.0",
     "@aws-cdk/aws-appsync": "~1.124.0",
@@ -64,6 +63,7 @@
     "vm2": "^3.9.8"
   },
   "peerDependencies": {
+    "amplify-cli-core": "^2.9.0",
     "amplify-prompts": "^2.0.1"
   },
   "devDependencies": {

--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -27,6 +27,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "amplify-cli-core": "^2.9.0",
     "@aws-amplify/graphql-transformer-interfaces": "1.14.7",
     "@aws-cdk/aws-applicationautoscaling": "~1.124.0",
     "@aws-cdk/aws-appsync": "~1.124.0",

--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -63,6 +63,7 @@
     "vm2": "^3.9.8"
   },
   "peerDependencies": {
+    "amplify-cli-core": "^2.9.0",
     "amplify-prompts": "^2.0.1"
   },
   "devDependencies": {

--- a/packages/amplify-graphql-transformer-core/src/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/index.ts
@@ -1,7 +1,13 @@
 import { print } from 'graphql';
 import { EXTRA_DIRECTIVES_DOCUMENT } from './transformation/validation';
+
 export { GraphQLTransform, GraphQLTransformOptions, SyncUtils } from './transformation';
-export { DeploymentResources, UserDefinedSlot, UserDefinedResolver } from './transformation/types';
+export {
+  DeploymentResources,
+  OverrideConfig,
+  UserDefinedSlot,
+  UserDefinedResolver,
+} from './transformation/types';
 export { validateModelSchema } from './transformation/validation';
 export {
   ConflictDetectionType,
@@ -14,6 +20,9 @@ export {
   TransformConfig,
   TransformerProjectConfig,
 } from './config/index';
+export {
+  Template,
+} from './config/project-config';
 export {
   getTable,
   getKeySchema,

--- a/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
@@ -1,6 +1,7 @@
 import { ArgumentNode, DirectiveNode, NameNode, valueFromASTUntyped, ValueNode, Location } from 'graphql';
 import _ from 'lodash';
 import { FeatureFlagProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import {FeatureFlags} from "amplify-cli-core";
 
 export class ArgumentWrapper {
   public readonly name: NameNode;
@@ -42,7 +43,8 @@ export class DirectiveWrapper {
       }),
       {},
     );
-    if (featureFlags.getBoolean('shouldDeepMergeDirectiveConfigDefaults', false)) {
+    if (featureFlags ? featureFlags.getBoolean('shouldDeepMergeDirectiveConfigDefaults', false)
+      : FeatureFlags.getBoolean('graphqltransformer.shouldDeepMergeDirectiveConfigDefaults')) {
       return _.merge(defaultValue, argValues);
     }
     return Object.assign(defaultValue, argValues);

--- a/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
@@ -1,7 +1,10 @@
 import { ArgumentNode, DirectiveNode, NameNode, valueFromASTUntyped, ValueNode, Location } from 'graphql';
 import _ from 'lodash';
 import { FeatureFlagProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { FeatureFlags } from 'amplify-cli-core';
+
+export type GetArgumentsOptions = {
+  deepMergeArguments?: boolean;
+}
 
 export class ArgumentWrapper {
   public readonly name: NameNode;
@@ -35,7 +38,7 @@ export class DirectiveWrapper {
       arguments: this.arguments.map(arg => arg.serialize()),
     };
   };
-  public getArguments = <T>(defaultValue: Required<T>, featureFlags?: FeatureFlagProvider): Required<T> => {
+  public getArguments = <T>(defaultValue: Required<T>, featureFlags?: FeatureFlagProvider, options?: GetArgumentsOptions): Required<T> => {
     const argValues = this.arguments.reduce(
       (acc: Record<string, any>, arg: ArgumentWrapper) => ({
         ...acc,
@@ -43,9 +46,10 @@ export class DirectiveWrapper {
       }),
       {},
     );
+    const deepMergeFlag = 'shouldDeepMergeDirectiveConfigDefaults';
     const useDeepMerge = featureFlags != null
-      ? featureFlags?.getBoolean('shouldDeepMergeDirectiveConfigDefaults', false)
-      : FeatureFlags.getBoolean('graphqltransformer.shouldDeepMergeDirectiveConfigDefaults');
+      ? featureFlags?.getBoolean(deepMergeFlag, false)
+      : options?.deepMergeArguments;
     if (useDeepMerge) {
       return _.merge(defaultValue, argValues);
     }

--- a/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
@@ -1,6 +1,7 @@
 import { ArgumentNode, DirectiveNode, NameNode, valueFromASTUntyped, ValueNode, Location } from 'graphql';
 import _ from 'lodash';
 import { FeatureFlagProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { FeatureFlags } from 'amplify-cli-core';
 
 export class ArgumentWrapper {
   public readonly name: NameNode;
@@ -42,7 +43,10 @@ export class DirectiveWrapper {
       }),
       {},
     );
-    if (featureFlags?.getBoolean('shouldDeepMergeDirectiveConfigDefaults', false)) {
+    const useDeepMerge = featureFlags != null
+      ? featureFlags?.getBoolean('shouldDeepMergeDirectiveConfigDefaults', false)
+      : FeatureFlags.getBoolean('graphqltransformer.shouldDeepMergeDirectiveConfigDefaults');
+    if (useDeepMerge) {
       return _.merge(defaultValue, argValues);
     }
     return Object.assign(defaultValue, argValues);

--- a/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
@@ -1,7 +1,6 @@
 import { ArgumentNode, DirectiveNode, NameNode, valueFromASTUntyped, ValueNode, Location } from 'graphql';
 import _ from 'lodash';
 import { FeatureFlagProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { FeatureFlags } from "amplify-cli-core";
 
 export class ArgumentWrapper {
   public readonly name: NameNode;
@@ -43,8 +42,7 @@ export class DirectiveWrapper {
       }),
       {},
     );
-    if (featureFlags ? featureFlags.getBoolean('shouldDeepMergeDirectiveConfigDefaults', false)
-      : FeatureFlags.getBoolean('graphqltransformer.shouldDeepMergeDirectiveConfigDefaults')) {
+    if (featureFlags?.getBoolean('shouldDeepMergeDirectiveConfigDefaults', false)) {
       return _.merge(defaultValue, argValues);
     }
     return Object.assign(defaultValue, argValues);

--- a/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
@@ -1,7 +1,7 @@
 import { ArgumentNode, DirectiveNode, NameNode, valueFromASTUntyped, ValueNode, Location } from 'graphql';
 import _ from 'lodash';
 import { FeatureFlagProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import {FeatureFlags} from "amplify-cli-core";
+import { FeatureFlags } from "amplify-cli-core";
 
 export class ArgumentWrapper {
   public readonly name: NameNode;
@@ -35,7 +35,7 @@ export class DirectiveWrapper {
       arguments: this.arguments.map(arg => arg.serialize()),
     };
   };
-  public getArguments = <T>(defaultValue: Required<T>, featureFlags: FeatureFlagProvider): Required<T> => {
+  public getArguments = <T>(defaultValue: Required<T>, featureFlags?: FeatureFlagProvider): Required<T> => {
     const argValues = this.arguments.reduce(
       (acc: Record<string, any>, arg: ArgumentWrapper) => ({
         ...acc,

--- a/packages/amplify-graphql-transformer-core/tsconfig.json
+++ b/packages/amplify-graphql-transformer-core/tsconfig.json
@@ -7,5 +7,8 @@
   "references": [
     {"path": "../amplify-graphql-transformer-interfaces"},
     {"path": "../graphql-transformer-common"}
+  ],
+  "include": [
+    "src"
   ]
 }

--- a/packages/amplify-util-mock/src/__tests__/velocity/acm-resolver-auth.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/velocity/acm-resolver-auth.test.ts
@@ -1,20 +1,19 @@
 import {
   AuthProvider,
+  AuthStrategy,
   AuthTransformer,
   ModelOperation,
 } from '@aws-amplify/graphql-auth-transformer';
-import { AppSyncGraphQLExecutionContext } from 'amplify-appsync-simulator/lib/utils/graphql-runner';
 import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-interfaces';
 import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
-import { AmplifyAppSyncSimulatorAuthenticationType } from 'amplify-appsync-simulator';
+import { AmplifyAppSyncSimulatorAuthenticationType, AppSyncGraphQLExecutionContext } from 'amplify-appsync-simulator';
 import { plurality } from 'graphql-transformer-common';
 import { PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
 import { featureFlags } from './test-helper';
 import {
   AppSyncVTLContext, getGenericToken, getIAMToken, getJWTToken, VelocityTemplateSimulator,
 } from '../../velocity';
-import { AuthStrategy } from '../../../../amplify-graphql-auth-transformer/src/utils/definitions';
 
 const USER_POOL_ID = 'us-fake-1ID';
 

--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -28,7 +28,7 @@ import {
 import {
   toUpper, plurality, graphqlName, ResourceConstants, ModelResourceIDs,
 } from 'graphql-transformer-common';
-import { MappingParameters } from 'graphql-transformer-core/lib/TransformerContext';
+import { MappingParameters } from 'graphql-transformer-core';
 
 /**
  * ResourceFactory

--- a/packages/graphql-transformer-core/src/__tests__/TransformFormatter.test.ts
+++ b/packages/graphql-transformer-core/src/__tests__/TransformFormatter.test.ts
@@ -1,7 +1,12 @@
 import { TransformFormatter } from '../TransformFormatter';
-import { Template, Fn, AppSync, DynamoDB } from 'cloudform-types';
+import {
+  Template,
+  Fn,
+  AppSync,
+  DynamoDB,
+} from 'cloudform-types';
 import { TransformerContext } from '..';
-import { NoopFeatureFlagProvider } from '../../lib/FeatureFlags';
+import { NoopFeatureFlagProvider } from '../FeatureFlags';
 
 const template: Template = {
   Parameters: {

--- a/packages/graphql-transformer-core/src/index.ts
+++ b/packages/graphql-transformer-core/src/index.ts
@@ -1,6 +1,6 @@
 import './polyfills/Object.assign';
 import { print } from 'graphql';
-import { TransformerContext } from './TransformerContext';
+import { TransformerContext, MappingParameters } from './TransformerContext';
 import { Transformer } from './Transformer';
 import { ITransformer } from './ITransformer';
 import { GraphQLTransform } from './GraphQLTransform';
@@ -47,6 +47,7 @@ export {
   GraphQLTransform,
   TransformConfig,
   TransformerContext,
+  MappingParameters,
   Transformer,
   ITransformer,
   collectDirectiveNames,

--- a/packages/graphql-transformers-e2e-tests/src/cognitoUtils.ts
+++ b/packages/graphql-transformers-e2e-tests/src/cognitoUtils.ts
@@ -14,7 +14,7 @@ import { ResourceConstants } from 'graphql-transformer-common';
 import { IAM as cfnIAM, Cognito as cfnCognito } from 'cloudform-types';
 import { CognitoIdentityServiceProvider as CognitoClient, CognitoIdentity } from 'aws-sdk';
 import TestStorage from './TestStorage';
-import DeploymentResources from 'graphql-transformer-core/lib/DeploymentResources';
+import { DeploymentResources } from 'graphql-transformer-core';
 
 interface E2Econfiguration {
   STACK_NAME?: string;

--- a/packages/graphql-transformers-e2e-tests/src/deployNestedStacks.ts
+++ b/packages/graphql-transformers-e2e-tests/src/deployNestedStacks.ts
@@ -2,7 +2,7 @@ import { S3Client } from './S3Client';
 import { CloudFormationClient } from './CloudFormationClient';
 import * as fs from 'fs';
 import * as path from 'path';
-import { DeploymentResources } from 'graphql-transformer-core/lib/DeploymentResources';
+import { DeploymentResources } from 'graphql-transformer-core';
 import { deleteUserPool, deleteIdentityPool } from './cognitoUtils';
 import { CognitoIdentityServiceProvider, CognitoIdentity } from 'aws-sdk';
 import emptyBucket from './emptyBucket';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Make FF provider input optional in `getAuthDirectiveRules` method to make the call from CLI to not break existing flows

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
