### PR TITLE
Set default lastSync correctly

### DIFF
--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
@@ -3681,7 +3681,7 @@ $util.qr($PkMap.put('createdAt' , 'ByCreatedAt'))
   \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"Sync\\",
   \\"limit\\": $limit,
-  \\"lastSync\\": $util.toJson($util.defaultIfNull($ctx.args.lastSync, null)),
+  \\"lastSync\\": $util.defaultIfNull($ctx.args.lastSync, null),
   \\"query\\": $modelQueryExpression
 } )
   #if( !$util.isNull($ctx.args.sortDirection)
@@ -3816,7 +3816,7 @@ $util.qr($PkMap.put('orderId' , 'dbTable'))
   \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"Sync\\",
   \\"limit\\": $limit,
-  \\"lastSync\\": $util.toJson($util.defaultIfNull($ctx.args.lastSync, null)),
+  \\"lastSync\\": $util.defaultIfNull($ctx.args.lastSync, null),
   \\"query\\": $modelQueryExpression
 } )
   #if( !$util.isNull($ctx.args.sortDirection)
@@ -4556,7 +4556,7 @@ $util.qr($PkMap.put('genre' , 'byGenre'))
   \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"Sync\\",
   \\"limit\\": $limit,
-  \\"lastSync\\": $util.toJson($util.defaultIfNull($ctx.args.lastSync, null)),
+  \\"lastSync\\": $util.defaultIfNull($ctx.args.lastSync, null),
   \\"query\\": $modelQueryExpression
 } )
   #if( !$util.isNull($ctx.args.sortDirection)
@@ -5296,7 +5296,7 @@ $util.qr($PkMap.put('genre' , 'byGenre'))
   \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"Sync\\",
   \\"limit\\": $limit,
-  \\"lastSync\\": $util.toJson($util.defaultIfNull($ctx.args.lastSync, null)),
+  \\"lastSync\\": $util.defaultIfNull($ctx.args.lastSync, null),
   \\"query\\": $modelQueryExpression
 } )
   #if( !$util.isNull($ctx.args.sortDirection)

--- a/packages/amplify-graphql-index-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers.ts
@@ -818,7 +818,7 @@ function makeSyncQueryResolver() {
             version: str(RESOLVER_VERSION_ID),
             operation: str('Sync'),
             limit: ref('limit'),
-            lastSync: ref('util.toJson($util.defaultIfNull($ctx.args.lastSync, null))'),
+            lastSync: ref('util.defaultIfNull($ctx.args.lastSync, null)'),
             query: ref(ResourceConstants.SNIPPETS.ModelQueryExpression),
           }),
         ),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The default value for `lastSync` should be set to `null` if it doesn't exist in the input arguments. However, currently it is set to "null" string because of converting it to JSON twice, which is being wrongly interpreted in the Sync Query request. This change fixes it.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-category-api/issues/806

#### Description of how you validated changes
Using the customer provided schema in the issue and a sample app.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
