### PR TITLE
feat: migrate predictions transformer to CDK v2

### DIFF
--- a/packages/amplify-graphql-predictions-transformer/package.json
+++ b/packages/amplify-graphql-predictions-transformer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-amplify/graphql-predictions-transformer",
-  "version": "0.6.28",
-  "description": "Amplify GraphQL @predictions tranformer",
+  "version": "1.0.0",
+  "description": "Amplify GraphQL @predictions transformer",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws-amplify/amplify-category-api.git",
@@ -27,18 +27,16 @@
     "test": "jest"
   },
   "dependencies": {
-    "@aws-amplify/graphql-transformer-core": "0.17.12",
-    "@aws-amplify/graphql-transformer-interfaces": "1.14.7",
-    "@aws-cdk/aws-appsync": "~1.124.0",
-    "@aws-cdk/aws-iam": "~1.124.0",
-    "@aws-cdk/aws-lambda": "~1.124.0",
-    "@aws-cdk/core": "~1.124.0",
+    "@aws-amplify/graphql-transformer-core": "1.0.0",
+    "@aws-amplify/graphql-transformer-interfaces": "2.0.0",
+    "aws-cdk-lib": "^2.41.0",
+    "@aws-cdk/aws-appsync-alpha": "^2.41.0-alpha.0",
+    "constructs": "^10.0.5",
     "graphql": "^14.5.8",
     "graphql-mapping-template": "4.20.5",
     "graphql-transformer-common": "4.24.0"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "~1.124.0",
     "bestzip": "^2.1.5"
   },
   "jest": {

--- a/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer-override.test.ts.snap
+++ b/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer-override.test.ts.snap
@@ -80,12 +80,28 @@ Object {
               Object {
                 "Action": "lambda:InvokeFunction",
                 "Effect": "Allow",
-                "Resource": Object {
-                  "Fn::GetAtt": Array [
-                    "predictionsLambda8B880A74",
-                    "Arn",
-                  ],
-                },
+                "Resource": Array [
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "predictionsLambda8B880A74",
+                      "Arn",
+                    ],
+                  },
+                  Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        Object {
+                          "Fn::GetAtt": Array [
+                            "predictionsLambda8B880A74",
+                            "Arn",
+                          ],
+                        },
+                        ":*",
+                      ],
+                    ],
+                  },
+                ],
               },
             ],
             "Version": "2012-10-17",

--- a/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer.test.ts.snap
+++ b/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer.test.ts.snap
@@ -182,12 +182,28 @@ Object {
             Object {
               "Action": "lambda:InvokeFunction",
               "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "predictionsLambda8B880A74",
-                  "Arn",
-                ],
-              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "predictionsLambda8B880A74",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "predictionsLambda8B880A74",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",

--- a/packages/amplify-graphql-predictions-transformer/src/__tests__/amplify-graphql-predictions-transformer.test.ts
+++ b/packages/amplify-graphql-predictions-transformer/src/__tests__/amplify-graphql-predictions-transformer.test.ts
@@ -1,5 +1,5 @@
 'use strict';
-import { anything, countResources, expect as cdkExpect, haveResourceLike } from '@aws-cdk/assert';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { GraphQLTransform, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
 import { parse } from 'graphql';
 import { PredictionsTransformer } from '..';
@@ -36,15 +36,15 @@ test('lambda function is added to pipeline when lambda dependent action is added
   expect(out.schema).toMatchSnapshot();
   const stack = out.stacks.PredictionsDirectiveStack;
   expect(stack).toBeDefined();
-  cdkExpect(stack).to(countResources('AWS::IAM::Role', 4));
-  cdkExpect(stack).to(countResources('AWS::IAM::Policy', 4));
-  cdkExpect(stack).to(countResources('AWS::AppSync::DataSource', 2));
-  cdkExpect(stack).to(countResources('AWS::AppSync::FunctionConfiguration', 2));
-  cdkExpect(stack).to(countResources('AWS::Lambda::Function', 1));
-  cdkExpect(stack).to(countResources('AWS::AppSync::Resolver', 1));
+  Template.fromJSON(stack).resourceCountIs('AWS::IAM::Role', 4);
+  Template.fromJSON(stack).resourceCountIs('AWS::IAM::Policy', 4);
+  Template.fromJSON(stack).resourceCountIs('AWS::AppSync::DataSource', 2);
+  Template.fromJSON(stack).resourceCountIs('AWS::AppSync::FunctionConfiguration', 2);
+  Template.fromJSON(stack).resourceCountIs('AWS::Lambda::Function', 1);
+  Template.fromJSON(stack).resourceCountIs('AWS::AppSync::Resolver', 1);
   expect(out.schema).toContain('speakTranslatedText(input: SpeakTranslatedTextInput!): String');
-  cdkExpect(stack).to(
-    haveResourceLike('AWS::IAM::Role', {
+  Template.fromJSON(stack)
+    .hasResourceProperties('AWS::IAM::Role', {
       AssumeRolePolicyDocument: {
         Statement: [
           {
@@ -57,23 +57,21 @@ test('lambda function is added to pipeline when lambda dependent action is added
         ],
         Version: '2012-10-17',
       },
-    }),
-  );
-  cdkExpect(stack).to(
-    haveResourceLike('AWS::IAM::Policy', {
+    });
+  Template.fromJSON(stack)
+    .hasResourceProperties('AWS::IAM::Policy', {
       PolicyDocument: {
         Statement: [
           {
             Action: 's3:GetObject',
             Effect: 'Allow',
-            Resource: anything(),
+            Resource: Match.anyValue(),
           },
         ],
       },
-    }),
-  );
-  cdkExpect(stack).to(
-    haveResourceLike('AWS::IAM::Policy', {
+    });
+  Template.fromJSON(stack)
+    .hasResourceProperties('AWS::IAM::Policy', {
       PolicyDocument: {
         Statement: [
           {
@@ -83,29 +81,27 @@ test('lambda function is added to pipeline when lambda dependent action is added
           },
         ],
       },
-    }),
-  );
-  cdkExpect(stack).to(
-    haveResourceLike('AWS::IAM::Policy', {
+    });
+  Template.fromJSON(stack)
+    .hasResourceProperties('AWS::IAM::Policy', {
       PolicyDocument: {
         Statement: [
           {
             Action: 'lambda:InvokeFunction',
             Effect: 'Allow',
-            Resource: { 'Fn::GetAtt': [anything(), 'Arn'] },
+            Resource: { 'Fn::GetAtt': [Match.anyValue(), 'Arn'] },
           },
         ],
       },
-    }),
-  );
-  cdkExpect(stack).to(
-    haveResourceLike('AWS::AppSync::Resolver', {
-      ApiId: { Ref: anything() },
+    });
+  Template.fromJSON(stack)
+    .hasResourceProperties('AWS::AppSync::Resolver', {
+      ApiId: { Ref: Match.anyValue() },
       FieldName: 'speakTranslatedText',
       TypeName: 'Query',
       Kind: 'PIPELINE',
       PipelineConfig: {
-        Functions: [{ 'Fn::GetAtt': [anything(), 'FunctionId'] }, { 'Fn::GetAtt': [anything(), 'FunctionId'] }],
+        Functions: [{ 'Fn::GetAtt': [Match.anyValue(), 'FunctionId'] }, { 'Fn::GetAtt': [Match.anyValue(), 'FunctionId'] }],
       },
       RequestMappingTemplate: {
         'Fn::Join': [
@@ -121,7 +117,7 @@ test('lambda function is added to pipeline when lambda dependent action is added
                       hash: {
                         'Fn::Select': [3, { 'Fn::Split': ['-', { Ref: 'AWS::StackName' }] }],
                       },
-                      env: { Ref: anything() },
+                      env: { Ref: Match.anyValue() },
                     },
                   ],
                 },
@@ -143,8 +139,7 @@ test('lambda function is added to pipeline when lambda dependent action is added
       },
       ResponseMappingTemplate:
         '## If the result is a list return the result as a list **\n#if( $ctx.stash.get("isList") )\n  #set( $result = $ctx.result.split("[ ,]+") )\n  $util.toJson($result)\n#else\n  $util.toJson($ctx.result)\n#end',
-    }),
-  );
+    });
 });
 
 test('return type is a list based on the action', () => {
@@ -162,10 +157,10 @@ test('return type is a list based on the action', () => {
   expect(out.schema).toMatchSnapshot();
   const stack = out.stacks.PredictionsDirectiveStack;
   expect(stack).toBeDefined();
-  cdkExpect(stack).to(countResources('AWS::IAM::Role', 3));
-  cdkExpect(stack).to(countResources('AWS::AppSync::DataSource', 2));
-  cdkExpect(stack).to(countResources('AWS::AppSync::FunctionConfiguration', 2));
-  cdkExpect(stack).to(countResources('AWS::AppSync::Resolver', 1));
+  Template.fromJSON(stack).resourceCountIs('AWS::IAM::Role', 3);
+  Template.fromJSON(stack).resourceCountIs('AWS::AppSync::DataSource', 2);
+  Template.fromJSON(stack).resourceCountIs('AWS::AppSync::FunctionConfiguration', 2);
+  Template.fromJSON(stack).resourceCountIs('AWS::AppSync::Resolver', 1);
   expect(out.schema).toContain('translateLabels(input: TranslateLabelsInput!): [String]');
 });
 

--- a/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
+++ b/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
@@ -13,10 +13,15 @@ import {
   TransformerSchemaVisitStepContextProvider,
   TransformerTransformSchemaStepContextProvider,
 } from '@aws-amplify/graphql-transformer-interfaces';
-import * as appsync from '@aws-cdk/aws-appsync';
-import * as cdk from '@aws-cdk/core';
-import * as iam from '@aws-cdk/aws-iam';
-import * as lambda from '@aws-cdk/aws-lambda';
+import {
+  DataSourceOptions,
+  HttpDataSource,
+  LambdaDataSource,
+} from '@aws-cdk/aws-appsync-alpha';
+import * as cdk from 'aws-cdk-lib';
+import { CfnResolver } from 'aws-cdk-lib/aws-appsync';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { makeListType, makeNamedType, makeNonNullType, PredictionsResourceIDs, ResourceConstants } from 'graphql-transformer-common';
 import {
   DirectiveNode,
@@ -44,7 +49,7 @@ import {
   str,
   toJson,
 } from 'graphql-mapping-template';
-import { AuthorizationType } from '@aws-cdk/aws-appsync';
+import { AuthorizationType } from '@aws-cdk/aws-appsync-alpha';
 import { actionToDataSourceMap, actionToRoleAction, allowedActions } from './utils/action-maps';
 import {
   amzJsonContentType,
@@ -265,7 +270,7 @@ function createPredictionsDataSource(
   action: string,
   role: iam.Role,
   lambdaFn?: lambda.IFunction,
-): appsync.LambdaDataSource | appsync.HttpDataSource {
+): LambdaDataSource | HttpDataSource {
   let datasource;
 
   switch (action) {
@@ -280,7 +285,7 @@ function createPredictionsDataSource(
             signingRegion: cdk.Fn.sub('${AWS::Region}'),
             signingServiceName: 'rekognition',
           },
-        } as appsync.DataSourceOptions,
+        } as DataSourceOptions,
         stack,
       );
       break;
@@ -293,7 +298,7 @@ function createPredictionsDataSource(
             signingRegion: cdk.Fn.sub('${AWS::Region}'),
             signingServiceName: 'translate',
           },
-        } as appsync.DataSourceOptions,
+        } as DataSourceOptions,
         stack,
       );
       break;
@@ -320,7 +325,7 @@ function createResolver(
   config: PredictionsDirectiveConfiguration,
   resolvers: any[],
   bucketName: string,
-): appsync.CfnResolver {
+): CfnResolver {
   const substitutions: { [key: string]: string } = {
     hash: cdk.Fn.select(3, cdk.Fn.split('-', cdk.Fn.ref('AWS::StackName'))),
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,6 +260,21 @@
     graphql-mapping-template "4.20.5"
     graphql-transformer-common "4.24.0"
 
+"@aws-amplify/graphql-predictions-transformer@0.6.28":
+  version "0.6.28"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/graphql-predictions-transformer/-/graphql-predictions-transformer-0.6.28.tgz#6d56977ddeadee5d1036f613e1d5cc1055c0a1a6"
+  integrity sha512-frbSqhWqv4JqyfXMpV0Kf/HGVUl/mOkx1LHA20BYPf6t4NUJ/rZVRhZS1AKXceQ4sm7sfKFExl0pVeAuXH4JqA==
+  dependencies:
+    "@aws-amplify/graphql-transformer-core" "0.17.12"
+    "@aws-amplify/graphql-transformer-interfaces" "1.14.7"
+    "@aws-cdk/aws-appsync" "~1.124.0"
+    "@aws-cdk/aws-iam" "~1.124.0"
+    "@aws-cdk/aws-lambda" "~1.124.0"
+    "@aws-cdk/core" "~1.124.0"
+    graphql "^14.5.8"
+    graphql-mapping-template "4.20.5"
+    graphql-transformer-common "4.24.0"
+
 "@aws-amplify/graphql-transformer-core@0.17.12", "@aws-amplify/graphql-transformer-core@^0.17.11":
   version "0.17.12"
   resolved "https://registry.yarnpkg.com/@aws-amplify/graphql-transformer-core/-/graphql-transformer-core-0.17.12.tgz#b965a07a8d23df2cf349366f39656a7ed2908154"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR migrates `@aws-amplify/graphql-predictions-transformer` to CDK v2.

Gotchas:
- There seems to be a change in `@aws-cdk/aws-appsync-alpha` that creates more permissive policy. See PR comment below.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

`yarn clean && yarn dev-build && yarn test` passes.

E2E don't compile yet.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] PR description included
- [ x] `yarn test` passes
- [ x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
