### PR TITLE
chore: add canary to run client e2e tests

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -371,7 +371,26 @@ workflows:
             - api-e2e-test-context
           requires:
             - build
-
+  canary:
+    triggers:
+      - schedule:
+          cron: "13 0,6,12,18 * * *" # Run 4 times daily, on the 13th minute of the hour
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - build
+      - publish_to_local_registry:
+          requires:
+            - build
+      - client_e2e_tests:
+          context:
+            - api-cleanup-resources
+            - e2e-auth-credentials
+            - api-e2e-test-context
+          requires:
+            - publish_to_local_registry
   build_test_deploy:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ parameters:
   setup:
     type: boolean
     default: true
+  canary:
+    type: boolean
+    default: false
 
 executors:
   linux: &linux-e2e-executor
@@ -24,6 +27,17 @@ executors:
     environment:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux-x64
+
+install_cli_from_local_registry: &install_cli_from_local_registry
+  name: Start verdaccio, install CLI
+  command: |
+    source .circleci/local_publish_helpers.sh
+    startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
+    setNpmRegistryUrlToLocal
+    changeNpmGlobalPath
+    npm install -g @aws-amplify/cli-internal
+    echo "using Amplify CLI version: "$(amplify --version)
+    unsetNpmRegistryUrl
 
 # our defined job, and its steps
 jobs:
@@ -106,6 +120,73 @@ jobs:
           when: always
       - store_artifacts:
           path: ~/repo/packages/amplify-e2e-tests/amplify-e2e-reports
+  publish_to_local_registry:
+    docker:
+      - image: public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:latest
+    working_directory: ~/repo
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux-x64
+    steps:
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: amplify-category-api-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{ arch }}
+      - run:
+          name: Publish to verdaccio
+          command: |
+            source .circleci/local_publish_helpers.sh
+            startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
+            setNpmRegistryUrlToLocal
+            git config user.email not@used.com
+            git config user.name "Doesnt Matter"
+            setNpmTag
+            if [ -z $NPM_TAG ]; then
+              yarn publish-to-verdaccio
+            else
+              yarn lerna publish --exact --dist-tag=latest --preid=$NPM_TAG --conventional-commits --conventional-prerelease --no-verify-access --yes --no-commit-hooks --no-push --no-git-tag-version
+            fi
+            unsetNpmRegistryUrl
+      - run:
+          name: Generate unified changelog
+          command: |
+            git reset --hard HEAD
+            yarn update-versions
+            yarn ts-node scripts/unified-changelog.ts
+      - save_cache:
+          key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ~/verdaccio-cache/
+      - save_cache:
+          key: amplify-unified-changelog-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ~/repo/UNIFIED_CHANGELOG.md
+  client_e2e_tests:
+    environment:
+      AMPLIFY_PATH: /home/circleci/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify
+    executor: 'linux'
+    working_directory: ~/repo
+    steps:
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: >-
+            amplify-category-api-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{
+            arch }}
+      - restore_cache:
+          key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
+      - restore_cache:
+          key: amplify-build-artifact-{{ .Revision }}-{{ arch }}
+      - run: *install_cli_from_local_registry
+      - run_client_tests
+      - scan_e2e_test_artifacts
+      - store_test_results:
+          path: client-test-apps/js/api-model-relationship-app/test-results
+      - store_artifacts:
+          path: client-test-apps/js/api-model-relationship-app/cypress/screenshots
+      - store_artifacts:
+          path: client-test-apps/js/api-model-relationship-app/cypress/videos
 
 # our single workflow, that triggers the setup job defined above
 workflows:
@@ -123,3 +204,46 @@ workflows:
             - api-e2e-test-context
           requires:
             - build
+  canary:
+    when: << pipeline.parameters.canary >>
+    jobs:
+      - build
+      - publish_to_local_registry:
+          requires:
+            - build
+      - client_e2e_tests:
+          context:
+            - api-cleanup-resources
+            - e2e-auth-credentials
+            - api-e2e-test-context
+          requires:
+            - publish_to_local_registry
+
+commands:
+  scan_e2e_test_artifacts:
+    description: "Scan And Cleanup E2E Test Artifacts"
+    steps:
+      - run:
+          name: Scan E2E artifacts
+          no_output_timeout: 90m
+          command: |
+            if ! yarn ts-node .circleci/scan_artifacts.ts; then
+              echo "Cleaning the repository"
+              git clean -fdx
+              exit 1
+            fi
+          when: always
+  run_client_tests:
+    description: "Run Amplify Client tests"
+    steps:
+      - run:
+          name: Run E2e Tests
+          command: |
+            echo "export PATH=$AMPLIFY_DIR:$PATH" >> $BASH_ENV
+            source $BASH_ENV
+            source .circleci/local_publish_helpers.sh
+            export CLI_REGION=us-west-2
+            cd client-test-apps/js/api-model-relationship-app
+            npm install
+            retry npm run test:ci
+          no_output_timeout: 90m


### PR DESCRIPTION
#### Description of changes
add canary to run client e2e tests, these can be triggered either by the schedule (4 times daily), or kicked off manually by setting the `canary` parameter.

__N.B. To support running both scheduled and from a manual kickoff I've had to redeclare the workflow in both `config.yml` and `config.base.yml`, and duplicate a few workflow steps and commands into `config.yml`. I'd rather have this duplication and the ability to trigger manual canary runs, at the cost of possible divergence.__

Publishing metrics to CW will come as a separate PR.

#### Issue #, if available
N/A

#### Description of how you validated changes
Verified the manual job in CCI, but still need to verify the scheduling. Because the job is running against main for scheduling, it's not finding the config on that branch, so I'll need to verify once this is merged. I have manually run a canary workflow here https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api/1320/workflows/d1b3cba7-b950-4cde-b2ea-937c52429312

#### Checklist
- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
