### PR TITLE
feat: migrate function transformer to CDK v2

### DIFF
--- a/packages/amplify-graphql-function-transformer/package.json
+++ b/packages/amplify-graphql-function-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/graphql-function-transformer",
-  "version": "0.7.28",
+  "version": "1.0.0",
   "description": "Amplify GraphQL @function transformer",
   "repository": {
     "type": "git",
@@ -27,17 +27,14 @@
     "test": "jest"
   },
   "dependencies": {
-    "@aws-amplify/graphql-transformer-core": "0.17.12",
-    "@aws-amplify/graphql-transformer-interfaces": "1.14.7",
-    "@aws-cdk/aws-appsync": "~1.124.0",
-    "@aws-cdk/aws-lambda": "~1.124.0",
-    "@aws-cdk/core": "~1.124.0",
+    "@aws-amplify/graphql-transformer-core": "1.0.0",
+    "@aws-amplify/graphql-transformer-interfaces": "2.0.0",
+    "aws-cdk-lib": "^2.41.0",
+    "@aws-cdk/aws-appsync-alpha": "^2.41.0-alpha.0",
+    "constructs": "^10.0.5",
     "graphql": "^14.5.8",
     "graphql-mapping-template": "4.20.5",
     "graphql-transformer-common": "4.24.0"
-  },
-  "devDependencies": {
-    "@aws-cdk/assert": "~1.124.0"
   },
   "jest": {
     "transform": {

--- a/packages/amplify-graphql-function-transformer/src/__tests__/__snapshots__/amplify-graphql-function-transformer-override.test.ts.snap
+++ b/packages/amplify-graphql-function-transformer/src/__tests__/__snapshots__/amplify-graphql-function-transformer-override.test.ts.snap
@@ -88,24 +88,52 @@ Object {
             Object {
               "Action": "lambda:InvokeFunction",
               "Effect": "Allow",
-              "Resource": Object {
-                "Fn::If": Array [
-                  "HasEnvironmentParameter",
-                  Object {
-                    "Fn::Sub": Array [
-                      "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:echofunction-\${env}",
-                      Object {
-                        "env": Object {
-                          "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+              "Resource": Array [
+                Object {
+                  "Fn::If": Array [
+                    "HasEnvironmentParameter",
+                    Object {
+                      "Fn::Sub": Array [
+                        "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:echofunction-\${env}",
+                        Object {
+                          "env": Object {
+                            "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                          },
                         },
+                      ],
+                    },
+                    Object {
+                      "Fn::Sub": "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:echofunction",
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::If": Array [
+                          "HasEnvironmentParameter",
+                          Object {
+                            "Fn::Sub": Array [
+                              "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:echofunction-\${env}",
+                              Object {
+                                "env": Object {
+                                  "Ref": "referencetotransformerrootstackenv10C5A902Ref",
+                                },
+                              },
+                            ],
+                          },
+                          Object {
+                            "Fn::Sub": "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:echofunction",
+                          },
+                        ],
                       },
+                      ":*",
                     ],
-                  },
-                  Object {
-                    "Fn::Sub": "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:echofunction",
-                  },
-                ],
-              },
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",
@@ -272,20 +300,44 @@ Object {
             Object {
               "Action": "lambda:InvokeFunction",
               "Effect": "Allow",
-              "Resource": Object {
-                "Fn::If": Array [
-                  "HasEnvironmentParameter",
-                  Object {
-                    "Fn::Sub": Array [
-                      "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:otherfunction",
-                      Object {},
+              "Resource": Array [
+                Object {
+                  "Fn::If": Array [
+                    "HasEnvironmentParameter",
+                    Object {
+                      "Fn::Sub": Array [
+                        "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:otherfunction",
+                        Object {},
+                      ],
+                    },
+                    Object {
+                      "Fn::Sub": "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:otherfunction",
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::If": Array [
+                          "HasEnvironmentParameter",
+                          Object {
+                            "Fn::Sub": Array [
+                              "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:otherfunction",
+                              Object {},
+                            ],
+                          },
+                          Object {
+                            "Fn::Sub": "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:otherfunction",
+                          },
+                        ],
+                      },
+                      ":*",
                     ],
-                  },
-                  Object {
-                    "Fn::Sub": "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:otherfunction",
-                  },
-                ],
-              },
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",

--- a/packages/amplify-graphql-function-transformer/src/__tests__/amplify-graphql-function-transformer.test.ts
+++ b/packages/amplify-graphql-function-transformer/src/__tests__/amplify-graphql-function-transformer.test.ts
@@ -1,5 +1,5 @@
 'use strict';
-import { anything, countResources, expect as cdkExpect, haveResource } from '@aws-cdk/assert';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import { parse } from 'graphql';
 import { FunctionTransformer } from '..';
@@ -21,13 +21,13 @@ test('it generates the expected resources', () => {
   parse(out.schema);
   const stack = out.stacks.FunctionDirectiveStack;
   expect(stack).toBeDefined();
-  cdkExpect(stack).to(countResources('AWS::IAM::Role', 1));
-  cdkExpect(stack).to(countResources('AWS::IAM::Policy', 1));
-  cdkExpect(stack).to(countResources('AWS::AppSync::DataSource', 1));
-  cdkExpect(stack).to(countResources('AWS::AppSync::FunctionConfiguration', 1));
-  cdkExpect(stack).to(countResources('AWS::AppSync::Resolver', 1));
-  cdkExpect(stack).to(
-    haveResource('AWS::IAM::Role', {
+  Template.fromJSON(stack).resourceCountIs('AWS::IAM::Role', 1);
+  Template.fromJSON(stack).resourceCountIs('AWS::IAM::Policy', 1);
+  Template.fromJSON(stack).resourceCountIs('AWS::AppSync::DataSource', 1);
+  Template.fromJSON(stack).resourceCountIs('AWS::AppSync::FunctionConfiguration', 1);
+  Template.fromJSON(stack).resourceCountIs('AWS::AppSync::Resolver', 1);
+  Template.fromJSON(stack)
+    .hasResourceProperties('AWS::IAM::Role', {
       AssumeRolePolicyDocument: {
         Statement: [
           {
@@ -40,35 +40,52 @@ test('it generates the expected resources', () => {
         ],
         Version: '2012-10-17',
       },
-    }),
-  );
-  cdkExpect(stack).to(
-    haveResource('AWS::IAM::Policy', {
+    });
+  Template.fromJSON(stack)
+    .hasResourceProperties('AWS::IAM::Policy', {
       PolicyDocument: {
         Statement: [
           {
             Action: 'lambda:InvokeFunction',
             Effect: 'Allow',
-            Resource: {
-              'Fn::If': [
-                'HasEnvironmentParameter',
-                {
-                  'Fn::Sub': ['arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:echofunction-${env}', { env: { Ref: anything() } }],
-                },
-                { 'Fn::Sub': 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:echofunction' },
-              ],
-            },
+            Resource: [
+              {
+                'Fn::If': [
+                  'HasEnvironmentParameter',
+                  {
+                    'Fn::Sub': ['arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:echofunction-${env}', { env: { Ref: Match.anyValue() } }],
+                  },
+                  { 'Fn::Sub': 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:echofunction' },
+                ],
+              },
+              {
+                'Fn::Join': [
+                  '',
+                  [
+                    {
+                      'Fn::If': [
+                        'HasEnvironmentParameter',
+                        {
+                          'Fn::Sub': ['arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:echofunction-${env}', { env: { Ref: Match.anyValue() } }],
+                        },
+                        { 'Fn::Sub': 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:echofunction' },
+                      ],
+                    },
+                    ':*',
+                  ],
+                ],
+              },
+            ],
           },
         ],
         Version: '2012-10-17',
       },
-      PolicyName: anything(),
-      Roles: [{ Ref: anything() }],
-    }),
-  );
-  cdkExpect(stack).to(
-    haveResource('AWS::AppSync::DataSource', {
-      ApiId: { Ref: anything() },
+      PolicyName: Match.anyValue(),
+      Roles: [{ Ref: Match.anyValue() }],
+    });
+  Template.fromJSON(stack)
+    .hasResourceProperties('AWS::AppSync::DataSource', {
+      ApiId: { Ref: Match.anyValue() },
       Name: 'EchofunctionLambdaDataSource',
       Type: 'AWS_LAMBDA',
       LambdaConfig: {
@@ -76,7 +93,7 @@ test('it generates the expected resources', () => {
           'Fn::If': [
             'HasEnvironmentParameter',
             {
-              'Fn::Sub': ['arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:echofunction-${env}', { env: { Ref: anything() } }],
+              'Fn::Sub': ['arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:echofunction-${env}', { env: { Ref: Match.anyValue() } }],
             },
             { 'Fn::Sub': 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:echofunction' },
           ],
@@ -85,37 +102,34 @@ test('it generates the expected resources', () => {
       ServiceRoleArn: {
         'Fn::GetAtt': ['EchofunctionLambdaDataSourceServiceRole3BE2FA57', 'Arn'],
       },
-    }),
-  );
-  cdkExpect(stack).to(
-    haveResource('AWS::AppSync::FunctionConfiguration', {
-      ApiId: { Ref: anything() },
-      DataSourceName: { 'Fn::GetAtt': [anything(), 'Name'] },
+    });
+  Template.fromJSON(stack)
+    .hasResourceProperties('AWS::AppSync::FunctionConfiguration', {
+      ApiId: { Ref: Match.anyValue() },
+      DataSourceName: { 'Fn::GetAtt': [Match.anyValue(), 'Name'] },
       FunctionVersion: '2018-05-29',
       Name: 'InvokeEchofunctionLambdaDataSource',
       RequestMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/InvokeEchofunctionLambdaDataSource.req.vtl']],
+        'Fn::Join': ['', ['s3://', { Ref: Match.anyValue() }, '/', { Ref: Match.anyValue() }, '/resolvers/InvokeEchofunctionLambdaDataSource.req.vtl']],
       },
       ResponseMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/InvokeEchofunctionLambdaDataSource.res.vtl']],
+        'Fn::Join': ['', ['s3://', { Ref: Match.anyValue() }, '/', { Ref: Match.anyValue() }, '/resolvers/InvokeEchofunctionLambdaDataSource.res.vtl']],
       },
-    }),
-  );
-  cdkExpect(stack).to(
-    haveResource('AWS::AppSync::Resolver', {
-      ApiId: { Ref: anything() },
+    });
+  Template.fromJSON(stack)
+    .hasResourceProperties('AWS::AppSync::Resolver', {
+      ApiId: { Ref: Match.anyValue() },
       FieldName: 'echo',
       TypeName: 'Query',
       Kind: 'PIPELINE',
       PipelineConfig: {
-        Functions: [{ 'Fn::GetAtt': [anything(), 'FunctionId'] }],
+        Functions: [{ 'Fn::GetAtt': [Match.anyValue(), 'FunctionId'] }],
       },
-      RequestMappingTemplate: anything(),
+      RequestMappingTemplate: Match.anyValue(),
       ResponseMappingTemplateS3Location: {
-        'Fn::Join': ['', ['s3://', { Ref: anything() }, '/', { Ref: anything() }, '/resolvers/Query.echo.res.vtl']],
+        'Fn::Join': ['', ['s3://', { Ref: Match.anyValue() }, '/', { Ref: Match.anyValue() }, '/resolvers/Query.echo.res.vtl']],
       },
-    }),
-  );
+    });
   expect(out.resolvers).toMatchSnapshot();
 });
 
@@ -136,11 +150,11 @@ test('two @function directives for the same lambda should produce a single datas
   expect(out.stacks).toBeDefined();
   const stack = out.stacks.FunctionDirectiveStack;
   expect(stack).toBeDefined();
-  cdkExpect(stack).to(countResources('AWS::IAM::Role', 1));
-  cdkExpect(stack).to(countResources('AWS::IAM::Policy', 1));
-  cdkExpect(stack).to(countResources('AWS::AppSync::DataSource', 1));
-  cdkExpect(stack).to(countResources('AWS::AppSync::FunctionConfiguration', 1));
-  cdkExpect(stack).to(countResources('AWS::AppSync::Resolver', 2));
+  Template.fromJSON(stack).resourceCountIs('AWS::IAM::Role', 1);
+  Template.fromJSON(stack).resourceCountIs('AWS::IAM::Policy', 1);
+  Template.fromJSON(stack).resourceCountIs('AWS::AppSync::DataSource', 1);
+  Template.fromJSON(stack).resourceCountIs('AWS::AppSync::FunctionConfiguration', 1);
+  Template.fromJSON(stack).resourceCountIs('AWS::AppSync::Resolver', 2);
 });
 
 test('two @function directives for the same field should be valid', () => {
@@ -159,18 +173,17 @@ test('two @function directives for the same field should be valid', () => {
   expect(out.stacks).toBeDefined();
   const stack = out.stacks.FunctionDirectiveStack;
   expect(stack).toBeDefined();
-  cdkExpect(stack).to(countResources('AWS::AppSync::Resolver', 1));
-  cdkExpect(stack).to(
-    haveResource('AWS::AppSync::Resolver', {
-      ApiId: { Ref: anything() },
+  Template.fromJSON(stack).resourceCountIs('AWS::AppSync::Resolver', 1);
+  Template.fromJSON(stack)
+    .hasResourceProperties('AWS::AppSync::Resolver', {
+      ApiId: { Ref: Match.anyValue() },
       FieldName: 'echo',
       TypeName: 'Query',
       Kind: 'PIPELINE',
       PipelineConfig: {
-        Functions: [{ 'Fn::GetAtt': [anything(), 'FunctionId'] }, { 'Fn::GetAtt': [anything(), 'FunctionId'] }],
+        Functions: [{ 'Fn::GetAtt': [Match.anyValue(), 'FunctionId'] }, { 'Fn::GetAtt': [Match.anyValue(), 'FunctionId'] }],
       },
-    }),
-  );
+    });
 });
 
 test('@function directive applied to Object should throw Error', () => {

--- a/packages/amplify-graphql-function-transformer/src/graphql-function-transformer.ts
+++ b/packages/amplify-graphql-function-transformer/src/graphql-function-transformer.ts
@@ -7,9 +7,9 @@ import {
   TransformerPluginBase,
 } from '@aws-amplify/graphql-transformer-core';
 import { TransformerContextProvider, TransformerSchemaVisitStepContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import * as lambda from '@aws-cdk/aws-lambda';
-import { AuthorizationType } from '@aws-cdk/aws-appsync';
-import * as cdk from '@aws-cdk/core';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { AuthorizationType } from '@aws-cdk/aws-appsync-alpha';
+import * as cdk from 'aws-cdk-lib';
 import { obj, str, ref, printBlock, compoundExpression, qref, raw, iff, Expression } from 'graphql-mapping-template';
 import { FunctionResourceIDs, ResolverResourceIDs, ResourceConstants } from 'graphql-transformer-common';
 import { DirectiveNode, ObjectTypeDefinitionNode, InterfaceTypeDefinitionNode, FieldDefinitionNode } from 'graphql';

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,6 +219,20 @@
     prettier "^1.19.1"
     yargs "^15.1.0"
 
+"@aws-amplify/graphql-function-transformer@0.7.28":
+  version "0.7.28"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/graphql-function-transformer/-/graphql-function-transformer-0.7.28.tgz#8c2f068c118466af861cb87baf0446db97a0d2bf"
+  integrity sha512-OhXGmdZ1gal3R2NEclSQd2ibNm53OZ2WrzLO97+vLM2FsqaCaPONCdZY6DC/H2peEXBuYJdHgz2eTr5YT7/TwA==
+  dependencies:
+    "@aws-amplify/graphql-transformer-core" "0.17.12"
+    "@aws-amplify/graphql-transformer-interfaces" "1.14.7"
+    "@aws-cdk/aws-appsync" "~1.124.0"
+    "@aws-cdk/aws-lambda" "~1.124.0"
+    "@aws-cdk/core" "~1.124.0"
+    graphql "^14.5.8"
+    graphql-mapping-template "4.20.5"
+    graphql-transformer-common "4.24.0"
+
 "@aws-amplify/graphql-index-transformer@0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@aws-amplify/graphql-index-transformer/-/graphql-index-transformer-0.14.0.tgz#7a9e9996e285622d638bf7f2f9ffa2f61c596fe9"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR migrates `@aws-amplify/graphql-function-transformer` to CDK v2.

Gotchas:
- There seems to be a change in `@aws-cdk/aws-appsync-alpha` that creates more permissive policy. See PR comment below.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

`yarn clean && yarn dev-build && yarn test` passes.

E2E don't compile yet.


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] PR description included
- [ x] `yarn test` passes
- [ x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
