### PR TITLE
fix: correct canary metric emission logic, remove all injected env variables to simplify calling

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -219,9 +219,6 @@ jobs:
       os:
         type: executor
         default: l
-      is_canary:
-        type: boolean
-        default: false
     executor: << parameters.os >>
     working_directory: ~/repo
     steps:
@@ -235,13 +232,6 @@ jobs:
           key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
       - restore_cache:
           key: amplify-build-artifact-{{ .Revision }}-{{ arch }}
-      - when:
-          condition: << parameters.is_canary >>
-          steps:
-              - run:
-                  name: Set Canary Metric
-                  command: |
-                      IS_CANARY=1
       - install_yarn:
           os: << parameters.os >>
       - run: *install_cli_from_local_registry
@@ -259,12 +249,12 @@ jobs:
           name: Emit Canary Success Metric
           command: |
             source .circleci/local_publish_helpers.sh
-            emitCanarySuccessRate 1
+            emitCanarySuccessMetric
       - run:
           name: Emit Canary Failure Metric
           command: |
               source .circleci/local_publish_helpers.sh
-              emitCanarySuccessRate 0
+              emitCanaryFailureMetric
           when: on_fail
 
   amplify_migration_tests_v5:
@@ -406,7 +396,6 @@ workflows:
           requires:
             - build
       - client_e2e_tests:
-          is_canary: true
           context:
             - api-cleanup-resources
             - e2e-auth-credentials

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,10 +163,6 @@ jobs:
           paths:
             - ~/repo/UNIFIED_CHANGELOG.md
   client_e2e_tests:
-    parameters:
-      is_canary:
-        type: boolean
-        default: true
     environment:
       AMPLIFY_PATH: /home/circleci/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify
     executor: 'linux'
@@ -182,13 +178,6 @@ jobs:
           key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
       - restore_cache:
           key: amplify-build-artifact-{{ .Revision }}-{{ arch }}
-      - when:
-          condition: << parameters.is_canary >>
-          steps:
-              - run:
-                  name: Set Canary Metric
-                  command: |
-                      IS_CANARY=1
       - run: *install_cli_from_local_registry
       - run_client_tests
       - scan_e2e_test_artifacts
@@ -202,12 +191,12 @@ jobs:
           name: Emit Canary Success Metric
           command: |
             source .circleci/local_publish_helpers.sh
-            emitCanarySuccessRate 1
+            emitCanarySuccessMetric
       - run:
           name: Emit Canary Failure Metric
           command: |
               source .circleci/local_publish_helpers.sh
-              emitCanarySuccessRate 0
+              emitCanaryFailureMetric
           when: on_fail
 
 # our single workflow, that triggers the setup job defined above

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -169,8 +169,8 @@ function runE2eTest {
 
 # Accepts the value as an input parameter, i.e. 1 for success, 0 for failure.
 # Only executes if IS_CANARY env variable is set
-function emitCanarySuccessRate {
-    if [[ -v IS_CANARY ]]; then
+function emitCanarySuccessMetric {
+    if [[ "$CIRCLE_BRANCH" = main ]]; then
         USE_PARENT_ACCOUNT=1
         setAwsAccountCredentials 
         aws cloudwatch \
@@ -178,8 +178,23 @@ function emitCanarySuccessRate {
             --metric-name CanarySuccessRate \
             --namespace amplify-category-api-e2e-tests \
             --unit Count \
-            --value $1 \
-            --dimensions branch=$CIRCLE_BRANCH \
+            --value 1 \
+            --dimensions branch=main \
+            --region us-west-2
+    fi
+}
+
+function emitCanaryFailureMetric {
+    if [[ "$CIRCLE_BRANCH" = main ]]; then
+        USE_PARENT_ACCOUNT=1
+        setAwsAccountCredentials 
+        aws cloudwatch \
+            put-metric-data \
+            --metric-name CanarySuccessRate \
+            --namespace amplify-category-api-e2e-tests \
+            --unit Count \
+            --value 0 \
+            --dimensions branch=main \
             --region us-west-2
     fi
 }


### PR DESCRIPTION
#### Description of changes
Two changes:
* Separate to have simple 'success/fail' bash commands
* Update conditional, which wasn't working in the previous state, now we just publish anytime we're on `main`.

#### Issue #, if available
N/A

#### Description of how you validated changes
Explicitly failed the workflow, and tested over here https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api/1409/workflows/200c8212-0cbe-4222-a620-20d00ebd7886/jobs/38690

#### Checklist
- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
