### PR TITLE
fix(transformer): sort resolvers to avoid circular dependency

### DIFF
--- a/packages/amplify-e2e-tests/schemas/circular_dependency_model.graphql
+++ b/packages/amplify-e2e-tests/schemas/circular_dependency_model.graphql
@@ -1,0 +1,11 @@
+type Member @model @auth(rules: [{ allow: owner }])
+{
+  owner: String! @primaryKey
+  secondaryIndex: String @index(name: "bySecondaryIndex", queryField: "memberBySecondaryIndex")
+  washCarTasks: [WashCarTask] @hasMany(indexName: "byOwner", fields: ["owner"])
+}
+
+type WashCarTask @model @auth(rules: [{ allow: owner }]) {
+  id: ID! @primaryKey
+  owner: String! @index(name: "byOwner", queryField: "washCarTaskByOwner")
+}

--- a/packages/amplify-e2e-tests/src/__tests__/graphql-v2/circular-dependency.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/graphql-v2/circular-dependency.test.ts
@@ -1,0 +1,42 @@
+import { addApi, addApiWithoutSchema, amplifyPush, cancelAmplifyMockApi, createNewProjectDir, deleteProject, deleteProjectDir, initJSProjectWithProfile, updateApiSchema } from "amplify-category-api-e2e-core";
+import { existsSync } from "fs-extra";
+import path from 'path';
+import { addCodegen } from "../../codegen/add";
+
+describe('Circurlar dependency tests', () => {
+  let projRoot: string;
+  let projFolderName: string;
+  beforeEach(async () => {
+    projFolderName = 'circulardependency';
+    projRoot = await createNewProjectDir(projFolderName);
+  });
+
+  afterEach(async () => {
+    const metaFilePath = path.join(projRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
+    if (existsSync(metaFilePath)) {
+      await deleteProject(projRoot);
+    }
+    deleteProjectDir(projRoot);
+  });
+  it('should not have circular dependency error when mocking api with a specific GraphQL schema', async () => {
+    const projName = 'circulardependency';
+    await initJSProjectWithProfile(projRoot, { name: projName });
+    await addApi(projRoot, {
+      'Amazon Cognito User Pool': {},
+      transformerVersion: 2,
+    });
+    await updateApiSchema(projRoot, projName, 'circular_dependency_model.graphql');
+    await addCodegen(projRoot, {});
+    await expect(cancelAmplifyMockApi(projRoot, {})).resolves.not.toThrow();
+  });
+  it('should not have circular dependency error when pushing api with a specific GraphQL schema', async () => {
+    const projName = 'circulardependency';
+    await initJSProjectWithProfile(projRoot, { name: projName });
+    await addApi(projRoot, {
+      'Amazon Cognito User Pool': {},
+      transformerVersion: 2,
+    });
+    await updateApiSchema(projRoot, projName, 'circular_dependency_model.graphql');
+    await expect(amplifyPush(projRoot)).resolves.not.toThrow();
+  });
+})

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -124,6 +124,7 @@ export class TransformerResolver implements TransformerResolverProvider {
   private readonly slotMap: Map<string, Slot[]> = new Map();
   private readonly slotNames: Set<string>;
   private stack?: Stack;
+  private stackName?: string;
   constructor(
     private typeName: string,
     private fieldName: string,
@@ -154,6 +155,11 @@ export class TransformerResolver implements TransformerResolverProvider {
 
   mapToStack = (stack: Stack) => {
     this.stack = stack;
+    this.stackName = stack.stackName;
+  };
+
+  getStackName = () => {
+    return this.stackName ?? '';
   };
 
   addToSlot = (


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

- Sorted resolvers before synthesis to ensure the resolvers are grouped in stack order.
- Added e2e tests for mock and push with the GQL schema which previously caused circular dependency problem

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
