### PR TITLE
test(graphql): add negative test cases for invalid inputs and arguments

### DIFF
--- a/packages/amplify-e2e-tests/schemas/model_with_datatypes.graphql
+++ b/packages/amplify-e2e-tests/schemas/model_with_datatypes.graphql
@@ -1,0 +1,7 @@
+type Task @model @auth(rules: [{ allow: public }]) {
+  id: ID! @primaryKey
+  title: String!
+  description: String
+  priority: Int
+  dueDate: AWSDateTime
+}

--- a/packages/amplify-e2e-tests/src/__tests__/graphql-v2/invalid-input-arguments.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/graphql-v2/invalid-input-arguments.test.ts
@@ -39,17 +39,7 @@ describe('Invalid arguments should throw an error', () => {
             { title: 'task 1', description: 'task 1 description', priority: "invalid", dueDate: '2022-01-01T00:00:00.000Z' }, // Passing string in place of int
         ];
         
-        await Promise.all(
-            invalid_create_inputs.map(async (input) => {
-                try {
-                    const createResult = await createTask(input);
-                    expect(false).toBeTruthy();
-                } catch (error) {
-                    expect(error.errors).toBeDefined();
-                    expect(error.errors.length).toBeGreaterThanOrEqual(1);
-                }
-            }),
-        );
+        await runQueryAndExpectError(createTask, invalid_create_inputs);
     });
 
     it('list query should error on invalid filter arguments', async () => {
@@ -65,17 +55,7 @@ describe('Invalid arguments should throw an error', () => {
             { or: [ { priority: { between: [1, 2.5] } }, { title: { gt: "test" } } ] }, // Incorrect argument value for between operator with 'or' condition
         ];
 
-        await Promise.all(
-            invalid_filter_inputs.map(async (input) => {
-                try {
-                    const listResult = await listTasks(input);
-                    expect(false).toBeTruthy();
-                } catch (error) {
-                    expect(error.errors).toBeDefined();
-                    expect(error.errors.length).toBeGreaterThanOrEqual(1);
-                }
-           }),
-        );
+        await runQueryAndExpectError(listTasks, invalid_filter_inputs);
     });
 
     const createTask = async (
@@ -147,5 +127,19 @@ describe('Invalid arguments should throw an error', () => {
             aws_appsync_authenticationType: 'API_KEY',
             aws_appsync_apiKey: apiKey,
         });
+    }
+
+    const runQueryAndExpectError = async (query: (input: any) => any, inputs: any[]) => {
+        await Promise.all(
+            inputs.map(async (input) => {
+                try {
+                    const queryResult = await query(input);
+                    expect(false).toBeTruthy();
+                } catch (error) {
+                    expect(error.errors).toBeDefined();
+                    expect(error.errors.length).toBeGreaterThanOrEqual(1);
+                }
+           }),
+        );
     }
 });

--- a/packages/amplify-e2e-tests/src/__tests__/graphql-v2/invalid-input-arguments.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/graphql-v2/invalid-input-arguments.ts
@@ -1,0 +1,149 @@
+import {
+    initJSProjectWithProfile,
+    deleteProject,
+    amplifyPush,
+} from 'amplify-category-api-e2e-core';
+import { addApiWithBlankSchemaAndConflictDetection, updateApiSchema, getProjectMeta } from 'amplify-category-api-e2e-core';
+import { createNewProjectDir, deleteProjectDir } from 'amplify-category-api-e2e-core';
+import gql from 'graphql-tag';
+import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
+(global as any).fetch = require('node-fetch');
+
+const projectName = 'invalidarguments';
+describe('Invalid arguments should throw an error', () => {
+    let projRoot: string;
+    let appSyncClient = undefined;
+
+    beforeAll(async () => {
+        projRoot = await createNewProjectDir(projectName);
+        await initJSProjectWithProfile(projRoot, {
+            name: projectName,
+        });
+        const v2Schema = 'model_with_datatypes.graphql';
+        await addApiWithBlankSchemaAndConflictDetection(projRoot, { transformerVersion: 2 });
+        await updateApiSchema(projRoot, projectName, v2Schema);
+        await amplifyPush(projRoot);
+
+        appSyncClient = getAppSyncClientFromProj(projRoot);
+    });
+
+    afterAll(async () => {
+        await deleteProject(projRoot);
+        deleteProjectDir(projRoot);
+    });
+
+    it('create mutation should error on invalid input arguments', async () => {
+        const invalid_create_inputs = [
+            { title: 'task 1', description: 'task 1 description', priority: 1, dueDate: 'invalid date' }, // Invalid date argument
+            { title: 'test', description: 'task 1 description', priority: 2, dueDate: 1000000 }, // Invalid date argument
+            { title: 'task 1', description: 'task 1 description', priority: 5.1, dueDate: '2022-01-01T00:00:00.000Z' }, // Passing float in place of int
+        ];
+        
+        await Promise.all(
+            invalid_create_inputs.map(async (input) => {
+                console.log(input);
+                try {
+                    const createResult = await createTask(input);
+                    expect(false).toBeTruthy();
+                } catch (error) {
+                    expect(true).toBeTruthy();
+                }
+            }),
+        );
+    });
+
+    it('list query should error on invalid filter arguments', async () => {
+        const invalid_filter_inputs = [
+            { priority: { eq: 1.5 } }, // Invalid datatype - passing float for int
+            { dueDate: { gt: 1000 } }, // Invalid datatype - datetime
+            { title: { eq: 1 } }, // Invalid datatype - passing int for string
+            { priority: { between: [1] } }, // Incorrect number of arguments for between operator
+        ];
+
+        await Promise.all(
+            invalid_filter_inputs.map(async (input) => {
+                console.log(input);
+                try {
+                    const listResult = await listTasks(input);
+                    expect(false).toBeTruthy();
+                } catch (error) {
+                    expect(true).toBeTruthy();
+                }
+            }),
+        );
+    });
+
+    const getAppSyncClientFromProj = (projRoot: string) => {
+        const meta = getProjectMeta(projRoot);
+        const region = meta['providers']['awscloudformation']['Region'] as string;
+        const { output } = meta.api[projectName];
+        const url = output.GraphQLAPIEndpointOutput as string;
+        const apiKey = output.GraphQLAPIKeyOutput as string;
+
+        return new AWSAppSyncClient({
+            url,
+            region,
+            disableOffline: true,
+            auth: {
+                type: AUTH_TYPE.API_KEY,
+                apiKey,
+            },
+        });
+    };
+
+    const createTask = async (
+        createInput: any
+    ): Promise<any> => {
+        const createMutation = /* GraphQL */ `
+            mutation CreateTask($input: CreateTaskInput!, $condition: ModelTaskConditionInput) {
+                createTask(input: $input, condition: $condition) {
+                    id
+                    title
+                    description
+                    priority
+                    dueDate
+                    _lastChangedAt
+                    _version
+                    _deleted
+                }
+            }
+        `;
+
+        const result: any = await appSyncClient.mutate({
+            mutation: gql(createMutation),
+            fetchPolicy: 'no-cache',
+            variables: {
+                input: createInput,
+            },
+        });
+        return result;
+    };
+
+    const listTasks = async (filter: any): Promise<any> => {
+        const listTasksQuery = /* GraphQL */ `
+            query ListTasks($filter: ModelTaskFilterInput) {
+                listTasks(filter: $filter) {
+                    items {
+                        id
+                        title
+                        description
+                        priority
+                        dueDate
+                        _lastChangedAt
+                        _version
+                        _deleted
+                    }
+                }
+            }
+        `;
+
+        const result: any = await appSyncClient.query({
+            query: gql(listTasksQuery),
+            fetchPolicy: 'no-cache',
+            variables: {
+                filter,
+            },
+        });
+        return result;
+    };
+});


### PR DESCRIPTION
#### Description of changes

Add negative test cases for mutations and queries with invalid inputs and arguments.

- Invalid data type check
- Invalid arguments length
- Invalid filter with 'and' and 'or' conditions

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
