### PR TITLE
fix(graphql): add rds datasource v1 fix

### DIFF
--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -116,12 +116,14 @@
     "amplify-headless-interface": "^1.15.0",
     "amplify-prompts": "^2.2.0",
     "amplify-provider-awscloudformation": "^6.6.0",
-    "amplify-util-headless-input": "^1.9.5"
+    "amplify-util-headless-input": "^1.9.5",
+    "@aws-amplify/amplify-environment-parameters": "^1.1.1"
   },
   "devDependencies": {
     "@aws-cdk/assertions": "~1.124.0",
     "@types/js-yaml": "^4.0.0",
-    "amplify-util-headless-input": "^1.9.5"
+    "amplify-util-headless-input": "^1.9.5",
+    "@types/node": "^12.12.6"
   },
   "jest": {
     "testURL": "http://localhost",

--- a/packages/amplify-category-api/src/commands/api/add-graphql-datasource.ts
+++ b/packages/amplify-category-api/src/commands/api/add-graphql-datasource.ts
@@ -14,6 +14,7 @@ import inquirer from 'inquirer';
 import _ from 'lodash';
 import * as path from 'path';
 import { supportedDataSources } from '../../provider-utils/supported-datasources';
+import { getEnvParamManager } from '@aws-amplify/amplify-environment-parameters';
 
 const subcommand = 'add-graphql-datasource';
 const categories = 'categories';
@@ -50,14 +51,12 @@ export const run = async (context: $TSContext): Promise<void> => {
     const currentEnv = context.amplify.getEnvInfo().envName;
     const teamProviderInfo = stateManager.getTeamProviderInfo();
 
-    _.set(teamProviderInfo, [currentEnv, categories, category, resourceName], {
+    getEnvParamManager(currentEnv).getResourceParamManager(category, resourceName).setParams({
       rdsRegion: answers.region,
       rdsClusterIdentifier: answers.dbClusterArn,
       rdsSecretStoreArn: answers.secretStoreArn,
       rdsDatabaseName: answers.databaseName,
     });
-
-    stateManager.setTeamProviderInfo(undefined, teamProviderInfo);
 
     const backendConfig = stateManager.getBackendConfig();
 

--- a/packages/amplify-category-api/src/commands/api/add-graphql-datasource.ts
+++ b/packages/amplify-category-api/src/commands/api/add-graphql-datasource.ts
@@ -44,7 +44,7 @@ export const run = async (context: $TSContext): Promise<void> => {
     const { resourceName, databaseName } = answers;
 
     /**
-     * Write the new env specific datasource information into
+     * Setting the params using getEnvParamManager.getResourceParamManager.setParams updates
      * the team-provider-info file
      */
     const currentEnv = context.amplify.getEnvInfo().envName;

--- a/packages/amplify-category-api/src/commands/api/add-graphql-datasource.ts
+++ b/packages/amplify-category-api/src/commands/api/add-graphql-datasource.ts
@@ -17,7 +17,6 @@ import { supportedDataSources } from '../../provider-utils/supported-datasources
 import { getEnvParamManager } from '@aws-amplify/amplify-environment-parameters';
 
 const subcommand = 'add-graphql-datasource';
-const categories = 'categories';
 const category = 'api';
 const providerName = 'awscloudformation';
 
@@ -49,8 +48,7 @@ export const run = async (context: $TSContext): Promise<void> => {
      * the team-provider-info file
      */
     const currentEnv = context.amplify.getEnvInfo().envName;
-    const teamProviderInfo = stateManager.getTeamProviderInfo();
-
+    
     getEnvParamManager(currentEnv).getResourceParamManager(category, resourceName).setParams({
       rdsRegion: answers.region,
       rdsClusterIdentifier: answers.dbClusterArn,

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.ts
@@ -3,7 +3,8 @@ import { printer, prompter } from 'amplify-prompts';
 import chalk from 'chalk';
 import { DataApiParams } from 'graphql-relational-schema-transformer';
 import ora from 'ora';
-import { cfnRootStackFileName } from 'amplify-provider-awscloudformation';
+import { rootStackFileName } from 'amplify-provider-awscloudformation';
+import * as path from 'path';
 
 const spinner = ora('');
 const category = 'api';
@@ -44,7 +45,7 @@ export async function serviceWalkthrough(context: $TSContext, datasourceMetadata
   const { inputs, availableRegions } = datasourceMetadata;
 
   // FIXME: We should NOT be treating CloudFormation templates as inputs to prompts! This a temporary exception while we move team-provider-info to a service.
-  const cfnJson: $TSAny = JSONUtilities.readJson(`${pathManager.getCurrentCloudRootStackDirPath(pathManager.findProjectRoot())}/${cfnRootStackFileName}`);
+  const cfnJson: $TSAny = JSONUtilities.readJson(path.join(pathManager.getCurrentCloudRootStackDirPath(pathManager.findProjectRoot()), rootStackFileName));
   const cfnJsonParameters = cfnJson?.Resources[`api${appSyncApi}`]?.Properties?.Parameters || {};
   let selectedRegion = cfnJsonParameters?.rdsRegion;
   // Region Question

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -742,6 +742,25 @@ export function addApi(projectDir: string, settings?: any) {
   });
 }
 
+export function addV1RDSDataSource(projectDir: string) {
+  return new Promise<void>((resolve, reject) => {
+    // This test executes only partial workflow
+    // This helps to detect any regression with add graphql datasource command
+    // Make sure that the testing account doesn't contain a Aurora Serverless database.
+    spawn(getCLIPath(), ['add-graphql-datasource', 'api'], { cwd: projectDir, stripColors: true })
+      .wait('Provide the region in which your cluster is located')
+      .sendKeyDown(5) // This will select 6th item on the region list 'ap-southeast-1'
+      .sendCarriageReturn() // This will throw an error 'No properly configured Aurora Serverless clusters found'.
+      .run((err: Error) => {
+        if (err && !/Killed the process as no output receive for/.test(err.message)) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+ });
+}
+
 function setupAuthType(authType: string, chain: any, settings?: any) {
   switch (authType) {
     case 'API key':

--- a/packages/amplify-e2e-tests/src/__tests__/api_9.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_9.test.ts
@@ -16,6 +16,7 @@ import {
   amplifyPushUpdateForDependentModel,
   amplifyPushForce,
   createRandomName,
+  addV1RDSDataSource,
 } from 'amplify-category-api-e2e-core';
 import path from 'path';
 import { existsSync } from 'fs';
@@ -79,6 +80,25 @@ describe('amplify add api (GraphQL)', () => {
 
     expect(graphqlApi).toBeDefined();
     expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
+  });
+
+  it('init a project and add v1 rds datasource', async () => {
+    const appName = createRandomName();
+    await initJSProjectWithProfile(projRoot, { name: appName });
+    await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
+    await updateApiSchema(projRoot, appName, 'simple_model.graphql');
+    await updateApiWithMultiAuth(projRoot, {});
+    await amplifyPush(projRoot);
+    
+    const meta = getProjectMeta(projRoot);
+    const { output } = meta.api[appName];
+    const { GraphQLAPIIdOutput } = output;
+    const { graphqlApi } = await getAppSyncApi(GraphQLAPIIdOutput, meta.providers.awscloudformation.Region);
+    
+    expect(graphqlApi).toBeDefined();
+    expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
+    
+    await expect(addV1RDSDataSource(projRoot)).rejects.toThrowError('Process exited with non zero exit code 1');
   });
 
   it('init a project and add the simple_model api, match transformer version to current version', async () => {


### PR DESCRIPTION
#### Description of changes
This PR fixes the `add-graphql-datasource` command workflow and amplify pull behavior for existing RDS projects.

#### Issue #, if available

Fixes #767, #481 

#### Description of how you validated changes
- manual test
(Writing an E2E for this requires a RDS instance, we need to come up with an option to include this on our E2E.)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
