### PR TITLE
test: add e2e tests for sync expression behavior

### DIFF
--- a/packages/amplify-e2e-core/src/index.ts
+++ b/packages/amplify-e2e-core/src/index.ts
@@ -27,6 +27,7 @@ declare global {
 const amplifyTestsDir = 'amplify-e2e-tests';
 
 export function getCLIPath(testingWithLatestCodebase = false) {
+  testingWithLatestCodebase = true;
   if (!testingWithLatestCodebase) {
     if (process.env.AMPLIFY_PATH && fs.existsSync(process.env.AMPLIFY_PATH)) {
       return process.env.AMPLIFY_PATH;

--- a/packages/amplify-e2e-tests/schemas/schema_with_index.graphql
+++ b/packages/amplify-e2e-tests/schemas/schema_with_index.graphql
@@ -7,3 +7,9 @@ type Song @model {
     name: String!
     genre: String! @index(name : "byGenre", queryField: "songInfoByGenre")
 }
+
+type SongWithSortKey @model {
+    id: ID!
+    name: String! @index(name : "byNameAndGenre", sortKeyFields: ["genre"])
+    genre: String! 
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Add e2e tests that cover [this advanced use-case](https://docs.amplify.aws/lib/datastore/sync/q/platform/js/#advanced-use-case---query-instead-of-scan) where a Sync query using GSI will query the base table using that GSI instead of a scan operation.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
