### PR TITLE
fix(api): gateway response dropping on update api

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
@@ -243,12 +243,16 @@ export class AmplifyApigwResourceStack extends cdk.Stack implements AmplifyApigw
         },
       },
     });
-    const default4xx = new apigw.CfnGatewayResponse(this, `${resourceName}Default4XXResponse`, {
+
+    // Append a random id to the logical id of the gateway response 
+    // This is required to resolve issue with dropping gateway responses on updating api resource
+    const [responseRandomId] = uuid().split('-');
+    const default4xx = new apigw.CfnGatewayResponse(this, `${resourceName}Default4XXResponse${responseRandomId}`, {
       responseType: 'DEFAULT_4XX',
       restApiId: cdk.Fn.ref(resourceName),
       responseParameters: defaultCorsGatewayResponseParams,
     });
-    const default5xx = new apigw.CfnGatewayResponse(this, `${resourceName}Default5XXResponse`, {
+    const default5xx = new apigw.CfnGatewayResponse(this, `${resourceName}Default5XXResponse${responseRandomId}`, {
       responseType: 'DEFAULT_5XX',
       restApiId: cdk.Fn.ref(resourceName),
       responseParameters: defaultCorsGatewayResponseParams,

--- a/packages/amplify-e2e-tests/src/__tests__/apigw.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/apigw.test.ts
@@ -77,7 +77,7 @@ describe('API Gateway e2e tests', () => {
     expect(secondItemsResJson).toEqual({ message: 'Missing Authentication Token' }); // Restricted API
   });
 
-  it.only('adds rest api and verify the default 4xx response', async () => {
+  it('adds rest api and verify the default 4xx response', async () => {
     const apiName = 'integtest';
     await addRestApi(projRoot, {
       apiName,

--- a/packages/amplify-e2e-tests/src/__tests__/apigw.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/apigw.test.ts
@@ -10,6 +10,7 @@ import {
   get,
   getProjectMeta,
   initJSProjectWithProfile,
+  updateRestApi,
 } from 'amplify-category-api-e2e-core';
 import { JSONUtilities, pathManager, stateManager } from 'amplify-cli-core';
 import * as fs from 'fs-extra';
@@ -76,7 +77,7 @@ describe('API Gateway e2e tests', () => {
     expect(secondItemsResJson).toEqual({ message: 'Missing Authentication Token' }); // Restricted API
   });
 
-  it('adds rest api and verify the default 4xx response', async () => {
+  it.only('adds rest api and verify the default 4xx response', async () => {
     const apiName = 'integtest';
     await addRestApi(projRoot, {
       apiName,
@@ -93,6 +94,16 @@ describe('API Gateway e2e tests', () => {
     expect(res.headers.get('access-control-allow-methods')).toEqual('DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT');
     expect(res.headers.get('access-control-allow-origin')).toEqual('*');
     expect(res.headers.get('access-control-expose-headers')).toEqual('Date,X-Amzn-ErrorType');
+
+    // Add a path and make sure that the gateway responses are preserved
+    await updateRestApi(projRoot);
+    await amplifyPushAuth(projRoot);
+    const responseAfterAddPath = await fetch(apiPath);
+    expect(responseAfterAddPath.status).toEqual(403);
+    expect(responseAfterAddPath.headers.get('access-control-allow-headers')).toEqual('Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token');
+    expect(responseAfterAddPath.headers.get('access-control-allow-methods')).toEqual('DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT');
+    expect(responseAfterAddPath.headers.get('access-control-allow-origin')).toEqual('*');
+    expect(responseAfterAddPath.headers.get('access-control-expose-headers')).toEqual('Date,X-Amzn-ErrorType');
   });
 
   it('adds and overrides a rest api, then pushes', async () => {


### PR DESCRIPTION
#### Description of changes

This PR will fix the rest api dropping gateway response on update api issue.

With this change, we will assign a new logical id to the gateway response resources on each push so it would be treated as deleting the old one and creating a new one instead of updating the existing one.

#### Issue #, if available

Fixes #30 

#### Description of how you validated changes
- manual test
- e2e test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
