### PR TITLE
Fix: Allow single static group as string

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/group-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/group-auth.test.ts
@@ -34,6 +34,30 @@ test('happy case with static groups', () => {
   );
 });
 
+test('Static groups with a single group provided as string does not error', () => {
+  const authConfig: AppSyncAuthConfiguration = {
+    defaultAuthentication: {
+      authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+    },
+    additionalAuthenticationProviders: [],
+  };
+  const invalidSchema = `
+    type Post @model @auth(rules: [{allow: groups, groups: "Admin"}]) {
+      id: ID!
+      title: String!
+      group: String
+      createdAt: String
+      updatedAt: String
+    }`;
+  const transformer = new GraphQLTransform({
+    authConfig,
+    transformers: [new ModelTransformer(), new AuthTransformer()],
+    featureFlags,
+  });
+  const out = transformer.transform(invalidSchema);
+  expect(out).toBeDefined();
+});
+
 test('happy case with dynamic groups', () => {
   const authConfig: AppSyncAuthConfiguration = {
     defaultAuthentication: {

--- a/packages/amplify-graphql-auth-transformer/src/utils/index.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/index.ts
@@ -53,8 +53,14 @@ export const getAuthDirectiveRules = (authDir: DirectiveWrapper, options?: GetAu
   };
 
   const { rules } = authDir.getArguments<{ rules: Array<AuthRule> }>({ rules: [] }, options);
-  rules.forEach(rule => {
+  rules.forEach((rule) => {
     const operations: (ModelOperation | 'read')[] = rule.operations ?? MODEL_OPERATIONS;
+
+    // In case a customer defines a single dynamic group as a string, put it to an array
+    if (rule.groups && typeof rule.groups === 'string') {
+      // eslint-disable-next-line no-param-reassign
+      rule.groups = [rule.groups];
+    }
 
     if (options?.isField && rule.operations && (rule.operations.some((operation: ModelOperation | 'read') => operation !== 'read' && READ_MODEL_OPERATIONS.includes(operation)))) {
       const offendingOperation = operations.filter(operation => operation !== 'read' && READ_MODEL_OPERATIONS.includes(operation));


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
If static groups are provided as a single string instead of a list, perform the conversion

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
https://github.com/aws-amplify/amplify-category-api/issues/760

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Unit testing

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
