### PR TITLE
fix(relation-transformer): belongsTo resolves to correct connected fields

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/utils.ts
+++ b/packages/amplify-graphql-relational-transformer/src/utils.ts
@@ -37,7 +37,7 @@ export function getRelatedTypeIndex(
       const directiveName = directive.name.value;
       const name = getIndexName(directive);
 
-      if ((!indexName && directiveName === 'primaryKey') || (indexName === name && directiveName === 'index')) {
+      if ((!indexName && directiveName === 'primaryKey') || (indexName && indexName === name && directiveName === 'index')) {
         partitionFieldName = field.name.value;
 
         for (const argument of directive.arguments!) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Add `indexName` existence check in case of getting into the wrong resolved connected fields
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Reported in the CPK bug bash slack channel
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
