### PR TITLE
feat: enable running client tests as part of circle ci workflow

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -212,6 +212,40 @@ jobs:
       - store_artifacts:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
 
+  client_e2e_tests:
+    environment:
+      AMPLIFY_PATH: /home/circleci/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify
+    parameters:
+      os:
+        type: executor
+        default: l
+    executor: << parameters.os >>
+    working_directory: ~/repo
+    steps:
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: >-
+            amplify-category-api-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{
+            arch }}
+      - restore_cache:
+          key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
+      - restore_cache:
+          key: amplify-build-artifact-{{ .Revision }}-{{ arch }}
+      - install_yarn:
+          os: << parameters.os >>
+      - run: *install_cli_from_local_registry
+      - run_client_tests:
+          os: << parameters.os >>
+      - scan_e2e_test_artifacts:
+          os: << parameters.os >>
+      - store_test_results:
+          path: client-test-apps/js/api-model-relationship-app/test-results
+      - store_artifacts:
+          path: client-test-apps/js/api-model-relationship-app/cypress/screenshots
+      - store_artifacts:
+          path: client-test-apps/js/api-model-relationship-app/cypress/videos
+
   amplify_migration_tests_v5:
     <<: *defaults
     steps:
@@ -390,6 +424,19 @@ workflows:
                 - /run-e2e\/.*/
           requires:
             - publish_to_local_registry
+      - client_e2e_tests:
+          context:
+            - api-cleanup-resources
+            - e2e-auth-credentials
+            - api-e2e-test-context
+          filters:
+            branches:
+              only:
+                - main
+                - /tagged-release\/.*/
+                - /run-e2e\/.*/
+          requires:
+            - publish_to_local_registry
       - amplify_migration_tests_v6:
           context:
             - e2e-auth-credentials
@@ -422,6 +469,7 @@ workflows:
             - api-e2e-test-context
           requires:
             - amplify_e2e_tests
+            - client_e2e_tests
             - graphql_e2e_tests
             - amplify_migration_tests_v6
             - amplify_migration_tests_v5
@@ -435,6 +483,7 @@ workflows:
             - mock_e2e_tests
             - graphql_e2e_tests
             - amplify_e2e_tests
+            - client_e2e_tests
             - amplify_migration_tests_v6
             - amplify_migration_tests_v5
           filters:
@@ -524,3 +573,39 @@ commands:
               exit 1
             fi
           when: always
+  run_client_tests:
+    description: "Run Amplify Client tests"
+    parameters:
+      os:
+        type: executor
+        default: l
+    steps:
+      - when:
+          condition:
+            equal: [*windows-e2e-executor, << parameters.os >>]
+          steps:
+            - run:
+                name: Run Client Tests
+                shell: bash.exe
+                command: |
+                  source .circleci/local_publish_helpers.sh
+                  export CLI_REGION=us-west-2
+                  cd client-test-apps/js/api-model-relationship-app
+                  npm install
+                  retry npm run test:ci
+                no_output_timeout: 90m
+      - when:
+          condition:
+            equal: [*linux-e2e-executor, << parameters.os >>]
+          steps:
+            - run:
+                name: Run E2e Tests
+                command: |
+                  echo "export PATH=$AMPLIFY_DIR:$PATH" >> $BASH_ENV
+                  source $BASH_ENV
+                  source .circleci/local_publish_helpers.sh
+                  export CLI_REGION=us-west-2
+                  cd client-test-apps/js/api-model-relationship-app
+                  npm install
+                  retry npm run test:ci
+                no_output_timeout: 90m

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -155,7 +155,6 @@ function runE2eTest {
 
     if [ -z "$FIRST_RUN" ] || [ "$FIRST_RUN" == "true" ]; then
         echo "using Amplify CLI version: "$(amplify --version)
-        echo "using amplify-app version: "$(amplify-app --version)
         cd $(pwd)/packages/amplify-e2e-tests
     fi
 

--- a/client-test-apps/js/api-model-relationship-app/.gitignore
+++ b/client-test-apps/js/api-model-relationship-app/.gitignore
@@ -1,11 +1,15 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
-# Test Artifacts and interstitials we don't want to persist
-test-results.xml
+# interstitials we don't want to persist
 amplify
 src/API.ts
 src/graphql
 .graphqlconfig.yml
+
+# Test Artifacts
+test-results
+cypress/videos
+cypress/screenshots
 
 # dependencies
 /node_modules

--- a/client-test-apps/js/api-model-relationship-app/package.json
+++ b/client-test-apps/js/api-model-relationship-app/package.json
@@ -7,6 +7,8 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "@types/hjson": "^2.4.3",
+    "@types/ini": "^1.3.31",
     "@types/jest": "^27.5.2",
     "@types/jest-dev-server": "^5.0.0",
     "@types/node": "^16.11.56",
@@ -15,7 +17,10 @@
     "aws-amplify": "^4.3.30",
     "cross-env": "^7.0.3",
     "cypress": "^10.4.0",
+    "hjson": "^3.2.2",
+    "ini": "^3.0.1",
     "jest-dev-server": "^6.1.1",
+    "jest-junit": "^14.0.1",
     "lodash": "^4.17.21",
     "node-pty": "^0.10.1",
     "pluralize": "^8.0.0",
@@ -33,10 +38,11 @@
     "build": "react-scripts build",
     "eject": "react-scripts eject",
     "test": "react-scripts test src/__tests__/api.test.ts",
-    "test:setup": "cross-env TEST_HARNESS_STAGE=setup react-scripts test src/__tests__/api.test.ts",
-    "test:execute": "cross-env TEST_HARNESS_STAGE=execute react-scripts test src/__tests__/api.test.ts",
-    "test:watch": "cross-env TEST_HARNESS_STAGE=watch react-scripts test src/__tests__/api.test.ts",
-    "test:teardown": "cross-env TEST_HARNESS_STAGE=teardown react-scripts test src/__tests__/api.test.ts"
+    "test:setup": "cross-env TEST_HARNESS_STAGE=setup npm run test",
+    "test:execute": "cross-env TEST_HARNESS_STAGE=execute npm run test",
+    "test:watch": "cross-env TEST_HARNESS_STAGE=watch npm run test",
+    "test:teardown": "cross-env TEST_HARNESS_STAGE=teardown npm run test",
+    "test:ci": "npm run test --testResultsProcessor=\"jest-junit\""
   },
   "eslintConfig": {
     "extends": [

--- a/client-test-apps/js/api-model-relationship-app/src/__tests__/utils/execUtils.ts
+++ b/client-test-apps/js/api-model-relationship-app/src/__tests__/utils/execUtils.ts
@@ -872,3 +872,21 @@ export const spawn = (command: string | string[], params: string[] = [], options
 
   return chain(context);
 };
+
+export const moveDown = (chain: ExecutionContext, nMoves: number) =>
+  Array.from(Array(nMoves).keys()).reduce((chain, _idx) => chain.send('j'), chain);
+  
+export const singleSelect = <T>(chain: ExecutionContext, item: T, allChoices: T[]) => multiSelect(chain, [item], allChoices);
+
+export const multiSelect = <T>(chain: ExecutionContext, items: T[] = [], allChoices: T[]) => {
+  items
+    .map(item => allChoices.indexOf(item))
+    .filter(idx => idx > -1)
+    .sort()
+    // calculate the diff with the latest, since items are sorted, always positive
+    // represents the numbers of moves down we need to make to selection
+    .reduce((diffs, move) => (diffs.length > 0 ? [...diffs, move - diffs[diffs.length - 1]] : [move]), [] as number[])
+    .reduce((chain, move) => moveDown(chain, move).send(' '), chain);
+  chain.sendCarriageReturn();
+  return chain;
+};

--- a/client-test-apps/js/api-model-relationship-app/src/__tests__/utils/jsonUtilities.ts
+++ b/client-test-apps/js/api-model-relationship-app/src/__tests__/utils/jsonUtilities.ts
@@ -1,0 +1,156 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as hjson from 'hjson';
+
+export class JSONUtilities {
+  public static readJson = <T>(
+    fileName: string,
+    options?: {
+      throwIfNotExist?: boolean;
+      preserveComments?: boolean;
+    },
+  ): T | undefined => {
+    if (!fileName) {
+      throw new Error(`'fileName' argument missing`);
+    }
+
+    const mergedOptions = {
+      throwIfNotExist: true,
+      preserveComments: false,
+      ...options,
+    };
+
+    if (!fs.existsSync(fileName)) {
+      if (mergedOptions.throwIfNotExist) {
+        throw new Error(`File at path: '${fileName}' does not exist`);
+      } else {
+        return undefined;
+      }
+    }
+
+    const content = fs.readFileSync(fileName, 'utf8');
+
+    const data = JSONUtilities.parse<T>(content, {
+      preserveComments: mergedOptions.preserveComments,
+    });
+
+    return data as T;
+  };
+
+  public static writeJson = (
+    fileName: string,
+    data: any,
+    options?: {
+      keepComments?: boolean;
+      mode?: number;
+      minify?: boolean;
+      secureFile?: boolean;
+    },
+  ): void => {
+    if (!fileName) {
+      throw new Error(`'fileName' argument missing`);
+    }
+
+    if (!data) {
+      throw new Error(`'data' argument missing`);
+    }
+
+    const mergedOptions = {
+      keepComments: false,
+      minify: false,
+      secureFile: false,
+      ...options,
+    };
+
+    const jsonString = JSONUtilities.stringify(data, {
+      minify: mergedOptions.minify,
+      keepComments: mergedOptions.keepComments,
+    });
+
+    // Create nested directories if needed
+    const dirPath = path.dirname(fileName);
+    fs.ensureDirSync(dirPath);
+
+    const writeFileOptions: { encoding: string; mode?: number } = { encoding: 'utf8', mode: options?.mode };
+    if (mergedOptions.secureFile) {
+      writeFileOptions.mode = 0o600;
+    }
+
+    fs.writeFileSync(fileName, jsonString, writeFileOptions);
+  };
+
+  public static parse = <T>(
+    jsonString: string,
+    options?: {
+      preserveComments?: boolean;
+    },
+  ): T => {
+    if (jsonString === undefined || (typeof jsonString === 'string' && jsonString.trim().length === 0)) {
+      throw new Error("'jsonString' argument missing or empty");
+    }
+
+    const mergedOptions = {
+      preserveComments: false,
+      ...options,
+    };
+
+    let data: T;
+
+    // By type definition we don't allow any value other than string, but to preserve JSON.parse behavior,
+    // which is against the MDN docs we support handling of non-string types like boolean and number.
+    if (typeof jsonString === 'string') {
+      let cleanString = jsonString;
+
+      // Strip BOM if input has it
+      if (cleanString.charCodeAt(0) === 0xfeff) {
+        cleanString = cleanString.slice(1);
+      }
+
+      data = hjson.parse(cleanString, {
+        keepWsc: mergedOptions.preserveComments,
+      });
+    } else {
+      return (jsonString as unknown) as T;
+    }
+
+    return data as T;
+  };
+
+  public static stringify = (
+    data: any,
+    options?: {
+      minify?: boolean;
+      keepComments?: boolean;
+    },
+  ): string | undefined => {
+    if (!data) {
+      throw new Error("'data' argument missing");
+    }
+
+    const mergedOptions = {
+      minify: false,
+      keepComments: false,
+      ...options,
+    };
+
+    let jsonString = '';
+
+    // For minification use builtin JSON.stringify as hjson has no option for it
+    if (mergedOptions.minify) {
+      jsonString = JSON.stringify(data);
+    } else {
+      // Temporarily fallback to builtin stringify until 'undefined' serialization can be solved with hjson
+      // This only affects comment roundtripping which we don't use explicitly anywhere yet.
+      jsonString = JSON.stringify(data, null, 2);
+      // jsonString = hjson.stringify(data, {
+      //   bracesSameLine: true,
+      //   space: 2,
+      //   separator: true,
+      //   quotes: 'all',
+      //   keepWsc: mergedOptions.keepComments,
+      // });
+    }
+
+    return jsonString;
+  };
+}

--- a/client-test-apps/js/api-model-relationship-app/src/__tests__/utils/testHarness.ts
+++ b/client-test-apps/js/api-model-relationship-app/src/__tests__/utils/testHarness.ts
@@ -102,7 +102,10 @@ export const executeAmplifyTestHarness = (testName: string, projectRoot: string,
         it('executes the cypress suite', async () => {
         const runResult = await cypress.run({
           reporter: 'junit',
-          browser: 'firefox',
+          browser: 'electron',
+          reporterOptions: {
+            mochaFile: 'test-results/cypress-test-results-[hash].xml'
+          },
           config: {
             video: true,
           },


### PR DESCRIPTION
#### Description of changes
Add a new Circle step to run the first client test app via Circle. Verified in a branch https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api/1126/workflows/bd73083d-ceea-4ae7-bf63-760085d38cfc/jobs/32937/steps

#### Issue #, if available
N/A

#### Description of how you validated changes
test runs/passes 2/2 for the last few runs

#### Checklist
- [x] PR description included
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
