### PR TITLE
chore(amplify-graphql-searchable-transformer): refactor the expression to construct aggregate values

### DIFF
--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
@@ -1226,11 +1226,18 @@ $util.toJson({})
   #else
     $util.error(\\"Unauthorized to run aggregation on field: \${aggItem.field}\\", \\"Unauthorized\\")
   #end
+  #set( $aggregateValue = {} )
+  $util.qr($aggregateValue.put(\\"filter\\", $aggFilter))
+  #set( $aggsValue = {} )
+  #set( $aggItemType = {} )
   #if( $nonKeywordFields.contains($aggItem.field) )
-    $util.qr($aggregateValues.put(\\"$aggItem.name\\", { \\"filter\\": $aggFilter, \\"aggs\\": { \\"$aggItem.name\\": { \\"$aggItem.type\\": { \\"field\\": \\"$aggItem.field\\" }}} }))
+    $util.qr($aggItemType.put(\\"$aggItem.type\\", { \\"field\\": \\"$aggItem.field\\" }))
   #else
-    $util.qr($aggregateValues.put(\\"$aggItem.name\\", { \\"filter\\": $aggFilter, \\"aggs\\": { \\"$aggItem.name\\": { \\"$aggItem.type\\": { \\"field\\": \\"\${aggItem.field}.keyword\\" }}} }))
+    $util.qr($aggItemType.put(\\"$aggItem.type\\", { \\"field\\": \\"\${aggItem.field}.keyword\\" }))
   #end
+  $util.qr($aggsValue.put(\\"$aggItem.name\\", $aggItemType))
+  $util.qr($aggregateValue.put(\\"aggs\\", $aggsValue))
+  $util.qr($aggregateValues.put(\\"$aggItem.name\\", $aggregateValue))
 #end
 #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
   #set( $filter = $ctx.stash.authFilter )
@@ -1405,11 +1412,18 @@ exports[`SearchableModelTransformer with datastore enabled and sort field define
   #else
     $util.error(\\"Unauthorized to run aggregation on field: \${aggItem.field}\\", \\"Unauthorized\\")
   #end
+  #set( $aggregateValue = {} )
+  $util.qr($aggregateValue.put(\\"filter\\", $aggFilter))
+  #set( $aggsValue = {} )
+  #set( $aggItemType = {} )
   #if( $nonKeywordFields.contains($aggItem.field) )
-    $util.qr($aggregateValues.put(\\"$aggItem.name\\", { \\"filter\\": $aggFilter, \\"aggs\\": { \\"$aggItem.name\\": { \\"$aggItem.type\\": { \\"field\\": \\"$aggItem.field\\" }}} }))
+    $util.qr($aggItemType.put(\\"$aggItem.type\\", { \\"field\\": \\"$aggItem.field\\" }))
   #else
-    $util.qr($aggregateValues.put(\\"$aggItem.name\\", { \\"filter\\": $aggFilter, \\"aggs\\": { \\"$aggItem.name\\": { \\"$aggItem.type\\": { \\"field\\": \\"\${aggItem.field}.keyword\\" }}} }))
+    $util.qr($aggItemType.put(\\"$aggItem.type\\", { \\"field\\": \\"\${aggItem.field}.keyword\\" }))
   #end
+  $util.qr($aggsValue.put(\\"$aggItem.name\\", $aggItemType))
+  $util.qr($aggregateValue.put(\\"aggs\\", $aggsValue))
+  $util.qr($aggregateValues.put(\\"$aggItem.name\\", $aggregateValue))
 #end
 #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
   #set( $filter = $ctx.stash.authFilter )
@@ -1543,11 +1557,18 @@ exports[`SearchableModelTransformer with datastore enabled vtl 1`] = `
   #else
     $util.error(\\"Unauthorized to run aggregation on field: \${aggItem.field}\\", \\"Unauthorized\\")
   #end
+  #set( $aggregateValue = {} )
+  $util.qr($aggregateValue.put(\\"filter\\", $aggFilter))
+  #set( $aggsValue = {} )
+  #set( $aggItemType = {} )
   #if( $nonKeywordFields.contains($aggItem.field) )
-    $util.qr($aggregateValues.put(\\"$aggItem.name\\", { \\"filter\\": $aggFilter, \\"aggs\\": { \\"$aggItem.name\\": { \\"$aggItem.type\\": { \\"field\\": \\"$aggItem.field\\" }}} }))
+    $util.qr($aggItemType.put(\\"$aggItem.type\\", { \\"field\\": \\"$aggItem.field\\" }))
   #else
-    $util.qr($aggregateValues.put(\\"$aggItem.name\\", { \\"filter\\": $aggFilter, \\"aggs\\": { \\"$aggItem.name\\": { \\"$aggItem.type\\": { \\"field\\": \\"\${aggItem.field}.keyword\\" }}} }))
+    $util.qr($aggItemType.put(\\"$aggItem.type\\", { \\"field\\": \\"\${aggItem.field}.keyword\\" }))
   #end
+  $util.qr($aggsValue.put(\\"$aggItem.name\\", $aggItemType))
+  $util.qr($aggregateValue.put(\\"aggs\\", $aggsValue))
+  $util.qr($aggregateValues.put(\\"$aggItem.name\\", $aggregateValue))
 #end
 #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
   #set( $filter = $ctx.stash.authFilter )

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
@@ -52,6 +52,8 @@ test('SearchableModelTransformer vtl', () => {
 
   const out = transformer.transform(validSchema);
   expect(parse(out.schema)).toBeDefined();
+  expect(out.resolvers['Query.searchPosts.req.vtl']).toBeDefined();
+  expect(out.resolvers['Query.searchPosts.req.vtl']).toContain('$util.qr($aggregateValues.put("$aggItem.name", $aggregateValue))');
   expect(out.resolvers).toMatchSnapshot();
 });
 
@@ -77,6 +79,8 @@ test('SearchableModelTransformer with datastore enabled vtl', () => {
 
   const out = transformer.transform(validSchema);
   expect(parse(out.schema)).toBeDefined();
+  expect(out.resolvers['Query.searchPosts.req.vtl']).toBeDefined();
+  expect(out.resolvers['Query.searchPosts.req.vtl']).toContain('$util.qr($aggregateValues.put("$aggItem.name", $aggregateValue))');
   expect(out.resolvers['Query.searchPosts.req.vtl']).toMatchSnapshot();
   expect(out.resolvers['Query.searchPosts.res.vtl']).toMatchSnapshot();
   expect(out.resolvers['Query.searchPosts.res.vtl']).toContain('$util.qr($row.put("_version", $entry.get("_version")))');


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
These changes refactor a step in the Request Mapping Template that is generated by the Searchable V2 transformer.
The step is responsible for constructing a Map that contains the Aggregate values that will eventually be used in the construction of the Search Query. The current refactor dynamically generates this Map instead of a raw JSON representation. 
This is necessary for the Searchable Mocking to work since the mock VTL compiler does not read raw JSON representations.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
The test snapshot updates show the change in the Request Mapping Template.
Added explicit checks as well.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
