### PR TITLE
fix(relation-transformer): relation field nullability in object and input type

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-belongs-to-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-belongs-to-transformer.test.ts
@@ -617,7 +617,7 @@ describe('@belongsTo connection field nullability tests', () => {
   });
 
   describe('@belongsTo with @hasMany', () => {
-    test('Should generate nullable connection fields in type definition and create/update input when belongsTo field is nullable', () => {
+    test('Should generate nullable connection fields in type definition and create/update input when hasMany field is nullable', () => {
       const inputSchema = `
         type Todo @model {
           todoid: ID! @primaryKey(sortKeyFields:["name"])
@@ -630,7 +630,7 @@ describe('@belongsTo connection field nullability tests', () => {
           taskid: ID! @primaryKey(sortKeyFields:["name"])
           name: String!
           description: String
-          todo: Todo @belongsTo
+          todo: Todo! @belongsTo
         }
       `;
       const transformer = new GraphQLTransform({
@@ -681,20 +681,20 @@ describe('@belongsTo connection field nullability tests', () => {
       expect(updateInputConnectedField2.type.name.value).toBe('String');
     });
   
-    test('Should generate non-nullable connection fields in type definition and create input while keeping nullable in update input when belongsTo field is non-nullable', () => {
+    test('Should generate non-nullable connection fields in type definition and create input while keeping nullable in update input when hasMany field is non-nullable', () => {
       const inputSchema = `
         type Todo @model {
           todoid: ID! @primaryKey(sortKeyFields:["name"])
           name: String!
           title: String!
           priority: Int
-          tasks: [Task] @hasMany
+          tasks: [Task]! @hasMany
         }
         type Task @model {
           taskid: ID! @primaryKey(sortKeyFields:["name"])
           name: String!
           description: String
-          todo: Todo! @belongsTo
+          todo: Todo @belongsTo
         }
       `;
       const transformer = new GraphQLTransform({

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-belongs-to-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-belongs-to-transformer.test.ts
@@ -1,6 +1,7 @@
 import { IndexTransformer, PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { GraphQLTransform, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
+import { FeatureFlagProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { DocumentNode, Kind, parse } from 'graphql';
 import { BelongsToTransformer, HasManyTransformer, HasOneTransformer } from '..';
 import { featureFlags } from './test-helpers';
@@ -471,4 +472,278 @@ test('Should not resolve to secondary index of connected model if the index is d
     ],
   });
   expect(() => transformer.transform(inputSchema)).not.toThrow();
+});
+
+describe('@belongsTo connection field nullability tests', () => {
+  const featureFlags: FeatureFlagProvider = {
+    getBoolean: (value: string, defaultValue: boolean): boolean => {
+      if (value === 'respectPrimaryKeyAttributesOnConnectionField') {
+        return true;
+      }
+      return defaultValue;
+    },
+    getNumber: jest.fn(),
+    getObject: jest.fn(),
+  };
+
+  describe('@belongsTo with @hasOne', () => {
+    test('Should generate nullable connection fields in type definition and create/update input when belongsTo field is nullable', () => {
+      const inputSchema = `
+        type Todo @model {
+          todoid: ID! @primaryKey(sortKeyFields:["name"])
+          name: String!
+          title: String!
+          priority: Int
+          task: Task @hasOne
+        }
+        type Task @model {
+          taskid: ID! @primaryKey(sortKeyFields:["name"])
+          name: String!
+          description: String
+          todo: Todo @belongsTo
+        }
+      `;
+      const transformer = new GraphQLTransform({
+        featureFlags,
+        transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
+      });
+    
+      const out = transformer.transform(inputSchema);
+      expect(out).toBeDefined();
+      const schema = parse(out.schema);
+      validateModelSchema(schema);
+      const connectionFieldName1 = 'taskTodoTodoid';
+      const connectionFieldName2 = 'taskTodoName';
+      //Type definition
+      const objType = schema.definitions.find((def: any) => def.name && def.name.value === 'Task') as any;
+      expect(objType).toBeDefined();
+      const relatedField1 = objType.fields.find((f: any) => f.name.value === connectionFieldName1);
+      expect(relatedField1).toBeDefined();
+      expect(relatedField1.type.kind).toBe(Kind.NAMED_TYPE);
+      expect(relatedField1.type.name.value).toBe('ID');
+      const relatedField2 = objType.fields.find((f: any) => f.name.value === connectionFieldName2);
+      expect(relatedField2).toBeDefined();
+      expect(relatedField2.type.kind).toBe(Kind.NAMED_TYPE);
+      expect(relatedField2.type.name.value).toBe('String');
+      //Create Input
+      const createInput = schema.definitions.find((def: any) => def.name && def.name.value === 'CreateTaskInput') as any;
+      expect(createInput).toBeDefined();
+      expect(createInput.fields.length).toEqual(5);
+      const createInputConnectedField1 = createInput.fields.find((f: any) => f.name.value === connectionFieldName1);
+      expect(createInputConnectedField1).toBeDefined();
+      expect(createInputConnectedField1.type.kind).toBe(Kind.NAMED_TYPE);
+      expect(createInputConnectedField1.type.name.value).toBe('ID');
+      const createInputConnectedField2 = createInput.fields.find((f: any) => f.name.value === connectionFieldName2);
+      expect(createInputConnectedField2).toBeDefined();
+      expect(createInputConnectedField2.type.kind).toBe(Kind.NAMED_TYPE);
+      expect(createInputConnectedField2.type.name.value).toBe('String');
+      //Update Input
+      const updateInput = schema.definitions.find((def: any) => def.name && def.name.value === 'UpdateTaskInput') as any;
+      expect(updateInput).toBeDefined();
+      expect(updateInput.fields.length).toEqual(5);
+      const updateInputConnectedField1 = updateInput.fields.find((f: any) => f.name.value === connectionFieldName1);
+      expect(updateInputConnectedField1).toBeDefined();
+      expect(updateInputConnectedField1.type.kind).toBe(Kind.NAMED_TYPE);
+      expect(updateInputConnectedField1.type.name.value).toBe('ID');
+      const updateInputConnectedField2 = updateInput.fields.find((f: any) => f.name.value === connectionFieldName2);
+      expect(updateInputConnectedField2).toBeDefined();
+      expect(updateInputConnectedField2.type.kind).toBe(Kind.NAMED_TYPE);
+      expect(updateInputConnectedField2.type.name.value).toBe('String');
+    });
+  
+    test('Should generate non-nullable connection fields in type definition and create input while keeping nullable in update input when belongsTo field is non-nullable', () => {
+      const inputSchema = `
+        type Todo @model {
+          todoid: ID! @primaryKey(sortKeyFields:["name"])
+          name: String!
+          title: String!
+          priority: Int
+          task: Task! @hasOne
+        }
+        type Task @model {
+          taskid: ID! @primaryKey(sortKeyFields:["name"])
+          name: String!
+          description: String
+          todo: Todo! @belongsTo
+        }
+      `;
+      const transformer = new GraphQLTransform({
+        featureFlags,
+        transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
+      });
+    
+      const out = transformer.transform(inputSchema);
+      expect(out).toBeDefined();
+      const schema = parse(out.schema);
+      validateModelSchema(schema);
+      const connectionFieldName1 = 'taskTodoTodoid';
+      const connectionFieldName2 = 'taskTodoName';
+      //Type definition
+      const objType = schema.definitions.find((def: any) => def.name && def.name.value === 'Task') as any;
+      expect(objType).toBeDefined();
+      const relatedField1 = objType.fields.find((f: any) => f.name.value === connectionFieldName1);
+      expect(relatedField1).toBeDefined();
+      expect(relatedField1.type.kind).toBe(Kind.NON_NULL_TYPE);
+      expect(relatedField1.type.type.name.value).toBe('ID');
+      const relatedField2 = objType.fields.find((f: any) => f.name.value === connectionFieldName2);
+      expect(relatedField2).toBeDefined();
+      expect(relatedField2.type.kind).toBe(Kind.NON_NULL_TYPE);
+      expect(relatedField2.type.type.name.value).toBe('String');
+      //Create Input
+      const createInput = schema.definitions.find((def: any) => def.name && def.name.value === 'CreateTaskInput') as any;
+      expect(createInput).toBeDefined();
+      expect(createInput.fields.length).toEqual(5);
+      const createInputConnectedField1 = createInput.fields.find((f: any) => f.name.value === connectionFieldName1);
+      expect(createInputConnectedField1).toBeDefined();
+      expect(createInputConnectedField1.type.kind).toBe(Kind.NON_NULL_TYPE);
+      expect(createInputConnectedField1.type.type.name.value).toBe('ID');
+      const createInputConnectedField2 = createInput.fields.find((f: any) => f.name.value === connectionFieldName2);
+      expect(createInputConnectedField2).toBeDefined();
+      expect(createInputConnectedField2.type.kind).toBe(Kind.NON_NULL_TYPE);
+      expect(createInputConnectedField2.type.type.name.value).toBe('String');
+      //Update Input
+      const updateInput = schema.definitions.find((def: any) => def.name && def.name.value === 'UpdateTaskInput') as any;
+      expect(updateInput).toBeDefined();
+      expect(updateInput.fields.length).toEqual(5);
+      const updateInputConnectedField1 = updateInput.fields.find((f: any) => f.name.value === connectionFieldName1);
+      expect(updateInputConnectedField1).toBeDefined();
+      expect(updateInputConnectedField1.type.kind).toBe(Kind.NAMED_TYPE);
+      expect(updateInputConnectedField1.type.name.value).toBe('ID');
+      const updateInputConnectedField2 = updateInput.fields.find((f: any) => f.name.value === connectionFieldName2);
+      expect(updateInputConnectedField2).toBeDefined();
+      expect(updateInputConnectedField2.type.kind).toBe(Kind.NAMED_TYPE);
+      expect(updateInputConnectedField2.type.name.value).toBe('String');
+    });
+  });
+
+  describe('@belongsTo with @hasMany', () => {
+    test('Should generate nullable connection fields in type definition and create/update input when belongsTo field is nullable', () => {
+      const inputSchema = `
+        type Todo @model {
+          todoid: ID! @primaryKey(sortKeyFields:["name"])
+          name: String!
+          title: String!
+          priority: Int
+          tasks: [Task] @hasMany
+        }
+        type Task @model {
+          taskid: ID! @primaryKey(sortKeyFields:["name"])
+          name: String!
+          description: String
+          todo: Todo @belongsTo
+        }
+      `;
+      const transformer = new GraphQLTransform({
+        featureFlags,
+        transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
+      });
+    
+      const out = transformer.transform(inputSchema);
+      expect(out).toBeDefined();
+      const schema = parse(out.schema);
+      validateModelSchema(schema);
+      const connectionFieldName1 = 'todoTasksTodoid';
+      const connectionFieldName2 = 'todoTasksName';
+      //Type definition
+      const objType = schema.definitions.find((def: any) => def.name && def.name.value === 'Task') as any;
+      expect(objType).toBeDefined();
+      const relatedField1 = objType.fields.find((f: any) => f.name.value === connectionFieldName1);
+      expect(relatedField1).toBeDefined();
+      expect(relatedField1.type.kind).toBe(Kind.NAMED_TYPE);
+      expect(relatedField1.type.name.value).toBe('ID');
+      const relatedField2 = objType.fields.find((f: any) => f.name.value === connectionFieldName2);
+      expect(relatedField2).toBeDefined();
+      expect(relatedField2.type.kind).toBe(Kind.NAMED_TYPE);
+      expect(relatedField2.type.name.value).toBe('String');
+      //Create Input
+      const createInput = schema.definitions.find((def: any) => def.name && def.name.value === 'CreateTaskInput') as any;
+      expect(createInput).toBeDefined();
+      expect(createInput.fields.length).toEqual(5);
+      const createInputConnectedField1 = createInput.fields.find((f: any) => f.name.value === connectionFieldName1);
+      expect(createInputConnectedField1).toBeDefined();
+      expect(createInputConnectedField1.type.kind).toBe(Kind.NAMED_TYPE);
+      expect(createInputConnectedField1.type.name.value).toBe('ID');
+      const createInputConnectedField2 = createInput.fields.find((f: any) => f.name.value === connectionFieldName2);
+      expect(createInputConnectedField2).toBeDefined();
+      expect(createInputConnectedField2.type.kind).toBe(Kind.NAMED_TYPE);
+      expect(createInputConnectedField2.type.name.value).toBe('String');
+      //Update Input
+      const updateInput = schema.definitions.find((def: any) => def.name && def.name.value === 'UpdateTaskInput') as any;
+      expect(updateInput).toBeDefined();
+      expect(updateInput.fields.length).toEqual(5);
+      const updateInputConnectedField1 = updateInput.fields.find((f: any) => f.name.value === connectionFieldName1);
+      expect(updateInputConnectedField1).toBeDefined();
+      expect(updateInputConnectedField1.type.kind).toBe(Kind.NAMED_TYPE);
+      expect(updateInputConnectedField1.type.name.value).toBe('ID');
+      const updateInputConnectedField2 = updateInput.fields.find((f: any) => f.name.value === connectionFieldName2);
+      expect(updateInputConnectedField2).toBeDefined();
+      expect(updateInputConnectedField2.type.kind).toBe(Kind.NAMED_TYPE);
+      expect(updateInputConnectedField2.type.name.value).toBe('String');
+    });
+  
+    test('Should generate non-nullable connection fields in type definition and create input while keeping nullable in update input when belongsTo field is non-nullable', () => {
+      const inputSchema = `
+        type Todo @model {
+          todoid: ID! @primaryKey(sortKeyFields:["name"])
+          name: String!
+          title: String!
+          priority: Int
+          tasks: [Task] @hasMany
+        }
+        type Task @model {
+          taskid: ID! @primaryKey(sortKeyFields:["name"])
+          name: String!
+          description: String
+          todo: Todo! @belongsTo
+        }
+      `;
+      const transformer = new GraphQLTransform({
+        featureFlags,
+        transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
+      });
+    
+      const out = transformer.transform(inputSchema);
+      expect(out).toBeDefined();
+      const schema = parse(out.schema);
+      validateModelSchema(schema);
+      const connectionFieldName1 = 'todoTasksTodoid';
+      const connectionFieldName2 = 'todoTasksName';
+      //Type definition
+      const objType = schema.definitions.find((def: any) => def.name && def.name.value === 'Task') as any;
+      expect(objType).toBeDefined();
+      const relatedField1 = objType.fields.find((f: any) => f.name.value === connectionFieldName1);
+      expect(relatedField1).toBeDefined();
+      expect(relatedField1.type.kind).toBe(Kind.NON_NULL_TYPE);
+      expect(relatedField1.type.type.name.value).toBe('ID');
+      const relatedField2 = objType.fields.find((f: any) => f.name.value === connectionFieldName2);
+      expect(relatedField2).toBeDefined();
+      expect(relatedField2.type.kind).toBe(Kind.NON_NULL_TYPE);
+      expect(relatedField2.type.type.name.value).toBe('String');
+      //Create Input
+      const createInput = schema.definitions.find((def: any) => def.name && def.name.value === 'CreateTaskInput') as any;
+      expect(createInput).toBeDefined();
+      expect(createInput.fields.length).toEqual(5);
+      const createInputConnectedField1 = createInput.fields.find((f: any) => f.name.value === connectionFieldName1);
+      expect(createInputConnectedField1).toBeDefined();
+      expect(createInputConnectedField1.type.kind).toBe(Kind.NON_NULL_TYPE);
+      expect(createInputConnectedField1.type.type.name.value).toBe('ID');
+      const createInputConnectedField2 = createInput.fields.find((f: any) => f.name.value === connectionFieldName2);
+      expect(createInputConnectedField2).toBeDefined();
+      expect(createInputConnectedField2.type.kind).toBe(Kind.NON_NULL_TYPE);
+      expect(createInputConnectedField2.type.type.name.value).toBe('String');
+      //Update Input
+      const updateInput = schema.definitions.find((def: any) => def.name && def.name.value === 'UpdateTaskInput') as any;
+      expect(updateInput).toBeDefined();
+      expect(updateInput.fields.length).toEqual(5);
+      const updateInputConnectedField1 = updateInput.fields.find((f: any) => f.name.value === connectionFieldName1);
+      expect(updateInputConnectedField1).toBeDefined();
+      expect(updateInputConnectedField1.type.kind).toBe(Kind.NAMED_TYPE);
+      expect(updateInputConnectedField1.type.name.value).toBe('ID');
+      const updateInputConnectedField2 = updateInput.fields.find((f: any) => f.name.value === connectionFieldName2);
+      expect(updateInputConnectedField2).toBeDefined();
+      expect(updateInputConnectedField2.type.kind).toBe(Kind.NAMED_TYPE);
+      expect(updateInputConnectedField2.type.name.value).toBe('String');
+    });
+  });
+ 
 });

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
@@ -863,7 +863,7 @@ describe('@hasMany connection field nullability tests', () => {
     getNumber: jest.fn(),
     getObject: jest.fn(),
   };
-  test('Should not affect the nullability of connection fields of the other side when the @hasMany field is non-nullable', () => {
+  test('Should not affect the nullability of connection fields of the other side update input when the @hasMany field is non-nullable', () => {
     const inputSchema = `
       type Todo @model {
         todoid: ID! @primaryKey(sortKeyFields:["name"])
@@ -894,24 +894,24 @@ describe('@hasMany connection field nullability tests', () => {
     expect(objType).toBeDefined();
     const relatedField1 = objType.fields.find((f: any) => f.name.value === connectionFieldName1);
     expect(relatedField1).toBeDefined();
-    expect(relatedField1.type.kind).toBe(Kind.NAMED_TYPE);
-    expect(relatedField1.type.name.value).toBe('ID');
+    expect(relatedField1.type.kind).toBe(Kind.NON_NULL_TYPE);
+    expect(relatedField1.type.type.name.value).toBe('ID');
     const relatedField2 = objType.fields.find((f: any) => f.name.value === connectionFieldName2);
     expect(relatedField2).toBeDefined();
-    expect(relatedField2.type.kind).toBe(Kind.NAMED_TYPE);
-    expect(relatedField2.type.name.value).toBe('String');
+    expect(relatedField2.type.kind).toBe(Kind.NON_NULL_TYPE);
+    expect(relatedField2.type.type.name.value).toBe('String');
     //Create Input
     const createInput = schema.definitions.find((def: any) => def.name && def.name.value === 'CreateTaskInput') as any;
     expect(createInput).toBeDefined();
     expect(createInput.fields.length).toEqual(5);
     const createInputConnectedField1 = createInput.fields.find((f: any) => f.name.value === connectionFieldName1);
     expect(createInputConnectedField1).toBeDefined();
-    expect(createInputConnectedField1.type.kind).toBe(Kind.NAMED_TYPE);
-    expect(createInputConnectedField1.type.name.value).toBe('ID');
+    expect(createInputConnectedField1.type.kind).toBe(Kind.NON_NULL_TYPE);
+    expect(createInputConnectedField1.type.type.name.value).toBe('ID');
     const createInputConnectedField2 = createInput.fields.find((f: any) => f.name.value === connectionFieldName2);
     expect(createInputConnectedField2).toBeDefined();
-    expect(createInputConnectedField2.type.kind).toBe(Kind.NAMED_TYPE);
-    expect(createInputConnectedField2.type.name.value).toBe('String');
+    expect(createInputConnectedField2.type.kind).toBe(Kind.NON_NULL_TYPE);
+    expect(createInputConnectedField2.type.type.name.value).toBe('String');
     //Update Input
     const updateInput = schema.definitions.find((def: any) => def.name && def.name.value === 'UpdateTaskInput') as any;
     expect(updateInput).toBeDefined();

--- a/packages/amplify-graphql-relational-transformer/src/schema.ts
+++ b/packages/amplify-graphql-relational-transformer/src/schema.ts
@@ -268,13 +268,9 @@ export const ensureHasManyConnectionField = (
   const relatedTypeObject = ctx.output.getType(relatedType.name.value) as ObjectTypeDefinitionNode;
   const connectionAttributeName = getConnectionAttributeName(ctx.featureFlags, object.name.value, field.name.value, connectionFieldName);
 
-  // The nullabilty of connection fields for hasMany depends on the other side belongsTo field
+  // The nullabilty of connection fields for hasMany depends on the hasMany field
   // Whereas in update input, they are always optional
-  const isConnectionFieldsNonNull = relatedTypeObject.fields?.some(field =>
-    getBaseType(field.type) === object.name.value
-    && field.directives?.some(d => d.name.value === 'belongsTo')
-    && isNonNullType(field.type)) ?? false;
-
+  const isConnectionFieldsNonNull = isNonNullType(field.type);
   const primaryKeyConnectionFieldType = getPrimaryKeyConnectionFieldType(ctx, primaryKeyField);
   if (relatedTypeObject) {
     updateTypeWithConnectionFields(

--- a/packages/amplify-graphql-relational-transformer/src/schema.ts
+++ b/packages/amplify-graphql-relational-transformer/src/schema.ts
@@ -641,7 +641,7 @@ const updateTypeWithConnectionFields = (
   primaryKeyConnectionFieldType: string,
   field: FieldDefinitionNode,
   sortKeyFields: FieldDefinitionNode[],
-  isConnectionFieldsNonNull: boolean = false,
+  isConnectionFieldsNonNull: boolean,
 ): void => {
   const updatedFields = [...targetObject.fields!];
   updatedFields.push(

--- a/packages/amplify-graphql-relational-transformer/src/schema.ts
+++ b/packages/amplify-graphql-relational-transformer/src/schema.ts
@@ -148,6 +148,9 @@ export const ensureHasOneConnectionField = (config: HasOneDirectiveConfiguration
   const sortKeyFields = getSortKeyFields(ctx, relatedType);
   const primaryKeyConnectionFieldType = getPrimaryKeyConnectionFieldType(ctx, primaryKeyField);
 
+  // The nullabilty of connection fields for hasOne depends on the hasOne field
+  // Whereas in update input, they are always optional
+  const isConnectionFieldsNonNull = isNonNullType(field.type);
   const typeObject = ctx.output.getType(object.name.value) as ObjectTypeDefinitionNode;
   if (typeObject) {
     updateTypeWithConnectionFields(
@@ -158,6 +161,7 @@ export const ensureHasOneConnectionField = (config: HasOneDirectiveConfiguration
       primaryKeyConnectionFieldType,
       field,
       sortKeyFields,
+      isConnectionFieldsNonNull,
     );
   }
 
@@ -165,7 +169,7 @@ export const ensureHasOneConnectionField = (config: HasOneDirectiveConfiguration
   const createInput = ctx.output.getType(createInputName) as InputObjectTypeDefinitionNode;
 
   if (createInput) {
-    updateInputWithConnectionFields(ctx, createInput, object, connectionAttributeName, primaryKeyConnectionFieldType, field, sortKeyFields);
+    updateInputWithConnectionFields(ctx, createInput, object, connectionAttributeName, primaryKeyConnectionFieldType, field, sortKeyFields, isConnectionFieldsNonNull);
   }
 
   const updateInputName = ModelResourceIDs.ModelUpdateInputObjectName(object.name.value);
@@ -262,6 +266,13 @@ export const ensureHasManyConnectionField = (
   const relatedTypeObject = ctx.output.getType(relatedType.name.value) as ObjectTypeDefinitionNode;
   const connectionAttributeName = getConnectionAttributeName(ctx.featureFlags, object.name.value, field.name.value, connectionFieldName);
 
+  // The nullabilty of connection fields for hasMany depends on the other side belongsTo field
+  // Whereas in update input, they are always optional
+  const isConnectionFieldsNonNull = relatedTypeObject.fields?.some(field =>
+    getBaseType(field.type) === object.name.value
+    && field.directives?.some(d => d.name.value === 'belongsTo')
+    && isNonNullType(field.type));
+
   const primaryKeyConnectionFieldType = getPrimaryKeyConnectionFieldType(ctx, primaryKeyField);
   if (relatedTypeObject) {
     updateTypeWithConnectionFields(
@@ -272,6 +283,7 @@ export const ensureHasManyConnectionField = (
       primaryKeyConnectionFieldType,
       field,
       sortKeyFields,
+      isConnectionFieldsNonNull,
     );
   }
 
@@ -279,7 +291,7 @@ export const ensureHasManyConnectionField = (
   const createInput = ctx.output.getType(createInputName) as InputObjectTypeDefinitionNode;
 
   if (createInput) {
-    updateInputWithConnectionFields(ctx, createInput, object, connectionAttributeName, primaryKeyConnectionFieldType, field, sortKeyFields);
+    updateInputWithConnectionFields(ctx, createInput, object, connectionAttributeName, primaryKeyConnectionFieldType, field, sortKeyFields, isConnectionFieldsNonNull);
   }
 
   const updateInputName = ModelResourceIDs.ModelUpdateInputObjectName(relatedType.name.value);
@@ -566,6 +578,7 @@ const updateInputWithConnectionFields = (
   primaryKeyConnectionFieldType: string,
   field: FieldDefinitionNode,
   sortKeyFields: FieldDefinitionNode[],
+  isConnectionFieldsNonNull: boolean = false,
 ): void => {
   const updatedFields = [...input.fields!];
   updatedFields.push(
@@ -573,14 +586,14 @@ const updateInputWithConnectionFields = (
       updatedFields,
       connectionAttributeName,
       primaryKeyConnectionFieldType,
-      isNonNullType(field.type),
+      isConnectionFieldsNonNull,
     ),
   );
   sortKeyFields.forEach(it => {
     updatedFields.push(...getInputFieldsWithConnectionField(updatedFields,
       getSortKeyConnectionAttributeName(object.name.value, field.name.value, it.name.value),
       getBaseType(it.type),
-      isNonNullType(field.type)));
+      isConnectionFieldsNonNull));
   });
   ctx.output.putType({
     ...input,
@@ -624,16 +637,17 @@ const updateTypeWithConnectionFields = (
   primaryKeyConnectionFieldType: string,
   field: FieldDefinitionNode,
   sortKeyFields: FieldDefinitionNode[],
+  isConnectionFieldsNonNull: boolean = false,
 ): void => {
   const updatedFields = [...targetObject.fields!];
   updatedFields.push(
-    ...getTypeFieldsWithConnectionField(updatedFields, connectionAttributeName, primaryKeyConnectionFieldType, isNonNullType(field.type)),
+    ...getTypeFieldsWithConnectionField(updatedFields, connectionAttributeName, primaryKeyConnectionFieldType, isConnectionFieldsNonNull),
   );
   sortKeyFields.forEach(it => {
     updatedFields.push(...getTypeFieldsWithConnectionField(updatedFields,
       getSortKeyConnectionAttributeName(object.name.value, field.name.value, it.name.value),
       getBaseType(it.type),
-      isNonNullType(field.type)));
+      isConnectionFieldsNonNull));
   });
   ctx.output.putType({
     ...targetObject,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Refactor the impact of non-nullable field with relation directive on the generated connection fields in object definition and input types.

- Connection fields(foreign keys) will always be nullable in the `UpdateInput` type, which is consistent to other non-nullable fields.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Fix https://github.com/aws-amplify/amplify-codegen/issues/461
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
