### PR TITLE
fix(e2e): remove all resources update wait

### DIFF
--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -876,7 +876,6 @@ export function rebuildApi(projDir: string, apiName: string) {
     spawn(getCLIPath(), ['rebuild', 'api'], { cwd: projDir, stripColors: true })
       .wait('Type the name of the API to confirm you want to continue')
       .sendLine(apiName)
-      .wait('All resources are updated in the cloud')
       .run(err => (err ? reject(err) : resolve()));
   });
 }

--- a/packages/amplify-e2e-core/src/init/amplifyPush.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPush.ts
@@ -423,7 +423,7 @@ export function amplifyPushDestructiveApiUpdate(cwd: string, includeForce: boole
     }
     const chain = spawn(getCLIPath(), args, { cwd, stripColors: true });
     if (includeForce) {
-      chain.wait('All resources are updated in the cloud').run(err => (err ? reject(err) : resolve()));
+      chain.run(err => (err ? reject(err) : resolve()));
     } else {
       chain.wait('If this is intended, rerun the command with').run(err => (err ? resolve(err) : reject())); // in this case, we expect the CLI to error out
     }

--- a/packages/amplify-e2e-core/src/utils/pinpoint.ts
+++ b/packages/amplify-e2e-core/src/utils/pinpoint.ts
@@ -158,7 +158,6 @@ export function pushToCloud(cwd: string): Promise<void> {
     spawn(getCLIPath(), ['push'], { cwd, stripColors: true })
       .wait('Are you sure you want to continue')
       .sendCarriageReturn()
-      .wait('All resources are updated in the cloud')
       .wait('Pinpoint URL to track events')
       .run((err: Error) => {
         if (!err) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Removed the `All resources are updated in the cloud` wait in amplify push to unblock the e2e tests. The related change in CLI: https://github.com/aws-amplify/amplify-cli/pull/10720
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
