### PR TITLE
feat(graphql): subscriptions rtf support

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
@@ -341,12 +341,15 @@ describe('schema generation directive tests', () => {
       expect(field?.directives?.find((d) => d.name.value === userPoolsDirectiveName)).toBeDefined();
     });
 
-    // Check that owner is required when only using owner auth rules
-    subscriptionType?.fields?.forEach((field) => {
-      expect(field.arguments).toHaveLength(1);
-      const arg: InputValueDefinitionNode = field.arguments![0];
-      expect(arg.name.value).toEqual('owner');
-      expect(arg.type.kind).toEqual(Kind.NAMED_TYPE);
+    // Check that owner argument is present when only using owner auth rules
+    subscriptionType?.fields?.forEach(field => {
+      expect(field.arguments).toHaveLength(2);
+      const ownerArg: InputValueDefinitionNode = field?.arguments![1];
+      expect(ownerArg.name.value).toEqual('owner');
+      expect(ownerArg.type.kind).toEqual(Kind.NAMED_TYPE);
+      const filterArg: InputValueDefinitionNode = field.arguments![0];
+      expect(filterArg.name.value).toEqual('filter');
+      expect(filterArg.type.kind).toEqual(Kind.NAMED_TYPE);
     });
 
     // Check that resolvers containing the authMode check block

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
@@ -153,9 +153,9 @@ describe('owner based @auth', () => {
     expect(out).toBeDefined();
 
     // expect 'postOwner' as an argument for subscription operations
-    expect(out.schema).toContain('onCreatePost(postOwner: String)');
-    expect(out.schema).toContain('onUpdatePost(postOwner: String)');
-    expect(out.schema).toContain('onDeletePost(postOwner: String)');
+    expect(out.schema).toContain('onCreatePost(filter: ModelSubscriptionPostFilterInput, postOwner: String)');
+    expect(out.schema).toContain('onUpdatePost(filter: ModelSubscriptionPostFilterInput, postOwner: String)');
+    expect(out.schema).toContain('onDeletePost(filter: ModelSubscriptionPostFilterInput, postOwner: String)');
 
     // expect logic in the resolvers to check for postOwner args as an allowed owner
     expect(out.resolvers['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
@@ -199,9 +199,9 @@ describe('owner based @auth', () => {
     expect(out).toBeDefined();
 
     // expect 'owner' and 'editors' as arguments for subscription operations
-    expect(out.schema).toContain('onCreatePost(owner: String, editor: String)');
-    expect(out.schema).toContain('onUpdatePost(owner: String, editor: String)');
-    expect(out.schema).toContain('onDeletePost(owner: String, editor: String)');
+    expect(out.schema).toContain('onCreatePost(filter: ModelSubscriptionPostFilterInput, owner: String, editor: String)');
+    expect(out.schema).toContain('onUpdatePost(filter: ModelSubscriptionPostFilterInput, owner: String, editor: String)');
+    expect(out.schema).toContain('onDeletePost(filter: ModelSubscriptionPostFilterInput, owner: String, editor: String)');
 
     // expect logic in the resolvers to check for owner args as an allowedOwner
     expect(out.resolvers['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
@@ -652,9 +652,9 @@ describe('owner based @auth', () => {
       expect(out).toBeDefined();
 
       // expect 'postOwner' as an argument for subscription operations
-      expect(out.schema).toContain('onCreatePost(postOwner: String)');
-      expect(out.schema).toContain('onUpdatePost(postOwner: String)');
-      expect(out.schema).toContain('onDeletePost(postOwner: String)');
+      expect(out.schema).toContain('onCreatePost(filter: ModelSubscriptionPostFilterInput, postOwner: String)');
+      expect(out.schema).toContain('onUpdatePost(filter: ModelSubscriptionPostFilterInput, postOwner: String)');
+      expect(out.schema).toContain('onDeletePost(filter: ModelSubscriptionPostFilterInput, postOwner: String)');
 
       // expect logic in the resolvers to check for postOwner args as an allowed owner
       expect(out.resolvers['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
@@ -700,9 +700,9 @@ describe('owner based @auth', () => {
       expect(out).toBeDefined();
 
       // expect 'owner' and 'editors' as arguments for subscription operations
-      expect(out.schema).toContain('onCreatePost(owner: String, editor: String)');
-      expect(out.schema).toContain('onUpdatePost(owner: String, editor: String)');
-      expect(out.schema).toContain('onDeletePost(owner: String, editor: String)');
+      expect(out.schema).toContain('onCreatePost(filter: ModelSubscriptionPostFilterInput, owner: String, editor: String)');
+      expect(out.schema).toContain('onUpdatePost(filter: ModelSubscriptionPostFilterInput, owner: String, editor: String)');
+      expect(out.schema).toContain('onDeletePost(filter: ModelSubscriptionPostFilterInput, owner: String, editor: String)');
 
       // expect logic in the resolvers to check for owner args as an allowedOwner
       expect(out.resolvers['Subscription.onCreatePost.auth.1.req.vtl']).toContain(

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -401,8 +401,8 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
       const subscriptionRoles = acm
         .getRolesPerOperation('listen')
         .map(role => this.roleMap.get(role)!)
-        // for subscriptions we only use static rules or owner rule where the field is not a list
-        .filter(roleDef => (roleDef.strategy === 'owner' && !fieldIsList(def.fields ?? [], roleDef.entity!)) || roleDef.static);
+        // for subscriptions we only use static rules or owner rule
+        .filter(roleDef => roleDef.strategy === 'owner' || roleDef.static);
       subscriptionFieldNames.forEach(subscription => {
         this.protectSubscriptionResolver(context, subscription.typeName, subscription.fieldName, subscriptionRoles);
       });

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/subscriptions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/subscriptions.ts
@@ -13,7 +13,12 @@ import {
   printBlock,
   or,
   and,
-  ifElse
+  ifElse,
+  comment,
+  forEach,
+  list,
+  qref,
+  raw
 } from 'graphql-mapping-template';
 import {
   COGNITO_AUTH_TYPE,
@@ -33,14 +38,19 @@ import {
   generateOwnerClaimExpression,
   generateOwnerClaimListExpression,
   generateOwnerMultiClaimExpression,
-  generateInvalidClaimsCondition
+  generateInvalidClaimsCondition,
+  getIdentityClaimExp,
+  getOwnerClaimReference
 } from './helpers';
 
 const dynamicRoleExpression = (roles: Array<RoleDefinition>): Array<Expression> => {
+  const dynamicExpression = new Array<Expression>();
   const ownerExpression = new Array<Expression>();
+  const groupExpression = new Array<Expression>();
   // we only check against owner rules which are not list fields
   roles.forEach((role, idx) => {
     if (role.strategy === 'owner') {
+      const ownerClaimRef = getOwnerClaimReference(role.claim!, `ownerClaim${idx}`);
       ownerExpression.push(
         generateOwnerClaimExpression(role.claim!, `ownerClaim${idx}`),
         iff(
@@ -48,6 +58,7 @@ const dynamicRoleExpression = (roles: Array<RoleDefinition>): Array<Expression> 
           compoundExpression([
             generateOwnerMultiClaimExpression(role.claim!, `ownerClaim${idx}`),
             generateOwnerClaimListExpression(role.claim!, `ownerClaimsList${idx}`),
+            qref(methodCall(ref('authOwnerRuntimeFilter.add'), raw(`{ "${role.entity}": { "${role.isEntityList ? 'contains' : 'eq'}": $${ownerClaimRef} } }`))),
             set(
               ref(`ownerEntity${idx}`),
               methodCall(ref('util.defaultIfNull'), ref(`ctx.args.${role.entity!}`), nul()),
@@ -71,11 +82,62 @@ const dynamicRoleExpression = (roles: Array<RoleDefinition>): Array<Expression> 
           ]),
         ),
       );
+    } else if (role.strategy === 'groups' && !role.static) {
+      // Loop through the cognito groups and set as runtime filter
+      groupExpression.push(
+        set(ref(`groupClaim${idx}`), getIdentityClaimExp(str(role.claim!), list([]))),
+        iff(
+          methodCall(ref('util.isString'), ref(`groupClaim${idx}`)),
+          ifElse(
+            methodCall(ref('util.isList'), methodCall(ref('util.parseJson'), ref(`groupClaim${idx}`))),
+            set(ref(`groupClaim${idx}`), methodCall(ref('util.parseJson'), ref(`groupClaim${idx}`))),
+            set(ref(`groupClaim${idx}`), list([ref(`groupClaim${idx}`)])),
+          ),
+        ),
+        forEach(ref('groupRole'), ref(`groupClaim${idx}`), [
+          qref(methodCall(ref('authGroupRuntimeFilter.add'), raw(`{ "${role.entity}": { "${role.isEntityList ? 'contains' : 'eq'}": $groupRole } }`))),
+        ]),
+      );
     }
   });
 
-  return [...(ownerExpression.length > 0 ? ownerExpression : [])];
+  dynamicExpression.push(
+    ...combineAuthExpressionAndFilter(ownerExpression, groupExpression),
+  );
+
+  return dynamicExpression;
 };
+
+const combineAuthExpressionAndFilter = (ownerExpression: Array<Expression>, groupExpression: Array<Expression>): Array<Expression> => [
+  set(ref('authRuntimeFilter'), list([])),
+  set(ref('authOwnerRuntimeFilter'), list([])),
+  set(ref('authGroupRuntimeFilter'), list([])),
+  ...(ownerExpression.length > 0 ? ownerExpression : []),
+  ...(groupExpression.length > 0 ? groupExpression : []),
+  comment('Apply dynamic roles auth if not previously authorized by static groups and owner argument'),
+  iff(
+    raw('$authOwnerRuntimeFilter.size() > 0'),
+    qref(methodCall(ref('authRuntimeFilter.addAll'), ref('authOwnerRuntimeFilter'))),
+  ),
+  iff(
+    raw('$authGroupRuntimeFilter.size() > 0'),
+    qref(methodCall(ref('authRuntimeFilter.addAll'), ref('authGroupRuntimeFilter'))),
+  ),
+  iff(
+    and([
+      not(ref(IS_AUTHORIZED_FLAG)),
+      raw('$authRuntimeFilter.size() > 0'),
+    ]),
+    compoundExpression([
+      ifElse(
+        methodCall(ref('util.isNullOrEmpty'), ref('ctx.args.filter')),
+        set(ref('ctx.args.filter'), raw('{ "or": $authRuntimeFilter }')),
+        set(ref('ctx.args.filter'), raw('{ "and": [ { "or": $authRuntimeFilter }, $ctx.args.filter ]}')),
+      ),
+      set(ref(IS_AUTHORIZED_FLAG), bool(true)),
+    ]),
+  ),
+];
 
 /**
  * Generates auth expressions for each auth type for Subscription requests

--- a/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
@@ -226,7 +226,7 @@ export const addSubscriptionArguments = (
   const subscriptionArgumentList = subscriptionRoles.map(role => makeInputValueDefinition(role.entity!, makeNamedType('String')));
   createField = {
     ...createField,
-    arguments: [...subscriptionArgumentList],
+    arguments: [...createField.arguments, ...subscriptionArgumentList],
   };
   subscription = {
     ...subscription,

--- a/packages/amplify-graphql-default-value-transformer/src/__tests__/__snapshots__/amplify-grapphql-default-value-transformer.test.ts.snap
+++ b/packages/amplify-graphql-default-value-transformer/src/__tests__/__snapshots__/amplify-grapphql-default-value-transformer.test.ts.snap
@@ -204,10 +204,17 @@ type Mutation {
   deleteTest(input: DeleteTestInput!, condition: ModelTestConditionInput): Test
 }
 
+input ModelSubscriptionTestFilterInput {
+  id: ModelSubscriptionIDInput
+  stringValue: ModelSubscriptionStringInput
+  and: [ModelSubscriptionTestFilterInput]
+  or: [ModelSubscriptionTestFilterInput]
+}
+
 type Subscription {
-  onCreateTest: Test @aws_subscribe(mutations: [\\"createTest\\"])
-  onUpdateTest: Test @aws_subscribe(mutations: [\\"updateTest\\"])
-  onDeleteTest: Test @aws_subscribe(mutations: [\\"deleteTest\\"])
+  onCreateTest(filter: ModelSubscriptionTestFilterInput): Test @aws_subscribe(mutations: [\\"createTest\\"])
+  onUpdateTest(filter: ModelSubscriptionTestFilterInput): Test @aws_subscribe(mutations: [\\"updateTest\\"])
+  onDeleteTest(filter: ModelSubscriptionTestFilterInput): Test @aws_subscribe(mutations: [\\"deleteTest\\"])
 }
 
 "
@@ -497,10 +504,31 @@ type Mutation {
   deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  stringValue: ModelSubscriptionStringInput
+  intVal: ModelSubscriptionIntInput
+  floatValue: ModelSubscriptionFloatInput
+  booleanValue: ModelSubscriptionBooleanInput
+  awsJsonValue: ModelSubscriptionStringInput
+  awsDateValue: ModelSubscriptionStringInput
+  awsTimestampValue: ModelSubscriptionIntInput
+  awsEmailValue: ModelSubscriptionStringInput
+  awsURLValue: ModelSubscriptionStringInput
+  awsPhoneValue: ModelSubscriptionStringInput
+  awsIPAddressValue1: ModelSubscriptionStringInput
+  awsIPAddressValue2: ModelSubscriptionStringInput
+  enumValue: ModelSubscriptionStringInput
+  awsTimeValue: ModelSubscriptionStringInput
+  awsDateTime: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
 }
 
 "

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
@@ -559,6 +559,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -574,6 +577,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -589,6 +595,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -1260,6 +1269,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1275,6 +1287,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1290,6 +1305,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -1814,6 +1832,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1829,6 +1850,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1844,6 +1868,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -2722,6 +2749,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2737,6 +2767,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2752,6 +2785,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -3905,6 +3941,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateItem.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -3920,6 +3959,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteItem.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -3935,6 +3977,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateItem.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -4645,6 +4690,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateSong.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -4660,6 +4708,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteSong.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -4675,6 +4726,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateSong.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -5385,6 +5439,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateSong.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5400,6 +5457,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteSong.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5415,6 +5475,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateSong.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -6243,6 +6306,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateItem.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -6258,6 +6324,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteItem.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateItem.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -6273,6 +6342,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateItem.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
@@ -607,6 +607,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -622,6 +625,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -637,6 +643,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -1193,6 +1202,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1208,6 +1220,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1223,6 +1238,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -1732,6 +1750,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1747,6 +1768,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1762,6 +1786,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -2318,6 +2345,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2333,6 +2363,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2348,6 +2381,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -2779,6 +2815,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2794,6 +2833,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2809,6 +2851,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -3365,6 +3410,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -3380,6 +3428,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateTest.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -3395,6 +3446,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateTest.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -211,13 +211,19 @@ type Mutation {
   deleteEmail(input: DeleteEmailInput!, condition: ModelEmailConditionInput): Email
 }
 
+input ModelSubscriptionTestFilterInput {
+  id: ModelSubscriptionIDInput
+  and: [ModelSubscriptionTestFilterInput]
+  or: [ModelSubscriptionTestFilterInput]
+}
+
 type Subscription {
-  onCreateTest: Test @aws_subscribe(mutations: [\\"createTest\\"])
-  onUpdateTest: Test @aws_subscribe(mutations: [\\"updateTest\\"])
-  onDeleteTest: Test @aws_subscribe(mutations: [\\"deleteTest\\"])
-  onCreateEmail: Email @aws_subscribe(mutations: [\\"createEmail\\"])
-  onUpdateEmail: Email @aws_subscribe(mutations: [\\"updateEmail\\"])
-  onDeleteEmail: Email @aws_subscribe(mutations: [\\"deleteEmail\\"])
+  onCreateTest(filter: ModelSubscriptionTestFilterInput): Test @aws_subscribe(mutations: [\\"createTest\\"])
+  onUpdateTest(filter: ModelSubscriptionTestFilterInput): Test @aws_subscribe(mutations: [\\"updateTest\\"])
+  onDeleteTest(filter: ModelSubscriptionTestFilterInput): Test @aws_subscribe(mutations: [\\"deleteTest\\"])
+  onCreateEmail(filter: ModelSubscriptionEmailFilterInput): Email @aws_subscribe(mutations: [\\"createEmail\\"])
+  onUpdateEmail(filter: ModelSubscriptionEmailFilterInput): Email @aws_subscribe(mutations: [\\"updateEmail\\"])
+  onDeleteEmail(filter: ModelSubscriptionEmailFilterInput): Email @aws_subscribe(mutations: [\\"deleteEmail\\"])
 }
 
 type ModelEmailConnection {
@@ -248,6 +254,12 @@ input UpdateEmailInput {
 
 input DeleteEmailInput {
   id: ID!
+}
+
+input ModelSubscriptionEmailFilterInput {
+  id: ModelSubscriptionIDInput
+  and: [ModelSubscriptionEmailFilterInput]
+  or: [ModelSubscriptionEmailFilterInput]
 }
 
 "
@@ -565,19 +577,30 @@ type Mutation {
   deleteComment(input: DeleteCommentInput!, condition: ModelCommentConditionInput): Comment
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionStringInput
+  updatedAt: ModelSubscriptionStringInput
+  appearsIn: ModelSubscriptionStringInput
+  episode: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
-  onCreateAuthor: Author @aws_subscribe(mutations: [\\"createAuthor\\"])
-  onUpdateAuthor: Author @aws_subscribe(mutations: [\\"updateAuthor\\"])
-  onDeleteAuthor: Author @aws_subscribe(mutations: [\\"deleteAuthor\\"])
-  onCreateRequire: Require @aws_subscribe(mutations: [\\"createRequire\\"])
-  onUpdateRequire: Require @aws_subscribe(mutations: [\\"updateRequire\\"])
-  onDeleteRequire: Require @aws_subscribe(mutations: [\\"deleteRequire\\"])
-  onCreateComment: Comment @aws_subscribe(mutations: [\\"createComment\\"])
-  onUpdateComment: Comment @aws_subscribe(mutations: [\\"updateComment\\"])
-  onDeleteComment: Comment @aws_subscribe(mutations: [\\"deleteComment\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreateAuthor(filter: ModelSubscriptionAuthorFilterInput): Author @aws_subscribe(mutations: [\\"createAuthor\\"])
+  onUpdateAuthor(filter: ModelSubscriptionAuthorFilterInput): Author @aws_subscribe(mutations: [\\"updateAuthor\\"])
+  onDeleteAuthor(filter: ModelSubscriptionAuthorFilterInput): Author @aws_subscribe(mutations: [\\"deleteAuthor\\"])
+  onCreateRequire(filter: ModelSubscriptionRequireFilterInput): Require @aws_subscribe(mutations: [\\"createRequire\\"])
+  onUpdateRequire(filter: ModelSubscriptionRequireFilterInput): Require @aws_subscribe(mutations: [\\"updateRequire\\"])
+  onDeleteRequire(filter: ModelSubscriptionRequireFilterInput): Require @aws_subscribe(mutations: [\\"deleteRequire\\"])
+  onCreateComment(filter: ModelSubscriptionCommentFilterInput): Comment @aws_subscribe(mutations: [\\"createComment\\"])
+  onUpdateComment(filter: ModelSubscriptionCommentFilterInput): Comment @aws_subscribe(mutations: [\\"updateComment\\"])
+  onDeleteComment(filter: ModelSubscriptionCommentFilterInput): Comment @aws_subscribe(mutations: [\\"deleteComment\\"])
 }
 
 type ModelAuthorConnection {
@@ -618,6 +641,13 @@ input DeleteAuthorInput {
   id: ID!
 }
 
+input ModelSubscriptionAuthorFilterInput {
+  id: ModelSubscriptionIDInput
+  name: ModelSubscriptionStringInput
+  and: [ModelSubscriptionAuthorFilterInput]
+  or: [ModelSubscriptionAuthorFilterInput]
+}
+
 type ModelRequireConnection {
   items: [Require]!
   nextToken: String
@@ -654,6 +684,14 @@ input UpdateRequireInput {
 
 input DeleteRequireInput {
   id: ID!
+}
+
+input ModelSubscriptionRequireFilterInput {
+  id: ModelSubscriptionIDInput
+  requiredField: ModelSubscriptionStringInput
+  notRequiredField: ModelSubscriptionStringInput
+  and: [ModelSubscriptionRequireFilterInput]
+  or: [ModelSubscriptionRequireFilterInput]
 }
 
 type ModelCommentConnection {
@@ -696,6 +734,15 @@ input UpdateCommentInput {
 
 input DeleteCommentInput {
   id: ID!
+}
+
+input ModelSubscriptionCommentFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  content: ModelSubscriptionStringInput
+  updatedOn: ModelSubscriptionIntInput
+  and: [ModelSubscriptionCommentFilterInput]
+  or: [ModelSubscriptionCommentFilterInput]
 }
 
 "
@@ -1199,6 +1246,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1214,6 +1264,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeletePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1229,6 +1282,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -1732,6 +1788,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1747,6 +1806,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeletePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1762,6 +1824,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -2265,6 +2330,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2280,6 +2348,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeletePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2295,6 +2366,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -2512,10 +2586,19 @@ type Mutation {
   deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  str: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionStringInput
+  updatedAt: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
 }
 
 "
@@ -3170,10 +3253,19 @@ type Mutation {
   deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  str: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionIntInput
+  updatedAt: ModelSubscriptionIntInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
 }
 
 "
@@ -3583,10 +3675,17 @@ type Mutation {
   deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  str: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
 }
 
 "
@@ -3998,10 +4097,17 @@ type Mutation {
   deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  str: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
 }
 
 "

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -1011,7 +1011,19 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
       case SubscriptionFieldType.ON_CREATE:
       case SubscriptionFieldType.ON_DELETE:
       case SubscriptionFieldType.ON_UPDATE:
-        return [];
+        const filterInputName = toPascalCase(['ModelSubscription', type.name.value, 'FilterInput']);
+        const filterInputs = createEnumModelFilters(ctx, type);
+        filterInputs.push(makeSubscriptionQueryFilterInput(ctx, filterInputName, type));
+        filterInputs.forEach(input => {
+          const conditionInputName = input.name.value;
+          if (!ctx.output.getType(conditionInputName)) {
+            ctx.output.addInput(input);
+          }
+        });
+
+        return [
+          makeInputValueDefinition('filter', makeNamedType(filterInputName)),
+        ];
 
       default:
         throw new Error('Unknown operation type');

--- a/packages/amplify-graphql-model-transformer/src/resolvers/subscriptions.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/subscriptions.ts
@@ -1,11 +1,24 @@
-import { compoundExpression, Expression, obj, printBlock, str, toJson, nul } from 'graphql-mapping-template';
-
+import {
+  compoundExpression, Expression, obj, printBlock, str, toJson, nul, iff, not, isNullOrEmpty, ref,
+} from 'graphql-mapping-template';
+/**
+ * Generates subscription request template
+ */
 export const generateSubscriptionRequestTemplate = (): string => {
   const statements: Expression[] = [toJson(obj({ version: str('2018-05-29'), payload: obj({}) }))];
   return printBlock('Subscription Request template')(compoundExpression(statements));
 };
 
+/**
+ * Generates subscription response template
+ */
 export const generateSubscriptionResponseTemplate = (): string => {
-  const statements: Expression[] = [toJson(nul())];
+  const statements: Expression[] = [
+    iff(
+      not(isNullOrEmpty(ref('ctx.args.filter'))),
+      ref('extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))'),
+    ),
+    toJson(nul()),
+  ];
   return printBlock('Subscription Response template')(compoundExpression(statements));
 };

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
@@ -7026,7 +7026,206 @@ Object {
       "directives": Array [],
       "fields": Array [
         Object {
-          "arguments": Array [],
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 4374,
+            "start": 4346,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 4348,
+              "start": 4346,
+            },
+            "value": "id",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 4374,
+              "start": 4350,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 4374,
+                "start": 4350,
+              },
+              "value": "ModelSubscriptionIDInput",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 4412,
+            "start": 4377,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 4382,
+              "start": 4377,
+            },
+            "value": "title",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 4412,
+              "start": 4384,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 4412,
+                "start": 4384,
+              },
+              "value": "ModelSubscriptionStringInput",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 4454,
+            "start": 4415,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 4418,
+              "start": 4415,
+            },
+            "value": "and",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 4454,
+              "start": 4420,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 4453,
+                "start": 4421,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 4453,
+                  "start": 4421,
+                },
+                "value": "ModelSubscriptionPostFilterInput",
+              },
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 4495,
+            "start": 4457,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 4459,
+              "start": 4457,
+            },
+            "value": "or",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 4495,
+              "start": 4461,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 4494,
+                "start": 4462,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 4494,
+                  "start": 4462,
+                },
+                "value": "ModelSubscriptionPostFilterInput",
+              },
+            },
+          },
+        },
+      ],
+      "kind": "InputObjectTypeDefinition",
+      "loc": Object {
+        "end": 4497,
+        "start": 4303,
+      },
+      "name": Object {
+        "kind": "Name",
+        "loc": Object {
+          "end": 4341,
+          "start": 4309,
+        },
+        "value": "ModelSubscriptionPostFilterInput",
+      },
+    },
+    Object {
+      "description": undefined,
+      "directives": Array [],
+      "fields": Array [
+        Object {
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 4574,
+                "start": 4534,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 4540,
+                  "start": 4534,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 4574,
+                  "start": 4542,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 4574,
+                    "start": 4542,
+                  },
+                  "value": "ModelSubscriptionPostFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -7034,30 +7233,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 4384,
-                    "start": 4359,
+                    "end": 4622,
+                    "start": 4597,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 4368,
-                      "start": 4359,
+                      "end": 4606,
+                      "start": 4597,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 4384,
-                      "start": 4370,
+                      "end": 4622,
+                      "start": 4608,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 4383,
-                          "start": 4371,
+                          "end": 4621,
+                          "start": 4609,
                         },
                         "value": "createPost",
                       },
@@ -7067,14 +7266,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 4385,
-                "start": 4344,
+                "end": 4623,
+                "start": 4582,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4358,
-                  "start": 4345,
+                  "end": 4596,
+                  "start": 4583,
                 },
                 "value": "aws_subscribe",
               },
@@ -7082,35 +7281,69 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4385,
-            "start": 4325,
+            "end": 4623,
+            "start": 4521,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4337,
-              "start": 4325,
+              "end": 4533,
+              "start": 4521,
             },
             "value": "onCreatePost",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4343,
-              "start": 4339,
+              "end": 4581,
+              "start": 4577,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4343,
-                "start": 4339,
+                "end": 4581,
+                "start": 4577,
               },
               "value": "Post",
             },
           },
         },
         Object {
-          "arguments": Array [],
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 4679,
+                "start": 4639,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 4645,
+                  "start": 4639,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 4679,
+                  "start": 4647,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 4679,
+                    "start": 4647,
+                  },
+                  "value": "ModelSubscriptionPostFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -7118,30 +7351,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 4447,
-                    "start": 4422,
+                    "end": 4727,
+                    "start": 4702,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 4431,
-                      "start": 4422,
+                      "end": 4711,
+                      "start": 4702,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 4447,
-                      "start": 4433,
+                      "end": 4727,
+                      "start": 4713,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 4446,
-                          "start": 4434,
+                          "end": 4726,
+                          "start": 4714,
                         },
                         "value": "updatePost",
                       },
@@ -7151,14 +7384,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 4448,
-                "start": 4407,
+                "end": 4728,
+                "start": 4687,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4421,
-                  "start": 4408,
+                  "end": 4701,
+                  "start": 4688,
                 },
                 "value": "aws_subscribe",
               },
@@ -7166,35 +7399,69 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4448,
-            "start": 4388,
+            "end": 4728,
+            "start": 4626,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4400,
-              "start": 4388,
+              "end": 4638,
+              "start": 4626,
             },
             "value": "onUpdatePost",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4406,
-              "start": 4402,
+              "end": 4686,
+              "start": 4682,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4406,
-                "start": 4402,
+                "end": 4686,
+                "start": 4682,
               },
               "value": "Post",
             },
           },
         },
         Object {
-          "arguments": Array [],
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 4784,
+                "start": 4744,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 4750,
+                  "start": 4744,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 4784,
+                  "start": 4752,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 4784,
+                    "start": 4752,
+                  },
+                  "value": "ModelSubscriptionPostFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -7202,30 +7469,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 4510,
-                    "start": 4485,
+                    "end": 4832,
+                    "start": 4807,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 4494,
-                      "start": 4485,
+                      "end": 4816,
+                      "start": 4807,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 4510,
-                      "start": 4496,
+                      "end": 4832,
+                      "start": 4818,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 4509,
-                          "start": 4497,
+                          "end": 4831,
+                          "start": 4819,
                         },
                         "value": "deletePost",
                       },
@@ -7235,14 +7502,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 4511,
-                "start": 4470,
+                "end": 4833,
+                "start": 4792,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4484,
-                  "start": 4471,
+                  "end": 4806,
+                  "start": 4793,
                 },
                 "value": "aws_subscribe",
               },
@@ -7250,35 +7517,69 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4511,
-            "start": 4451,
+            "end": 4833,
+            "start": 4731,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4463,
-              "start": 4451,
+              "end": 4743,
+              "start": 4731,
             },
             "value": "onDeletePost",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4469,
-              "start": 4465,
+              "end": 4791,
+              "start": 4787,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4469,
-                "start": 4465,
+                "end": 4791,
+                "start": 4787,
               },
               "value": "Post",
             },
           },
         },
         Object {
-          "arguments": Array [],
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 4901,
+                "start": 4855,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 4861,
+                  "start": 4855,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 4901,
+                  "start": 4863,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 4901,
+                    "start": 4863,
+                  },
+                  "value": "ModelSubscriptionPostEditorFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -7286,30 +7587,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 4591,
-                    "start": 4560,
+                    "end": 4961,
+                    "start": 4930,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 4569,
-                      "start": 4560,
+                      "end": 4939,
+                      "start": 4930,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 4591,
-                      "start": 4571,
+                      "end": 4961,
+                      "start": 4941,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 4590,
-                          "start": 4572,
+                          "end": 4960,
+                          "start": 4942,
                         },
                         "value": "createPostEditor",
                       },
@@ -7319,14 +7620,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 4592,
-                "start": 4545,
+                "end": 4962,
+                "start": 4915,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4559,
-                  "start": 4546,
+                  "end": 4929,
+                  "start": 4916,
                 },
                 "value": "aws_subscribe",
               },
@@ -7334,35 +7635,69 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4592,
-            "start": 4514,
+            "end": 4962,
+            "start": 4836,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4532,
-              "start": 4514,
+              "end": 4854,
+              "start": 4836,
             },
             "value": "onCreatePostEditor",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4544,
-              "start": 4534,
+              "end": 4914,
+              "start": 4904,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4544,
-                "start": 4534,
+                "end": 4914,
+                "start": 4904,
               },
               "value": "PostEditor",
             },
           },
         },
         Object {
-          "arguments": Array [],
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 5030,
+                "start": 4984,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 4990,
+                  "start": 4984,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 5030,
+                  "start": 4992,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 5030,
+                    "start": 4992,
+                  },
+                  "value": "ModelSubscriptionPostEditorFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -7370,30 +7705,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 4672,
-                    "start": 4641,
+                    "end": 5090,
+                    "start": 5059,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 4650,
-                      "start": 4641,
+                      "end": 5068,
+                      "start": 5059,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 4672,
-                      "start": 4652,
+                      "end": 5090,
+                      "start": 5070,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 4671,
-                          "start": 4653,
+                          "end": 5089,
+                          "start": 5071,
                         },
                         "value": "updatePostEditor",
                       },
@@ -7403,14 +7738,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 4673,
-                "start": 4626,
+                "end": 5091,
+                "start": 5044,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4640,
-                  "start": 4627,
+                  "end": 5058,
+                  "start": 5045,
                 },
                 "value": "aws_subscribe",
               },
@@ -7418,35 +7753,69 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4673,
-            "start": 4595,
+            "end": 5091,
+            "start": 4965,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4613,
-              "start": 4595,
+              "end": 4983,
+              "start": 4965,
             },
             "value": "onUpdatePostEditor",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4625,
-              "start": 4615,
+              "end": 5043,
+              "start": 5033,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4625,
-                "start": 4615,
+                "end": 5043,
+                "start": 5033,
               },
               "value": "PostEditor",
             },
           },
         },
         Object {
-          "arguments": Array [],
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 5159,
+                "start": 5113,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 5119,
+                  "start": 5113,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 5159,
+                  "start": 5121,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 5159,
+                    "start": 5121,
+                  },
+                  "value": "ModelSubscriptionPostEditorFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -7454,30 +7823,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 4753,
-                    "start": 4722,
+                    "end": 5219,
+                    "start": 5188,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 4731,
-                      "start": 4722,
+                      "end": 5197,
+                      "start": 5188,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 4753,
-                      "start": 4733,
+                      "end": 5219,
+                      "start": 5199,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 4752,
-                          "start": 4734,
+                          "end": 5218,
+                          "start": 5200,
                         },
                         "value": "deletePostEditor",
                       },
@@ -7487,14 +7856,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 4754,
-                "start": 4707,
+                "end": 5220,
+                "start": 5173,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4721,
-                  "start": 4708,
+                  "end": 5187,
+                  "start": 5174,
                 },
                 "value": "aws_subscribe",
               },
@@ -7502,35 +7871,69 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4754,
-            "start": 4676,
+            "end": 5220,
+            "start": 5094,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4694,
-              "start": 4676,
+              "end": 5112,
+              "start": 5094,
             },
             "value": "onDeletePostEditor",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4706,
-              "start": 4696,
+              "end": 5172,
+              "start": 5162,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4706,
-                "start": 4696,
+                "end": 5172,
+                "start": 5162,
               },
               "value": "PostEditor",
             },
           },
         },
         Object {
-          "arguments": Array [],
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 5276,
+                "start": 5236,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 5242,
+                  "start": 5236,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 5276,
+                  "start": 5244,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 5276,
+                    "start": 5244,
+                  },
+                  "value": "ModelSubscriptionUserFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -7538,30 +7941,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 4816,
-                    "start": 4791,
+                    "end": 5324,
+                    "start": 5299,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 4800,
-                      "start": 4791,
+                      "end": 5308,
+                      "start": 5299,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 4816,
-                      "start": 4802,
+                      "end": 5324,
+                      "start": 5310,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 4815,
-                          "start": 4803,
+                          "end": 5323,
+                          "start": 5311,
                         },
                         "value": "createUser",
                       },
@@ -7571,14 +7974,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 4817,
-                "start": 4776,
+                "end": 5325,
+                "start": 5284,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4790,
-                  "start": 4777,
+                  "end": 5298,
+                  "start": 5285,
                 },
                 "value": "aws_subscribe",
               },
@@ -7586,35 +7989,69 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4817,
-            "start": 4757,
+            "end": 5325,
+            "start": 5223,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4769,
-              "start": 4757,
+              "end": 5235,
+              "start": 5223,
             },
             "value": "onCreateUser",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4775,
-              "start": 4771,
+              "end": 5283,
+              "start": 5279,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4775,
-                "start": 4771,
+                "end": 5283,
+                "start": 5279,
               },
               "value": "User",
             },
           },
         },
         Object {
-          "arguments": Array [],
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 5381,
+                "start": 5341,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 5347,
+                  "start": 5341,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 5381,
+                  "start": 5349,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 5381,
+                    "start": 5349,
+                  },
+                  "value": "ModelSubscriptionUserFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -7622,30 +8059,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 4879,
-                    "start": 4854,
+                    "end": 5429,
+                    "start": 5404,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 4863,
-                      "start": 4854,
+                      "end": 5413,
+                      "start": 5404,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 4879,
-                      "start": 4865,
+                      "end": 5429,
+                      "start": 5415,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 4878,
-                          "start": 4866,
+                          "end": 5428,
+                          "start": 5416,
                         },
                         "value": "updateUser",
                       },
@@ -7655,14 +8092,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 4880,
-                "start": 4839,
+                "end": 5430,
+                "start": 5389,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4853,
-                  "start": 4840,
+                  "end": 5403,
+                  "start": 5390,
                 },
                 "value": "aws_subscribe",
               },
@@ -7670,35 +8107,69 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4880,
-            "start": 4820,
+            "end": 5430,
+            "start": 5328,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4832,
-              "start": 4820,
+              "end": 5340,
+              "start": 5328,
             },
             "value": "onUpdateUser",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4838,
-              "start": 4834,
+              "end": 5388,
+              "start": 5384,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4838,
-                "start": 4834,
+                "end": 5388,
+                "start": 5384,
               },
               "value": "User",
             },
           },
         },
         Object {
-          "arguments": Array [],
+          "arguments": Array [
+            Object {
+              "defaultValue": undefined,
+              "description": undefined,
+              "directives": Array [],
+              "kind": "InputValueDefinition",
+              "loc": Object {
+                "end": 5486,
+                "start": 5446,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 5452,
+                  "start": 5446,
+                },
+                "value": "filter",
+              },
+              "type": Object {
+                "kind": "NamedType",
+                "loc": Object {
+                  "end": 5486,
+                  "start": 5454,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 5486,
+                    "start": 5454,
+                  },
+                  "value": "ModelSubscriptionUserFilterInput",
+                },
+              },
+            },
+          ],
           "description": undefined,
           "directives": Array [
             Object {
@@ -7706,30 +8177,30 @@ Object {
                 Object {
                   "kind": "Argument",
                   "loc": Object {
-                    "end": 4942,
-                    "start": 4917,
+                    "end": 5534,
+                    "start": 5509,
                   },
                   "name": Object {
                     "kind": "Name",
                     "loc": Object {
-                      "end": 4926,
-                      "start": 4917,
+                      "end": 5518,
+                      "start": 5509,
                     },
                     "value": "mutations",
                   },
                   "value": Object {
                     "kind": "ListValue",
                     "loc": Object {
-                      "end": 4942,
-                      "start": 4928,
+                      "end": 5534,
+                      "start": 5520,
                     },
                     "values": Array [
                       Object {
                         "block": false,
                         "kind": "StringValue",
                         "loc": Object {
-                          "end": 4941,
-                          "start": 4929,
+                          "end": 5533,
+                          "start": 5521,
                         },
                         "value": "deleteUser",
                       },
@@ -7739,14 +8210,14 @@ Object {
               ],
               "kind": "Directive",
               "loc": Object {
-                "end": 4943,
-                "start": 4902,
+                "end": 5535,
+                "start": 5494,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 4916,
-                  "start": 4903,
+                  "end": 5508,
+                  "start": 5495,
                 },
                 "value": "aws_subscribe",
               },
@@ -7754,28 +8225,28 @@ Object {
           ],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 4943,
-            "start": 4883,
+            "end": 5535,
+            "start": 5433,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4895,
-              "start": 4883,
+              "end": 5445,
+              "start": 5433,
             },
             "value": "onDeleteUser",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 4901,
-              "start": 4897,
+              "end": 5493,
+              "start": 5489,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 4901,
-                "start": 4897,
+                "end": 5493,
+                "start": 5489,
               },
               "value": "User",
             },
@@ -7785,14 +8256,14 @@ Object {
       "interfaces": Array [],
       "kind": "ObjectTypeDefinition",
       "loc": Object {
-        "end": 4945,
-        "start": 4303,
+        "end": 5537,
+        "start": 4499,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4320,
-          "start": 4308,
+          "end": 4516,
+          "start": 4504,
         },
         "value": "Subscription",
       },
@@ -7807,28 +8278,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5007,
-            "start": 4987,
+            "end": 5599,
+            "start": 5579,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 4993,
-              "start": 4987,
+              "end": 5585,
+              "start": 5579,
             },
             "value": "postID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5007,
-              "start": 4995,
+              "end": 5599,
+              "start": 5587,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5007,
-                "start": 4995,
+                "end": 5599,
+                "start": 5587,
               },
               "value": "ModelIDInput",
             },
@@ -7840,28 +8311,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5032,
-            "start": 5010,
+            "end": 5624,
+            "start": 5602,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5018,
-              "start": 5010,
+              "end": 5610,
+              "start": 5602,
             },
             "value": "editorID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5032,
-              "start": 5020,
+              "end": 5624,
+              "start": 5612,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5032,
-                "start": 5020,
+                "end": 5624,
+                "start": 5612,
               },
               "value": "ModelIDInput",
             },
@@ -7873,34 +8344,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5071,
-            "start": 5035,
+            "end": 5663,
+            "start": 5627,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5038,
-              "start": 5035,
+              "end": 5630,
+              "start": 5627,
             },
             "value": "and",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 5071,
-              "start": 5040,
+              "end": 5663,
+              "start": 5632,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5070,
-                "start": 5041,
+                "end": 5662,
+                "start": 5633,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5070,
-                  "start": 5041,
+                  "end": 5662,
+                  "start": 5633,
                 },
                 "value": "ModelPostEditorConditionInput",
               },
@@ -7913,34 +8384,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5109,
-            "start": 5074,
+            "end": 5701,
+            "start": 5666,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5076,
-              "start": 5074,
+              "end": 5668,
+              "start": 5666,
             },
             "value": "or",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 5109,
-              "start": 5078,
+              "end": 5701,
+              "start": 5670,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5108,
-                "start": 5079,
+                "end": 5700,
+                "start": 5671,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5108,
-                  "start": 5079,
+                  "end": 5700,
+                  "start": 5671,
                 },
                 "value": "ModelPostEditorConditionInput",
               },
@@ -7953,28 +8424,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5146,
-            "start": 5112,
+            "end": 5738,
+            "start": 5704,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5115,
-              "start": 5112,
+              "end": 5707,
+              "start": 5704,
             },
             "value": "not",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5146,
-              "start": 5117,
+              "end": 5738,
+              "start": 5709,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5146,
-                "start": 5117,
+                "end": 5738,
+                "start": 5709,
               },
               "value": "ModelPostEditorConditionInput",
             },
@@ -7983,14 +8454,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5148,
-        "start": 4947,
+        "end": 5740,
+        "start": 5539,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 4982,
-          "start": 4953,
+          "end": 5574,
+          "start": 5545,
         },
         "value": "ModelPostEditorConditionInput",
       },
@@ -8005,28 +8476,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5188,
-            "start": 5182,
+            "end": 5780,
+            "start": 5774,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5184,
-              "start": 5182,
+              "end": 5776,
+              "start": 5774,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5188,
-              "start": 5186,
+              "end": 5780,
+              "start": 5778,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5188,
-                "start": 5186,
+                "end": 5780,
+                "start": 5778,
               },
               "value": "ID",
             },
@@ -8038,34 +8509,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5202,
-            "start": 5191,
+            "end": 5794,
+            "start": 5783,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5197,
-              "start": 5191,
+              "end": 5789,
+              "start": 5783,
             },
             "value": "postID",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 5202,
-              "start": 5199,
+              "end": 5794,
+              "start": 5791,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5201,
-                "start": 5199,
+                "end": 5793,
+                "start": 5791,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5201,
-                  "start": 5199,
+                  "end": 5793,
+                  "start": 5791,
                 },
                 "value": "ID",
               },
@@ -8078,34 +8549,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5218,
-            "start": 5205,
+            "end": 5810,
+            "start": 5797,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5213,
-              "start": 5205,
+              "end": 5805,
+              "start": 5797,
             },
             "value": "editorID",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 5218,
-              "start": 5215,
+              "end": 5810,
+              "start": 5807,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5217,
-                "start": 5215,
+                "end": 5809,
+                "start": 5807,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5217,
-                  "start": 5215,
+                  "end": 5809,
+                  "start": 5807,
                 },
                 "value": "ID",
               },
@@ -8115,14 +8586,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5220,
-        "start": 5150,
+        "end": 5812,
+        "start": 5742,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5177,
-          "start": 5156,
+          "end": 5769,
+          "start": 5748,
         },
         "value": "CreatePostEditorInput",
       },
@@ -8137,34 +8608,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5261,
-            "start": 5254,
+            "end": 5853,
+            "start": 5846,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5256,
-              "start": 5254,
+              "end": 5848,
+              "start": 5846,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 5261,
-              "start": 5258,
+              "end": 5853,
+              "start": 5850,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5260,
-                "start": 5258,
+                "end": 5852,
+                "start": 5850,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5260,
-                  "start": 5258,
+                  "end": 5852,
+                  "start": 5850,
                 },
                 "value": "ID",
               },
@@ -8177,28 +8648,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5274,
-            "start": 5264,
+            "end": 5866,
+            "start": 5856,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5270,
-              "start": 5264,
+              "end": 5862,
+              "start": 5856,
             },
             "value": "postID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5274,
-              "start": 5272,
+              "end": 5866,
+              "start": 5864,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5274,
-                "start": 5272,
+                "end": 5866,
+                "start": 5864,
               },
               "value": "ID",
             },
@@ -8210,28 +8681,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5289,
-            "start": 5277,
+            "end": 5881,
+            "start": 5869,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5285,
-              "start": 5277,
+              "end": 5877,
+              "start": 5869,
             },
             "value": "editorID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5289,
-              "start": 5287,
+              "end": 5881,
+              "start": 5879,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5289,
-                "start": 5287,
+                "end": 5881,
+                "start": 5879,
               },
               "value": "ID",
             },
@@ -8240,14 +8711,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5291,
-        "start": 5222,
+        "end": 5883,
+        "start": 5814,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5249,
-          "start": 5228,
+          "end": 5841,
+          "start": 5820,
         },
         "value": "UpdatePostEditorInput",
       },
@@ -8262,34 +8733,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5332,
-            "start": 5325,
+            "end": 5924,
+            "start": 5917,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5327,
-              "start": 5325,
+              "end": 5919,
+              "start": 5917,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 5332,
-              "start": 5329,
+              "end": 5924,
+              "start": 5921,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5331,
-                "start": 5329,
+                "end": 5923,
+                "start": 5921,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5331,
-                  "start": 5329,
+                  "end": 5923,
+                  "start": 5921,
                 },
                 "value": "ID",
               },
@@ -8299,16 +8770,214 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5334,
-        "start": 5293,
+        "end": 5926,
+        "start": 5885,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5320,
-          "start": 5299,
+          "end": 5912,
+          "start": 5891,
         },
         "value": "DeletePostEditorInput",
+      },
+    },
+    Object {
+      "description": undefined,
+      "directives": Array [],
+      "fields": Array [
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6005,
+            "start": 5977,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 5979,
+              "start": 5977,
+            },
+            "value": "id",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 6005,
+              "start": 5981,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 6005,
+                "start": 5981,
+              },
+              "value": "ModelSubscriptionIDInput",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6040,
+            "start": 6008,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 6014,
+              "start": 6008,
+            },
+            "value": "postID",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 6040,
+              "start": 6016,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 6040,
+                "start": 6016,
+              },
+              "value": "ModelSubscriptionIDInput",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6077,
+            "start": 6043,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 6051,
+              "start": 6043,
+            },
+            "value": "editorID",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 6077,
+              "start": 6053,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 6077,
+                "start": 6053,
+              },
+              "value": "ModelSubscriptionIDInput",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6125,
+            "start": 6080,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 6083,
+              "start": 6080,
+            },
+            "value": "and",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 6125,
+              "start": 6085,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 6124,
+                "start": 6086,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 6124,
+                  "start": 6086,
+                },
+                "value": "ModelSubscriptionPostEditorFilterInput",
+              },
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6172,
+            "start": 6128,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 6130,
+              "start": 6128,
+            },
+            "value": "or",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 6172,
+              "start": 6132,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 6171,
+                "start": 6133,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 6171,
+                  "start": 6133,
+                },
+                "value": "ModelSubscriptionPostEditorFilterInput",
+              },
+            },
+          },
+        },
+      ],
+      "kind": "InputObjectTypeDefinition",
+      "loc": Object {
+        "end": 6174,
+        "start": 5928,
+      },
+      "name": Object {
+        "kind": "Name",
+        "loc": Object {
+          "end": 5972,
+          "start": 5934,
+        },
+        "value": "ModelSubscriptionPostEditorFilterInput",
       },
     },
     Object {
@@ -8321,40 +8990,40 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 5379,
-            "start": 5365,
+            "end": 6219,
+            "start": 6205,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5370,
-              "start": 5365,
+              "end": 6210,
+              "start": 6205,
             },
             "value": "items",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 5379,
-              "start": 5372,
+              "end": 6219,
+              "start": 6212,
             },
             "type": Object {
               "kind": "ListType",
               "loc": Object {
-                "end": 5378,
-                "start": 5372,
+                "end": 6218,
+                "start": 6212,
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 5377,
-                  "start": 5373,
+                  "end": 6217,
+                  "start": 6213,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 5377,
-                    "start": 5373,
+                    "end": 6217,
+                    "start": 6213,
                   },
                   "value": "User",
                 },
@@ -8368,28 +9037,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 5399,
-            "start": 5382,
+            "end": 6239,
+            "start": 6222,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5391,
-              "start": 5382,
+              "end": 6231,
+              "start": 6222,
             },
             "value": "nextToken",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5399,
-              "start": 5393,
+              "end": 6239,
+              "start": 6233,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5399,
-                "start": 5393,
+                "end": 6239,
+                "start": 6233,
               },
               "value": "String",
             },
@@ -8399,14 +9068,14 @@ Object {
       "interfaces": Array [],
       "kind": "ObjectTypeDefinition",
       "loc": Object {
-        "end": 5401,
-        "start": 5336,
+        "end": 6241,
+        "start": 6176,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5360,
-          "start": 5341,
+          "end": 6200,
+          "start": 6181,
         },
         "value": "ModelUserConnection",
       },
@@ -8421,28 +9090,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5450,
-            "start": 5434,
+            "end": 6290,
+            "start": 6274,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5436,
-              "start": 5434,
+              "end": 6276,
+              "start": 6274,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5450,
-              "start": 5438,
+              "end": 6290,
+              "start": 6278,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5450,
-                "start": 5438,
+                "end": 6290,
+                "start": 6278,
               },
               "value": "ModelIDInput",
             },
@@ -8454,28 +9123,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5479,
-            "start": 5453,
+            "end": 6319,
+            "start": 6293,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5461,
-              "start": 5453,
+              "end": 6301,
+              "start": 6293,
             },
             "value": "username",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5479,
-              "start": 5463,
+              "end": 6319,
+              "start": 6303,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5479,
-                "start": 5463,
+                "end": 6319,
+                "start": 6303,
               },
               "value": "ModelStringInput",
             },
@@ -8487,34 +9156,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5509,
-            "start": 5482,
+            "end": 6349,
+            "start": 6322,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5485,
-              "start": 5482,
+              "end": 6325,
+              "start": 6322,
             },
             "value": "and",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 5509,
-              "start": 5487,
+              "end": 6349,
+              "start": 6327,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5508,
-                "start": 5488,
+                "end": 6348,
+                "start": 6328,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5508,
-                  "start": 5488,
+                  "end": 6348,
+                  "start": 6328,
                 },
                 "value": "ModelUserFilterInput",
               },
@@ -8527,34 +9196,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5538,
-            "start": 5512,
+            "end": 6378,
+            "start": 6352,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5514,
-              "start": 5512,
+              "end": 6354,
+              "start": 6352,
             },
             "value": "or",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 5538,
-              "start": 5516,
+              "end": 6378,
+              "start": 6356,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5537,
-                "start": 5517,
+                "end": 6377,
+                "start": 6357,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5537,
-                  "start": 5517,
+                  "end": 6377,
+                  "start": 6357,
                 },
                 "value": "ModelUserFilterInput",
               },
@@ -8567,28 +9236,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5566,
-            "start": 5541,
+            "end": 6406,
+            "start": 6381,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5544,
-              "start": 5541,
+              "end": 6384,
+              "start": 6381,
             },
             "value": "not",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5566,
-              "start": 5546,
+              "end": 6406,
+              "start": 6386,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5566,
-                "start": 5546,
+                "end": 6406,
+                "start": 6386,
               },
               "value": "ModelUserFilterInput",
             },
@@ -8597,14 +9266,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5568,
-        "start": 5403,
+        "end": 6408,
+        "start": 6243,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5429,
-          "start": 5409,
+          "end": 6269,
+          "start": 6249,
         },
         "value": "ModelUserFilterInput",
       },
@@ -8619,28 +9288,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5630,
-            "start": 5604,
+            "end": 6470,
+            "start": 6444,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5612,
-              "start": 5604,
+              "end": 6452,
+              "start": 6444,
             },
             "value": "username",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5630,
-              "start": 5614,
+              "end": 6470,
+              "start": 6454,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5630,
-                "start": 5614,
+                "end": 6470,
+                "start": 6454,
               },
               "value": "ModelStringInput",
             },
@@ -8652,34 +9321,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5663,
-            "start": 5633,
+            "end": 6503,
+            "start": 6473,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5636,
-              "start": 5633,
+              "end": 6476,
+              "start": 6473,
             },
             "value": "and",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 5663,
-              "start": 5638,
+              "end": 6503,
+              "start": 6478,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5662,
-                "start": 5639,
+                "end": 6502,
+                "start": 6479,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5662,
-                  "start": 5639,
+                  "end": 6502,
+                  "start": 6479,
                 },
                 "value": "ModelUserConditionInput",
               },
@@ -8692,34 +9361,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5695,
-            "start": 5666,
+            "end": 6535,
+            "start": 6506,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5668,
-              "start": 5666,
+              "end": 6508,
+              "start": 6506,
             },
             "value": "or",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 5695,
-              "start": 5670,
+              "end": 6535,
+              "start": 6510,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5694,
-                "start": 5671,
+                "end": 6534,
+                "start": 6511,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5694,
-                  "start": 5671,
+                  "end": 6534,
+                  "start": 6511,
                 },
                 "value": "ModelUserConditionInput",
               },
@@ -8732,28 +9401,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5726,
-            "start": 5698,
+            "end": 6566,
+            "start": 6538,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5701,
-              "start": 5698,
+              "end": 6541,
+              "start": 6538,
             },
             "value": "not",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5726,
-              "start": 5703,
+              "end": 6566,
+              "start": 6543,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5726,
-                "start": 5703,
+                "end": 6566,
+                "start": 6543,
               },
               "value": "ModelUserConditionInput",
             },
@@ -8762,14 +9431,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5728,
-        "start": 5570,
+        "end": 6568,
+        "start": 6410,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5599,
-          "start": 5576,
+          "end": 6439,
+          "start": 6416,
         },
         "value": "ModelUserConditionInput",
       },
@@ -8784,28 +9453,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5762,
-            "start": 5756,
+            "end": 6602,
+            "start": 6596,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5758,
-              "start": 5756,
+              "end": 6598,
+              "start": 6596,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5762,
-              "start": 5760,
+              "end": 6602,
+              "start": 6600,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5762,
-                "start": 5760,
+                "end": 6602,
+                "start": 6600,
               },
               "value": "ID",
             },
@@ -8817,34 +9486,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5782,
-            "start": 5765,
+            "end": 6622,
+            "start": 6605,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5773,
-              "start": 5765,
+              "end": 6613,
+              "start": 6605,
             },
             "value": "username",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 5782,
-              "start": 5775,
+              "end": 6622,
+              "start": 6615,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5781,
-                "start": 5775,
+                "end": 6621,
+                "start": 6615,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5781,
-                  "start": 5775,
+                  "end": 6621,
+                  "start": 6615,
                 },
                 "value": "String",
               },
@@ -8854,14 +9523,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5784,
-        "start": 5730,
+        "end": 6624,
+        "start": 6570,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5751,
-          "start": 5736,
+          "end": 6591,
+          "start": 6576,
         },
         "value": "CreateUserInput",
       },
@@ -8876,34 +9545,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5819,
-            "start": 5812,
+            "end": 6659,
+            "start": 6652,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5814,
-              "start": 5812,
+              "end": 6654,
+              "start": 6652,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 5819,
-              "start": 5816,
+              "end": 6659,
+              "start": 6656,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5818,
-                "start": 5816,
+                "end": 6658,
+                "start": 6656,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5818,
-                  "start": 5816,
+                  "end": 6658,
+                  "start": 6656,
                 },
                 "value": "ID",
               },
@@ -8916,28 +9585,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5838,
-            "start": 5822,
+            "end": 6678,
+            "start": 6662,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5830,
-              "start": 5822,
+              "end": 6670,
+              "start": 6662,
             },
             "value": "username",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5838,
-              "start": 5832,
+              "end": 6678,
+              "start": 6672,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5838,
-                "start": 5832,
+                "end": 6678,
+                "start": 6672,
               },
               "value": "String",
             },
@@ -8946,14 +9615,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5840,
-        "start": 5786,
+        "end": 6680,
+        "start": 6626,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5807,
-          "start": 5792,
+          "end": 6647,
+          "start": 6632,
         },
         "value": "UpdateUserInput",
       },
@@ -8968,34 +9637,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5875,
-            "start": 5868,
+            "end": 6715,
+            "start": 6708,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5870,
-              "start": 5868,
+              "end": 6710,
+              "start": 6708,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 5875,
-              "start": 5872,
+              "end": 6715,
+              "start": 6712,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5874,
-                "start": 5872,
+                "end": 6714,
+                "start": 6712,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5874,
-                  "start": 5872,
+                  "end": 6714,
+                  "start": 6712,
                 },
                 "value": "ID",
               },
@@ -9005,14 +9674,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5877,
-        "start": 5842,
+        "end": 6717,
+        "start": 6682,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5863,
-          "start": 5848,
+          "end": 6703,
+          "start": 6688,
         },
         "value": "DeleteUserInput",
       },
@@ -9027,28 +9696,193 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5920,
-            "start": 5914,
+            "end": 6790,
+            "start": 6762,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5916,
-              "start": 5914,
+              "end": 6764,
+              "start": 6762,
+            },
+            "value": "id",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 6790,
+              "start": 6766,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 6790,
+                "start": 6766,
+              },
+              "value": "ModelSubscriptionIDInput",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6831,
+            "start": 6793,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 6801,
+              "start": 6793,
+            },
+            "value": "username",
+          },
+          "type": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 6831,
+              "start": 6803,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 6831,
+                "start": 6803,
+              },
+              "value": "ModelSubscriptionStringInput",
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6873,
+            "start": 6834,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 6837,
+              "start": 6834,
+            },
+            "value": "and",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 6873,
+              "start": 6839,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 6872,
+                "start": 6840,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 6872,
+                  "start": 6840,
+                },
+                "value": "ModelSubscriptionUserFilterInput",
+              },
+            },
+          },
+        },
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6914,
+            "start": 6876,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 6878,
+              "start": 6876,
+            },
+            "value": "or",
+          },
+          "type": Object {
+            "kind": "ListType",
+            "loc": Object {
+              "end": 6914,
+              "start": 6880,
+            },
+            "type": Object {
+              "kind": "NamedType",
+              "loc": Object {
+                "end": 6913,
+                "start": 6881,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 6913,
+                  "start": 6881,
+                },
+                "value": "ModelSubscriptionUserFilterInput",
+              },
+            },
+          },
+        },
+      ],
+      "kind": "InputObjectTypeDefinition",
+      "loc": Object {
+        "end": 6916,
+        "start": 6719,
+      },
+      "name": Object {
+        "kind": "Name",
+        "loc": Object {
+          "end": 6757,
+          "start": 6725,
+        },
+        "value": "ModelSubscriptionUserFilterInput",
+      },
+    },
+    Object {
+      "description": undefined,
+      "directives": Array [],
+      "fields": Array [
+        Object {
+          "defaultValue": undefined,
+          "description": undefined,
+          "directives": Array [],
+          "kind": "InputValueDefinition",
+          "loc": Object {
+            "end": 6959,
+            "start": 6953,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 6955,
+              "start": 6953,
             },
             "value": "eq",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5920,
-              "start": 5918,
+              "end": 6959,
+              "start": 6957,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5920,
-                "start": 5918,
+                "end": 6959,
+                "start": 6957,
               },
               "value": "ID",
             },
@@ -9060,28 +9894,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5929,
-            "start": 5923,
+            "end": 6968,
+            "start": 6962,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5925,
-              "start": 5923,
+              "end": 6964,
+              "start": 6962,
             },
             "value": "le",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5929,
-              "start": 5927,
+              "end": 6968,
+              "start": 6966,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5929,
-                "start": 5927,
+                "end": 6968,
+                "start": 6966,
               },
               "value": "ID",
             },
@@ -9093,28 +9927,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5938,
-            "start": 5932,
+            "end": 6977,
+            "start": 6971,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5934,
-              "start": 5932,
+              "end": 6973,
+              "start": 6971,
             },
             "value": "lt",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5938,
-              "start": 5936,
+              "end": 6977,
+              "start": 6975,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5938,
-                "start": 5936,
+                "end": 6977,
+                "start": 6975,
               },
               "value": "ID",
             },
@@ -9126,28 +9960,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5947,
-            "start": 5941,
+            "end": 6986,
+            "start": 6980,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5943,
-              "start": 5941,
+              "end": 6982,
+              "start": 6980,
             },
             "value": "ge",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5947,
-              "start": 5945,
+              "end": 6986,
+              "start": 6984,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5947,
-                "start": 5945,
+                "end": 6986,
+                "start": 6984,
               },
               "value": "ID",
             },
@@ -9159,28 +9993,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5956,
-            "start": 5950,
+            "end": 6995,
+            "start": 6989,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5952,
-              "start": 5950,
+              "end": 6991,
+              "start": 6989,
             },
             "value": "gt",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5956,
-              "start": 5954,
+              "end": 6995,
+              "start": 6993,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5956,
-                "start": 5954,
+                "end": 6995,
+                "start": 6993,
               },
               "value": "ID",
             },
@@ -9192,34 +10026,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5972,
-            "start": 5959,
+            "end": 7011,
+            "start": 6998,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5966,
-              "start": 5959,
+              "end": 7005,
+              "start": 6998,
             },
             "value": "between",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 5972,
-              "start": 5968,
+              "end": 7011,
+              "start": 7007,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 5971,
-                "start": 5969,
+                "end": 7010,
+                "start": 7008,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 5971,
-                  "start": 5969,
+                  "end": 7010,
+                  "start": 7008,
                 },
                 "value": "ID",
               },
@@ -9232,28 +10066,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 5989,
-            "start": 5975,
+            "end": 7028,
+            "start": 7014,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 5985,
-              "start": 5975,
+              "end": 7024,
+              "start": 7014,
             },
             "value": "beginsWith",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 5989,
-              "start": 5987,
+              "end": 7028,
+              "start": 7026,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 5989,
-                "start": 5987,
+                "end": 7028,
+                "start": 7026,
               },
               "value": "ID",
             },
@@ -9262,14 +10096,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 5991,
-        "start": 5879,
+        "end": 7030,
+        "start": 6918,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 5909,
-          "start": 5885,
+          "end": 6948,
+          "start": 6924,
         },
         "value": "ModelIDKeyConditionInput",
       },
@@ -9284,40 +10118,40 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 6048,
-            "start": 6028,
+            "end": 7087,
+            "start": 7067,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 6033,
-              "start": 6028,
+              "end": 7072,
+              "start": 7067,
             },
             "value": "items",
           },
           "type": Object {
             "kind": "NonNullType",
             "loc": Object {
-              "end": 6048,
-              "start": 6035,
+              "end": 7087,
+              "start": 7074,
             },
             "type": Object {
               "kind": "ListType",
               "loc": Object {
-                "end": 6047,
-                "start": 6035,
+                "end": 7086,
+                "start": 7074,
               },
               "type": Object {
                 "kind": "NamedType",
                 "loc": Object {
-                  "end": 6046,
-                  "start": 6036,
+                  "end": 7085,
+                  "start": 7075,
                 },
                 "name": Object {
                   "kind": "Name",
                   "loc": Object {
-                    "end": 6046,
-                    "start": 6036,
+                    "end": 7085,
+                    "start": 7075,
                   },
                   "value": "PostEditor",
                 },
@@ -9331,28 +10165,28 @@ Object {
           "directives": Array [],
           "kind": "FieldDefinition",
           "loc": Object {
-            "end": 6068,
-            "start": 6051,
+            "end": 7107,
+            "start": 7090,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 6060,
-              "start": 6051,
+              "end": 7099,
+              "start": 7090,
             },
             "value": "nextToken",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 6068,
-              "start": 6062,
+              "end": 7107,
+              "start": 7101,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 6068,
-                "start": 6062,
+                "end": 7107,
+                "start": 7101,
               },
               "value": "String",
             },
@@ -9362,14 +10196,14 @@ Object {
       "interfaces": Array [],
       "kind": "ObjectTypeDefinition",
       "loc": Object {
-        "end": 6070,
-        "start": 5993,
+        "end": 7109,
+        "start": 7032,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 6023,
-          "start": 5998,
+          "end": 7062,
+          "start": 7037,
         },
         "value": "ModelPostEditorConnection",
       },
@@ -9384,28 +10218,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 6125,
-            "start": 6109,
+            "end": 7164,
+            "start": 7148,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 6111,
-              "start": 6109,
+              "end": 7150,
+              "start": 7148,
             },
             "value": "id",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 6125,
-              "start": 6113,
+              "end": 7164,
+              "start": 7152,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 6125,
-                "start": 6113,
+                "end": 7164,
+                "start": 7152,
               },
               "value": "ModelIDInput",
             },
@@ -9417,28 +10251,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 6148,
-            "start": 6128,
+            "end": 7187,
+            "start": 7167,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 6134,
-              "start": 6128,
+              "end": 7173,
+              "start": 7167,
             },
             "value": "postID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 6148,
-              "start": 6136,
+              "end": 7187,
+              "start": 7175,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 6148,
-                "start": 6136,
+                "end": 7187,
+                "start": 7175,
               },
               "value": "ModelIDInput",
             },
@@ -9450,28 +10284,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 6173,
-            "start": 6151,
+            "end": 7212,
+            "start": 7190,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 6159,
-              "start": 6151,
+              "end": 7198,
+              "start": 7190,
             },
             "value": "editorID",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 6173,
-              "start": 6161,
+              "end": 7212,
+              "start": 7200,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 6173,
-                "start": 6161,
+                "end": 7212,
+                "start": 7200,
               },
               "value": "ModelIDInput",
             },
@@ -9483,34 +10317,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 6209,
-            "start": 6176,
+            "end": 7248,
+            "start": 7215,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 6179,
-              "start": 6176,
+              "end": 7218,
+              "start": 7215,
             },
             "value": "and",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 6209,
-              "start": 6181,
+              "end": 7248,
+              "start": 7220,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 6208,
-                "start": 6182,
+                "end": 7247,
+                "start": 7221,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 6208,
-                  "start": 6182,
+                  "end": 7247,
+                  "start": 7221,
                 },
                 "value": "ModelPostEditorFilterInput",
               },
@@ -9523,34 +10357,34 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 6244,
-            "start": 6212,
+            "end": 7283,
+            "start": 7251,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 6214,
-              "start": 6212,
+              "end": 7253,
+              "start": 7251,
             },
             "value": "or",
           },
           "type": Object {
             "kind": "ListType",
             "loc": Object {
-              "end": 6244,
-              "start": 6216,
+              "end": 7283,
+              "start": 7255,
             },
             "type": Object {
               "kind": "NamedType",
               "loc": Object {
-                "end": 6243,
-                "start": 6217,
+                "end": 7282,
+                "start": 7256,
               },
               "name": Object {
                 "kind": "Name",
                 "loc": Object {
-                  "end": 6243,
-                  "start": 6217,
+                  "end": 7282,
+                  "start": 7256,
                 },
                 "value": "ModelPostEditorFilterInput",
               },
@@ -9563,28 +10397,28 @@ Object {
           "directives": Array [],
           "kind": "InputValueDefinition",
           "loc": Object {
-            "end": 6278,
-            "start": 6247,
+            "end": 7317,
+            "start": 7286,
           },
           "name": Object {
             "kind": "Name",
             "loc": Object {
-              "end": 6250,
-              "start": 6247,
+              "end": 7289,
+              "start": 7286,
             },
             "value": "not",
           },
           "type": Object {
             "kind": "NamedType",
             "loc": Object {
-              "end": 6278,
-              "start": 6252,
+              "end": 7317,
+              "start": 7291,
             },
             "name": Object {
               "kind": "Name",
               "loc": Object {
-                "end": 6278,
-                "start": 6252,
+                "end": 7317,
+                "start": 7291,
               },
               "value": "ModelPostEditorFilterInput",
             },
@@ -9593,14 +10427,14 @@ Object {
       ],
       "kind": "InputObjectTypeDefinition",
       "loc": Object {
-        "end": 6280,
-        "start": 6072,
+        "end": 7319,
+        "start": 7111,
       },
       "name": Object {
         "kind": "Name",
         "loc": Object {
-          "end": 6104,
-          "start": 6078,
+          "end": 7143,
+          "start": 7117,
         },
         "value": "ModelPostEditorFilterInput",
       },
@@ -9608,7 +10442,7 @@ Object {
   ],
   "kind": "Document",
   "loc": Object {
-    "end": 6282,
+    "end": 7321,
     "start": 0,
   },
 }
@@ -14122,6 +14956,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateChild.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreateFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14137,6 +14974,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateFriendship.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreateParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14152,6 +14992,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateParent.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14167,6 +15010,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreatePostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14182,6 +15028,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreatePostAuthor.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreatePostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14197,6 +15046,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreatePostModel.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14212,6 +15064,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateUser.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreateUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14227,6 +15082,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateUserModel.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14242,6 +15100,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteChild.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14257,6 +15118,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteFriendship.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14272,6 +15136,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteParent.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14287,6 +15154,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeletePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeletePostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14302,6 +15172,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeletePostAuthor.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeletePostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14317,6 +15190,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeletePostModel.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14332,6 +15208,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteUser.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14347,6 +15226,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteUserModel.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateChild.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14362,6 +15244,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateChild.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateFriendship.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14377,6 +15262,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateFriendship.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateParent.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14392,6 +15280,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateParent.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14407,6 +15298,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdatePostAuthor.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14422,6 +15316,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdatePostAuthor.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdatePostModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14437,6 +15334,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdatePostModel.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateUser.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14452,6 +15352,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateUser.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateUserModel.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -14467,6 +15370,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateUserModel.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "User.friendships.req.vtl": "#if( $ctx.source.deniedField )

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
@@ -235,16 +235,23 @@ type Mutation {
   deleteModelAModelB(input: DeleteModelAModelBInput!, condition: ModelModelAModelBConditionInput): ModelAModelB
 }
 
+input ModelSubscriptionModelAFilterInput {
+  id: ModelSubscriptionIDInput
+  sortId: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelAFilterInput]
+  or: [ModelSubscriptionModelAFilterInput]
+}
+
 type Subscription {
-  onCreateModelA: ModelA @aws_subscribe(mutations: [\\"createModelA\\"])
-  onUpdateModelA: ModelA @aws_subscribe(mutations: [\\"updateModelA\\"])
-  onDeleteModelA: ModelA @aws_subscribe(mutations: [\\"deleteModelA\\"])
-  onCreateModelB: ModelB @aws_subscribe(mutations: [\\"createModelB\\"])
-  onUpdateModelB: ModelB @aws_subscribe(mutations: [\\"updateModelB\\"])
-  onDeleteModelB: ModelB @aws_subscribe(mutations: [\\"deleteModelB\\"])
-  onCreateModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"createModelAModelB\\"])
-  onUpdateModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"updateModelAModelB\\"])
-  onDeleteModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"deleteModelAModelB\\"])
+  onCreateModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"createModelA\\"])
+  onUpdateModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"updateModelA\\"])
+  onDeleteModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"deleteModelA\\"])
+  onCreateModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"createModelB\\"])
+  onUpdateModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"updateModelB\\"])
+  onDeleteModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"deleteModelB\\"])
+  onCreateModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"createModelAModelB\\"])
+  onUpdateModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"updateModelAModelB\\"])
+  onDeleteModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"deleteModelAModelB\\"])
 }
 
 type ModelModelBConnection {
@@ -279,6 +286,13 @@ input UpdateModelBInput {
 input DeleteModelBInput {
   id: ID!
   sortId: ID!
+}
+
+input ModelSubscriptionModelBFilterInput {
+  id: ModelSubscriptionIDInput
+  sortId: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelBFilterInput]
+  or: [ModelSubscriptionModelBFilterInput]
 }
 
 type ModelModelAModelBConnection {
@@ -325,6 +339,16 @@ input UpdateModelAModelBInput {
 
 input DeleteModelAModelBInput {
   id: ID!
+}
+
+input ModelSubscriptionModelAModelBFilterInput {
+  id: ModelSubscriptionIDInput
+  modelAID: ModelSubscriptionIDInput
+  modelAsortId: ModelSubscriptionIDInput
+  modelBID: ModelSubscriptionIDInput
+  modelBsortId: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelAModelBFilterInput]
+  or: [ModelSubscriptionModelAModelBFilterInput]
 }
 
 input ModelIDKeyConditionInput {
@@ -2099,6 +2123,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateModelA.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreateModelAModelB.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2114,6 +2141,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateModelAModelB.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreateModelB.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2129,6 +2159,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateModelB.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteModelA.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2144,6 +2177,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteModelA.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteModelAModelB.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2159,6 +2195,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteModelAModelB.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteModelB.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2174,6 +2213,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteModelB.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateModelA.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2189,6 +2231,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateModelA.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateModelAModelB.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2204,6 +2249,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateModelAModelB.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateModelB.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -2219,6 +2267,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateModelB.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -3467,16 +3518,24 @@ type Mutation {
   deleteModelAModelB(input: DeleteModelAModelBInput!, condition: ModelModelAModelBConditionInput): ModelAModelB
 }
 
+input ModelSubscriptionModelAFilterInput {
+  id: ModelSubscriptionIDInput
+  sortId: ModelSubscriptionIDInput
+  secondSortId: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelAFilterInput]
+  or: [ModelSubscriptionModelAFilterInput]
+}
+
 type Subscription {
-  onCreateModelA: ModelA @aws_subscribe(mutations: [\\"createModelA\\"])
-  onUpdateModelA: ModelA @aws_subscribe(mutations: [\\"updateModelA\\"])
-  onDeleteModelA: ModelA @aws_subscribe(mutations: [\\"deleteModelA\\"])
-  onCreateModelB: ModelB @aws_subscribe(mutations: [\\"createModelB\\"])
-  onUpdateModelB: ModelB @aws_subscribe(mutations: [\\"updateModelB\\"])
-  onDeleteModelB: ModelB @aws_subscribe(mutations: [\\"deleteModelB\\"])
-  onCreateModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"createModelAModelB\\"])
-  onUpdateModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"updateModelAModelB\\"])
-  onDeleteModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"deleteModelAModelB\\"])
+  onCreateModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"createModelA\\"])
+  onUpdateModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"updateModelA\\"])
+  onDeleteModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"deleteModelA\\"])
+  onCreateModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"createModelB\\"])
+  onUpdateModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"updateModelB\\"])
+  onDeleteModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"deleteModelB\\"])
+  onCreateModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"createModelAModelB\\"])
+  onUpdateModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"updateModelAModelB\\"])
+  onDeleteModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"deleteModelAModelB\\"])
 }
 
 type ModelModelBConnection {
@@ -3511,6 +3570,13 @@ input UpdateModelBInput {
 input DeleteModelBInput {
   id: ID!
   sortId: ID!
+}
+
+input ModelSubscriptionModelBFilterInput {
+  id: ModelSubscriptionIDInput
+  sortId: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelBFilterInput]
+  or: [ModelSubscriptionModelBFilterInput]
 }
 
 type ModelModelAModelBConnection {
@@ -3561,6 +3627,17 @@ input UpdateModelAModelBInput {
 
 input DeleteModelAModelBInput {
   id: ID!
+}
+
+input ModelSubscriptionModelAModelBFilterInput {
+  id: ModelSubscriptionIDInput
+  modelAID: ModelSubscriptionIDInput
+  modelAsortId: ModelSubscriptionIDInput
+  modelAsecondSortId: ModelSubscriptionIDInput
+  modelBID: ModelSubscriptionIDInput
+  modelBsortId: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelAModelBFilterInput]
+  or: [ModelSubscriptionModelAModelBFilterInput]
 }
 
 input ModelModelAPrimaryCompositeKeyConditionInput {
@@ -3839,16 +3916,23 @@ type Mutation {
   deleteModelAModelB(input: DeleteModelAModelBInput!, condition: ModelModelAModelBConditionInput): ModelAModelB
 }
 
+input ModelSubscriptionModelAFilterInput {
+  id: ModelSubscriptionIDInput
+  sortId: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelAFilterInput]
+  or: [ModelSubscriptionModelAFilterInput]
+}
+
 type Subscription {
-  onCreateModelA: ModelA @aws_subscribe(mutations: [\\"createModelA\\"])
-  onUpdateModelA: ModelA @aws_subscribe(mutations: [\\"updateModelA\\"])
-  onDeleteModelA: ModelA @aws_subscribe(mutations: [\\"deleteModelA\\"])
-  onCreateModelB: ModelB @aws_subscribe(mutations: [\\"createModelB\\"])
-  onUpdateModelB: ModelB @aws_subscribe(mutations: [\\"updateModelB\\"])
-  onDeleteModelB: ModelB @aws_subscribe(mutations: [\\"deleteModelB\\"])
-  onCreateModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"createModelAModelB\\"])
-  onUpdateModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"updateModelAModelB\\"])
-  onDeleteModelAModelB: ModelAModelB @aws_subscribe(mutations: [\\"deleteModelAModelB\\"])
+  onCreateModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"createModelA\\"])
+  onUpdateModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"updateModelA\\"])
+  onDeleteModelA(filter: ModelSubscriptionModelAFilterInput): ModelA @aws_subscribe(mutations: [\\"deleteModelA\\"])
+  onCreateModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"createModelB\\"])
+  onUpdateModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"updateModelB\\"])
+  onDeleteModelB(filter: ModelSubscriptionModelBFilterInput): ModelB @aws_subscribe(mutations: [\\"deleteModelB\\"])
+  onCreateModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"createModelAModelB\\"])
+  onUpdateModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"updateModelAModelB\\"])
+  onDeleteModelAModelB(filter: ModelSubscriptionModelAModelBFilterInput): ModelAModelB @aws_subscribe(mutations: [\\"deleteModelAModelB\\"])
 }
 
 type ModelModelBConnection {
@@ -3879,6 +3963,12 @@ input UpdateModelBInput {
 
 input DeleteModelBInput {
   id: ID!
+}
+
+input ModelSubscriptionModelBFilterInput {
+  id: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelBFilterInput]
+  or: [ModelSubscriptionModelBFilterInput]
 }
 
 type ModelModelAModelBConnection {
@@ -3921,6 +4011,15 @@ input UpdateModelAModelBInput {
 
 input DeleteModelAModelBInput {
   id: ID!
+}
+
+input ModelSubscriptionModelAModelBFilterInput {
+  id: ModelSubscriptionIDInput
+  modelAID: ModelSubscriptionIDInput
+  modelAsortId: ModelSubscriptionIDInput
+  modelBID: ModelSubscriptionIDInput
+  and: [ModelSubscriptionModelAModelBFilterInput]
+  or: [ModelSubscriptionModelAModelBFilterInput]
 }
 
 input ModelIDKeyConditionInput {
@@ -4163,16 +4262,22 @@ type Mutation {
   deleteFooBar(input: DeleteFooBarInput!, condition: ModelFooBarConditionInput): FooBar
 }
 
+input ModelSubscriptionFooFilterInput {
+  id: ModelSubscriptionIDInput
+  and: [ModelSubscriptionFooFilterInput]
+  or: [ModelSubscriptionFooFilterInput]
+}
+
 type Subscription {
-  onCreateFoo: Foo @aws_subscribe(mutations: [\\"createFoo\\"])
-  onUpdateFoo: Foo @aws_subscribe(mutations: [\\"updateFoo\\"])
-  onDeleteFoo: Foo @aws_subscribe(mutations: [\\"deleteFoo\\"])
-  onCreateBar: Bar @aws_subscribe(mutations: [\\"createBar\\"])
-  onUpdateBar: Bar @aws_subscribe(mutations: [\\"updateBar\\"])
-  onDeleteBar: Bar @aws_subscribe(mutations: [\\"deleteBar\\"])
-  onCreateFooBar: FooBar @aws_subscribe(mutations: [\\"createFooBar\\"])
-  onUpdateFooBar: FooBar @aws_subscribe(mutations: [\\"updateFooBar\\"])
-  onDeleteFooBar: FooBar @aws_subscribe(mutations: [\\"deleteFooBar\\"])
+  onCreateFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"createFoo\\"])
+  onUpdateFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"updateFoo\\"])
+  onDeleteFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"deleteFoo\\"])
+  onCreateBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"createBar\\"])
+  onUpdateBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"updateBar\\"])
+  onDeleteBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"deleteBar\\"])
+  onCreateFooBar(filter: ModelSubscriptionFooBarFilterInput): FooBar @aws_subscribe(mutations: [\\"createFooBar\\"])
+  onUpdateFooBar(filter: ModelSubscriptionFooBarFilterInput): FooBar @aws_subscribe(mutations: [\\"updateFooBar\\"])
+  onDeleteFooBar(filter: ModelSubscriptionFooBarFilterInput): FooBar @aws_subscribe(mutations: [\\"deleteFooBar\\"])
 }
 
 type ModelBarConnection {
@@ -4203,6 +4308,12 @@ input UpdateBarInput {
 
 input DeleteBarInput {
   id: ID!
+}
+
+input ModelSubscriptionBarFilterInput {
+  id: ModelSubscriptionIDInput
+  and: [ModelSubscriptionBarFilterInput]
+  or: [ModelSubscriptionBarFilterInput]
 }
 
 type ModelFooBarConnection {
@@ -4241,6 +4352,14 @@ input UpdateFooBarInput {
 
 input DeleteFooBarInput {
   id: ID!
+}
+
+input ModelSubscriptionFooBarFilterInput {
+  id: ModelSubscriptionIDInput
+  fooID: ModelSubscriptionIDInput
+  barID: ModelSubscriptionIDInput
+  and: [ModelSubscriptionFooBarFilterInput]
+  or: [ModelSubscriptionFooBarFilterInput]
 }
 
 "
@@ -5789,6 +5908,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateBar.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreateFoo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5804,6 +5926,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateFoo.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onCreateFooBar.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5819,6 +5944,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreateFooBar.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteBar.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5834,6 +5962,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteBar.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteFoo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5849,6 +5980,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteFoo.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeleteFooBar.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5864,6 +5998,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeleteFooBar.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateBar.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5879,6 +6016,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateBar.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateFoo.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5894,6 +6034,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateFoo.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdateFooBar.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -5909,6 +6052,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdateFooBar.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
@@ -252,10 +252,19 @@ type Mutation {
   deleteEmployee(input: DeleteEmployeeInput!, condition: ModelEmployeeConditionInput): Employee
 }
 
+input ModelSubscriptionEmployeeFilterInput {
+  id: ModelSubscriptionIDInput
+  firstName: ModelSubscriptionStringInput
+  lastName: ModelSubscriptionStringInput
+  type: ModelSubscriptionStringInput
+  and: [ModelSubscriptionEmployeeFilterInput]
+  or: [ModelSubscriptionEmployeeFilterInput]
+}
+
 type Subscription {
-  onCreateEmployee: Employee @aws_subscribe(mutations: [\\"createEmployee\\"])
-  onUpdateEmployee: Employee @aws_subscribe(mutations: [\\"updateEmployee\\"])
-  onDeleteEmployee: Employee @aws_subscribe(mutations: [\\"deleteEmployee\\"])
+  onCreateEmployee(filter: ModelSubscriptionEmployeeFilterInput): Employee @aws_subscribe(mutations: [\\"createEmployee\\"])
+  onUpdateEmployee(filter: ModelSubscriptionEmployeeFilterInput): Employee @aws_subscribe(mutations: [\\"updateEmployee\\"])
+  onDeleteEmployee(filter: ModelSubscriptionEmployeeFilterInput): Employee @aws_subscribe(mutations: [\\"deleteEmployee\\"])
 }
 
 input SearchableStringFilterInput {
@@ -613,10 +622,19 @@ type Mutation {
   deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionStringInput
+  updatedAt: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
 }
 
 input SearchableStringFilterInput {
@@ -1319,6 +1337,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onCreatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onDeletePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1334,6 +1355,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onDeletePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
   "Subscription.onUpdatePost.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
@@ -1349,6 +1373,9 @@ $util.toJson({
 })
 ## [End] Subscription Request template. **",
   "Subscription.onUpdatePost.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
 }
@@ -1904,13 +1931,22 @@ type Mutation {
   deleteUser(input: DeleteUserInput!, condition: ModelUserConditionInput): User
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionStringInput
+  updatedAt: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
-  onCreateUser: User @aws_subscribe(mutations: [\\"createUser\\"])
-  onUpdateUser: User @aws_subscribe(mutations: [\\"updateUser\\"])
-  onDeleteUser: User @aws_subscribe(mutations: [\\"deleteUser\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreateUser(filter: ModelSubscriptionUserFilterInput): User @aws_subscribe(mutations: [\\"createUser\\"])
+  onUpdateUser(filter: ModelSubscriptionUserFilterInput): User @aws_subscribe(mutations: [\\"updateUser\\"])
+  onDeleteUser(filter: ModelSubscriptionUserFilterInput): User @aws_subscribe(mutations: [\\"deleteUser\\"])
 }
 
 type ModelUserConnection {
@@ -1945,6 +1981,13 @@ input UpdateUserInput {
 
 input DeleteUserInput {
   id: ID!
+}
+
+input ModelSubscriptionUserFilterInput {
+  id: ModelSubscriptionIDInput
+  name: ModelSubscriptionStringInput
+  and: [ModelSubscriptionUserFilterInput]
+  or: [ModelSubscriptionUserFilterInput]
 }
 
 input SearchableStringFilterInput {
@@ -2319,8 +2362,17 @@ type Mutation {
   customCreatePost(input: CreatePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionStringInput
+  updatedAt: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"customCreatePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"customCreatePost\\"])
 }
 
 input SearchableStringFilterInput {
@@ -2673,10 +2725,19 @@ type Mutation {
   deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionStringInput
+  updatedAt: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
 }
 
 input SearchableStringFilterInput {
@@ -3029,10 +3090,19 @@ type Mutation {
   deletePost(input: DeletePostInput!, condition: ModelPostConditionInput): Post
 }
 
+input ModelSubscriptionPostFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionStringInput
+  updatedAt: ModelSubscriptionStringInput
+  and: [ModelSubscriptionPostFilterInput]
+  or: [ModelSubscriptionPostFilterInput]
+}
+
 type Subscription {
-  onCreatePost: Post @aws_subscribe(mutations: [\\"createPost\\"])
-  onUpdatePost: Post @aws_subscribe(mutations: [\\"updatePost\\"])
-  onDeletePost: Post @aws_subscribe(mutations: [\\"deletePost\\"])
+  onCreatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"createPost\\"])
+  onUpdatePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"updatePost\\"])
+  onDeletePost(filter: ModelSubscriptionPostFilterInput): Post @aws_subscribe(mutations: [\\"deletePost\\"])
 }
 
 input SearchableStringFilterInput {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts
@@ -1,0 +1,1041 @@
+import { GRAPHQL_AUTH_MODE } from '@aws-amplify/api';
+import { AWS } from '@aws-amplify/core';
+import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
+import { API, Auth } from 'aws-amplify';
+import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
+import { CognitoIdentity, CognitoIdentityServiceProvider as CognitoClient, S3 } from 'aws-sdk';
+import { Output } from 'aws-sdk/clients/cloudformation';
+import gql from 'graphql-tag';
+import { ResourceConstants } from 'graphql-transformer-common';
+import 'isomorphic-fetch';
+import { default as moment } from 'moment';
+import * as Observable from 'zen-observable';
+import { CloudFormationClient } from '../CloudFormationClient';
+import {
+  addUserToGroup, authenticateUser, configureAmplify, createGroup, createIdentityPool, createUserPool,
+  createUserPoolClient, signupUser
+} from '../cognitoUtils';
+import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
+import { IAMHelper } from '../IAMHelper';
+import { withTimeOut } from '../promiseWithTimeout';
+import { S3Client } from '../S3Client';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+// to deal with subscriptions in node env
+(global as any).WebSocket = require('ws');
+
+// To overcome of the way of how AmplifyJS picks up currentUserCredentials
+const anyAWS = AWS as any;
+if (anyAWS && anyAWS.config && anyAWS.config.credentials) {
+  delete anyAWS.config.credentials;
+}
+
+// delay times
+const SUBSCRIPTION_DELAY = 10000;
+const PROPAGATION_DELAY = 5000;
+const JEST_TIMEOUT = 2000000;
+const SUBSCRIPTION_TIMEOUT = 10000;
+
+jest.setTimeout(JEST_TIMEOUT);
+
+function outputValueSelector(key: string) {
+  return (outputs: Output[]) => {
+    const output = outputs.find((o: Output) => o.OutputKey === key);
+    return output ? output.OutputValue : null;
+  };
+}
+
+const AWS_REGION = 'us-west-2';
+const cf = new CloudFormationClient(AWS_REGION);
+const customS3Client = new S3Client(AWS_REGION);
+const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: AWS_REGION });
+const identityClient = new CognitoIdentity({ apiVersion: '2014-06-30', region: AWS_REGION });
+const iamHelper = new IAMHelper(AWS_REGION);
+const awsS3Client = new S3({ region: AWS_REGION });
+
+// stack info
+const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
+const STACK_NAME = `SubscriptionRTFTests-${BUILD_TIMESTAMP}`;
+const BUCKET_NAME = `subscription-rtf-tests-bucket-${BUILD_TIMESTAMP}`;
+const LOCAL_FS_BUILD_DIR = '/tmp/subscription_rtf_tests/';
+const S3_ROOT_DIR_KEY = 'deployments';
+const AUTH_ROLE_NAME = `${STACK_NAME}-authRole`;
+const UNAUTH_ROLE_NAME = `${STACK_NAME}-unauthRole`;
+let USER_POOL_ID: string;
+let IDENTITY_POOL_ID: string;
+let GRAPHQL_ENDPOINT: string;
+let API_KEY: string;
+
+/**
+ * Client 1 is logged in and is a member of the Admin group.
+ */
+let GRAPHQL_CLIENT_1: AWSAppSyncClient<any> = undefined;
+
+/**
+ * Client 2 is logged in and is a member of the Devs group.
+ */
+let GRAPHQL_CLIENT_2: AWSAppSyncClient<any> = undefined;
+
+/**
+ * Auth IAM Client
+ */
+let GRAPHQL_IAM_AUTH_CLIENT: AWSAppSyncClient<any> = undefined;
+
+const USERNAME1 = 'user1@test.com';
+const USERNAME2 = 'user2@test.com';
+const USERNAME3 = 'user3@test.com';
+const TMP_PASSWORD = 'Password123!';
+const REAL_PASSWORD = 'Password1234!';
+
+const INSTRUCTOR_GROUP_NAME = 'Instructor';
+const MEMBER_GROUP_NAME = 'Member';
+const ADMIN_GROUP_NAME = 'Admin';
+
+// interface inputs
+interface CreateTaskInput {
+  id?: string;
+  title?: string,
+  description?: string,
+  priority?: number,
+  severity?: number,
+  owner?: string
+  readOwners?: string[]
+}
+
+interface UpdateTaskInput {
+  id?: string;
+  title?: string,
+  description?: string,
+  priority?: number,
+  severity?: number,
+  owner?: string
+  readOwners?: string[]
+}
+
+interface DeleteTaskInput {
+  id?: string;
+  title?: string,
+  description?: string,
+  priority?: number,
+  severity?: number,
+  owner?: string
+  readOwners?: string[]
+}
+
+interface CreateTodoInput {
+  id?: string;
+  name?: string;
+  description?: string;
+  level?: number;
+  owner?: string;
+  sharedOwners?: [string];
+  status?: string;
+}
+
+interface UpdateTodoInput {
+  id?: string;
+  name?: string;
+  description?: string;
+  level?: number;
+  owner?: string;
+  sharedOwners?: [string];
+  status?: string;
+}
+
+interface DeleteTodoInput {
+  id?: string;
+  name?: string;
+  description?: string;
+  level?: number;
+  owner?: string;
+  sharedOwners?: [string];
+  status?: string;
+}
+
+beforeEach(async () => {
+  try {
+    await Auth.signOut();
+  } catch (ex) {
+    // don't need to fail tests on this error
+  }
+});
+
+beforeAll(async () => {
+  const validSchema = `
+  type Task @model
+  @auth(rules: [
+      {allow: owner, ownerField: "owner", identityClaim: "username"}
+      {allow: owner, ownerField: "readOwners", operations: [read], identityClaim: "username"}
+  ]) {
+      id: String,
+      title: String,
+      description: String,
+      priority: Int,
+      severity: Int,
+      owner: String
+      readOwners: [String]
+  }
+  
+  type Todo @model
+  @auth(rules: [
+      {allow: groups, groups: ["Admin"]}
+      {allow: owner, ownerField: "owner", identityClaim: "username"}
+      {allow: owner, ownerField: "sharedOwners", identityClaim: "username"}
+  ]) {
+      id: String,
+      name: String,
+      description: String,
+      level: Int,
+      owner: String
+      sharedOwners: [String]
+      status: TodoStatus
+  }
+  
+  enum TodoStatus {
+    NOTSTARTED
+    STARTED
+    COMPLETED
+  }`;
+  const transformer = new GraphQLTransform({
+    authConfig: {
+      defaultAuthentication: {
+        authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+      },
+      additionalAuthenticationProviders: [
+        {
+          authenticationType: 'API_KEY',
+          apiKeyConfig: {
+            description: 'E2E Test API Key',
+            apiKeyExpirationDays: 300,
+          },
+        },
+        {
+          authenticationType: 'AWS_IAM',
+        },
+      ],
+    },
+    transformers: [new ModelTransformer(), new AuthTransformer()],
+    featureFlags: {
+      getBoolean: (value: string, defaultValue?: boolean) => {
+        if (value === 'useSubUsernameForDefaultIdentityClaim') {
+          return false;
+        }
+        return defaultValue;
+      },
+
+
+      getNumber: jest.fn(),
+      getObject: jest.fn(),
+    },
+  });
+
+  try {
+    await awsS3Client.createBucket({ Bucket: BUCKET_NAME }).promise();
+  } catch (e) {
+    console.error(`Failed to create bucket: ${e}`);
+  }
+
+  // create userpool
+  const userPoolResponse = await createUserPool(cognitoClient, `UserPool${STACK_NAME}`);
+  USER_POOL_ID = userPoolResponse.UserPool.Id;
+  const userPoolClientResponse = await createUserPoolClient(cognitoClient, USER_POOL_ID, `UserPool${STACK_NAME}`);
+  const userPoolClientId = userPoolClientResponse.UserPoolClient.ClientId;
+  // create auth and unauthroles
+  const { authRole, unauthRole } = await iamHelper.createRoles(AUTH_ROLE_NAME, UNAUTH_ROLE_NAME);
+  // create identitypool
+  IDENTITY_POOL_ID = await createIdentityPool(identityClient, `IdentityPool${STACK_NAME}`, {
+    authRoleArn: authRole.Arn,
+    unauthRoleArn: unauthRole.Arn,
+    providerName: `cognito-idp.${AWS_REGION}.amazonaws.com/${USER_POOL_ID}`,
+    clientId: userPoolClientId,
+  });
+  const out = transformer.transform(validSchema);
+  const finishedStack = await deploy(
+    customS3Client,
+    cf,
+    STACK_NAME,
+    out,
+    { AuthCognitoUserPoolId: USER_POOL_ID, authRoleName: authRole.RoleName, unauthRoleName: unauthRole.RoleName },
+    LOCAL_FS_BUILD_DIR,
+    BUCKET_NAME,
+    S3_ROOT_DIR_KEY,
+    BUILD_TIMESTAMP,
+  );
+
+  expect(finishedStack).toBeDefined();
+  const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput);
+  const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput);
+  GRAPHQL_ENDPOINT = getApiEndpoint(finishedStack.Outputs);
+
+  API_KEY = getApiKey(finishedStack.Outputs);
+  expect(API_KEY).toBeTruthy();
+
+  // Verify we have all the details
+  expect(GRAPHQL_ENDPOINT).toBeTruthy();
+  expect(USER_POOL_ID).toBeTruthy();
+  expect(userPoolClientId).toBeTruthy();
+
+  // Configure Amplify, create users, and sign in
+  configureAmplify(USER_POOL_ID, userPoolClientId, IDENTITY_POOL_ID);
+
+  await signupUser(USER_POOL_ID, USERNAME1, TMP_PASSWORD);
+  await signupUser(USER_POOL_ID, USERNAME2, TMP_PASSWORD);
+  await signupUser(USER_POOL_ID, USERNAME3, TMP_PASSWORD);
+
+  await createGroup(USER_POOL_ID, INSTRUCTOR_GROUP_NAME);
+  await createGroup(USER_POOL_ID, MEMBER_GROUP_NAME);
+  await createGroup(USER_POOL_ID, ADMIN_GROUP_NAME);
+  await addUserToGroup(ADMIN_GROUP_NAME, USERNAME1, USER_POOL_ID);
+  await addUserToGroup(MEMBER_GROUP_NAME, USERNAME2, USER_POOL_ID);
+  await addUserToGroup(INSTRUCTOR_GROUP_NAME, USERNAME1, USER_POOL_ID);
+  await addUserToGroup(INSTRUCTOR_GROUP_NAME, USERNAME2, USER_POOL_ID);
+
+  // authenticate user3 we'll use amplify api for subscription calls
+  await authenticateUser(USERNAME3, TMP_PASSWORD, REAL_PASSWORD);
+
+  const authResAfterGroup: any = await authenticateUser(USERNAME1, TMP_PASSWORD, REAL_PASSWORD);
+  const idToken = authResAfterGroup.getIdToken().getJwtToken();
+  GRAPHQL_CLIENT_1 = new AWSAppSyncClient({
+    url: GRAPHQL_ENDPOINT,
+    region: AWS_REGION,
+    disableOffline: true,
+    auth: {
+      type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
+      jwtToken: idToken,
+    },
+  });
+  const authRes2AfterGroup: any = await authenticateUser(USERNAME2, TMP_PASSWORD, REAL_PASSWORD);
+  const idToken2 = authRes2AfterGroup.getIdToken().getJwtToken();
+  GRAPHQL_CLIENT_2 = new AWSAppSyncClient({
+    url: GRAPHQL_ENDPOINT,
+    region: AWS_REGION,
+    disableOffline: true,
+    auth: {
+      type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
+      jwtToken: idToken2,
+    },
+  });
+
+  await Auth.signIn(USERNAME1, REAL_PASSWORD);
+  const authCreds = await Auth.currentCredentials();
+  GRAPHQL_IAM_AUTH_CLIENT = new AWSAppSyncClient({
+    url: GRAPHQL_ENDPOINT,
+    region: AWS_REGION,
+    disableOffline: true,
+    auth: {
+      type: AUTH_TYPE.AWS_IAM,
+      credentials: authCreds,
+    },
+  });
+  // Wait for any propagation to avoid random
+  // "The security token included in the request is invalid" errors
+  await new Promise(res => setTimeout(res, PROPAGATION_DELAY));
+});
+
+afterAll(async () => {
+  await cleanupStackAfterTest(
+    BUCKET_NAME,
+    STACK_NAME,
+    cf,
+    { cognitoClient, userPoolId: USER_POOL_ID },
+    { identityClient, identityPoolId: IDENTITY_POOL_ID },
+  );
+  await iamHelper.deleteRole(AUTH_ROLE_NAME);
+  await iamHelper.deleteRole(UNAUTH_ROLE_NAME);
+});
+
+/**
+ * Tests
+ */
+
+/**
+ * Subscriptions with runtime filtering basic use case
+ * User1 is running the mutation and subscription
+ */
+test('Basic runtime filtering with subscriptions work', async () => {
+  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
+  await Auth.signIn(USERNAME1, REAL_PASSWORD);
+  const observer = API.graphql({
+    // @ts-ignore
+    query: gql`
+      subscription OnCreateTask {
+        onCreateTask(filter: {
+          and: [
+            { priority: { eq: 8 } }
+            { severity: { gt: 5 } }
+          ]
+        }) {
+          id
+          title
+          description
+          priority
+          severity
+          owner
+          readOwners
+        }
+      }
+    `,
+    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
+  }) as unknown as Observable<any>;
+  let subscription: ZenObservable.Subscription;
+  const subscriptionPromise = new Promise((resolve, _) => {
+    subscription = observer.subscribe((event: any) => {
+      const task = event.value.data.onCreateTask;
+      subscription.unsubscribe();
+      expect(task.title).toEqual('task2');
+      expect(task.description).toEqual('description2');
+      expect(task.priority).toEqual(8);
+      expect(task.severity).toEqual(7);
+      resolve(undefined);
+    });
+  });
+
+  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
+
+  await createTask(GRAPHQL_CLIENT_1, {
+    title: 'task1',
+    description: 'description1',
+    priority: 5,
+    severity: 5,
+  });
+
+  await createTask(GRAPHQL_CLIENT_1, {
+    title: 'task2',
+    description: 'description2',
+    priority: 8,
+    severity: 7,
+  });
+
+  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateTask Subscription timed out', () => {
+    subscription?.unsubscribe();
+  });
+});
+
+/**
+ * Runtime filtering supports multiple owners auth
+ * User1 is running the subscription and User2 is running the mutations
+ */
+test('Multiple owners auth is supported for subscriptions', async () => {
+  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
+  await Auth.signIn(USERNAME1, REAL_PASSWORD);
+  const observer = API.graphql({
+    // @ts-ignore
+    query: gql`
+      subscription OnCreateTask {
+        onCreateTask {
+          id
+          title
+          description
+          priority
+          severity
+          owner
+          readOwners
+        }
+      }
+    `,
+    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
+  }) as unknown as Observable<any>;
+  let subscription: ZenObservable.Subscription;
+  const subscriptionPromise = new Promise((resolve, _) => {
+    subscription = observer.subscribe((event: any) => {
+      const task = event.value.data.onCreateTask;
+      subscription.unsubscribe();
+      expect(task.title).toEqual('task3');
+      expect(task.description).toEqual('description3');
+      expect(task.priority).toEqual(1);
+      expect(task.severity).toEqual(2);
+      resolve(undefined);
+    });
+  });
+
+  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
+
+  await createTask(GRAPHQL_CLIENT_2, {
+    title: 'task3',
+    description: 'description3',
+    priority: 1,
+    severity: 2,
+    readOwners: [USERNAME1],
+  });
+
+  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateTask Subscription timed out', () => {
+    subscription?.unsubscribe();
+  });
+});
+
+/**
+ * Runtime filtering supports multiple owners auth and filter argument
+ * User1 is running the subscription and User2 is running the mutations
+ */
+test('Basic runtime filtering with subscriptions and multiple owners auth work', async () => {
+  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
+  await Auth.signIn(USERNAME1, REAL_PASSWORD);
+  const observer = API.graphql({
+    // @ts-ignore
+    query: gql`
+      subscription OnCreateTask {
+        onCreateTask(filter: {
+          or: [
+            { priority: { gt: 5 } }
+            { severity: { gt: 5 } }
+          ]
+        }) {
+          id
+          title
+          description
+          priority
+          severity
+          owner
+          readOwners
+        }
+      }
+    `,
+    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
+  }) as unknown as Observable<any>;
+  let subscription: ZenObservable.Subscription;
+  const subscriptionPromise = new Promise((resolve, _) => {
+    subscription = observer.subscribe((event: any) => {
+      const task = event.value.data.onCreateTask;
+      subscription.unsubscribe();
+      expect(task.title).toEqual('task5');
+      expect(task.description).toEqual('description5');
+      expect(task.priority).toEqual(1);
+      expect(task.severity).toEqual(6);
+      resolve(undefined);
+    });
+  });
+
+  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
+
+  await createTask(GRAPHQL_CLIENT_2, {
+    title: 'task4',
+    description: 'description4',
+    priority: 4,
+    severity: 4,
+  });
+
+  await createTask(GRAPHQL_CLIENT_2, {
+    title: 'task5',
+    description: 'description5',
+    priority: 1,
+    severity: 6,
+    readOwners: [USERNAME1],
+  });
+
+  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateTask Subscription timed out', () => {
+    subscription?.unsubscribe();
+  });
+});
+
+/**
+ * Runtime filtering on update mutation
+ * User1 is running the subscription and User2 is running the mutations
+ */
+test('Runtime filtering works with update mutation and multiple owners auth', async () => {
+  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
+  await Auth.signIn(USERNAME1, REAL_PASSWORD);
+  const observer = API.graphql({
+    // @ts-ignore
+    query: gql`
+      subscription OnUpdateTask {
+        onUpdateTask(filter: {
+          or: [
+            { priority: { lt: 5 } }
+            { severity: { lt: 5 } }
+          ]
+        }) {
+          id
+          title
+          description
+          priority
+          severity
+          owner
+          readOwners
+        }
+      }
+    `,
+    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
+  }) as unknown as Observable<any>;
+  let subscription: ZenObservable.Subscription;
+  const subscriptionPromise = new Promise((resolve, _) => {
+    subscription = observer.subscribe((event: any) => {
+      const task = event.value.data.onUpdateTask;
+      subscription.unsubscribe();
+      expect(task.title).toEqual('task7');
+      expect(task.description).toEqual('description7');
+      expect(task.priority).toEqual(2);
+      expect(task.severity).toEqual(3);
+      resolve(undefined);
+    });
+  });
+
+  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
+
+  await createTask(GRAPHQL_CLIENT_2, {
+    id: 'task-06',
+    title: 'task6',
+    description: 'description6',
+    priority: 6,
+    severity: 6,
+    readOwners: [USERNAME1],
+  });
+
+  await createTask(GRAPHQL_CLIENT_2, {
+    id: 'task-07',
+    title: 'task7',
+    description: 'description7',
+    priority: 2,
+    severity: 3,
+    readOwners: [USERNAME1],
+  });
+
+  await updateTask(GRAPHQL_CLIENT_2, {
+    id: 'task-06',
+    title: 'task6',
+    description: 'description6',
+    priority: 6,
+    severity: 6,
+    readOwners: [USERNAME1],
+  });
+
+  await updateTask(GRAPHQL_CLIENT_2, {
+    id: 'task-07',
+    title: 'task7',
+    description: 'description7',
+    priority: 2,
+    severity: 3,
+    readOwners: [USERNAME1],
+  });
+
+  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateTask Subscription timed out', () => {
+    subscription?.unsubscribe();
+  });
+});
+
+/**
+ * Runtime filtering on delete mutation
+ * User1 is running the subscription and User2 is running the mutations
+ */
+test('Runtime filtering works with delete mutation and multiple owners auth', async () => {
+  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
+  await Auth.signIn(USERNAME1, REAL_PASSWORD);
+  const observer = API.graphql({
+    // @ts-ignore
+    query: gql`
+      subscription OnDeleteTask {
+        onDeleteTask(filter: {
+          severity: { eq: 10 }
+        }) {
+          id
+          title
+          description
+          priority
+          severity
+          owner
+          readOwners
+        }
+      }
+    `,
+    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
+  }) as unknown as Observable<any>;
+  let subscription: ZenObservable.Subscription;
+  const subscriptionPromise = new Promise((resolve, _) => {
+    subscription = observer.subscribe((event: any) => {
+      const task = event.value.data.onDeleteTask;
+      subscription.unsubscribe();
+      expect(task.title).toEqual('task9');
+      expect(task.description).toEqual('description9');
+      expect(task.priority).toEqual(3);
+      expect(task.severity).toEqual(10);
+      resolve(undefined);
+    });
+  });
+
+  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
+
+  await createTask(GRAPHQL_CLIENT_2, {
+    id: 'task-08',
+    title: 'task8',
+    description: 'description8',
+    priority: 8,
+    severity: 8,
+    readOwners: [USERNAME1],
+  });
+
+  await createTask(GRAPHQL_CLIENT_2, {
+    id: 'task-09',
+    title: 'task9',
+    description: 'description9',
+    priority: 3,
+    severity: 10,
+    readOwners: [USERNAME1],
+  });
+
+  await deleteTask(GRAPHQL_CLIENT_2, {
+    id: 'task-08',
+  });
+
+  await deleteTask(GRAPHQL_CLIENT_2, {
+    id: 'task-09',
+  });
+
+  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateTask Subscription timed out', () => {
+    subscription?.unsubscribe();
+  });
+});
+
+const reconfigureAmplifyAPI = (appSyncAuthType: string, apiKey?: string):void => {
+  if (appSyncAuthType === 'API_KEY') {
+    API.configure({
+      aws_appsync_graphqlEndpoint: GRAPHQL_ENDPOINT,
+      aws_appsync_region: AWS_REGION,
+      aws_appsync_authenticationType: appSyncAuthType,
+      aws_appsync_apiKey: apiKey,
+    });
+  } else {
+    API.configure({
+      aws_appsync_graphqlEndpoint: GRAPHQL_ENDPOINT,
+      aws_appsync_region: AWS_REGION,
+      aws_appsync_authenticationType: appSyncAuthType,
+    });
+  }
+};
+
+test('Static group auth should get precedence over owner argument', async () => {
+  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
+  await Auth.signIn(USERNAME1, REAL_PASSWORD);
+  const observer = API.graphql({
+    // @ts-ignore
+    query: gql`
+      subscription OnCreateTodo {
+        onCreateTodo(owner: "${USERNAME2}") {
+          id
+          name
+          description
+          level
+          owner
+          sharedOwners
+          status
+        }
+      }
+    `,
+    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
+  }) as unknown as Observable<any>;
+  let subscription: ZenObservable.Subscription;
+  const subscriptionPromise = new Promise((resolve, _) => {
+    subscription = observer.subscribe((event: any) => {
+      const todo = event.value.data.onCreateTodo;
+      subscription.unsubscribe();
+      expect(todo.name).toEqual('todo1');
+      expect(todo.description).toEqual('description1');
+      expect(todo.level).toEqual(4);
+      resolve(undefined);
+    });
+  });
+
+  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
+
+  await createTodo(GRAPHQL_CLIENT_2, {
+    name: 'todo1',
+    description: 'description1',
+    level: 4,
+    owner: USERNAME2,
+    status: 'NOTSTARTED',
+  });
+
+  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateTodo Subscription timed out', () => {
+    subscription?.unsubscribe();
+  });
+});
+
+test('Runtime Filter with AND condition and IN & BEGINSWITH operators', async () => {
+  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
+  await Auth.signIn(USERNAME1, REAL_PASSWORD);
+  const observer = API.graphql({
+    // @ts-ignore
+    query: gql`
+      subscription OnCreateTodo {
+        onCreateTodo(filter: {
+          and: [
+            {name: { in: ["todo", "test", "Testing"]}}
+            {description: { beginsWith: "Test"}}
+          ]
+        }) {
+          id
+          name
+          description
+          level
+          owner
+          sharedOwners
+          status
+        }
+      }
+    `,
+    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
+  }) as unknown as Observable<any>;
+  let subscription: ZenObservable.Subscription;
+  const subscriptionPromise = new Promise((resolve, _) => {
+    subscription = observer.subscribe((event: any) => {
+      const todo = event.value.data.onCreateTodo;
+      subscription.unsubscribe();
+      expect(todo.name).toEqual('Testing');
+      expect(todo.description).toEqual('Testing Desc');
+      expect(todo.level).toEqual(6);
+      resolve(undefined);
+    });
+  });
+
+  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
+
+  await createTodo(GRAPHQL_CLIENT_1, {
+    name: 'todo',
+    description: 'description2',
+    level: 4,
+    owner: USERNAME1,
+    status: 'NOTSTARTED',
+  });
+
+  await createTodo(GRAPHQL_CLIENT_1, {
+    name: 'Test',
+    description: 'description3',
+    level: 5,
+    owner: USERNAME1,
+    status: 'NOTSTARTED',
+  });
+
+  await createTodo(GRAPHQL_CLIENT_1, {
+    name: 'Testing',
+    description: 'Testing Desc',
+    level: 6,
+    owner: USERNAME1,
+    status: 'NOTSTARTED',
+  });
+
+  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateTodo Subscription timed out', () => {
+    subscription?.unsubscribe();
+  });
+});
+
+test('Runtime Filter with OR condition and NOTIN & BETWEEN operators', async () => {
+  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
+  await Auth.signIn(USERNAME1, REAL_PASSWORD);
+  const observer = API.graphql({
+    // @ts-ignore
+    query: gql`
+      subscription OnCreateTodo {
+        onCreateTodo(filter: {
+          or: [
+            {name: { notIn: ["todo", "test", "Testing"]}}
+            {level: { between: [5, 10]}}
+          ]
+        }) {
+          id
+          name
+          description
+          level
+          owner
+          sharedOwners
+          status
+        }
+      }
+    `,
+    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
+  }) as unknown as Observable<any>;
+  let subscription: ZenObservable.Subscription;
+  const subscriptionPromise = new Promise((resolve, _) => {
+    subscription = observer.subscribe((event: any) => {
+      const todo = event.value.data.onCreateTodo;
+      subscription.unsubscribe();
+      expect(todo.name).toEqual('Test4');
+      expect(todo.description).toEqual('description4');
+      expect(todo.level).toEqual(8);
+      resolve(undefined);
+    });
+  });
+
+  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
+
+  await createTodo(GRAPHQL_CLIENT_1, {
+    name: 'todo',
+    description: 'description2',
+    level: 4,
+    owner: USERNAME1,
+    status: 'NOTSTARTED',
+  });
+
+  await createTodo(GRAPHQL_CLIENT_1, {
+    name: 'Test4',
+    description: 'description4',
+    level: 8,
+    owner: USERNAME1,
+    status: 'NOTSTARTED',
+  });
+
+  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateTodo Subscription timed out', () => {
+    subscription?.unsubscribe();
+  });
+});
+
+test('Runtime Filter enum field type should be treated as string', async () => {
+  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
+  await Auth.signIn(USERNAME1, REAL_PASSWORD);
+  const observer = API.graphql({
+    // @ts-ignore
+    query: gql`
+      subscription OnCreateTodo {
+        onCreateTodo(filter: {
+          status: { eq: "COMPLETED" }
+        }) {
+          id
+          name
+          description
+          level
+          owner
+          sharedOwners
+          status
+        }
+      }
+    `,
+    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
+  }) as unknown as Observable<any>;
+  let subscription: ZenObservable.Subscription;
+  const subscriptionPromise = new Promise((resolve, _) => {
+    subscription = observer.subscribe((event: any) => {
+      const todo = event.value.data.onCreateTodo;
+      subscription.unsubscribe();
+      expect(todo.name).toEqual('Test6');
+      expect(todo.description).toEqual('description6');
+      expect(todo.level).toEqual(8);
+      expect(todo.status).toEqual('COMPLETED');
+      resolve(undefined);
+    });
+  });
+
+  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
+
+  await createTodo(GRAPHQL_CLIENT_1, {
+    name: 'todo5',
+    description: 'description5',
+    level: 4,
+    owner: USERNAME1,
+    status: 'NOTSTARTED',
+  });
+
+  await createTodo(GRAPHQL_CLIENT_1, {
+    name: 'Test6',
+    description: 'description6',
+    level: 8,
+    owner: USERNAME1,
+    status: 'COMPLETED',
+  });
+
+  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateTodo Subscription timed out', () => {
+    subscription?.unsubscribe();
+  });
+});
+
+// mutations
+const createTask = async (client: AWSAppSyncClient<any>, input: CreateTaskInput): Promise<any> => {
+  const request = gql`
+    mutation CreateTask($input: CreateTaskInput!) {
+      createTask(input: $input) {
+        id
+        title
+        description
+        priority
+        severity
+        owner
+        readOwners
+      }
+    }
+  `;
+  return client.mutate<any>({ mutation: request, variables: { input } });
+};
+
+const updateTask = async (client: AWSAppSyncClient<any>, input: UpdateTaskInput): Promise<any> => {
+  const request = gql`
+    mutation UpdateTask($input: UpdateTaskInput!) {
+      updateTask(input: $input) {
+        id
+        title
+        description
+        priority
+        severity
+        owner
+        readOwners
+      }
+    }
+  `;
+  return client.mutate<any>({ mutation: request, variables: { input } });
+};
+
+const deleteTask = async (client: AWSAppSyncClient<any>, input: DeleteTaskInput): Promise<any> => {
+  const request = gql`
+    mutation DeleteTask($input: DeleteTaskInput!) {
+      deleteTask(input: $input) {
+        id
+        title
+        description
+        priority
+        severity
+        owner
+        readOwners
+      }
+    }
+  `;
+  return client.mutate<any>({ mutation: request, variables: { input } });
+};
+
+const createTodo = async (client: AWSAppSyncClient<any>, input: CreateTodoInput): Promise<any> => {
+  const request = gql`
+    mutation CreateTodo($input: CreateTodoInput!) {
+      createTodo(input: $input) {
+        id
+        name
+        description
+        level
+        owner
+        sharedOwners
+        status
+      }
+    }
+  `;
+  return client.mutate<any>({ mutation: request, variables: { input } });
+};
+
+const updateTodo = async (client: AWSAppSyncClient<any>, input: UpdateTodoInput): Promise<any> => {
+  const request = gql`
+    mutation UpdateTodo($input: UpdateTodoInput!) {
+      updateTodo(input: $input) {
+        id
+        name
+        description
+        level
+        owner
+        sharedOwners
+        status
+      }
+    }
+  `;
+  return client.mutate<any>({ mutation: request, variables: { input } });
+};
+
+const deleteTodo = async (client: AWSAppSyncClient<any>, input: DeleteTodoInput): Promise<any> => {
+  const request = gql`
+    mutation DeleteTodo($input: DeleteTodoInput!) {
+      deleteTodo(input: $input) {
+        id
+        name
+        description
+        level
+        owner
+        sharedOwners
+        status
+      }
+    }
+  `;
+  return client.mutate<any>({ mutation: request, variables: { input } });
+};

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts
@@ -994,8 +994,8 @@ test('Test onCreatePost with incorrect owner argument should throw an error', as
   const failedObserver = API.graphql({
     // @ts-ignore
     query: gql`
-      subscription OnCreatePost(postOwner: "${USERNAME2}") {
-        onCreatePost {
+      subscription OnCreatePost {
+        onCreatePost(postOwner: "${USERNAME2}") {
           id
           title
           postOwner

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts
@@ -685,51 +685,6 @@ test('Test that only authorized members are allowed to view subscriptions', asyn
   });
 });
 
-test('Test that an user not in the group is not allowed to view the subscription', async () => {
-  // subscribe to create students as user 3
-  // const observer = onCreateStudent(GRAPHQL_CLIENT_3)
-  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
-  await Auth.signIn(USERNAME3, REAL_PASSWORD);
-  const observer = API.graphql({
-    // @ts-ignore
-    query: gql`
-      subscription OnCreateStudent {
-        onCreateStudent {
-          id
-          name
-          email
-          ssn
-          owner
-        }
-      }
-    `,
-    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
-  }) as unknown as Observable<any>;
-  let subscription: ZenObservable.Subscription;
-  const subscriptionPromise = new Promise((resolve, _) => {
-    subscription = observer.subscribe({
-      error: (err: any) => {
-        expect(err.error.errors[0].message).toEqual(
-          'Connection failed: {"errors":[{"errorType":"Unauthorized","message":"Not Authorized to access onCreateStudent on type Subscription"}]}',
-        );
-        resolve(undefined);
-      },
-    });
-  });
-
-  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
-
-  await createStudent(GRAPHQL_CLIENT_1, {
-    name: 'student2',
-    email: 'student2@domain.com',
-    ssn: 'BBB-00-SNSN',
-  });
-
-  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'Subscription timed out', () => {
-    subscription?.unsubscribe();
-  });
-});
-
 test('Test a subscription on update', async () => {
   // subscribe to update students as user 2
   reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
@@ -1033,13 +988,13 @@ test('Test subscription onCreatePost with ownerField', async () => {
   });
 });
 
-test('Test onCreatePost with optional argument', async () => {
+test('Test onCreatePost with incorrect owner argument should throw an error', async () => {
   reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
   await Auth.signIn(USERNAME1, REAL_PASSWORD);
   const failedObserver = API.graphql({
     // @ts-ignore
     query: gql`
-      subscription OnCreatePost {
+      subscription OnCreatePost(postOwner: "${USERNAME2}") {
         onCreatePost {
           id
           title

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts
@@ -722,8 +722,8 @@ test('Test onCreatePost with incorrect owner argument should throw an error', as
   const failedObserver = API.graphql({
     // @ts-ignore
     query: gql`
-      subscription OnCreatePost(postOwner: "${USERNAME2}") {
-        onCreatePost {
+      subscription OnCreatePost {
+        onCreatePost(postOwner: "${USERNAME2}") {
           id
           title
           postOwner

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts
@@ -413,51 +413,6 @@ test('Test that only authorized members are allowed to view subscriptions', asyn
   });
 });
 
-test('Test that an user not in the group is not allowed to view the subscription', async () => {
-  // subscribe to create students as user 3
-  // const observer = onCreateStudent(GRAPHQL_CLIENT_3)
-  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
-  await Auth.signIn(USERNAME3, REAL_PASSWORD);
-  const observer = API.graphql({
-    // @ts-ignore
-    query: gql`
-      subscription OnCreateStudent {
-        onCreateStudent {
-          id
-          name
-          email
-          ssn
-          owner
-        }
-      }
-    `,
-    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
-  }) as unknown as Observable<any>;
-  let subscription: ZenObservable.Subscription;
-  const subscriptionPromise = new Promise((resolve, _) => {
-    subscription = observer.subscribe({
-      error: (err: any) => {
-        expect(err.error.errors[0].message).toEqual(
-          'Connection failed: {"errors":[{"errorType":"Unauthorized","message":"Not Authorized to access onCreateStudent on type Student"}]}',
-        );
-        resolve(undefined);
-      },
-    });
-  });
-
-  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
-
-  await createStudent(GRAPHQL_CLIENT_1, {
-    name: 'student2',
-    email: 'student2@domain.com',
-    ssn: 'BBB-00-SNSN',
-  });
-
-  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'Subscription timed out', () => {
-    subscription?.unsubscribe();
-  });
-});
-
 test('Test a subscription on update', async () => {
   // subscribe to update students as user 2
   reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
@@ -761,13 +716,13 @@ test('Test subscription onCreatePost with ownerField', async () => {
   });
 });
 
-test('Test onCreatePost with optional argument', async () => {
+test('Test onCreatePost with incorrect owner argument should throw an error', async () => {
   reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
   await Auth.signIn(USERNAME1, REAL_PASSWORD);
   const failedObserver = API.graphql({
     // @ts-ignore
     query: gql`
-      subscription OnCreatePost {
+      subscription OnCreatePost(postOwner: "${USERNAME2}") {
         onCreatePost {
           id
           title

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2WithFF.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2WithFF.e2e.test.ts
@@ -708,8 +708,8 @@ test('Test onCreatePost with incorrect owner argument should throw an error', as
   const failedObserver = API.graphql({
     // @ts-ignore
     query: gql`
-      subscription OnCreatePost(postOwner: "${USERNAME2}") {
-        onCreatePost {
+      subscription OnCreatePost {
+        onCreatePost(postOwner: "${USERNAME2}") {
           id
           title
           postOwner

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2WithFF.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2WithFF.e2e.test.ts
@@ -399,51 +399,6 @@ test('Test that only authorized members are allowed to view subscriptions', asyn
   });
 });
 
-test('Test that an user not in the group is not allowed to view the subscription', async () => {
-  // subscribe to create students as user 3
-  // const observer = onCreateStudent(GRAPHQL_CLIENT_3)
-  reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
-  await Auth.signIn(USERNAME3, REAL_PASSWORD);
-  const observer = API.graphql({
-    // @ts-ignore
-    query: gql`
-      subscription OnCreateStudent {
-        onCreateStudent {
-          id
-          name
-          email
-          ssn
-          owner
-        }
-      }
-    `,
-    authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
-  }) as unknown as Observable<any>;
-  let subscription: ZenObservable.Subscription;
-  const subscriptionPromise = new Promise((resolve, _) => {
-    subscription = observer.subscribe({
-      error: (err: any) => {
-        expect(err.error.errors[0].message).toEqual(
-          'Connection failed: {"errors":[{"errorType":"Unauthorized","message":"Not Authorized to access onCreateStudent on type Student"}]}',
-        );
-        resolve(undefined);
-      },
-    });
-  });
-
-  await new Promise(res => setTimeout(res, SUBSCRIPTION_DELAY));
-
-  await createStudent(GRAPHQL_CLIENT_1, {
-    name: 'student2',
-    email: 'student2@domain.com',
-    ssn: 'BBB-00-SNSN',
-  });
-
-  return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'Subscription timed out', () => {
-    subscription?.unsubscribe();
-  });
-});
-
 test('Test a subscription on update', async () => {
   // subscribe to update students as user 2
   reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
@@ -747,13 +702,13 @@ test('Test subscription onCreatePost with ownerField', async () => {
   });
 });
 
-test('Test onCreatePost with optional argument', async () => {
+test('Test onCreatePost with incorrect owner argument should throw an error', async () => {
   reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
   await Auth.signIn(USERNAME1, REAL_PASSWORD);
   const failedObserver = API.graphql({
     // @ts-ignore
     query: gql`
-      subscription OnCreatePost {
+      subscription OnCreatePost(postOwner: "${USERNAME2}") {
         onCreatePost {
           id
           title


### PR DESCRIPTION
#### Description of changes

This PR enables subscription runtime filtering.

- Adds filter argument to subscriptions to provide server side filtering.
- Supports subscriptions with multiple owners auth rules.

#### Description of how you validated changes
- yarn test
- manual test
- e2e test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
