### PR TITLE
feat: migrate searchable transformer to CDK v2

### DIFF
--- a/packages/amplify-graphql-searchable-transformer/package.json
+++ b/packages/amplify-graphql-searchable-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/graphql-searchable-transformer",
-  "version": "0.16.0",
+  "version": "1.0.0",
   "description": "Amplfy GraphQL @searchable transformer",
   "repository": {
     "type": "git",
@@ -27,22 +27,17 @@
     "test": "jest"
   },
   "dependencies": {
-    "@aws-amplify/graphql-model-transformer": "0.16.0",
-    "@aws-amplify/graphql-transformer-core": "0.17.12",
-    "@aws-amplify/graphql-transformer-interfaces": "1.14.7",
-    "@aws-cdk/aws-appsync": "~1.124.0",
-    "@aws-cdk/aws-dynamodb": "~1.124.0",
-    "@aws-cdk/aws-ec2": "~1.124.0",
-    "@aws-cdk/aws-elasticsearch": "~1.124.0",
-    "@aws-cdk/aws-iam": "~1.124.0",
-    "@aws-cdk/aws-lambda": "~1.124.0",
-    "@aws-cdk/core": "~1.124.0",
+    "@aws-amplify/graphql-model-transformer": "1.0.0",
+    "@aws-amplify/graphql-transformer-core": "1.0.0",
+    "@aws-amplify/graphql-transformer-interfaces": "2.0.0",
+    "aws-cdk-lib": "^2.41.0",
+    "@aws-cdk/aws-appsync-alpha": "^2.41.0-alpha.0",
+    "constructs": "^10.0.5",
     "graphql": "^14.5.8",
     "graphql-mapping-template": "4.20.5",
     "graphql-transformer-common": "4.24.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "~1.124.0",
     "@types/node": "^12.12.6"
   },
   "jest": {

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer-override.test.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer-override.test.ts
@@ -1,6 +1,8 @@
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
-import { anything, expect as cdkExpect, haveResource } from '@aws-cdk/assert';
+import {
+  Match, Template,
+} from 'aws-cdk-lib/assertions';
 import * as path from 'path';
 import { SearchableModelTransformer } from '..';
 
@@ -40,10 +42,10 @@ test('it overrides expected resources', () => {
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
   const searchableStack = out.stacks.SearchableStack;
-  cdkExpect(searchableStack).to(
-    haveResource('AWS::AppSync::DataSource', {
+  Template.fromJSON(searchableStack)
+    .hasResourceProperties('AWS::AppSync::DataSource', {
       ApiId: {
-        Ref: anything(),
+        Ref: Match.anyValue(),
       },
       Name: 'OpenSearchDataSource',
       Type: 'AMAZON_ELASTICSEARCH',
@@ -55,7 +57,7 @@ test('it overrides expected resources', () => {
               'Fn::Split': [
                 ':',
                 {
-                  'Fn::GetAtt': ['OpenSearchDomain', 'Arn'],
+                  'Fn::GetAtt': ['OpenSearchDomain85D65221', 'Arn'],
                 },
               ],
             },
@@ -67,47 +69,44 @@ test('it overrides expected resources', () => {
             [
               'https://',
               {
-                'Fn::GetAtt': ['OpenSearchDomain', 'DomainEndpoint'],
+                'Fn::GetAtt': ['OpenSearchDomain85D65221', 'DomainEndpoint'],
               },
             ],
           ],
         },
       },
       ServiceRoleArn: 'mockArn',
-    }),
-  );
-  cdkExpect(searchableStack).to(
-    haveResource('AWS::Elasticsearch::Domain', {
-      DomainName: anything(),
-      EBSOptions: anything(),
-      ElasticsearchClusterConfig: anything(),
+    });
+  Template.fromJSON(searchableStack)
+    .hasResourceProperties('AWS::Elasticsearch::Domain', {
+      DomainName: Match.anyValue(),
+      EBSOptions: Match.anyValue(),
+      ElasticsearchClusterConfig: Match.anyValue(),
       ElasticsearchVersion: '7.10',
       EncryptionAtRestOptions: {
         Enabled: true,
         KmsKeyId: '1a2a3a4-1a2a-3a4a-5a6a-1a2a3a4a5a6a',
       },
-    }),
-  );
-  cdkExpect(searchableStack).to(
-    haveResource('AWS::AppSync::Resolver', {
+    });
+  Template.fromJSON(searchableStack)
+    .hasResourceProperties('AWS::AppSync::Resolver', {
       ApiId: {
-        Ref: anything(),
+        Ref: Match.anyValue(),
       },
-      FieldName: anything(),
+      FieldName: Match.anyValue(),
       TypeName: 'Query',
       Kind: 'PIPELINE',
       PipelineConfig: {
         Functions: [
           {
-            Ref: anything(),
+            Ref: Match.anyValue(),
           },
           {
-            'Fn::GetAtt': [anything(), 'FunctionId'],
+            'Fn::GetAtt': [Match.anyValue(), 'FunctionId'],
           },
         ],
       },
       RequestMappingTemplate: 'mockTemplate',
       ResponseMappingTemplate: '$util.toJson($ctx.prev.result)',
-    }),
-  );
+    });
 });

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
@@ -1,8 +1,8 @@
 import { ConflictHandlerType, GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import {
-  anything, countResources, expect as cdkExpect, haveResource, ResourcePart,
-} from '@aws-cdk/assert';
+  Match, Template,
+} from 'aws-cdk-lib/assertions';
 import { parse } from 'graphql';
 import { SearchableModelTransformer } from '..';
 
@@ -192,8 +192,8 @@ test('it generates expected resources', () => {
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
   const searchableStack = out.stacks.SearchableStack;
-  cdkExpect(searchableStack).to(
-    haveResource('AWS::IAM::Role', {
+  Template.fromJSON(searchableStack)
+    .hasResourceProperties('AWS::IAM::Role', {
       AssumeRolePolicyDocument: {
         Statement: [
           {
@@ -206,10 +206,9 @@ test('it generates expected resources', () => {
         ],
         Version: '2012-10-17',
       },
-    }),
-  );
-  cdkExpect(searchableStack).to(
-    haveResource('AWS::IAM::Role', {
+    });
+  Template.fromJSON(searchableStack)
+    .hasResourceProperties('AWS::IAM::Role', {
       AssumeRolePolicyDocument: {
         Statement: [
           {
@@ -222,26 +221,23 @@ test('it generates expected resources', () => {
         ],
         Version: '2012-10-17',
       },
-    }),
-  );
-  cdkExpect(searchableStack).to(
-    haveResource('AWS::Elasticsearch::Domain', {
-      DomainName: anything(),
-      EBSOptions: anything(),
-      ElasticsearchClusterConfig: anything(),
+    });
+  Template.fromJSON(searchableStack)
+    .hasResourceProperties('AWS::Elasticsearch::Domain', {
+      DomainName: Match.anyValue(),
+      EBSOptions: Match.anyValue(),
+      ElasticsearchClusterConfig: Match.anyValue(),
       ElasticsearchVersion: '7.10',
-    }, ResourcePart.Properties),
-  );
-  cdkExpect(searchableStack).to(
-    haveResource('AWS::Elasticsearch::Domain', {
+    });
+  Template.fromJSON(searchableStack)
+    .hasResource('AWS::Elasticsearch::Domain', {
       UpdateReplacePolicy: 'Delete',
       DeletionPolicy: 'Delete',
-    }, ResourcePart.CompleteDefinition),
-  );
-  cdkExpect(searchableStack).to(
-    haveResource('AWS::AppSync::DataSource', {
+    });
+  Template.fromJSON(searchableStack)
+    .hasResourceProperties('AWS::AppSync::DataSource', {
       ApiId: {
-        Ref: anything(),
+        Ref: Match.anyValue(),
       },
       Name: 'OpenSearchDataSource',
       Type: 'AMAZON_ELASTICSEARCH',
@@ -253,7 +249,7 @@ test('it generates expected resources', () => {
               'Fn::Split': [
                 ':',
                 {
-                  'Fn::GetAtt': ['OpenSearchDomain', 'Arn'],
+                  'Fn::GetAtt': ['OpenSearchDomain85D65221', 'Arn'],
                 },
               ],
             },
@@ -265,7 +261,7 @@ test('it generates expected resources', () => {
             [
               'https://',
               {
-                'Fn::GetAtt': ['OpenSearchDomain', 'DomainEndpoint'],
+                'Fn::GetAtt': ['OpenSearchDomain85D65221', 'DomainEndpoint'],
               },
             ],
           ],
@@ -274,24 +270,23 @@ test('it generates expected resources', () => {
       ServiceRoleArn: {
         'Fn::GetAtt': ['OpenSearchAccessIAMRole6A1D9CC5', 'Arn'],
       },
-    }),
-  );
-  cdkExpect(searchableStack).to(countResources('AWS::AppSync::Resolver', 2));
-  cdkExpect(searchableStack).to(
-    haveResource('AWS::AppSync::Resolver', {
+    });
+  Template.fromJSON(searchableStack).resourceCountIs('AWS::AppSync::Resolver', 2);
+  Template.fromJSON(searchableStack)
+    .hasResourceProperties('AWS::AppSync::Resolver', {
       ApiId: {
-        Ref: anything(),
+        Ref: Match.anyValue(),
       },
-      FieldName: anything(),
+      FieldName: Match.anyValue(),
       TypeName: 'Query',
       Kind: 'PIPELINE',
       PipelineConfig: {
         Functions: [
           {
-            Ref: anything(),
+            Ref: Match.anyValue(),
           },
           {
-            'Fn::GetAtt': [anything(), 'FunctionId'],
+            'Fn::GetAtt': [Match.anyValue(), 'FunctionId'],
           },
         ],
       },
@@ -299,44 +294,43 @@ test('it generates expected resources', () => {
         'Fn::Join': [
           '',
           [
-            anything(),
+            Match.anyValue(),
             {
-              Ref: anything(),
+              Ref: Match.anyValue(),
             },
             '"))\n$util.qr($ctx.stash.put("endpoint", "https://',
             {
-              'Fn::GetAtt': ['OpenSearchDomain', 'DomainEndpoint'],
+              'Fn::GetAtt': ['OpenSearchDomain85D65221', 'DomainEndpoint'],
             },
             '"))\n$util.toJson({})',
           ],
         ],
       },
       ResponseMappingTemplate: '$util.toJson($ctx.prev.result)',
-    }),
-  );
-  cdkExpect(searchableStack).to(
-    haveResource('AWS::AppSync::FunctionConfiguration', {
+    });
+  Template.fromJSON(searchableStack)
+    .hasResourceProperties('AWS::AppSync::FunctionConfiguration', {
       ApiId: {
-        Ref: anything(),
+        Ref: Match.anyValue(),
       },
       DataSourceName: {
-        'Fn::GetAtt': [anything(), 'Name'],
+        'Fn::GetAtt': [Match.anyValue(), 'Name'],
       },
       FunctionVersion: '2018-05-29',
-      Name: anything(),
+      Name: Match.anyValue(),
       RequestMappingTemplateS3Location: {
         'Fn::Join': [
           '',
           [
             's3://',
             {
-              Ref: anything(),
+              Ref: Match.anyValue(),
             },
             '/',
             {
-              Ref: anything(),
+              Ref: Match.anyValue(),
             },
-            anything(),
+            Match.anyValue(),
           ],
         ],
       },
@@ -346,18 +340,17 @@ test('it generates expected resources', () => {
           [
             's3://',
             {
-              Ref: anything(),
+              Ref: Match.anyValue(),
             },
             '/',
             {
-              Ref: anything(),
+              Ref: Match.anyValue(),
             },
-            anything(),
+            Match.anyValue(),
           ],
         ],
       },
-    }),
-  );
+    });
 });
 
 test('SearchableModelTransformer enum type generates StringFilterInput', () => {

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-cfnOutput.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-cfnOutput.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-new */
-import { Construct, Fn } from '@aws-cdk/core';
-import { CfnOutput } from '@aws-cdk/core';
+import { CfnOutput, Fn } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import { ResourceConstants } from 'graphql-transformer-common';
 
 export const createStackOutputs = (stack: Construct, endpoint: string, apiId: string, arn: string): void => {

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-cfnParameters.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-cfnParameters.ts
@@ -1,5 +1,5 @@
 import { ResourceConstants } from 'graphql-transformer-common';
-import { CfnParameter, Stack } from '@aws-cdk/core';
+import { CfnParameter, Stack } from 'aws-cdk-lib';
 
 export const createParametersStack = (stack: Stack): Map<string, CfnParameter> => {
   const {

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-layer-cfnMapping.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-layer-cfnMapping.ts
@@ -1,4 +1,5 @@
-import { CfnMapping, Construct } from '@aws-cdk/core';
+import { CfnMapping } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 
 export const setMappings = (scope: Construct): CfnMapping => new CfnMapping(
   scope,

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-datasource.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-datasource.ts
@@ -1,8 +1,8 @@
 import { GraphQLAPIProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { BaseDataSource } from '@aws-cdk/aws-appsync';
-import { IRole } from '@aws-cdk/aws-iam';
+import { BaseDataSource } from '@aws-cdk/aws-appsync-alpha';
+import { IRole } from 'aws-cdk-lib/aws-iam';
 import { ResourceConstants } from 'graphql-transformer-common';
-import { Stack } from '@aws-cdk/core';
+import { Stack } from 'aws-cdk-lib';
 
 export const createSearchableDataSource = (
   stack: Stack,

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
@@ -1,13 +1,13 @@
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { EbsDeviceVolumeType } from '@aws-cdk/aws-ec2';
-import { CfnDomain, Domain, ElasticsearchVersion } from '@aws-cdk/aws-elasticsearch';
-import { IRole, Role, ServicePrincipal } from '@aws-cdk/aws-iam';
+import { EbsDeviceVolumeType } from 'aws-cdk-lib/aws-ec2';
+import { CfnDomain, Domain, ElasticsearchVersion } from 'aws-cdk-lib/aws-elasticsearch';
+import { IRole, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import {
   CfnParameter,
-  Construct,
   Fn,
   RemovalPolicy,
-} from '@aws-cdk/core';
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import { ResourceConstants } from 'graphql-transformer-common';
 
 export const createSearchableDomain = (stack: Construct, parameterMap: Map<string, CfnParameter>, apiId: string): Domain => {

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-streaming-lambda.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-streaming-lambda.ts
@@ -1,13 +1,14 @@
 import { GraphQLAPIProvider, TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import {
   EventSourceMapping, IFunction, LayerVersion, Runtime, StartingPosition,
-} from '@aws-cdk/aws-lambda';
+} from 'aws-cdk-lib/aws-lambda';
 import {
-  CfnParameter, Construct, Fn, Stack, Duration,
-} from '@aws-cdk/core';
+  CfnParameter, Fn, Stack, Duration,
+} from 'aws-cdk-lib';
 import {
   Effect, IRole, Policy, PolicyStatement, Role, ServicePrincipal,
-} from '@aws-cdk/aws-iam';
+} from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
 import { ResourceConstants, SearchableResourceIDs } from 'graphql-transformer-common';
 import * as path from 'path';
 

--- a/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
@@ -1,8 +1,9 @@
 import {
-  TransformerPluginBase,
+  DirectiveWrapper,
   generateGetArgumentsInput,
   InvalidDirectiveError,
-  MappingTemplate, DirectiveWrapper,
+  MappingTemplate,
+  TransformerPluginBase,
 } from '@aws-amplify/graphql-transformer-core';
 import {
   DataSourceProvider,
@@ -11,11 +12,12 @@ import {
   TransformerSchemaVisitStepContextProvider,
   TransformerTransformSchemaStepContextProvider,
 } from '@aws-amplify/graphql-transformer-interfaces';
-import { DynamoDbDataSource } from '@aws-cdk/aws-appsync';
-import { Table } from '@aws-cdk/aws-dynamodb';
+import { DynamoDbDataSource } from '@aws-cdk/aws-appsync-alpha';
+import { Table } from 'aws-cdk-lib/aws-dynamodb';
 import {
-  CfnCondition, CfnParameter, Fn, IConstruct,
-} from '@aws-cdk/core';
+  ArnFormat, CfnCondition, CfnParameter, Fn,
+} from 'aws-cdk-lib';
+import { IConstruct } from 'constructs';
 import { DirectiveNode, InputObjectTypeDefinitionNode, ObjectTypeDefinitionNode } from 'graphql';
 import { Expression, str } from 'graphql-mapping-template';
 import {
@@ -301,7 +303,7 @@ export class SearchableModelTransformer extends TransformerPluginBase {
 
     domain.grantReadWrite(openSearchRole);
 
-    const { region } = stack.parseArn(domain.domainArn);
+    const { region } = stack.splitArn(domain.domainArn, ArnFormat.SLASH_RESOURCE_NAME);
     if (!region) {
       throw new Error('Could not access region from search domain');
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,6 +260,25 @@
     graphql-mapping-template "4.20.5"
     graphql-transformer-common "4.24.0"
 
+"@aws-amplify/graphql-searchable-transformer@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/graphql-searchable-transformer/-/graphql-searchable-transformer-0.16.0.tgz#a3e321b42f88b01fe3a1d90e395252507c33c4cf"
+  integrity sha512-E/OaK1tqS8wvVwHmvcnuuTBlRbIMy8gpKPQ+lXMq16nZzOwrzqiwpCNlAEAeCgyu1EJTzO1b5SKd4ZQC0MJqAQ==
+  dependencies:
+    "@aws-amplify/graphql-model-transformer" "0.16.0"
+    "@aws-amplify/graphql-transformer-core" "0.17.12"
+    "@aws-amplify/graphql-transformer-interfaces" "1.14.7"
+    "@aws-cdk/aws-appsync" "~1.124.0"
+    "@aws-cdk/aws-dynamodb" "~1.124.0"
+    "@aws-cdk/aws-ec2" "~1.124.0"
+    "@aws-cdk/aws-elasticsearch" "~1.124.0"
+    "@aws-cdk/aws-iam" "~1.124.0"
+    "@aws-cdk/aws-lambda" "~1.124.0"
+    "@aws-cdk/core" "~1.124.0"
+    graphql "^14.5.8"
+    graphql-mapping-template "4.20.5"
+    graphql-transformer-common "4.24.0"
+
 "@aws-amplify/graphql-transformer-core@0.17.12", "@aws-amplify/graphql-transformer-core@^0.17.11":
   version "0.17.12"
   resolved "https://registry.yarnpkg.com/@aws-amplify/graphql-transformer-core/-/graphql-transformer-core-0.17.12.tgz#b965a07a8d23df2cf349366f39656a7ed2908154"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Migrate `@aws-amplify/graphql-searchable-transformer` to use CDKv2.

Follow ups for later:
- Investigate if `OpenSearchDomain` -> `OpenSearchDomain85D65221` is breaking anything. https://app.asana.com/0/1202389680978480/1203144344852802/f
- Deprecated API usage `Domain from 'aws-cdk-lib/aws-elasticsearch'` and `domain.*` apis. https://app.asana.com/0/1202389680978480/1203144344852804/f

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

`yarn clean && yarn dev-build && yarn test` passes.

E2E don't compile yet.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] PR description included
- [ x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
