### PR TITLE
chore: remove all asserts in source code, replace with error for internal exceptions, and InvalidDirectiveExceptions for input errors

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/accesscontrol/acm.ts
+++ b/packages/amplify-graphql-auth-transformer/src/accesscontrol/acm.ts
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import { InvalidDirectiveError, TransformerContractError } from '@aws-amplify/graphql-transformer-core';
 import { ModelOperation } from '../utils/definitions';
 
@@ -62,7 +61,9 @@ export class AccessControlMatrix {
       allowedVector = this.getResourceOperationMatrix({ operations, resource });
       this.roles.push(input.role);
       this.matrix.push(allowedVector);
-      assert(this.roles.length === this.matrix.length, 'Roles are not aligned with Roles added in Matrix');
+      if (this.roles.length !== this.matrix.length) {
+        throw new Error('Roles are not aligned with Roles added in Matrix');
+      }
     } else if (this.roles.includes(role) && (resource || allowRoleOverwrite)) {
       allowedVector = this.getResourceOperationMatrix({ operations, resource, role });
       const roleIndex = this.roles.indexOf(role);

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/resolvers.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/resolvers.test.ts
@@ -1,0 +1,30 @@
+import { HasOneDirectiveConfiguration, HasManyDirectiveConfiguration } from '../types';
+import { makeGetItemConnectionWithKeyResolver, makeQueryConnectionWithKeyResolver } from '../resolvers';
+
+/**
+ * Utility to create a partial of a given type for mocking purposes. Getting the right fields in place is on you.
+ * @param mockFields the fields to pass into your mock, optional.
+ * @returns a typed object with the input type, and the provided (or no) fields
+ */
+const createPartialMock = <T>(mockFields?: Partial<T>): T => (mockFields || {}) as unknown as T;
+
+describe('makeGetItemConnectionWithKeyResolver', () => {
+  test('it throws on empty related type index field', () => {
+    expect(() => makeGetItemConnectionWithKeyResolver(
+      createPartialMock<HasOneDirectiveConfiguration>({ relatedTypeIndex: [] }),
+      createPartialMock(),
+    )).toThrowErrorMatchingInlineSnapshot('"Expected relatedType index fields to be set for connection."');
+  });
+});
+
+describe('makeQueryConnectionWithKeyResolver', () => {
+  test('it requires either fields or connection fields to be populated with values', () => {
+    expect(() => makeQueryConnectionWithKeyResolver(
+      createPartialMock<HasManyDirectiveConfiguration>({
+        fields: [],
+        connectionFields: [],
+      }),
+      createPartialMock(),
+    )).toThrowErrorMatchingInlineSnapshot('"Either connection fields or local fields should be populated."');
+  });
+});

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/schema.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/schema.test.ts
@@ -1,0 +1,65 @@
+import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { TransformerContextOutputProvider } from '@aws-amplify/graphql-transformer-interfaces/src';
+import { Kind, NameNode, ObjectTypeDefinitionNode } from 'graphql';
+import { getPartitionKeyField, getSortKeyFields } from '../schema';
+
+/**
+ * Utility to create a partial of a given type for mocking purposes. Getting the right fields in place is on you.
+ * @param mockFields the fields to pass into your mock, optional.
+ * @returns a typed object with the input type, and the provided (or no) fields
+ */
+const createPartialMock = <T>(mockFields?: Partial<T>): T => (mockFields || {}) as unknown as T;
+
+describe('get key field helpers', () => {
+  const OBJECT_NAME = 'objectName';
+  const createObjectDefinitionWithName = (objectName: string): ObjectTypeDefinitionNode => createPartialMock<ObjectTypeDefinitionNode>({
+    name: createPartialMock<NameNode>({ value: objectName }),
+    fields: [],
+  });
+  const MOCK_CONTEXT = createPartialMock<TransformerContextProvider>({
+    output: createPartialMock<TransformerContextOutputProvider>({
+      getType: jest.fn((name: string) => {
+        if (name === OBJECT_NAME) {
+          return {
+            kind: Kind.SCHEMA_DEFINITION,
+            operationTypes: [],
+            fields: [],
+          };
+        }
+        return undefined;
+      }),
+    }),
+  });
+
+  describe('getPartitionKeyField', () => {
+    it('looks up the type by the object definition name', () => {
+      expect(getPartitionKeyField(
+        MOCK_CONTEXT,
+        createObjectDefinitionWithName(OBJECT_NAME),
+      )).toBeDefined();
+    });
+
+    it('throws when the output type is not defined on the context', () => {
+      expect(() => getPartitionKeyField(
+        MOCK_CONTEXT,
+        createObjectDefinitionWithName('unexpectedName'),
+      )).toThrowErrorMatchingInlineSnapshot('"Expected to find output object defined for unexpectedName, but did not."');
+    });
+  });
+
+  describe('getSortKeyFields', () => {
+    it('looks up the type by the object definition name', () => {
+      expect(getSortKeyFields(
+        MOCK_CONTEXT,
+        createObjectDefinitionWithName(OBJECT_NAME),
+      )).toBeDefined();
+    });
+
+    it('throws when the output type is not defined on the context', () => {
+      expect(() => getSortKeyFields(
+        MOCK_CONTEXT,
+        createObjectDefinitionWithName('unexpectedName'),
+      )).toThrowErrorMatchingInlineSnapshot('"Expected to find output object defined for unexpectedName, but did not."');
+    });
+  });
+});

--- a/packages/amplify-graphql-relational-transformer/src/schema.ts
+++ b/packages/amplify-graphql-relational-transformer/src/schema.ts
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import { generateModelScalarFilterInputName, makeModelSortDirectionEnumObject } from '@aws-amplify/graphql-model-transformer';
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import {
@@ -55,7 +54,9 @@ export const extendTypeWithConnection = (config: HasManyDirectiveConfiguration, 
   // Extensions are not allowed to re-declare fields so we must replace it in place.
   const type = ctx.output.getType(object.name.value) as ObjectTypeDefinitionNode;
 
-  assert(type?.kind === Kind.OBJECT_TYPE_DEFINITION || type?.kind === Kind.INTERFACE_TYPE_DEFINITION);
+  if (type?.kind !== Kind.OBJECT_TYPE_DEFINITION && type?.kind !== Kind.INTERFACE_TYPE_DEFINITION) {
+    throw new Error(`Expected referenced type to be either and object or interface definition, got ${type?.kind}`);
+  }
 
   const newFields = type.fields!.map((f: FieldDefinitionNode) => {
     if (f.name.value === field.name.value) {
@@ -488,7 +489,9 @@ const makeModelXFilterInputObject = (
  */
 export const getPartitionKeyField = (ctx: TransformerContextProvider, object: ObjectTypeDefinitionNode): FieldDefinitionNode => {
   const outputObject = ctx.output.getType(object.name.value) as ObjectTypeDefinitionNode;
-  assert(outputObject);
+  if (!outputObject) {
+    throw new Error(`Expected to find output object defined for ${object.name.value}, but did not.`);
+  }
   return getPartitionKeyFieldNoContext(outputObject);
 };
 
@@ -514,7 +517,9 @@ export const getPartitionKeyFieldNoContext = (object: ObjectTypeDefinitionNode |
  */
 export const getSortKeyFields = (ctx: TransformerContextProvider, object: ObjectTypeDefinitionNode): FieldDefinitionNode[] => {
   const outputObject = ctx.output.getType(object.name.value) as ObjectTypeDefinitionNode;
-  assert(outputObject);
+  if (!outputObject) {
+    throw new Error(`Expected to find output object defined for ${object.name.value}, but did not.`);
+  }
   return getSortKeyFieldsNoContext(outputObject);
 };
 

--- a/packages/amplify-graphql-relational-transformer/src/utils.ts
+++ b/packages/amplify-graphql-relational-transformer/src/utils.ts
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import { getFieldNameFor, InvalidDirectiveError } from '@aws-amplify/graphql-transformer-core';
 import {
   FeatureFlagProvider,
@@ -67,12 +66,16 @@ export function getRelatedTypeIndex(
   }
 
   partitionField = fieldMap.get(partitionFieldName);
-  assert(partitionField);
+  if (!partitionField) {
+    throw new Error(`Expected partition field ${partitionFieldName} to be found in map.`);
+  }
 
   for (const sortFieldName of sortFieldNames) {
     const sortField = fieldMap.get(sortFieldName);
 
-    assert(sortField);
+    if (!sortField) {
+      throw new Error(`Expected sort field ${sortFieldName} to be found in map.`);
+    }
     sortFields.push(sortField);
   }
 
@@ -132,7 +135,9 @@ export function getRelatedType(
     (d: any) => d.kind === Kind.OBJECT_TYPE_DEFINITION && d.name.value === relatedTypeName,
   ) as ObjectTypeDefinitionNode | undefined;
 
-  assert(relatedType);
+  if (!relatedType) {
+    throw new Error(`Could not find related type with name ${relatedTypeName} while processing relationships.`);
+  }
   return relatedType;
 }
 
@@ -212,7 +217,9 @@ export function validateDisallowedDataStoreRelationships(
 
   const modelType = config.object.name.value;
   const relatedType = ctx.output.getType(config.relatedType.name.value) as ObjectTypeDefinitionNode;
-  assert(relatedType);
+  if (!relatedType) {
+    throw new Error(`Expected related type ${config.relatedType.name.value} to be found in output, but did not.`);
+  }
 
   // Recursive relationships on the same type are allowed.
   if (modelType === relatedType.name.value) {

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-datasource.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-datasource.ts
@@ -2,7 +2,6 @@ import { GraphQLAPIProvider } from '@aws-amplify/graphql-transformer-interfaces'
 import { BaseDataSource } from '@aws-cdk/aws-appsync';
 import { IRole } from '@aws-cdk/aws-iam';
 import { ResourceConstants } from 'graphql-transformer-common';
-import assert from 'assert';
 import { Stack } from '@aws-cdk/core';
 
 export const createSearchableDataSource = (
@@ -10,10 +9,9 @@ export const createSearchableDataSource = (
   graphqlApiProvider: GraphQLAPIProvider,
   domainEndpoint: string,
   role: IRole,
-  region?: string,
+  region: string,
 ): BaseDataSource => {
   const { OpenSearchDataSourceLogicalID } = ResourceConstants.RESOURCES;
-  assert(region);
   const dsEndpoint = `https://${domainEndpoint}`;
   return graphqlApiProvider.host.addSearchableDataSource(
     OpenSearchDataSourceLogicalID,

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
@@ -6,7 +6,6 @@ import {
   CfnParameter, Construct, Fn, RemovalPolicy,
 } from '@aws-cdk/core';
 import { ResourceConstants } from 'graphql-transformer-common';
-import assert from 'assert';
 
 export const createSearchableDomain = (stack: Construct, parameterMap: Map<string, CfnParameter>, apiId: string): Domain => {
   const { OpenSearchEBSVolumeGB, OpenSearchInstanceType, OpenSearchInstanceCount } = ResourceConstants.PARAMETERS;
@@ -43,7 +42,9 @@ export const createSearchableDomainRole = (
   const { OpenSearchAccessIAMRoleLogicalID } = ResourceConstants.RESOURCES;
   const { OpenSearchAccessIAMRoleName } = ResourceConstants.PARAMETERS;
   const roleName = parameterMap.get(OpenSearchAccessIAMRoleName)?.valueAsString;
-  assert(roleName);
+  if (!roleName) {
+    throw new Error(`Could find role name parameter for ${OpenSearchAccessIAMRoleName}`);
+  }
   return new Role(stack, OpenSearchAccessIAMRoleLogicalID, {
     assumedBy: new ServicePrincipal('appsync.amazonaws.com'),
     roleName: context.resourceHelper.generateIAMRoleName(roleName),

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-streaming-lambda.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-streaming-lambda.ts
@@ -10,7 +10,6 @@ import {
 } from '@aws-cdk/aws-iam';
 import { ResourceConstants, SearchableResourceIDs } from 'graphql-transformer-common';
 import * as path from 'path';
-import assert from 'assert';
 
 export const createLambda = (
   stack: Stack,
@@ -19,9 +18,8 @@ export const createLambda = (
   lambdaRole: IRole,
   endpoint: string,
   isProjectUsingDataStore: boolean,
-  region?: string,
+  region: string,
 ): IFunction => {
-  assert(region);
   const { OpenSearchStreamingLambdaFunctionLogicalID } = ResourceConstants.RESOURCES;
   const { OpenSearchStreamingLambdaHandlerName, OpenSearchDebugStreamingLambda } = ResourceConstants.PARAMETERS;
   const enviroment: { [key: string]: string } = {
@@ -78,10 +76,9 @@ export const createEventSourceMapping = (
   type: string,
   target: IFunction,
   parameterMap: Map<string, CfnParameter>,
-  tableStreamArn?: string,
+  tableStreamArn: string,
 ): EventSourceMapping => {
   const { OpenSearchStreamBatchSize, OpenSearchStreamMaximumBatchingWindowInSeconds } = ResourceConstants.PARAMETERS;
-  assert(tableStreamArn);
   return new EventSourceMapping(stack, SearchableResourceIDs.SearchableEventSourceMappingID(type), {
     eventSourceArn: tableStreamArn,
     target,

--- a/packages/amplify-graphql-searchable-transformer/src/definitions.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/definitions.ts
@@ -24,8 +24,8 @@ import {
   extensionWithDirectives,
   extendFieldWithDirectives,
 } from 'graphql-transformer-common';
-import assert from 'assert';
 import { TransformerTransformSchemaStepContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { InvalidDirectiveError } from '@aws-amplify/graphql-transformer-core';
 
 const ID_CONDITIONS = [
   'ne',
@@ -114,7 +114,9 @@ export const makeSearchableScalarInputObject = (type: string): InputObjectTypeDe
 
 export const makeSearchableXFilterInputObject = (obj: ObjectTypeDefinitionNode, document: DocumentNode): InputObjectTypeDefinitionNode => {
   const name = SearchableResourceIDs.SearchableFilterInputTypeName(obj.name.value);
-  assert(obj.fields);
+  if (!obj.fields) {
+    throw new InvalidDirectiveError('Models decorated with @searchable require fields defined within them.');
+  }
   const fields: InputValueDefinitionNode[] = obj.fields
     .filter((field: FieldDefinitionNode) => isScalar(field.type))
     .map(
@@ -215,7 +217,9 @@ export const makeSearchableSortDirectionEnumObject = (): EnumTypeDefinitionNode 
 
 export const makeSearchableXSortableFieldsEnumObject = (obj: ObjectTypeDefinitionNode): EnumTypeDefinitionNode => {
   const name = graphqlName(`Searchable${obj.name.value}SortableFields`);
-  assert(obj.fields);
+  if (!obj.fields) {
+    throw new InvalidDirectiveError('Models decorated with @searchable require fields defined within them.');
+  }
   const values: EnumValueDefinitionNode[] = obj.fields
     .filter((field: FieldDefinitionNode) => isScalar(field.type))
     .map((field: FieldDefinitionNode) => ({
@@ -237,7 +241,9 @@ export const makeSearchableXSortableFieldsEnumObject = (obj: ObjectTypeDefinitio
 
 export const makeSearchableXAggregateFieldEnumObject = (obj: ObjectTypeDefinitionNode, document: DocumentNode): EnumTypeDefinitionNode => {
   const name = graphqlName(`Searchable${obj.name.value}AggregateField`);
-  assert(obj.fields);
+  if (!obj.fields) {
+    throw new InvalidDirectiveError('Models decorated with @searchable require fields defined within them.');
+  }
   const values: EnumValueDefinitionNode[] = obj.fields
     .filter((field: FieldDefinitionNode) => isScalar(field.type) || isEnum(field.type, document))
     .map((field: FieldDefinitionNode) => ({

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -11,7 +11,6 @@ import {
   App, Aws, CfnOutput, CfnResource, Fn,
 } from '@aws-cdk/core';
 import { printer } from 'amplify-prompts';
-import assert from 'assert';
 import * as fs from 'fs-extra';
 import {
   EnumTypeDefinitionNode,
@@ -383,7 +382,9 @@ export class GraphQLTransform {
       type: 'String',
     }).valueAsString;
     const envName = stackManager.getParameter('env');
-    assert(envName);
+    if (!envName) {
+      throw new Error('Parameter `env` not configured properly.');
+    }
     const api = new GraphQLApi(rootStack, 'GraphQLAPI', {
       name: `${apiName}-${envName.valueAsString}`,
       authorizationConfig,

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/output.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/output.ts
@@ -25,7 +25,6 @@ import {
 import { stripDirectives } from '../utils/strip-directives';
 import { DEFAULT_SCHEMA_DEFINITION } from '../utils/defaultSchema';
 import { TransformerContextOutputProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import assert from 'assert';
 
 const AMPLIFY = 'AMPLIFY';
 
@@ -313,7 +312,9 @@ export class TransformerOutput implements TransformerContextOutputProvider {
     }
     // AppSync does not yet understand type extensions so fold the types in.
     const oldNode = this.getObject(obj.name.value);
-    assert(oldNode);
+    if (!oldNode) {
+      throw new Error('Failure adding object extension');
+    }
     const newDirs = [];
     const oldDirs = oldNode?.directives || [];
 

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -9,10 +9,10 @@ import {
 } from '@aws-amplify/graphql-transformer-interfaces';
 import { AuthorizationType, CfnFunctionConfiguration } from '@aws-cdk/aws-appsync';
 import { isResolvableObject, Stack, CfnParameter } from '@aws-cdk/core';
-import assert from 'assert';
 import { toPascalCase } from 'graphql-transformer-common';
 import { dedent } from 'ts-dedent';
 import { MappingTemplate, S3MappingTemplate } from '../cdk-compat';
+import { InvalidDirectiveError } from '../errors';
 import * as SyncUtils from '../transformation/sync-utils';
 import { IAM_AUTH_ROLE_PARAMETER, IAM_UNAUTH_ROLE_PARAMETER } from '../utils';
 import { StackManager } from './stack-manager';
@@ -134,11 +134,21 @@ export class TransformerResolver implements TransformerResolverProvider {
     private responseSlots: string[],
     private datasource?: DataSourceProvider,
   ) {
-    assert(typeName, 'typeName is required');
-    assert(fieldName, 'fieldName is required');
-    assert(resolverLogicalId, 'resolverLogicalId is required');
-    assert(requestMappingTemplate, 'requestMappingTemplate is required');
-    assert(responseMappingTemplate, 'responseMappingTemplate is required');
+    if (!typeName) {
+      throw new InvalidDirectiveError('typeName is required');
+    }
+    if (!fieldName) {
+      throw new InvalidDirectiveError('fieldName is required');
+    }
+    if (!resolverLogicalId) {
+      throw new InvalidDirectiveError('resolverLogicalId is required');
+    }
+    if (!requestMappingTemplate) {
+      throw new InvalidDirectiveError('requestMappingTemplate is required');
+    }
+    if (!responseMappingTemplate) {
+      throw new InvalidDirectiveError('responseMappingTemplate is required');
+    }
     this.slotNames = new Set([...requestSlots, ...responseSlots]);
   }
 

--- a/packages/amplify-graphql-transformer-core/src/utils/schema-utils.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/schema-utils.ts
@@ -2,7 +2,6 @@
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { DynamoDbDataSource } from '@aws-cdk/aws-appsync';
 import { Table } from '@aws-cdk/aws-dynamodb';
-import * as assert from 'assert';
 import { ListValueNode, ObjectTypeDefinitionNode, StringValueNode } from 'graphql';
 import { ModelResourceIDs } from 'graphql-transformer-common';
 
@@ -24,7 +23,9 @@ export const getTable = (ctx: TransformerContextProvider, object: ObjectTypeDefi
   const tableName = ModelResourceIDs.ModelTableResourceID(object.name.value);
   const table = ddbDataSource.ds.stack.node.findChild(tableName) as Table;
 
-  assert.ok(table);
+  if (!table) {
+    throw new Error(`Table not found for name ${tableName}`);
+  }
   return table;
 };
 


### PR DESCRIPTION
#### Description of changes
Today, we have a number of `assert` statements in source which we shouldn't do. This PR replaces those with either `Error`s for faults, or `InvalidDirectiveExceptions` where invalid input is caught, to provide better visibility into operator error vs bugs.

#### Issue #, if available
N/A

#### Description of how you validated changes
I would have like to add more unit tests, but given the surface area of the change that was slowing me down, so I'm relying on e2e tests to verify all use-cases here.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
