### PR TITLE
chore: adding regression test for apikey+owner auth model to verify that subscriptions where owner is undefined works

### DIFF
--- a/client-test-apps/js/api-model-relationship-app/cypress/e2e/auth-modes.cy.ts
+++ b/client-test-apps/js/api-model-relationship-app/cypress/e2e/auth-modes.cy.ts
@@ -1,0 +1,41 @@
+/// <reference types='cypress' />
+
+
+const uuid = () => Cypress._.random(0, 1e6)
+
+const TEST_ID = `${uuid()}`;
+const PAGE_ROUTE = 'http://localhost:3000/auth-modes';
+const SUCCESS_MARK = '✅';
+const FAILURE_MARK = '❌';
+const PAGE_TITLE = 'Multiauth Controls';
+
+/**
+ * It's not great practice, but these tests rely on being in-order for now.
+ */
+describe('auth-mode interactions', () => {
+  before(() => {
+    cy.visit(PAGE_ROUTE)
+  });
+
+  describe('page state is stable', () => {
+    it('loads', () => {
+      cy.contains(PAGE_TITLE);
+    })
+  
+    /**
+     * Non-owner based subscriptions work for models which also have owner-based auth attached.
+     */
+    it('initializes subscriptions when owner auth is not selected, despite existing on the model', () => {
+      cy.get('#subscription-state').contains(SUCCESS_MARK);
+    })
+  });
+
+  describe('simple create model emits an event', () => {
+    it('creates a record and sees the result in the observable', () => {
+      cy.get('#MultiAuth-id-input').clear().type(TEST_ID);
+      cy.get('#MultiAuth-create').click();
+      cy.get('#MultiAuth-is-created').within(() => { cy.contains(SUCCESS_MARK) });
+      cy.get('#created-MultiAuths-subscription').within(() => { cy.contains(TEST_ID) });
+    });
+  });
+});

--- a/client-test-apps/js/api-model-relationship-app/src/App.tsx
+++ b/client-test-apps/js/api-model-relationship-app/src/App.tsx
@@ -12,6 +12,7 @@ import {
   Todos,
   Blogs,
   Listings,
+  AuthModes,
 } from './pages';
 
 Amplify.configure(awsconfig);
@@ -26,6 +27,7 @@ const App = () => {
             <Route path="todos" element={<Todos />} />
             <Route path="blogs" element={<Blogs />} />
             <Route path="listings" element={<Listings />} />
+            <Route path="auth-modes" element={<AuthModes />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/client-test-apps/js/api-model-relationship-app/src/NavBar.tsx
+++ b/client-test-apps/js/api-model-relationship-app/src/NavBar.tsx
@@ -6,7 +6,8 @@ export const NavBar = () => {
     <Flex direction='row'>
       <Link to="/todos">Todos</Link> |{" "}
       <Link to="/blogs">Blogs</Link> |{" "}
-      <Link to="/listings">Listings</Link>
+      <Link to="/listings">Listings</Link> |{" "}
+      <Link to="/auth-modes">Auth Modes</Link>
     </Flex>
   );
 };

--- a/client-test-apps/js/api-model-relationship-app/src/__tests__/api.test.ts
+++ b/client-test-apps/js/api-model-relationship-app/src/__tests__/api.test.ts
@@ -3,70 +3,78 @@ import { AmplifyCLI } from './utils/amplifyCLI';
 import { executeAmplifyTestHarness } from './utils/testHarness';
 
 const PROJECT_ROOT = path.join(__dirname, '..', '..');
+const envName = 'devtest';
+const projName = 'simplemodel';
+const schemaText = `
+# Standalone Model
+# Non-Model Types
+type Todo @model @auth(rules: [{ provider: apiKey, allow: public }]) {
+  id: ID!
+  content: String
+  metadata: TodoMetadata
+}
+
+type TodoMetadata {
+  targetCompletionDate: AWSDate
+  percentChanceOfCompletion: Float
+}
+
+# HasMany Relationship
+# BelongsTo Relationship
+# Secondary Index
+type Blog @model @auth(rules: [{ provider: apiKey, allow: public }]) {
+  id: ID!
+  title: String!
+  author: String! @index(name: "byAuthor", queryField: "blogByAuthor")
+  posts: [Post] @hasMany
+}
+
+type Post @model @auth(rules: [{ provider: apiKey, allow: public }]) {
+  id: ID!
+  title: String!
+  content: String!
+  blog: Blog @belongsTo
+}
+
+# ManyToMany Relationship
+# Enum Values
+type Listing @model @auth(rules: [{ provider: apiKey, allow: public }]) {
+  id: ID!
+  title: String!
+  bedroomCount: Int
+  bathroomCount: Int
+  listPriceUSD: Float
+  state: ListingState
+  isHotProperty: Boolean
+  tags: [Tag] @manyToMany(relationName: "ListingTags")
+}
+
+enum ListingState {
+  OPEN
+  UNDER_REVIEW
+  SOLD
+}
+
+type Tag @model @auth(rules: [{ provider: apiKey, allow: public }]) {
+  id: ID!
+  label: String!
+  listings: [Listing] @manyToMany(relationName: "ListingTags")
+}
+
+type MultiAuth @model @auth(rules: [
+  { provider: apiKey, allow: public },
+  { provider: userPools, allow: owner }
+]) {
+  id: ID!
+  content: String @default(value: "Default Content")
+}
+`;
 
 executeAmplifyTestHarness('simple test', PROJECT_ROOT, async (cli: AmplifyCLI) => {
-  const envName = 'devtest';
-  const projName = 'simplemodel';
-  const schemaText = `
-  # Standalone Model
-  # Non-Model Types
-  type Todo @model @auth(rules: [{ allow: public }]) {
-    id: ID!
-    content: String
-    metadata: TodoMetadata
-  }
-
-  type TodoMetadata {
-    targetCompletionDate: AWSDate
-    percentChanceOfCompletion: Float
-  }
-
-  # HasMany Relationship
-  # BelongsTo Relationship
-  # Secondary Index
-  type Blog @model @auth(rules: [{ allow: public }]) {
-    id: ID!
-    title: String!
-    author: String! @index(name: "byAuthor", queryField: "blogByAuthor")
-    posts: [Post] @hasMany
-  }
-  
-  type Post @model @auth(rules: [{ allow: public }]) {
-    id: ID!
-    title: String!
-    content: String!
-    blog: Blog @belongsTo
-  }
-
-  # ManyToMany Relationship
-  # Enum Values
-  type Listing @model {
-    id: ID!
-    title: String!
-    bedroomCount: Int
-    bathroomCount: Int
-    listPriceUSD: Float
-    state: ListingState
-    isHotProperty: Boolean
-    tags: [Tag] @manyToMany(relationName: "ListingTags")
-  }
-
-  enum ListingState {
-    OPEN
-    UNDER_REVIEW
-    SOLD
-  }
-  
-  type Tag @model {
-    id: ID!
-    label: String!
-    listings: [Listing] @manyToMany(relationName: "ListingTags")
-  }
-  `;
-
   await cli.initializeProject({ name: projName, envName });
   await cli.addApiWithoutSchema();
   await cli.updateSchema(projName, schemaText);
+  await cli.addAuth();
   await cli.push();
   await cli.codegen({ statementDepth: 3 });
 });

--- a/client-test-apps/js/api-model-relationship-app/src/__tests__/utils/amplifyCLI.ts
+++ b/client-test-apps/js/api-model-relationship-app/src/__tests__/utils/amplifyCLI.ts
@@ -386,4 +386,16 @@ export class AmplifyCLI {
       .wait('Code generated successfully')
       .runAsync();
   }
+
+  addAuth (): Promise<void> {
+    console.log('Executing Add Auth');
+    return spawn(getCLIPath(), ['add', 'auth'], { cwd: this.projectRoot, noOutputTimeout: pushTimeoutMS })
+      .wait('Do you want to use the default authentication and security configuration?')
+      .sendCarriageReturn()
+      .wait('How do you want users to be able to sign in?')
+      .sendCarriageReturn()
+      .wait('Do you want to configure advanced settings?')
+      .sendCarriageReturn()
+      .runAsync();
+  }
 };

--- a/client-test-apps/js/api-model-relationship-app/src/__tests__/utils/testHarness.ts
+++ b/client-test-apps/js/api-model-relationship-app/src/__tests__/utils/testHarness.ts
@@ -84,7 +84,7 @@ export const executeAmplifyTestHarness = (testName: string, projectRoot: string,
      */
     afterAll(async () => {
       if (getTestExecutionStages().has(TestExecutionStage.TEARDOWN)) {
-          try {
+        try {
           await cli.delete();
           cleanupJSGeneratedFiles(projectRoot);
         } catch (e) {}

--- a/client-test-apps/js/api-model-relationship-app/src/components/AuthModePicker.tsx
+++ b/client-test-apps/js/api-model-relationship-app/src/components/AuthModePicker.tsx
@@ -1,0 +1,31 @@
+import { RadioGroupField, Radio } from "@aws-amplify/ui-react";
+import { useState, SetStateAction, useEffect } from "react";
+import { AuthMode } from "./HarnessContext";
+
+type OverrideAuthMode = AuthMode | 'unset';
+
+type AuthModePickerProps = {
+  initialAuthMode?: OverrideAuthMode;
+  onAuthModeUpdates: (updatedAuthMode?: AuthMode) => void;
+};
+
+export const AuthModePicker = ({ initialAuthMode, onAuthModeUpdates }: AuthModePickerProps) => {
+  const [overrideAuthMode, setOverrideAuthMode] = useState<OverrideAuthMode>(initialAuthMode ?? 'unset');
+
+  useEffect(() => {
+    onAuthModeUpdates(overrideAuthMode === 'unset' ? undefined : overrideAuthMode);
+  }, [overrideAuthMode, onAuthModeUpdates]);
+  
+  return (
+    <RadioGroupField
+      label="Auth Type Override"
+      name="authTypeOverride"
+      value={overrideAuthMode}
+      onChange={(e) => setOverrideAuthMode(e.target.value as unknown as SetStateAction<OverrideAuthMode>)}
+    >
+      <Radio value='unset'>Not Set</Radio>
+      <Radio value='API_KEY'>API Key</Radio>
+      <Radio value='AMAZON_COGNITO_USER_POOLS'>User Pool</Radio>
+    </RadioGroupField>
+  );
+};

--- a/client-test-apps/js/api-model-relationship-app/src/components/CRUDLComponents.tsx
+++ b/client-test-apps/js/api-model-relationship-app/src/components/CRUDLComponents.tsx
@@ -1,9 +1,10 @@
 import { Button, Card, Collection, Flex, Heading, TextField } from '@aws-amplify/ui-react';
-import { API, graphqlOperation } from 'aws-amplify';
+import { API } from 'aws-amplify';
 import _ from 'lodash';
 import pluralize from 'pluralize';
 import { useState } from 'react';
 import { OperationStateIndicator, useOperationStateWrapper } from '.';
+import { HarnessContext, HarnessContextType } from './HarnessContext';
 
 type DetailState = 'view' | 'edit';
 
@@ -21,24 +22,28 @@ export type createDetailComponentProps<T> = {
 export const createDetailComponent = <T extends any>({ deleteMutation, recordName, ViewComp, EditComp }: createDetailComponentProps<T>): RecordComponentType<T> => {
   const capitalizedRecordName = _.capitalize(recordName)
   return ({ record }: SimpleIdRecordProps<T>) => {
-    const { wrappedFn, opState } = useOperationStateWrapper(async () => await API.graphql(graphqlOperation(deleteMutation, { input: { id: record.id } })));
+    const { wrappedFn, opState } = useOperationStateWrapper(async ({ authMode }: HarnessContextType) => await API.graphql({ query: deleteMutation, variables: { input: { id: record.id } }, authMode }));
     const [detailState, setDetailState] = useState<DetailState>('view');
   
     return (
-      <Card variation='elevated'>
-        <Heading level={5}>{ capitalizedRecordName }</Heading>
-        <span>ID: { record.id }</span>
-        { detailState === 'view'
-          ? <ViewComp record={record} />
-          : <EditComp record={record} />
+      <HarnessContext.Consumer>
+        { context => 
+          <Card variation='elevated'>
+            <Heading level={5}>{ capitalizedRecordName }</Heading>
+            <span>ID: { record.id }</span>
+            { detailState === 'view'
+              ? <ViewComp record={record} />
+              : <EditComp record={record} />
+            }
+            <Button id={`delete-${recordName}`} size='small' onClick={() => wrappedFn(context)}>Delete</Button>
+            <OperationStateIndicator id={`${recordName}-is-deleted`} state={opState} />
+            { detailState === 'view'
+              ? <Button size='small' onClick={() => setDetailState('edit')}>Edit</Button>
+              : <Button size='small' onClick={() => setDetailState('view')}>View</Button>
+            }
+          </Card>
         }
-        <Button id={`delete-${recordName}`} size='small' onClick={wrappedFn}>Delete</Button>
-        <OperationStateIndicator id={`${recordName}-is-deleted`} state={opState} />
-        { detailState === 'view'
-          ? <Button size='small' onClick={() => setDetailState('edit')}>Edit</Button>
-          : <Button size='small' onClick={() => setDetailState('view')}>View</Button>
-        }
-      </Card>
+      </HarnessContext.Consumer>
     );
   };
 };
@@ -52,18 +57,22 @@ export type createCreateRecordComponentProps = {
 export const createCreateRecordComponent = ({ recordName, createMutation, sentinelData }: createCreateRecordComponentProps) => {
   const capitalizedRecordName = _.capitalize(recordName);
   return () => {
-    const { wrappedFn, opState } = useOperationStateWrapper(async () => await API.graphql(graphqlOperation(createMutation, { input: { ...sentinelData, id } })));
+    const { wrappedFn, opState } = useOperationStateWrapper(async ({ authMode }: HarnessContextType) => await API.graphql({ query: createMutation, variables: { input: { ...sentinelData, id } }, authMode }));
     const [id, setId] = useState('');
   
     return (
-      <Flex direction='column'>
-        <Heading level={3}>Create A { capitalizedRecordName }</Heading>
-        <Flex direction='row'>
-          <TextField id={`${recordName}-id-input`} label='Test Id' onChange={(event: any) => { setId(event.target.value) }}/>
-          <Button id={`${recordName}-create`} onClick={wrappedFn}>Create { capitalizedRecordName }</Button>
-          <OperationStateIndicator id={`${recordName}-is-created`} state={opState} />
-        </Flex>
-      </Flex>
+      <HarnessContext.Consumer>
+        { context => 
+          <Flex direction='column'>
+            <Heading level={3}>Create A { capitalizedRecordName }</Heading>
+            <Flex direction='row'>
+              <TextField id={`${recordName}-id-input`} label='Test Id' onChange={(event: any) => { setId(event.target.value) }}/>
+              <Button id={`${recordName}-create`} onClick={() => wrappedFn(context)}>Create { capitalizedRecordName }</Button>
+              <OperationStateIndicator id={`${recordName}-is-created`} state={opState} />
+            </Flex>
+          </Flex>
+        }
+      </HarnessContext.Consumer>
     );
   };
 };
@@ -80,24 +89,28 @@ export const createGetRecordComponent = <T extends any>({ getQuery, recordName, 
   return () => {
     const [retrievedRecord, setRecord] = useState<T | undefined>();
     const [id, setId] = useState('');
-    const { wrappedFn, opState } = useOperationStateWrapper(async () => {
-      const response = await API.graphql(graphqlOperation(getQuery, { id }));
+    const { wrappedFn, opState } = useOperationStateWrapper(async ({ authMode }: HarnessContextType) => {
+      const response = await API.graphql({ query: getQuery, variables: { id }, authMode});
       // @ts-ignore
       setRecord(response.data[getRecordDataLoc]);
     });
 
     return (
-      <Flex direction='column'>
-        <Heading level={3}>Get A { capitalizedRecordName }</Heading>
-        <Flex direction='row'>
-          <TextField id={`retrieve-${recordName}-id`} label={`${capitalizedRecordName} Id`} onChange={(event: any) => { setId(event.target.value) }}/>
-          <Button id={`retrieve-${recordName}-button`} onClick={wrappedFn}>Get { capitalizedRecordName }</Button>
-          <OperationStateIndicator id={`${recordName}-is-retrieved`} state={opState} />
-        </Flex>
-        <div id={`retrieved-${recordName}`}>
-          { retrievedRecord && <DetailComp record={retrievedRecord as SimpleIdRecord<T>} /> }
-        </div>
-      </Flex>
+      <HarnessContext.Consumer>
+        { context => 
+          <Flex direction='column'>
+            <Heading level={3}>Get A { capitalizedRecordName }</Heading>
+            <Flex direction='row'>
+              <TextField id={`retrieve-${recordName}-id`} label={`${capitalizedRecordName} Id`} onChange={(event: any) => { setId(event.target.value) }}/>
+              <Button id={`retrieve-${recordName}-button`} onClick={() => wrappedFn(context)}>Get { capitalizedRecordName }</Button>
+              <OperationStateIndicator id={`${recordName}-is-retrieved`} state={opState} />
+            </Flex>
+            <div id={`retrieved-${recordName}`}>
+              { retrievedRecord && <DetailComp record={retrievedRecord as SimpleIdRecord<T>} /> }
+            </div>
+          </Flex>
+        }
+      </HarnessContext.Consumer>
     );
   };
 };
@@ -114,30 +127,34 @@ export const createListComponent = <T extends any>({ listQuery, recordName, Deta
   const capitalizedPluralizedRecordName = _.capitalize(pluralizedRecordName);
   return () => {
     const [records, setRecords] = useState<SimpleIdRecord<T>[]>([]);
-    const { wrappedFn, opState } = useOperationStateWrapper(async () => {
-      const response = await API.graphql({ query: listQuery }) as any;
+    const { wrappedFn, opState } = useOperationStateWrapper(async ({ authMode }: HarnessContextType) => {
+      const response = await API.graphql({ query: listQuery, authMode }) as any;
       setRecords(response.data[listRecordsDataLoc].items);
     });
   
     return (
-      <Flex direction='column'>
-        <Heading level={3}>List { capitalizedPluralizedRecordName }</Heading>
-        <Flex direction='row'>
-          <Button id={`list-${pluralizedRecordName}`} onClick={wrappedFn}>Load { capitalizedPluralizedRecordName }</Button>
-          <OperationStateIndicator id={`${pluralizedRecordName}-are-listed`} state={opState} />
-        </Flex>
-        <div id={`listed-${pluralizedRecordName}`}>
-          <Collection
-            items={records}
-            type='list'
-            direction='column'
-            gap='20px'
-            wrap='nowrap'
-          >
-            { (record: SimpleIdRecord<T>) => <DetailComp key={record.id} record={record} /> }
-          </Collection>
-        </div>
-      </Flex>
+      <HarnessContext.Consumer>
+        { context => 
+          <Flex direction='column'>
+            <Heading level={3}>List { capitalizedPluralizedRecordName }</Heading>
+            <Flex direction='row'>
+              <Button id={`list-${pluralizedRecordName}`} onClick={() => wrappedFn(context)}>Load { capitalizedPluralizedRecordName }</Button>
+              <OperationStateIndicator id={`${pluralizedRecordName}-are-listed`} state={opState} />
+            </Flex>
+            <div id={`listed-${pluralizedRecordName}`}>
+              <Collection
+                items={records}
+                type='list'
+                direction='column'
+                gap='20px'
+                wrap='nowrap'
+              >
+                { (record: SimpleIdRecord<T>) => <DetailComp key={record.id} record={record} /> }
+              </Collection>
+            </div>
+          </Flex>
+        }
+      </HarnessContext.Consumer>
     );
   };
 };
@@ -166,28 +183,32 @@ export type createEditCompProps<T> = {
 export const createEditComp = <T extends object>({ updateMutation, fields, recordName }: createEditCompProps<T>): RecordComponentType<T> => {
   return ({ record }: SimpleIdRecordProps<T>) => {
     const [updatedFields, setUpdatedFields] = useState({});
-    const { wrappedFn, opState } = useOperationStateWrapper(async () => await API.graphql(graphqlOperation(updateMutation, { input: { ...updatedFields, id: record.id} })));
+    const { wrappedFn, opState } = useOperationStateWrapper(async ({ authMode }: HarnessContextType) => await API.graphql({ query: updateMutation, variables: { input: { ...updatedFields, id: record.id} }, authMode }));
   
     const updateField = (fieldName: keyof T, updatedValue: string) => {
       setUpdatedFields((oldFields) => ({ ...oldFields, [fieldName]: updatedValue }));
     };
 
     return (
-      <Flex direction='row'>
-        { fields.map(field => { return (
-          <TextField
-            key={`${recordName}-${String(field)}`}
-            id={`update-${String(field)}-input`}
-            label={_.capitalize(String(field))}
-            placeholder={ String(record[field]) || '' }
-            onChange={(event: any) => {
-              updateField(field, event.target.value);
-            }}
-          />
-        ) }) }
-        <Button id={`update-${recordName}`} onClick={wrappedFn}>Update</Button>
-        <OperationStateIndicator id={`${recordName}-is-updated`} state={opState} />
-      </Flex>
+      <HarnessContext.Consumer>
+        { context => 
+          <Flex direction='row'>
+            { fields.map(field => { return (
+              <TextField
+                key={`${recordName}-${String(field)}`}
+                id={`update-${String(field)}-input`}
+                label={_.capitalize(String(field))}
+                placeholder={ String(record[field]) || '' }
+                onChange={(event: any) => {
+                  updateField(field, event.target.value);
+                }}
+              />
+            ) }) }
+            <Button id={`update-${recordName}`} onClick={() => wrappedFn(context)}>Update</Button>
+            <OperationStateIndicator id={`${recordName}-is-updated`} state={opState} />
+          </Flex>
+        }
+      </HarnessContext.Consumer>
     );
   };
 };

--- a/client-test-apps/js/api-model-relationship-app/src/components/HarnessContext.tsx
+++ b/client-test-apps/js/api-model-relationship-app/src/components/HarnessContext.tsx
@@ -1,0 +1,13 @@
+import { GRAPHQL_AUTH_MODE } from '@aws-amplify/api';
+import { createContext } from 'react';
+
+export type AuthMode = keyof typeof GRAPHQL_AUTH_MODE;
+
+export type HarnessContextType = {
+  authMode?: AuthMode;
+};
+
+// Context lets us pass a value deep into the component tree
+// without explicitly threading it through every component.
+// Create a context for the current theme (with "light" as the default).
+export const HarnessContext = createContext<HarnessContextType>({});

--- a/client-test-apps/js/api-model-relationship-app/src/components/ModelHarness.tsx
+++ b/client-test-apps/js/api-model-relationship-app/src/components/ModelHarness.tsx
@@ -3,7 +3,6 @@ import { Flex, Heading } from '@aws-amplify/ui-react';
 import _ from 'lodash';
 import { createCRUDLControls, createCRUDLControlsProps, Subscriptions } from '../components';
 
-
 export type createModelHarnessProps<T> = createCRUDLControlsProps<T> & {
   onCreateSubscription: string;
   onUpdateSubscription: string;

--- a/client-test-apps/js/api-model-relationship-app/src/components/OperationStateHandler.tsx
+++ b/client-test-apps/js/api-model-relationship-app/src/components/OperationStateHandler.tsx
@@ -7,13 +7,13 @@ export const OperationStateIndicator = ({ id, state }: { id: string, state: Oper
   return <span id={id}>{ state === 'Succeeded' ? '✅' : '❌' }</span>;
 }
 
-export const useOperationStateWrapper = (fn: () => Promise<any>): { wrappedFn: () => Promise<void>, opState: OperationState } => {
+export const useOperationStateWrapper = <T extends Array<any>>(fn: (...args: T) => Promise<any>): { wrappedFn: (...args: T) => Promise<void>, opState: OperationState } => {
   const [opState, setState] = useState<OperationState>('NotStarted');
 
-  const wrappedFn = async () => {
+  const wrappedFn = async (...args: T): Promise<void> => {
     setState('NotStarted')
     try {
-      await fn();
+      await fn(...args);
       setState('Succeeded');
     } catch (e) {
       console.error(e);

--- a/client-test-apps/js/api-model-relationship-app/src/pages/AuthModes.tsx
+++ b/client-test-apps/js/api-model-relationship-app/src/pages/AuthModes.tsx
@@ -1,0 +1,41 @@
+import { Flex, Heading } from '@aws-amplify/ui-react';
+import { useState } from 'react';
+import { MultiAuth } from '../API';
+import { createModelHarness } from '../components';
+import { AuthModePicker } from '../components/AuthModePicker';
+import { AuthMode, HarnessContext } from '../components/HarnessContext';
+import { createMultiAuth, updateMultiAuth, deleteMultiAuth } from '../graphql/mutations';
+import { getMultiAuth, listMultiAuths } from '../graphql/queries';
+import { onCreateMultiAuth, onDeleteMultiAuth, onUpdateMultiAuth } from '../graphql/subscriptions';
+import { NavBar } from '../NavBar';
+
+const ModelHarness = createModelHarness<MultiAuth>({
+  recordName: 'MultiAuth',
+  fields: ['content'],
+  createMutation: createMultiAuth,
+  updateMutation: updateMultiAuth,
+  getQuery: getMultiAuth,
+  listQuery: listMultiAuths,
+  deleteMutation: deleteMultiAuth,
+  onCreateSubscription: onCreateMultiAuth,
+  onUpdateSubscription: onUpdateMultiAuth,
+  onDeleteSubscription: onDeleteMultiAuth,
+  sentinelData: { content: null },
+});
+
+export const AuthModes = () => {
+  const [authMode, setAuthMode] = useState<AuthMode>();
+
+  return (
+    <Flex direction='column'>
+      <NavBar />
+      <Heading level={1}>Auth Controls</Heading>
+      <Flex direction='row'>
+        <AuthModePicker onAuthModeUpdates={(updatedAuthMode) => { setAuthMode(updatedAuthMode) }} />
+      </Flex>
+      <HarnessContext.Provider value={{ authMode }}>
+        <ModelHarness />
+      </HarnessContext.Provider>
+    </Flex>
+  );
+};

--- a/client-test-apps/js/api-model-relationship-app/src/pages/index.ts
+++ b/client-test-apps/js/api-model-relationship-app/src/pages/index.ts
@@ -1,3 +1,4 @@
 export * from './Blogs';
 export * from './Todos';
 export * from './Listings';
+export * from './AuthModes';


### PR DESCRIPTION
#### Description of changes
This verifies the behavior that was witnessed in these a few bugs, has not regressed. I've added an owner-auth enabled model, and verified that I can successfully subscribe and receive subscription data w/ no owner set.

#### Issue #, if available
https://github.com/aws-amplify/amplify-category-api/issues/758, https://github.com/aws-amplify/amplify-category-api/issues/134

#### Description of how you validated changes
Tested locally, and ran in CI - https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api/1264/workflows/e5a29202-2bc2-4c0c-af0c-c4a4e3ebd388/jobs/37099

#### Checklist
- [x] PR description included
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
