### PR TITLE
fix: 🐛 Floats ending in .0 now being parsed as float type

### DIFF
--- a/packages/amplify-graphql-searchable-transformer/package.json
+++ b/packages/amplify-graphql-searchable-transformer/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc && cd streaming-lambda && bestzip --force node ../lib/streaming-lambda.zip python_streaming_function.py",
+    "build": "tsc && cd streaming-lambda && cp python_streaming_function.py ../lib",
     "watch": "tsc -w",
     "clean": "rimraf ./lib",
     "test": "jest"
@@ -37,12 +37,14 @@
     "@aws-cdk/aws-iam": "~1.124.0",
     "@aws-cdk/aws-lambda": "~1.124.0",
     "@aws-cdk/core": "~1.124.0",
+    "adm-zip": "0.5.9",
     "graphql": "^14.5.8",
     "graphql-mapping-template": "4.20.5",
     "graphql-transformer-common": "4.24.0"
   },
   "devDependencies": {
     "@aws-cdk/assert": "~1.124.0",
+    "@types/adm-zip": "^0.5.0",
     "@types/node": "^12.12.6"
   },
   "jest": {

--- a/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
@@ -2,7 +2,8 @@ import {
   TransformerPluginBase,
   generateGetArgumentsInput,
   InvalidDirectiveError,
-  MappingTemplate, DirectiveWrapper,
+  MappingTemplate,
+  DirectiveWrapper,
 } from '@aws-amplify/graphql-transformer-core';
 import {
   DataSourceProvider,
@@ -71,8 +72,11 @@ const getTable = (context: TransformerContextProvider, definition: ObjectTypeDef
 
 const getNonKeywordFields = (def: ObjectTypeDefinitionNode): Expression[] => {
   const nonKeywordTypeSet = new Set(nonKeywordTypes);
-  return def.fields?.filter((field) => nonKeywordTypeSet.has(getBaseType(field.type))
-    && !DATASTORE_SYNC_FIELDS.includes(field.name.value)).map((field) => str(field.name.value)) || [];
+  return (
+    def.fields
+      ?.filter((field) => nonKeywordTypeSet.has(getBaseType(field.type)) && !DATASTORE_SYNC_FIELDS.includes(field.name.value))
+      .map((field) => str(field.name.value)) || []
+  );
 };
 
 /**
@@ -327,6 +331,7 @@ export class SearchableModelTransformer extends TransformerPluginBase {
       domain.domainEndpoint,
       isProjectUsingDataStore,
       region,
+      this.searchableObjectTypeDefinitions,
     );
 
     for (const def of this.searchableObjectTypeDefinitions) {
@@ -362,7 +367,7 @@ export class SearchableModelTransformer extends TransformerPluginBase {
         MappingTemplate.s3MappingTemplateFromString(
           requestTemplate(
             attributeName,
-            getNonKeywordFields((context.output.getObject(type))as ObjectTypeDefinitionNode),
+            getNonKeywordFields(context.output.getObject(type) as ObjectTypeDefinitionNode),
             context.isProjectUsingDataStore(),
             openSearchIndexName,
             keyFields,

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,65 @@
     signedsource "^1.0.0"
     yargs "^15.3.1"
 
+"@aws-amplify/amplify-appsync-simulator@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/amplify-appsync-simulator/-/amplify-appsync-simulator-2.6.1.tgz#1f2faa83f37be8b1c18b20ba2c645ce6f1cbd6d3"
+  integrity sha512-sDTcDj6NaHaBOHGTWSayCLXhN0eyXsjUi2CyL5eDWCeuefqU6xhXribX06tNg85mreSrMUtMBm2+3fdB/UBwDw==
+  dependencies:
+    "@graphql-tools/schema" "^8.3.1"
+    "@graphql-tools/utils" "^8.5.1"
+    amplify-velocity-template "1.4.8"
+    aws-sdk "^2.1113.0"
+    chalk "^4.1.1"
+    cors "^2.8.5"
+    dataloader "^2.0.0"
+    express "^4.17.3"
+    get-port "^5.1.1"
+    graphql "^14.5.8"
+    graphql-iso-date "^3.6.1"
+    graphql-subscriptions "^1.1.0"
+    ip "^1.1.5"
+    js-string-escape "^1.0.1"
+    jwt-decode "^2.2.0"
+    libphonenumber-js "1.9.47"
+    lodash "^4.17.21"
+    moment "^2.24.0"
+    moment-jdateformatparser "^1.2.1"
+    moment-timezone "0.5.35"
+    promise-toolbox "^0.20.0"
+    slash "^3.0.0"
+    uuid "^8.3.2"
+    ws "^8.5.0"
+
+"@aws-amplify/amplify-category-auth@2.12.2":
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/amplify-category-auth/-/amplify-category-auth-2.12.2.tgz#b1c48718122f1cde876b01b59d17a1d184e145c5"
+  integrity sha512-wjxyL8ZMay4eCilPwaQz8W/VeSbTvJW36F7I70j1zVWuuOK4F0l31LJhH+sVCxmji2ttm4JC2q+Jg49bL3H2LA==
+  dependencies:
+    "@aws-amplify/amplify-environment-parameters" "1.1.2"
+    "@aws-amplify/cli-extensibility-helper" "2.4.2"
+    "@aws-cdk/aws-cognito" "~1.124.0"
+    "@aws-cdk/aws-iam" "~1.124.0"
+    "@aws-cdk/aws-lambda" "~1.124.0"
+    "@aws-cdk/core" "~1.124.0"
+    amplify-cli-core "3.2.1"
+    amplify-headless-interface "1.15.0"
+    amplify-prompts "2.5.0"
+    amplify-util-headless-input "1.9.5"
+    amplify-util-import "2.2.36"
+    aws-sdk "^2.1113.0"
+    chalk "^4.1.1"
+    change-case "^4.1.1"
+    enquirer "^2.3.6"
+    fs-extra "^8.1.0"
+    inquirer "^7.3.3"
+    lodash "^4.17.21"
+    mime-types "^2.1.26"
+    ora "^4.0.3"
+    promise-sequential "^1.1.1"
+    uuid "^8.3.2"
+    vm2 "^3.9.8"
+
 "@aws-amplify/amplify-category-custom@2.5.1":
   version "2.5.1"
   resolved "https://registry.npmjs.org/@aws-amplify/amplify-category-custom/-/amplify-category-custom-2.5.1.tgz#92deb405e39f79125ee6340cd0e50662ca30b867"
@@ -54,6 +113,43 @@
     ora "^4.0.3"
     uuid "^8.3.2"
 
+"@aws-amplify/amplify-category-custom@2.5.2":
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/amplify-category-custom/-/amplify-category-custom-2.5.2.tgz#6b7d0da3ea9102f07ea82ea966fe00b8894af095"
+  integrity sha512-+7autZfcKpGQKJBxvlYDfpO38afC7Em4eyEijkngEdPD42vGBeNt30aVbyOwmtYiOxfmoi49Cbp+t9oY2BZ0Fw==
+  dependencies:
+    amplify-cli-core "3.2.1"
+    amplify-prompts "2.5.0"
+    execa "^5.1.1"
+    fs-extra "^8.1.0"
+    glob "^7.2.0"
+    inquirer "^7.3.3"
+    ora "^4.0.3"
+    uuid "^8.3.2"
+
+"@aws-amplify/amplify-category-storage@3.5.2":
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/amplify-category-storage/-/amplify-category-storage-3.5.2.tgz#913f6f255aab85f2093cc180c1cc378883778c9e"
+  integrity sha512-lSsXYA86JWTNReX62nds68kCWtrV+l7JJGfdWJWrWlwmHnHXynlIZS6a4HNne3q2xQXOKRvPSZMxzcTWOdM7YQ==
+  dependencies:
+    "@aws-amplify/amplify-environment-parameters" "1.1.2"
+    "@aws-amplify/cli-extensibility-helper" "2.4.2"
+    "@aws-cdk/aws-dynamodb" "~1.124.0"
+    "@aws-cdk/aws-s3" "~1.124.0"
+    "@aws-cdk/core" "~1.124.0"
+    amplify-cli-core "3.2.1"
+    amplify-headless-interface "1.15.0"
+    amplify-prompts "2.5.0"
+    amplify-util-import "2.2.36"
+    aws-sdk "^2.1113.0"
+    chalk "^4.1.1"
+    enquirer "^2.3.6"
+    fs-extra "^8.1.0"
+    lodash "^4.17.21"
+    promise-sequential "^1.1.1"
+    uuid "^8.3.2"
+    vm2 "^3.9.8"
+
 "@aws-amplify/amplify-environment-parameters@1.1.1":
   version "1.1.1"
   resolved "https://registry.npmjs.org/@aws-amplify/amplify-environment-parameters/-/amplify-environment-parameters-1.1.1.tgz#0437719fb1e8f09528d811437cb4c52aa024fd16"
@@ -61,6 +157,26 @@
   dependencies:
     amplify-cli-core "3.2.0"
     lodash "^4.17.21"
+
+"@aws-amplify/amplify-environment-parameters@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/amplify-environment-parameters/-/amplify-environment-parameters-1.1.2.tgz#ca367db0992515c8062a8660fcd41b7cb2947bcb"
+  integrity sha512-VNvF39KksgVmM3QHLJUa33nAzJOuEFKygELiuoBfVSwPvx27/o830aTNpFvk757NLhMm566UdU4/NUaJbVAInQ==
+  dependencies:
+    amplify-cli-core "3.2.1"
+    lodash "^4.17.21"
+
+"@aws-amplify/amplify-util-uibuilder@1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/amplify-util-uibuilder/-/amplify-util-uibuilder-1.4.2.tgz#819f555574e941e01b5e09ce8942311815755bc6"
+  integrity sha512-IWHPYLWSWM+u60h+5Tgpd+gKDIOpiTvUEy6QRTNWkdNh5X5C54auaaSP8/JhAyr9BuZ0c8UEz6o4CZDIlqwnmA==
+  dependencies:
+    "@aws-amplify/codegen-ui" "^2.3.2"
+    "@aws-amplify/codegen-ui-react" "^2.3.2"
+    amplify-cli-core "3.2.1"
+    amplify-prompts "2.5.0"
+    aws-sdk "^2.1113.0"
+    ora "^4.0.3"
 
 "@aws-amplify/analytics@5.2.21":
   version "5.2.21"
@@ -158,6 +274,118 @@
     "@aws-cdk/aws-s3" "~1.124.0"
     "@aws-cdk/core" "~1.124.0"
     amplify-cli-core "3.2.0"
+
+"@aws-amplify/cli-extensibility-helper@2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/cli-extensibility-helper/-/cli-extensibility-helper-2.4.2.tgz#5e30c331fad846150b6303b0b0407127e8da5dfd"
+  integrity sha512-OROzlXa/gTHM7LlCFhBrQHYi9Knw++jTwQ9nIh6/JKKGc79DbHGXpRJodyujEF+GEaduJpBfQXExe6wLq1Aijg==
+  dependencies:
+    "@aws-amplify/amplify-category-custom" "2.5.2"
+    "@aws-cdk/aws-apigateway" "~1.124.0"
+    "@aws-cdk/aws-appsync" "~1.124.0"
+    "@aws-cdk/aws-cognito" "~1.124.0"
+    "@aws-cdk/aws-dynamodb" "~1.124.0"
+    "@aws-cdk/aws-elasticsearch" "~1.124.0"
+    "@aws-cdk/aws-iam" "~1.124.0"
+    "@aws-cdk/aws-lambda" "~1.124.0"
+    "@aws-cdk/aws-s3" "~1.124.0"
+    "@aws-cdk/core" "~1.124.0"
+    amplify-cli-core "3.2.1"
+
+"@aws-amplify/cli-internal@^10.2.3":
+  version "10.2.3"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/cli-internal/-/cli-internal-10.2.3.tgz#6556098bcb64a77c26573f3ec9e295329c569f5c"
+  integrity sha512-+DjUeCbkvlFOwswTFklCQPORzLpBzVSOkJWgSl1mruWq2SM/PvJgt8y9u/ofMLL+6co0IY3MPzwwRCk03q7Ggw==
+  dependencies:
+    "@aws-amplify/amplify-category-api" "^4.0.2"
+    "@aws-amplify/amplify-category-auth" "2.12.2"
+    "@aws-amplify/amplify-category-custom" "2.5.2"
+    "@aws-amplify/amplify-category-storage" "3.5.2"
+    "@aws-amplify/amplify-environment-parameters" "1.1.2"
+    "@aws-amplify/amplify-util-uibuilder" "1.4.2"
+    "@aws-amplify/graphql-auth-transformer" "^1.0.2"
+    "@aws-cdk/cloudformation-diff" "~1.124.0"
+    amplify-app "4.3.2"
+    amplify-category-analytics "4.1.2"
+    amplify-category-function "4.1.2"
+    amplify-category-geo "2.8.2"
+    amplify-category-hosting "3.4.2"
+    amplify-category-interactions "4.1.2"
+    amplify-category-notifications "2.20.2"
+    amplify-category-predictions "4.1.2"
+    amplify-category-xr "3.3.2"
+    amplify-cli-core "3.2.1"
+    amplify-cli-logger "1.2.0"
+    amplify-cli-shared-interfaces "1.1.0"
+    amplify-codegen "^3.1.0"
+    amplify-console-hosting "2.3.2"
+    amplify-container-hosting "2.5.2"
+    amplify-dotnet-function-runtime-provider "1.6.10"
+    amplify-dotnet-function-template-provider "2.3.2"
+    amplify-frontend-android "3.4.0"
+    amplify-frontend-flutter "1.3.5"
+    amplify-frontend-ios "3.5.2"
+    amplify-frontend-javascript "3.6.2"
+    amplify-go-function-runtime-provider "2.3.2"
+    amplify-go-function-template-provider "1.3.14"
+    amplify-java-function-runtime-provider "2.3.2"
+    amplify-java-function-template-provider "1.5.14"
+    amplify-nodejs-function-runtime-provider "2.3.2"
+    amplify-nodejs-function-template-provider "2.5.2"
+    amplify-prompts "2.5.0"
+    amplify-provider-awscloudformation "6.7.2"
+    amplify-python-function-runtime-provider "2.4.2"
+    amplify-python-function-template-provider "1.3.16"
+    amplify-util-import "2.2.36"
+    amplify-util-mock "4.5.2"
+    aws-sdk "^2.1113.0"
+    chalk "^4.1.1"
+    ci-info "^2.0.0"
+    cli-table3 "^0.6.0"
+    colors "1.4.0"
+    ejs "^3.1.7"
+    env-editor "^0.5.0"
+    execa "^5.1.1"
+    folder-hash "^4.0.2"
+    fs-extra "^8.1.0"
+    glob "^7.2.0"
+    global-prefix "^3.0.0"
+    graphql-transformer-core "^7.6.5"
+    gunzip-maybe "^1.4.2"
+    hidefile "^3.0.0"
+    ini "^1.3.5"
+    inquirer "^7.3.3"
+    lodash "^4.17.21"
+    node-fetch "^2.6.7"
+    open "^8.4.0"
+    ora "^4.0.3"
+    progress "^2.0.3"
+    promise-sequential "^1.1.1"
+    semver "^7.3.5"
+    tar-fs "^2.1.1"
+    treeify "^1.1.0"
+    update-notifier "^5.1.0"
+    uuid "^8.3.2"
+    which "^2.0.2"
+
+"@aws-amplify/codegen-ui-react@^2.3.2":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.5.0.tgz#be074c17325415f67d46ac27c1b814ab7af71c7c"
+  integrity sha512-CVddcwNMBO6VVL9m2mHAmygBWya1WlMFqVkzC+WcS8I84oLR1bKdQg3DW/NLCxxKfgtGsPvMJw8/l2aHE+tS9A==
+  dependencies:
+    "@aws-amplify/codegen-ui" "2.5.0"
+    "@typescript/vfs" "~1.3.5"
+    typescript "<=4.5.0"
+  optionalDependencies:
+    prettier "2.3.2"
+
+"@aws-amplify/codegen-ui@2.5.0", "@aws-amplify/codegen-ui@^2.3.2":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/codegen-ui/-/codegen-ui-2.5.0.tgz#c83ddd3ab66334e85bf144336e3d79af63b102e5"
+  integrity sha512-mQJCxOI/L1fZOfUt41l5riS2jJZ+zNnZTlGSBPfxhpQ2bv0mjAcykjrHRDAlweZYJZHKGhM+RXbx7cW36dL9pw==
+  dependencies:
+    change-case "^4.1.2"
+    yup "^0.32.11"
 
 "@aws-amplify/core@4.7.5":
   version "4.7.5"
@@ -4909,6 +5137,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.15.4":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.4.tgz#a42f814502ee467d55b38dd1c256f53a7b885c78"
+  integrity sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.18.10", "@babel/template@^7.3.3":
   version "7.18.10"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
@@ -6743,6 +6978,11 @@
     "@babel/runtime" "^7.9.6"
     redux-persist "^4.6.0"
 
+"@sindresorhus/is@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
+  integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
+
 "@sindresorhus/is@^5.2.0":
   version "5.3.0"
   resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-5.3.0.tgz#0ec9264cf54a527671d990eb874e030b55b70dcc"
@@ -6782,6 +7022,13 @@
   version "0.7.2"
   resolved "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz#5981a8db18b56ba38ef0efb7d995b12aa7b51918"
   integrity sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==
+
+"@szmarczak/http-timer@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
+  integrity sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
+  dependencies:
+    defer-to-connect "^1.0.1"
 
 "@szmarczak/http-timer@^5.0.1":
   version "5.0.1"
@@ -6839,6 +7086,13 @@
   integrity sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==
   dependencies:
     "@turf/helpers" "^6.5.0"
+
+"@types/adm-zip@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@types/adm-zip/-/adm-zip-0.5.0.tgz#94c90a837ce02e256c7c665a6a1eb295906333c1"
+  integrity sha512-FCJBJq9ODsQZUNURo5ILAQueuA8WJhRvuihS3ke2iI25mJlfV2LK8jG2Qj2z2AWg8U0FtWWqBHVRetceLskSaw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/async@2.0.50":
   version "2.0.50"
@@ -6981,6 +7235,11 @@
   version "4.14.185"
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.185.tgz#c9843f5a40703a8f5edfd53358a58ae729816908"
   integrity sha512-evMDG1bC4rgQg4ku9tKpuMh5iBNEwNa3tf9zRHdP1qlv+1WUg44xat4IxCE14gIpZRGUUWAx2VhItCZc25NfMA==
+
+"@types/lodash@^4.14.175":
+  version "4.14.186"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.186.tgz#862e5514dd7bd66ada6c70ee5fce844b06c8ee97"
+  integrity sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==
 
 "@types/md5@^2.3.1":
   version "2.3.2"
@@ -7227,6 +7486,13 @@
     "@typescript-eslint/types" "5.38.0"
     eslint-visitor-keys "^3.3.0"
 
+"@typescript/vfs@~1.3.5":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@typescript/vfs/-/vfs-1.3.6.tgz#02ed6de964ecdd73cd71a506b78e50e177682291"
+  integrity sha512-VSLn7rs46Qhe4gYxbK1/IB4NPLvgKl0I6SgeVyJwW5efYAELvDVqf1gVOG7JaKtW8qlMtBaZP02/4TRN39AkEQ==
+  dependencies:
+    debug "^4.1.1"
+
 "@wry/equality@^0.1.2":
   version "0.1.11"
   resolved "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz#35cb156e4a96695aa81a9ecc4d03787bc17f1790"
@@ -7331,6 +7597,11 @@ address@^1.0.1:
   resolved "https://registry.npmjs.org/address/-/address-1.2.1.tgz#25bb61095b7522d65b357baa11bc05492d4c8acd"
   integrity sha512-B+6bi5D34+fDYENiH5qOlA0cV2rAGKuWZ9LeyUUehbXy8e0VS9e498yO0Jeeh+iM+6KbfudHTFjXw2MmJD4QRA==
 
+adm-zip@0.5.9:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.9.tgz#b33691028333821c0cf95c31374c5462f2905a83"
+  integrity sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==
+
 agent-base@6, agent-base@^6.0.0, agent-base@^6.0.2:
   version "6.0.2"
   resolved "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -7399,6 +7670,27 @@ amazon-cognito-identity-js@5.2.10:
     isomorphic-unfetch "^3.0.0"
     js-cookie "^2.2.1"
 
+amplify-app@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/amplify-app/-/amplify-app-4.3.2.tgz#046193aa587383833542da75221fe965d5a80b58"
+  integrity sha512-XrLYAC6SzA6gKSN5CMfWL/H8vO4PZhjOWf5IULJHypoUpE58DcXZYHEN/QOoANO9klc5W7X1YDsqRj1lJ57pIA==
+  dependencies:
+    amplify-frontend-android "3.4.0"
+    amplify-frontend-flutter "1.3.5"
+    amplify-frontend-ios "3.5.2"
+    amplify-frontend-javascript "3.6.2"
+    chalk "^4.1.1"
+    execa "^5.1.1"
+    fs-extra "^8.1.0"
+    ini "^1.3.5"
+    inquirer "^7.3.3"
+    node-emoji "^1.10.0"
+    ora "^4.0.3"
+    rimraf "^3.0.0"
+    semver "^7.3.5"
+    xcode "^2.1.0"
+    yargs "^15.1.0"
+
 amplify-app@^4.2.39:
   version "4.3.1"
   resolved "https://registry.npmjs.org/amplify-app/-/amplify-app-4.3.1.tgz#f8b7934d41733293a4aee1c96b010fa24c8dfd29"
@@ -7456,6 +7748,42 @@ amplify-appsync-simulator@^2.3.12:
     uuid "^8.3.2"
     ws "^7.5.7"
 
+amplify-category-analytics@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/amplify-category-analytics/-/amplify-category-analytics-4.1.2.tgz#317cbe4f2f5a8101f791626eae191c24e24a3ad2"
+  integrity sha512-6eMvxm73tZKuq6qfIGczrOHaOVZSLpKZG8V1UjZaERlVM9s0GCZSv3BmTdowKPuus8DYXhJn2ZP6Z2gvDiBtbQ==
+  dependencies:
+    amplify-cli-core "3.2.1"
+    fs-extra "^8.1.0"
+    inquirer "^7.3.3"
+    uuid "^8.3.2"
+
+amplify-category-function@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/amplify-category-function/-/amplify-category-function-4.1.2.tgz#8cafbca07be78f44dfd114d66bc3e21a19b12392"
+  integrity sha512-2XoCAJ9CsT2uFRlg1QYAzt3ra5K9E2fWdllymJwEoyRIbuiq40JE0maZIeXA1SGNjnT/7DY7OgKRNyG16ZHz+A==
+  dependencies:
+    "@aws-amplify/amplify-environment-parameters" "1.1.2"
+    amplify-cli-core "3.2.1"
+    amplify-function-plugin-interface "1.9.5"
+    amplify-prompts "2.5.0"
+    archiver "^5.3.0"
+    aws-sdk "^2.1113.0"
+    chalk "^4.1.1"
+    cloudform-types "^4.2.0"
+    enquirer "^2.3.6"
+    folder-hash "^4.0.2"
+    fs-extra "^8.1.0"
+    globby "^11.0.3"
+    graphql-transformer-core "^7.6.5"
+    inquirer "^7.3.3"
+    inquirer-datepicker "^2.0.0"
+    jstreemap "^1.28.2"
+    lodash "^4.17.21"
+    ora "^4.0.3"
+    promise-sequential "^1.1.1"
+    uuid "^8.3.2"
+
 amplify-category-function@^4.0.12:
   version "4.1.1"
   resolved "https://registry.npmjs.org/amplify-category-function/-/amplify-category-function-4.1.1.tgz#dd5f3cf52f2d2c8c51e7e92240fba39271e97598"
@@ -7482,10 +7810,118 @@ amplify-category-function@^4.0.12:
     promise-sequential "^1.1.1"
     uuid "^8.3.2"
 
+amplify-category-geo@2.8.2:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/amplify-category-geo/-/amplify-category-geo-2.8.2.tgz#7c350026d92f513b0931d9ad46606348e71f5162"
+  integrity sha512-QguhAxmh5aFqMgbE/sBnCce3wiX95O4Jyxb9+OUNNEWAtNkw418FQf4nb5I63mNZVeb4S2b1tKTHymP6WeE2hw==
+  dependencies:
+    "@aws-cdk/aws-iam" "~1.124.0"
+    "@aws-cdk/aws-lambda" "~1.124.0"
+    "@aws-cdk/core" "~1.124.0"
+    ajv "^6.12.6"
+    amplify-cli-core "3.2.1"
+    amplify-headless-interface "1.15.0"
+    amplify-prompts "2.5.0"
+    amplify-util-headless-input "1.9.5"
+    aws-sdk "^2.1113.0"
+    fs-extra "^8.1.0"
+    lodash "^4.17.21"
+    uuid "^8.3.2"
+
+amplify-category-hosting@3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/amplify-category-hosting/-/amplify-category-hosting-3.4.2.tgz#4cc9cb228372e74e0b0855f5095940b0f596fdb7"
+  integrity sha512-keiK6D3xU34chVzo2KKYPh5Fnh/IJ3+ZEL9FlTVpCHJSNmyp/s+Rvou/d8T8eWmCa8OyKzNLKugmFLVfvD4NiA==
+  dependencies:
+    amplify-cli-core "3.2.1"
+    chalk "^4.1.1"
+    fs-extra "^8.1.0"
+    inquirer "^7.3.3"
+    mime-types "^2.1.26"
+    minimatch "^3.0.4"
+    moment "^2.24.0"
+    ora "^4.0.3"
+    promise-sequential "^1.1.1"
+
+amplify-category-interactions@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/amplify-category-interactions/-/amplify-category-interactions-4.1.2.tgz#c3fd33045e07343310efa35ebac826cdbf518d06"
+  integrity sha512-VU9mX/H+fc2H1TwjOKhLObG+OLj5f/VR6vZQ4RyjeNClK4W35V4tkMYlmtt4ksj0M/+qHntImF37M3fVXQxpCg==
+  dependencies:
+    amplify-cli-core "3.2.1"
+    fs-extra "^8.1.0"
+    fuzzy "^0.1.3"
+    inquirer "^7.3.3"
+    inquirer-autocomplete-prompt "^1.4.0"
+    uuid "^8.3.2"
+
+amplify-category-notifications@2.20.2:
+  version "2.20.2"
+  resolved "https://registry.yarnpkg.com/amplify-category-notifications/-/amplify-category-notifications-2.20.2.tgz#b876c9cb6045645bebf526d06e79a0556b17b64c"
+  integrity sha512-AqnZx/FNMdZaIApHURb+ww4MIQAgsc6kpLWVVlunJtaVdGBnqfIBUqnb7+re1EGBcIkBGnQdUtabVHucH8Om1A==
+  dependencies:
+    "@aws-amplify/amplify-environment-parameters" "1.1.2"
+    fs-extra "^8.1.0"
+    inquirer "^7.3.3"
+    lodash "^4.17.21"
+    ora "^4.0.3"
+    promise-sequential "^1.1.1"
+
+amplify-category-predictions@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/amplify-category-predictions/-/amplify-category-predictions-4.1.2.tgz#c8e983b211a74d1bbac7c096ed374ed3a3b19a7e"
+  integrity sha512-4TM7sOvuffhu6FzvQPpJd3+InkGAfaGkMsPHCqf4yi/q+JqUQB0BDxO+q98Ygg4oMotLGgWNuRD5X+NNkaQYZA==
+  dependencies:
+    amplify-cli-core "3.2.1"
+    aws-sdk "^2.1113.0"
+    chalk "^4.1.1"
+    fs-extra "^8.1.0"
+    inquirer "^7.3.3"
+    uuid "^8.3.2"
+
+amplify-category-xr@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/amplify-category-xr/-/amplify-category-xr-3.3.2.tgz#355a2609d5a9800dcbd3a2cd492d38d0118ce16b"
+  integrity sha512-3CsCr2ly4370U7wCd9uwCtdF9K0sZZR23OwxMtvlF4bNOgnTne0+zhfH/pkeeNjIh2H89L6i6mPPCDzVr+oKGA==
+  dependencies:
+    amplify-cli-core "3.2.1"
+    chalk "^4.1.1"
+    fs-extra "^8.1.0"
+    inquirer "^7.3.3"
+
 amplify-cli-core@3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/amplify-cli-core/-/amplify-cli-core-3.2.0.tgz#96f6141d3cf7c29cc7a890c1e7b56d74d48d6b34"
   integrity sha512-fLbKv+2CMj1qBeHmkBm7pguOfj5CkBJ3LYU5jBXvPHug6B+R+gmGJaEaw9xuYdOR+KseexqhIqv1G+2xv/cHGA==
+  dependencies:
+    "@aws-amplify/graphql-transformer-core" "^0.17.11"
+    "@aws-amplify/graphql-transformer-interfaces" "^1.14.7"
+    ajv "^6.12.6"
+    amplify-cli-logger "1.2.0"
+    amplify-prompts "2.5.0"
+    chalk "^4.1.1"
+    ci-info "^2.0.0"
+    cloudform-types "^4.2.0"
+    dotenv "^8.2.0"
+    execa "^5.1.1"
+    fs-extra "^8.1.0"
+    globby "^11.0.3"
+    graphql-transformer-core "^7.6.5"
+    hjson "^3.2.1"
+    js-yaml "^4.0.0"
+    lodash "^4.17.21"
+    node-fetch "^2.6.7"
+    open "^8.4.0"
+    ora "^4.0.3"
+    proxy-agent "^5.0.0"
+    semver "^7.3.5"
+    typescript-json-schema "~0.52.0"
+    which "^2.0.2"
+
+amplify-cli-core@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/amplify-cli-core/-/amplify-cli-core-3.2.1.tgz#c368f4eb03b43de3ef014272642f0db156ae668c"
+  integrity sha512-uuD1EWEkTETfojANcFtJpi7gasLcelWFtb5LyP9WSNGmyzWvqEKm0jOvnIZfB0G7Nv5qMNip1jmv1aoegS+YvQ==
   dependencies:
     "@aws-amplify/graphql-transformer-core" "^0.17.11"
     "@aws-amplify/graphql-transformer-interfaces" "^1.14.7"
@@ -7545,6 +7981,70 @@ amplify-codegen@^3.1.0:
     semver "^7.3.5"
     slash "^3.0.0"
 
+amplify-console-hosting@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/amplify-console-hosting/-/amplify-console-hosting-2.3.2.tgz#b336f170f4fc1d90f5a1b017ab8482bc0b22a341"
+  integrity sha512-r7hWKj8H21gVKD+OiQDaJPzgtsH+jCVtkRbYrybmW+/l3d8w1BkyD969WDkseJclcaf7W0zXnh4t6WYwWik4FA==
+  dependencies:
+    "@aws-amplify/amplify-environment-parameters" "1.1.2"
+    amplify-cli-core "3.2.1"
+    archiver "^5.3.0"
+    chalk "^4.1.1"
+    cli-table3 "^0.6.0"
+    execa "^5.1.1"
+    fs-extra "^8.1.0"
+    glob "^7.2.0"
+    inquirer "^7.3.3"
+    node-fetch "^2.6.7"
+    ora "^4.0.3"
+
+amplify-container-hosting@2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/amplify-container-hosting/-/amplify-container-hosting-2.5.2.tgz#8b96c65bba7cb159c115c7503ad860240c163421"
+  integrity sha512-BMPaorOfwsyA74dxbZ7x2bOCHxYyEvcN8dggbmGVLsMv7sbbKzBdZAT0h6ezqsK2UVBoVWq+4un10ui1BvYp7A==
+  dependencies:
+    "@aws-amplify/amplify-category-api" "^4.0.2"
+    amplify-cli-core "3.2.1"
+    fs-extra "^8.1.0"
+    inquirer "^7.3.3"
+    mime-types "^2.1.26"
+    promise-sequential "^1.1.1"
+
+amplify-dotnet-function-runtime-provider@1.6.10:
+  version "1.6.10"
+  resolved "https://registry.yarnpkg.com/amplify-dotnet-function-runtime-provider/-/amplify-dotnet-function-runtime-provider-1.6.10.tgz#1efacb746f248b8032e2e1ca7f8235f88154e933"
+  integrity sha512-tHRUDnd9FUgttHctbx5PVJ2DUtHUDSqZYqjZiEmTUN2Q4MwrIMPRPfeJAASO2Tc2RoQ0oQv4Irogw6AA/PZXaA==
+  dependencies:
+    amplify-function-plugin-interface "1.9.5"
+    execa "^5.1.1"
+    fs-extra "^8.1.0"
+    glob "^7.2.0"
+    which "^2.0.2"
+
+amplify-dotnet-function-template-provider@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/amplify-dotnet-function-template-provider/-/amplify-dotnet-function-template-provider-2.3.2.tgz#71e2e02cac83abd034669989680b728943aa0efe"
+  integrity sha512-L6W5TzG42oxUijUxAh2vD+VRstgqeo0RT5P/zWmv3MD6YZPqKrsRYMlQTbsZPfp74wpRWkMddYNan+S41HKJoQ==
+  dependencies:
+    amplify-cli-core "3.2.1"
+    amplify-function-plugin-interface "1.9.5"
+    graphql-transformer-core "^7.6.5"
+
+amplify-dynamodb-simulator@2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/amplify-dynamodb-simulator/-/amplify-dynamodb-simulator-2.4.2.tgz#e2b28d9a5af38a6897090543c636cd11c9f0c6c5"
+  integrity sha512-XFpBLxsPcGAQy5IWejsQLYc6OwNpuS1bDRafi1kR+7EUpv5KHkr4RdHl4upxopc5rjCpaqeBwCewTzd1L0wItA==
+  dependencies:
+    amplify-cli-core "3.2.1"
+    aws-sdk "^2.1113.0"
+    detect-port "^1.3.0"
+    execa "^5.1.1"
+    fs-extra "^8.1.0"
+    logdown "^3.3.0"
+    promise-toolbox "^0.20.0"
+    wait-port "^0.2.7"
+    which "^2.0.2"
+
 amplify-frontend-android@3.4.0:
   version "3.4.0"
   resolved "https://registry.npmjs.org/amplify-frontend-android/-/amplify-frontend-android-3.4.0.tgz#15b37dce216c3bf4beb0de94711f013948edf6da"
@@ -7574,6 +8074,17 @@ amplify-frontend-ios@3.5.1:
     graphql-config "^2.2.1"
     lodash "^4.17.21"
 
+amplify-frontend-ios@3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/amplify-frontend-ios/-/amplify-frontend-ios-3.5.2.tgz#ccae2ba782b3044669d0315f1b89bdef025ba5b7"
+  integrity sha512-jv25Q5ZeU8ZD0vKf7G6MGzfkOMqfPWF6PSyaRcCJGX8SM4Lv73ZynWVL1ihPrSjI37pc4soR0pgtDYBf7ZGCWw==
+  dependencies:
+    amplify-cli-core "3.2.1"
+    execa "^5.1.1"
+    fs-extra "^8.1.0"
+    graphql-config "^2.2.1"
+    lodash "^4.17.21"
+
 amplify-frontend-javascript@3.6.1:
   version "3.6.1"
   resolved "https://registry.npmjs.org/amplify-frontend-javascript/-/amplify-frontend-javascript-3.6.1.tgz#eb41317cceb88a5c433690faa0004584d503ec8f"
@@ -7589,15 +8100,84 @@ amplify-frontend-javascript@3.6.1:
     inquirer "^7.3.3"
     lodash "^4.17.21"
 
+amplify-frontend-javascript@3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/amplify-frontend-javascript/-/amplify-frontend-javascript-3.6.2.tgz#4db63f67e0a251f9d07dd879e6b72ade637afdd0"
+  integrity sha512-YcrIPpVEo2r0I5wQTejDR2DrpmXEWNL9qe0MfzvEJft1b7YAwDamq1gEN/vibCtIs7XU/yejfZb6Je5aO6cNsQ==
+  dependencies:
+    "@babel/core" "^7.10.5"
+    "@babel/plugin-transform-modules-commonjs" "7.10.4"
+    amplify-cli-core "3.2.1"
+    chalk "^4.1.1"
+    execa "^5.1.1"
+    fs-extra "^8.1.0"
+    graphql-config "^2.2.1"
+    inquirer "^7.3.3"
+    lodash "^4.17.21"
+
 amplify-function-plugin-interface@1.9.5, amplify-function-plugin-interface@^1.9.4:
   version "1.9.5"
   resolved "https://registry.npmjs.org/amplify-function-plugin-interface/-/amplify-function-plugin-interface-1.9.5.tgz#caa95891f7976d29a3d43c51f7c6a372178b9a81"
   integrity sha512-x49gI8U1863JC7akkUTQ5WrAhOPD8/PRx9LCwRshl1RJNMH4AaF40Gx+ueDVV/SLAsFc2GM0xoigxsvX+Cu4qQ==
 
+amplify-go-function-runtime-provider@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/amplify-go-function-runtime-provider/-/amplify-go-function-runtime-provider-2.3.2.tgz#037fd0e3b329df2c9234556741a19b683510acae"
+  integrity sha512-3+KHnCZY4hcyYkx6D/b95pgdvWJU9D338EM6gonmM2dlf5gBtb5GVBT0ve258nuFk+EgKVfAoypv3eB/t7N6Yg==
+  dependencies:
+    amplify-cli-core "3.2.1"
+    amplify-function-plugin-interface "1.9.5"
+    archiver "^5.3.0"
+    execa "^5.1.1"
+    fs-extra "^8.1.0"
+    get-port "^5.1.1"
+    glob "^7.2.0"
+    semver "^7.3.5"
+    which "^2.0.2"
+
+amplify-go-function-template-provider@1.3.14:
+  version "1.3.14"
+  resolved "https://registry.yarnpkg.com/amplify-go-function-template-provider/-/amplify-go-function-template-provider-1.3.14.tgz#6996570ff961018aaad8381104fc0c67738b04cf"
+  integrity sha512-K1W0qSTjwn7OFjqAGWqQEp2D6lzVCY/FnNoQqL93xO+4uZKnQFPY4wESFzJLQft5m+2aUCbyue1pViydeAHPqw==
+  dependencies:
+    amplify-function-plugin-interface "1.9.5"
+
 amplify-headless-interface@1.15.0, amplify-headless-interface@^1.14.2:
   version "1.15.0"
   resolved "https://registry.npmjs.org/amplify-headless-interface/-/amplify-headless-interface-1.15.0.tgz#a72d001d11d230ab48844b6e57b5f5c9f1cb030e"
   integrity sha512-6U22nhKLu67i6/zbBXZO+1TYmLXym+/e9fnwqeOhnctMCybU56RdWvj4/MhQIywn4DyOTHvYBkRT5o4f1hFSPg==
+
+amplify-java-function-runtime-provider@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/amplify-java-function-runtime-provider/-/amplify-java-function-runtime-provider-2.3.2.tgz#8b9d199bc50fe37a24eb62bdb32bfe62597a8cb3"
+  integrity sha512-gzBASWD0RwfF4ZkpAqeWpFdysHuFI5ZHYT/BPCJCnWLR/HIULaqlcimdmnIstPGXMtk68C6wnCfVyOXsFu2CpA==
+  dependencies:
+    amplify-cli-core "3.2.1"
+    amplify-function-plugin-interface "1.9.5"
+    execa "^5.1.1"
+    fs-extra "^8.1.0"
+    glob "^7.2.0"
+    semver "^7.3.5"
+    which "^2.0.2"
+
+amplify-java-function-template-provider@1.5.14:
+  version "1.5.14"
+  resolved "https://registry.yarnpkg.com/amplify-java-function-template-provider/-/amplify-java-function-template-provider-1.5.14.tgz#8b3908383293fbcf84ae825c5611a69256f0789c"
+  integrity sha512-XBkfnfUg1hxOWTDltx+fpSjo9cts5tkzhPUXKh9baNcGV19SuJoWLPNRiBeDp4gE56T2yRitxkM2J/9ywDjLCQ==
+  dependencies:
+    amplify-function-plugin-interface "1.9.5"
+
+amplify-nodejs-function-runtime-provider@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/amplify-nodejs-function-runtime-provider/-/amplify-nodejs-function-runtime-provider-2.3.2.tgz#7dd56873c1469f7758dd86fb0853df4fbf4e6b90"
+  integrity sha512-eBG6vJro9buMLNQMRQ76YCWv40jgcOShrXOcClJL6B8MXcwBaeoJkx20aL8wC267Dm4trARIViGNN6PYiFauBQ==
+  dependencies:
+    amplify-cli-core "3.2.1"
+    amplify-function-plugin-interface "1.9.5"
+    execa "^5.1.1"
+    exit "^0.1.2"
+    fs-extra "^8.1.0"
+    glob "^7.2.0"
 
 amplify-nodejs-function-runtime-provider@^2.2.28:
   version "2.3.1"
@@ -7611,6 +8191,16 @@ amplify-nodejs-function-runtime-provider@^2.2.28:
     fs-extra "^8.1.0"
     glob "^7.2.0"
 
+amplify-nodejs-function-template-provider@2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/amplify-nodejs-function-template-provider/-/amplify-nodejs-function-template-provider-2.5.2.tgz#70ee6703a06d5fa78eae0f01b64a82691a80920d"
+  integrity sha512-1eodxyRkBOs2jcIrCO8TVn5uRlSSp8y66R0xJWDy68Ix8hZDLqCz++3x/IPUQO37bR915dlarm+1AMWgXc/QAw==
+  dependencies:
+    amplify-cli-core "3.2.1"
+    amplify-function-plugin-interface "1.9.5"
+    graphql-transformer-core "^7.6.5"
+    lodash "^4.17.21"
+
 amplify-prompts@2.5.0:
   version "2.5.0"
   resolved "https://registry.npmjs.org/amplify-prompts/-/amplify-prompts-2.5.0.tgz#9c2dc604ac5c05b65d5b01efd285e6d424388110"
@@ -7619,6 +8209,78 @@ amplify-prompts@2.5.0:
     amplify-cli-shared-interfaces "1.1.0"
     chalk "^4.1.1"
     enquirer "^2.3.6"
+
+amplify-provider-awscloudformation@6.7.2:
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/amplify-provider-awscloudformation/-/amplify-provider-awscloudformation-6.7.2.tgz#3520f993409e2bf330f92bde8279d237e1998da7"
+  integrity sha512-Im35S98ZuiAHd8lpiFg41vxBZCac+6zvYqoHGGfSNP8Q0TrQ6qdWw1KcD+X093sw2KbyQHdpd2ZIFPKqVWzi3A==
+  dependencies:
+    "@aws-amplify/amplify-category-custom" "2.5.2"
+    "@aws-amplify/amplify-environment-parameters" "1.1.2"
+    "@aws-amplify/cli-extensibility-helper" "2.4.2"
+    "@aws-amplify/graphql-transformer-core" "^0.17.11"
+    "@aws-amplify/graphql-transformer-interfaces" "^1.14.7"
+    "@aws-cdk/assert" "~1.124.0"
+    "@aws-cdk/aws-apigatewayv2" "~1.124.0"
+    "@aws-cdk/aws-autoscaling" "~1.124.0"
+    "@aws-cdk/aws-cloudwatch" "~1.124.0"
+    "@aws-cdk/aws-ec2" "~1.124.0"
+    "@aws-cdk/aws-ecr" "~1.124.0"
+    "@aws-cdk/aws-ecr-assets" "~1.124.0"
+    "@aws-cdk/aws-ecs" "~1.124.0"
+    "@aws-cdk/aws-elasticloadbalancing" "~1.124.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "~1.124.0"
+    "@aws-cdk/aws-events" "~1.124.0"
+    "@aws-cdk/aws-iam" "~1.124.0"
+    "@aws-cdk/aws-kms" "~1.124.0"
+    "@aws-cdk/aws-lambda" "~1.124.0"
+    "@aws-cdk/aws-logs" "~1.124.0"
+    "@aws-cdk/aws-route53" "~1.124.0"
+    "@aws-cdk/aws-s3" "~1.124.0"
+    "@aws-cdk/aws-s3-assets" "~1.124.0"
+    "@aws-cdk/aws-secretsmanager" "~1.124.0"
+    "@aws-cdk/aws-servicediscovery" "~1.124.0"
+    "@aws-cdk/aws-sns" "~1.124.0"
+    "@aws-cdk/aws-sqs" "~1.124.0"
+    "@aws-cdk/core" "~1.124.0"
+    "@aws-cdk/region-info" "~1.124.0"
+    amplify-cli-core "3.2.1"
+    amplify-cli-logger "1.2.0"
+    amplify-codegen "^3.1.0"
+    amplify-prompts "2.5.0"
+    amplify-util-import "2.2.36"
+    archiver "^5.3.0"
+    aws-sdk "^2.1113.0"
+    bottleneck "2.19.5"
+    chalk "^4.1.1"
+    cloudform "^4.2.0"
+    cloudform-types "^4.2.0"
+    columnify "^1.5.4"
+    constructs "^3.3.125"
+    cors "^2.8.5"
+    deep-diff "^1.0.2"
+    extract-zip "^2.0.1"
+    folder-hash "^4.0.2"
+    fs-extra "^8.1.0"
+    glob "^7.2.0"
+    graphql "^14.5.8"
+    graphql-transformer-core "^7.6.5"
+    ignore "^5.2.0"
+    ini "^1.3.5"
+    inquirer "^7.3.3"
+    is-wsl "^2.2.0"
+    jose "^4.3.7"
+    lodash "^4.17.21"
+    lodash.throttle "^4.1.1"
+    moment "^2.24.0"
+    netmask "^2.0.2"
+    node-fetch "^2.6.7"
+    ora "^4.0.3"
+    promise-sequential "^1.1.1"
+    proxy-agent "^5.0.0"
+    rimraf "^3.0.0"
+    vm2 "^3.9.8"
+    xstate "^4.14.0"
 
 amplify-provider-awscloudformation@^6.6.0:
   version "6.7.1"
@@ -7692,7 +8354,27 @@ amplify-provider-awscloudformation@^6.6.0:
     vm2 "^3.9.8"
     xstate "^4.14.0"
 
-amplify-storage-simulator@^1.6.7:
+amplify-python-function-runtime-provider@2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/amplify-python-function-runtime-provider/-/amplify-python-function-runtime-provider-2.4.2.tgz#1ceaadc991aef0c25bdf2e5d6de80e46bba34839"
+  integrity sha512-KFs89W61Cx5Xn0tUcyeQrutpIUUNBgcrVvZU5B9H++jQOPvW3UVrYNtg4L4rkIRa48AsJnRid/lFdK1ZwIlblA==
+  dependencies:
+    amplify-cli-core "3.2.1"
+    amplify-function-plugin-interface "1.9.5"
+    execa "^5.1.1"
+    glob "^7.2.0"
+    ini "^1.3.5"
+    semver "^7.3.5"
+    which "^2.0.2"
+
+amplify-python-function-template-provider@1.3.16:
+  version "1.3.16"
+  resolved "https://registry.yarnpkg.com/amplify-python-function-template-provider/-/amplify-python-function-template-provider-1.3.16.tgz#453b9a82671c3bf63d3556607244e5df558164c3"
+  integrity sha512-Oz8aRmbf4ANGls+gaLwevxAqskMwwwG8nCP6euwifQP5jK5HTH9c4ApBmy1UK+fK+xxQ4ArPAjUOB6VETwOdlQ==
+  dependencies:
+    amplify-function-plugin-interface "1.9.5"
+
+amplify-storage-simulator@1.6.7, amplify-storage-simulator@^1.6.7:
   version "1.6.7"
   resolved "https://registry.npmjs.org/amplify-storage-simulator/-/amplify-storage-simulator-1.6.7.tgz#4967fd4f9903910ab096ebd09d56e53de6398238"
   integrity sha512-6fgaJogsMzm1UmErlTlN3xVQI9HIhlj/SkvVlFbk8CPKpzw8TtW9WEz9Mt1yOvyz+im7Z3+JLi17MTlZ1P6Bbw==
@@ -7710,7 +8392,7 @@ amplify-storage-simulator@^1.6.7:
     xml "^1.0.1"
     xml-js "^1.6.11"
 
-amplify-util-headless-input@^1.9.5:
+amplify-util-headless-input@1.9.5, amplify-util-headless-input@^1.9.5:
   version "1.9.5"
   resolved "https://registry.npmjs.org/amplify-util-headless-input/-/amplify-util-headless-input-1.9.5.tgz#30cec34338140b1938b7bddf2e7d07095941b58b"
   integrity sha512-dAXewft+FW80TQ4Iwq/f45jDyNn6rFivGOo6cQd7xIQgKmBPwyz24+/5KL363AwX+gkXFFPizacTgMAqigwjcw==
@@ -7725,6 +8407,30 @@ amplify-util-import@2.2.36:
   dependencies:
     aws-sdk "^2.1113.0"
 
+amplify-util-mock@4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/amplify-util-mock/-/amplify-util-mock-4.5.2.tgz#240440f13d2ee2440e6fc16336d535dcf7da01b6"
+  integrity sha512-npubG2b/s7OZAfi19kQZ0/JEj0l7sa7qP6rPIuYcWBTj0KCS0w6g7YF/CuuhTCYfMf/0GPTUQS9I0KSfjDmh7A==
+  dependencies:
+    "@aws-amplify/amplify-appsync-simulator" "2.6.1"
+    "@hapi/topo" "^5.0.0"
+    amplify-category-function "4.1.2"
+    amplify-cli-core "3.2.1"
+    amplify-codegen "^3.1.0"
+    amplify-dynamodb-simulator "2.4.2"
+    amplify-prompts "2.5.0"
+    amplify-provider-awscloudformation "6.7.2"
+    amplify-storage-simulator "1.6.7"
+    chokidar "^3.5.3"
+    detect-port "^1.3.0"
+    dotenv "^8.2.0"
+    execa "^5.1.1"
+    fs-extra "^8.1.0"
+    inquirer "^7.3.3"
+    lodash "^4.17.21"
+    semver "^7.3.5"
+    which "^2.0.2"
+
 amplify-velocity-template@1.4.8:
   version "1.4.8"
   resolved "https://registry.npmjs.org/amplify-velocity-template/-/amplify-velocity-template-1.4.8.tgz#78b67a58485bae952bf4b031228ba179f54b5fe4"
@@ -7732,7 +8438,7 @@ amplify-velocity-template@1.4.8:
   dependencies:
     lodash "^4.17.21"
 
-ansi-align@^3.0.1:
+ansi-align@^3.0.0, ansi-align@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz#0cdf12e111ace773a86e9a1fad1225c43cb19a59"
   integrity sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==
@@ -7749,7 +8455,7 @@ ansi-escapes@^3.2.0:
   resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
-ansi-escapes@^4.2.1:
+ansi-escapes@^4.2.1, ansi-escapes@^4.3.1:
   version "4.3.2"
   resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
@@ -8669,6 +9375,20 @@ bowser@^2.11.0:
   resolved "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
   integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
 
+boxen@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-5.1.2.tgz#788cb686fc83c1f486dfa8a40c68fc2b831d2b50"
+  integrity sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==
+  dependencies:
+    ansi-align "^3.0.0"
+    camelcase "^6.2.0"
+    chalk "^4.1.0"
+    cli-boxes "^2.2.1"
+    string-width "^4.2.2"
+    type-fest "^0.20.2"
+    widest-line "^3.1.0"
+    wrap-ansi "^7.0.0"
+
 boxen@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/boxen/-/boxen-7.0.0.tgz#9e5f8c26e716793fc96edcf7cf754cdf5e3fbf32"
@@ -8890,6 +9610,19 @@ cacheable-request@^10.1.2:
     normalize-url "^7.1.0"
     responselike "^3.0.0"
 
+cacheable-request@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
+  integrity sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==
+  dependencies:
+    clone-response "^1.0.2"
+    get-stream "^5.1.0"
+    http-cache-semantics "^4.0.0"
+    keyv "^3.0.0"
+    lowercase-keys "^2.0.0"
+    normalize-url "^4.1.0"
+    responselike "^1.0.2"
+
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
@@ -8960,7 +9693,7 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-camelcase@^6.0.0:
+camelcase@^6.0.0, camelcase@^6.2.0:
   version "6.3.0"
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
@@ -9021,7 +9754,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
+chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -9169,6 +9902,11 @@ clean-stack@^2.0.0:
   resolved "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
+cli-boxes@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
+  integrity sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==
+
 cli-boxes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz#71a10c716feeba005e4504f36329ef0b17cf3145"
@@ -9197,6 +9935,15 @@ cli-spinners@^2.2.0, cli-spinners@^2.5.0:
   version "2.7.0"
   resolved "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz#f815fd30b5f9eaac02db604c7a231ed7cb2f797a"
   integrity sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==
+
+cli-table3@^0.6.0:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.3.tgz#61ab765aac156b52f222954ffc607a6f01dbeeb2"
+  integrity sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    "@colors/colors" "1.5.0"
 
 cli-table@^0.3.11:
   version "0.3.11"
@@ -9241,6 +9988,13 @@ clone-deep@^4.0.1:
     is-plain-object "^2.0.4"
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
+
+clone-response@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.3.tgz#af2032aa47816399cf5f0a1d0db902f517abb8c3"
+  integrity sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==
+  dependencies:
+    mimic-response "^1.0.0"
 
 clone@^1.0.2:
   version "1.0.4"
@@ -9358,7 +10112,7 @@ colors@1.0.3:
   resolved "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==
 
-colors@^1.4.0:
+colors@1.4.0, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -9471,6 +10225,18 @@ config-chain@^1.1.11, config-chain@^1.1.12:
   dependencies:
     ini "^1.3.4"
     proto-list "~1.2.1"
+
+configstore@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/configstore/-/configstore-5.0.1.tgz#d365021b5df4b98cdd187d6a3b0e3f6a7cc5ed96"
+  integrity sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==
+  dependencies:
+    dot-prop "^5.2.0"
+    graceful-fs "^4.1.2"
+    make-dir "^3.0.0"
+    unique-string "^2.0.0"
+    write-file-atomic "^3.0.0"
+    xdg-basedir "^4.0.0"
 
 configstore@^6.0.0:
   version "6.0.0"
@@ -9771,6 +10537,11 @@ crypto-js@^4.1.1:
   resolved "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
   integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
 
+crypto-random-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
+  integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
+
 crypto-random-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz#5a3cc53d7dd86183df5da0312816ceeeb5bb1fc2"
@@ -9893,6 +10664,13 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==
 
+decompress-response@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
+  integrity sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==
+  dependencies:
+    mimic-response "^1.0.0"
+
 decompress-response@^4.2.0:
   version "4.2.1"
   resolved "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
@@ -9938,6 +10716,11 @@ defaults@^1.0.3:
   integrity sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==
   dependencies:
     clone "^1.0.2"
+
+defer-to-connect@^1.0.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"
+  integrity sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
 
 defer-to-connect@^2.0.1:
   version "2.0.1"
@@ -10130,7 +10913,7 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
-dot-prop@^5.1.0:
+dot-prop@^5.1.0, dot-prop@^5.2.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
   integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
@@ -10153,6 +10936,11 @@ dotenv@~10.0.0:
   version "10.0.0"
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
+
+duplexer3@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.5.tgz#0b5e4d7bad5de8901ea4440624c8e1d20099217e"
+  integrity sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==
 
 duplexer@^0.1.1:
   version "0.1.2"
@@ -10185,6 +10973,13 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
+
+ejs@^3.1.7:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.8.tgz#758d32910c78047585c7ef1f92f9ee041c1c190b"
+  integrity sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==
+  dependencies:
+    jake "^10.8.5"
 
 electron-to-chromium@^1.4.251:
   version "1.4.261"
@@ -10246,6 +11041,11 @@ entities@2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
+env-editor@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/env-editor/-/env-editor-0.5.0.tgz#03d82facf6899fc73f5e7c8562fdeca3eda51ca0"
+  integrity sha512-ig2BZVD0/9p4NsPvFJIXu3EbXrgjHgRmhRkKKflx8jlZoADhD2O6rf6wCy0vZ56HnmrQTimR/oN4s34pMt5CAw==
 
 env-paths@^2.2.0:
   version "2.2.1"
@@ -10319,6 +11119,11 @@ escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
+escape-goat@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-2.1.1.tgz#1b2dc77003676c457ec760b2dc68edb648188675"
+  integrity sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==
 
 escape-goat@^4.0.0:
   version "4.0.0"
@@ -10974,7 +11779,7 @@ fflate@0.7.3:
   resolved "https://registry.npmjs.org/fflate/-/fflate-0.7.3.tgz#288b034ff0e9c380eaa2feff48c787b8371b7fa5"
   integrity sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw==
 
-figures@3.2.0, figures@^3.0.0:
+figures@3.2.0, figures@^3.0.0, figures@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
@@ -11006,6 +11811,13 @@ file-uri-to-path@2:
   version "2.0.0"
   resolved "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz#7b415aeba227d575851e0a5b0c640d7656403fba"
   integrity sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==
+
+filelist@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.4.tgz#f78978a1e944775ff9e62e744424f215e58352b5"
+  integrity sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==
+  dependencies:
+    minimatch "^5.0.1"
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -11222,6 +12034,11 @@ fsevents@^2.1.2, fsevents@~2.3.2:
   resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
+fswin@^3.18.918:
+  version "3.22.106"
+  resolved "https://registry.yarnpkg.com/fswin/-/fswin-3.22.106.tgz#16724074a63e0bca193c89d311cec56a59f15f1d"
+  integrity sha512-j/fa7L2fiwEZkyLHRVecd2d5iZAvFUIS8VcvqaSN1SQe5WlL9xfQT4wZFUl8YafH9vTGZlNohJyI3p/Hrtu1WQ==
+
 ftp@^0.3.10:
   version "0.3.10"
   resolved "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz#9197d861ad8142f3e63d5a83bfe4c59f7330885d"
@@ -11254,6 +12071,11 @@ functions-have-names@^1.2.2:
   version "1.2.3"
   resolved "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
+fuzzy@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/fuzzy/-/fuzzy-0.1.3.tgz#4c76ec2ff0ac1a36a9dccf9a00df8623078d4ed8"
+  integrity sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==
 
 gauge@^4.0.3:
   version "4.0.4"
@@ -11332,7 +12154,7 @@ get-stdin@^8.0.0:
   resolved "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
   integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==
 
-get-stream@^4.0.0:
+get-stream@^4.0.0, get-stream@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
   integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
@@ -11494,6 +12316,15 @@ global-dirs@^3.0.0:
   dependencies:
     ini "2.0.0"
 
+global-prefix@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-3.0.0.tgz#fc85f73064df69f50421f47f883fe5b913ba9b97"
+  integrity sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==
+  dependencies:
+    ini "^1.3.5"
+    kind-of "^6.0.2"
+    which "^1.3.1"
+
 globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
@@ -11534,6 +12365,23 @@ got@^12.1.0:
     lowercase-keys "^3.0.0"
     p-cancelable "^3.0.0"
     responselike "^3.0.0"
+
+got@^9.6.0:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
+  integrity sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==
+  dependencies:
+    "@sindresorhus/is" "^0.14.0"
+    "@szmarczak/http-timer" "^1.1.2"
+    cacheable-request "^6.0.0"
+    decompress-response "^3.3.0"
+    duplexer3 "^0.1.4"
+    get-stream "^4.1.0"
+    lowercase-keys "^1.0.1"
+    mimic-response "^1.0.1"
+    p-cancelable "^1.0.0"
+    to-readable-stream "^1.0.0"
+    url-parse-lax "^3.0.0"
 
 graceful-fs@4.2.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@~4.2.9:
   version "4.2.10"
@@ -11708,6 +12556,11 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
+has-yarn@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/has-yarn/-/has-yarn-2.1.0.tgz#137e11354a7b5bf11aa5cb649cf0c6f3ff2b2e77"
+  integrity sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==
+
 has-yarn@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/has-yarn/-/has-yarn-3.0.0.tgz#c3c21e559730d1d3b57e28af1f30d06fac38147d"
@@ -11743,6 +12596,13 @@ header-case@^2.0.4:
   dependencies:
     capital-case "^1.0.4"
     tslib "^2.0.3"
+
+hidefile@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hidefile/-/hidefile-3.0.0.tgz#5d2fb892a00a9285385ca8cc4aefc6952084ac2c"
+  integrity sha512-AvJ9joE59PQPGOB78smS63K60KKpTK5GBIagupfK9Hw6zpA0JKba2D9uAnDycaI8/bN30ltHWGZVXIkQ4BU6oA==
+  dependencies:
+    winattr "^3.0.0"
 
 hjson@^3.2.1:
   version "3.2.2"
@@ -11787,7 +12647,7 @@ html-escaper@^2.0.0:
   resolved "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
-http-cache-semantics@^4.1.0:
+http-cache-semantics@^4.0.0, http-cache-semantics@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
@@ -11984,6 +12844,11 @@ import-global@^0.1.0:
   dependencies:
     global-dirs "^0.1.0"
 
+import-lazy@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
+  integrity sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==
+
 import-lazy@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
@@ -12052,6 +12917,17 @@ init-package-json@^3.0.2:
     semver "^7.3.5"
     validate-npm-package-license "^3.0.4"
     validate-npm-package-name "^4.0.0"
+
+inquirer-autocomplete-prompt@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-1.4.0.tgz#e767592f747e3d5bb6336fe71fb4094352e4c317"
+  integrity sha512-qHgHyJmbULt4hI+kCmwX92MnSxDs/Yhdt4wPA30qnoa01OF6uTXV8yvH4hKXgdaTNmkZ9D01MHjqKYEuJN+ONw==
+  dependencies:
+    ansi-escapes "^4.3.1"
+    chalk "^4.0.0"
+    figures "^3.2.0"
+    run-async "^2.4.0"
+    rxjs "^6.6.2"
 
 inquirer-datepicker@^2.0.0:
   version "2.0.2"
@@ -12416,6 +13292,11 @@ is-negative-zero@^2.0.2:
   resolved "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
   integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
 
+is-npm@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-5.0.0.tgz#43e8d65cc56e1b67f8d47262cf667099193f45a8"
+  integrity sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==
+
 is-npm@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/is-npm/-/is-npm-6.0.0.tgz#b59e75e8915543ca5d881ecff864077cba095261"
@@ -12598,6 +13479,11 @@ is-wsl@^2.2.0:
   dependencies:
     is-docker "^2.0.0"
 
+is-yarn-global@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz#d502d3382590ea3004893746754c89139973e232"
+  integrity sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==
+
 is-yarn-global@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.4.0.tgz#714d94453327db9ea98fbf1a0c5f2b88f59ddd5c"
@@ -12707,6 +13593,16 @@ iterall@^1.1.3, iterall@^1.2.2, iterall@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
+
+jake@^10.8.5:
+  version "10.8.5"
+  resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.5.tgz#f2183d2c59382cb274226034543b9c03b8164c46"
+  integrity sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==
+  dependencies:
+    async "^3.2.3"
+    chalk "^4.0.2"
+    filelist "^1.0.1"
+    minimatch "^3.0.4"
 
 jest-changed-files@^26.6.2:
   version "26.6.2"
@@ -13211,6 +14107,11 @@ jsesc@^2.5.1:
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
+json-buffer@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
+  integrity sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==
+
 json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
@@ -13377,6 +14278,13 @@ jwt-decode@^2.2.0:
   resolved "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
   integrity sha512-86GgN2vzfUu7m9Wcj63iUkuDzFNYFVmjeDm2GzWpUk+opB0pEpMsw6ePCMrhYkumz2C1ihqtZzOMAg7FiXcNoQ==
 
+keyv@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
+  integrity sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==
+  dependencies:
+    json-buffer "3.0.0"
+
 keyv@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/keyv/-/keyv-4.5.0.tgz#dbce9ade79610b6e641a9a65f2f6499ba06b9bc6"
@@ -13434,6 +14342,13 @@ language-tags@^1.0.5:
   integrity sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==
   dependencies:
     language-subtag-registry "~0.3.2"
+
+latest-version@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
+  integrity sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==
+  dependencies:
+    package-json "^6.3.0"
 
 latest-version@^7.0.0:
   version "7.0.0"
@@ -13588,7 +14503,7 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.4, lodash-es@^4.2.1:
+lodash-es@^4.17.21, lodash-es@^4.17.4, lodash-es@^4.2.1:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
@@ -13743,6 +14658,16 @@ lower-case@^2.0.2:
   integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
   dependencies:
     tslib "^2.0.3"
+
+lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
+  integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
+
+lowercase-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
+  integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
 lowercase-keys@^3.0.0:
   version "3.0.0"
@@ -13922,7 +14847,7 @@ mime-db@1.52.0:
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.26, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -13943,6 +14868,11 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+mimic-response@^1.0.0, mimic-response@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
+  integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
 mimic-response@^2.0.0:
   version "2.1.0"
@@ -14117,7 +15047,7 @@ moment-jdateformatparser@^1.2.1:
   resolved "https://registry.npmjs.org/moment-jdateformatparser/-/moment-jdateformatparser-1.2.1.tgz#336c41ef7a6db8021d7ca086385a35fb8a648456"
   integrity sha512-lpUeQtMaxmpK+pPPHGWMnqzgsB/nunbAGPg72mzvRNbxxeQ2uBurdq9EJmvJtOiYB6k/4T9kuvQFbb+8Tirn4A==
 
-moment-timezone@0.5.34, moment-timezone@^0.5.35:
+moment-timezone@0.5.34, moment-timezone@0.5.35, moment-timezone@^0.5.35:
   version "0.5.37"
   resolved "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.37.tgz#adf97f719c4e458fdb12e2b4e87b8bec9f4eef1e"
   integrity sha512-uEDzDNFhfaywRl+vwXxffjjq1q0Vzr+fcQpQ1bU0kbzorfS7zVtZnCnGc8mhWmF39d4g4YriF6kwA75mJKE/Zg==
@@ -14197,6 +15127,11 @@ nan@^2.14.0:
   version "2.16.0"
   resolved "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz#664f43e45460fb98faf00edca0bb0d7b8dce7916"
   integrity sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==
+
+nanoclone@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
+  integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
 
 nanoid@^3.3.1:
   version "3.3.4"
@@ -14408,6 +15343,11 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+normalize-url@^4.1.0:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a"
+  integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
 
 normalize-url@^7.1.0:
   version "7.1.0"
@@ -14843,6 +15783,11 @@ os-tmpdir@~1.0.2:
   resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
+p-cancelable@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
+  integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
+
 p-cancelable@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz#63826694b54d61ca1c20ebcb6d3ecf5e14cd8050"
@@ -14982,6 +15927,16 @@ pac-resolver@^5.0.0:
     degenerator "^3.0.2"
     ip "^1.1.5"
     netmask "^2.0.2"
+
+package-json@^6.3.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/package-json/-/package-json-6.5.0.tgz#6feedaca35e75725876d0b0e64974697fed145b0"
+  integrity sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==
+  dependencies:
+    got "^9.6.0"
+    registry-auth-token "^4.0.0"
+    registry-url "^5.0.0"
+    semver "^6.2.0"
 
 package-json@^8.1.0:
   version "8.1.0"
@@ -15386,6 +16341,16 @@ prelude-ls@~1.1.2:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
+prepend-http@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
+  integrity sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==
+
+prettier@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
+
 prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
@@ -15495,6 +16460,11 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+property-expr@^2.0.4:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
+  integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -15577,6 +16547,13 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+pupa@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/pupa/-/pupa-2.1.1.tgz#f5e8fd4afc2c5d97828faa523549ed8744a20d62"
+  integrity sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==
+  dependencies:
+    escape-goat "^2.0.0"
+
 pupa@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/pupa/-/pupa-3.1.0.tgz#f15610274376bbcc70c9a3aa8b505ea23f41c579"
@@ -15656,7 +16633,7 @@ rc-config-loader@^4.1.0:
     json5 "^2.1.2"
     require-from-string "^2.0.2"
 
-rc@1.2.8, rc@^1.2.7:
+rc@1.2.8, rc@^1.2.7, rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -15884,12 +16861,26 @@ regextras@^0.8.0:
   resolved "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz#ec0f99853d4912839321172f608b544814b02217"
   integrity sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==
 
+registry-auth-token@^4.0.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-4.2.2.tgz#f02d49c3668884612ca031419491a13539e21fac"
+  integrity sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==
+  dependencies:
+    rc "1.2.8"
+
 registry-auth-token@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.1.tgz#5e6cd106e6c251135a046650c58476fc03e92833"
   integrity sha512-UfxVOj8seK1yaIOiieV4FIP01vfBDLsY0H9sQzi9EbbUdJiuuBjJgLa1DpImXMNPnVkBD4eVxTEXcrZA6kfpJA==
   dependencies:
     "@pnpm/npm-conf" "^1.0.4"
+
+registry-url@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-5.1.0.tgz#e98334b50d5434b81136b44ec638d9c2009c5009"
+  integrity sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==
+  dependencies:
+    rc "^1.2.8"
 
 registry-url@^6.0.0:
   version "6.0.1"
@@ -16018,6 +17009,13 @@ resolve@^2.0.0-next.3:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+responselike@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
+  integrity sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==
+  dependencies:
+    lowercase-keys "^1.0.0"
+
 responselike@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz#20decb6c298aff0dbee1c355ca95461d42823626"
@@ -16097,7 +17095,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^6.4.0, rxjs@^6.6.0:
+rxjs@^6.4.0, rxjs@^6.6.0, rxjs@^6.6.2:
   version "6.6.7"
   resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -16198,6 +17196,13 @@ semver-compare@^1.0.0:
   resolved "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==
 
+semver-diff@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-3.1.1.tgz#05f77ce59f325e00e2706afd67bb506ddb1ca32b"
+  integrity sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==
+  dependencies:
+    semver "^6.3.0"
+
 semver-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz#3afcf5ed6d62259f5c72d0d5d50dffbdc9680df5"
@@ -16229,7 +17234,7 @@ semver@7.3.7, semver@7.x, semver@^7.0.0, semver@^7.1.1, semver@^7.2.1, semver@^7
   dependencies:
     lru-cache "^6.0.0"
 
-semver@^6.0.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -16719,7 +17724,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -17107,6 +18112,11 @@ to-object-path@^0.3.0:
   dependencies:
     kind-of "^3.0.2"
 
+to-readable-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz#ce0aa0c2f3df6adf852efb404a783e77c0475771"
+  integrity sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==
+
 to-regex-range@^2.1.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
@@ -17137,6 +18147,11 @@ toidentifier@1.0.1:
   resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
+
 tough-cookie@^4.0.0:
   version "4.1.2"
   resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz#e53e84b85f24e0b65dd526f46628db6c85f6b874"
@@ -17163,6 +18178,11 @@ traverse@^0.6.6:
   version "0.6.6"
   resolved "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
   integrity sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw==
+
+treeify@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/treeify/-/treeify-1.1.0.tgz#4e31c6a463accd0943879f30667c4fdaff411bb8"
+  integrity sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==
 
 treeverse@^2.0.0:
   version "2.0.0"
@@ -17393,6 +18413,11 @@ typescript-json-schema@~0.52.0:
     typescript "~4.4.4"
     yargs "^17.1.1"
 
+typescript@<=4.5.0, typescript@~4.4.4:
+  version "4.4.4"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
+  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+
 "typescript@^3 || ^4", typescript@^4.4.3, typescript@^4.5.5:
   version "4.8.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
@@ -17402,11 +18427,6 @@ typescript@^3.8.3:
   version "3.9.10"
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
-
-typescript@~4.4.4:
-  version "4.4.4"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
 ua-parser-js@^0.7.30:
   version "0.7.31"
@@ -17466,6 +18486,13 @@ unique-slug@^3.0.0:
   integrity sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==
   dependencies:
     imurmurhash "^0.1.4"
+
+unique-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
+  integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
+  dependencies:
+    crypto-random-string "^2.0.0"
 
 unique-string@^3.0.0:
   version "3.0.0"
@@ -17533,6 +18560,26 @@ update-browserslist-db@^1.0.9:
     escalade "^3.1.1"
     picocolors "^1.0.0"
 
+update-notifier@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-5.1.0.tgz#4ab0d7c7f36a231dd7316cf7729313f0214d9ad9"
+  integrity sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==
+  dependencies:
+    boxen "^5.0.0"
+    chalk "^4.1.0"
+    configstore "^5.0.1"
+    has-yarn "^2.1.0"
+    import-lazy "^2.1.0"
+    is-ci "^2.0.0"
+    is-installed-globally "^0.4.0"
+    is-npm "^5.0.0"
+    is-yarn-global "^0.3.0"
+    latest-version "^5.1.0"
+    pupa "^2.1.1"
+    semver "^7.3.4"
+    semver-diff "^3.1.1"
+    xdg-basedir "^4.0.0"
+
 update-notifier@^6.0.2:
   version "6.0.2"
   resolved "https://registry.npmjs.org/update-notifier/-/update-notifier-6.0.2.tgz#a6990253dfe6d5a02bd04fbb6a61543f55026b60"
@@ -17590,6 +18637,13 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==
+
+url-parse-lax@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
+  integrity sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==
+  dependencies:
+    prepend-http "^2.0.0"
 
 url-parse@^1.5.3:
   version "1.5.10"
@@ -17852,7 +18906,7 @@ which-typed-array@^1.1.2:
     has-tostringtag "^1.0.0"
     is-typed-array "^1.1.9"
 
-which@^1.2.9:
+which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -17873,12 +18927,26 @@ wide-align@^1.1.0, wide-align@^1.1.5:
   dependencies:
     string-width "^1.0.2 || 2 || 3 || 4"
 
+widest-line@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-3.1.0.tgz#8292333bbf66cb45ff0de1603b136b7ae1496eca"
+  integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
+  dependencies:
+    string-width "^4.0.0"
+
 widest-line@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz#a0fc673aaba1ea6f0a0d35b3c2795c9a9cc2ebf2"
   integrity sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==
   dependencies:
     string-width "^5.0.1"
+
+winattr@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/winattr/-/winattr-3.0.0.tgz#33e430c41510ce4018a0daaabb24927c162f1b1d"
+  integrity sha512-dt33rYsTYcGbB+I1ubB6ZLODibRSCW//TgY/SuajLllR9kHnHnbUMqnXIe0osYsXUdRLGs770zb3t9z/ScGUpw==
+  dependencies:
+    fswin "^3.18.918"
 
 winston-daily-rotate-file@^4.5.0:
   version "4.7.1"
@@ -18023,6 +19091,11 @@ ws@^7.4.6, ws@^7.5.7:
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
+ws@^8.5.0:
+  version "8.9.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.9.0.tgz#2a994bb67144be1b53fe2d23c53c028adeb7f45e"
+  integrity sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==
+
 xcode@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/xcode/-/xcode-2.1.0.tgz#bab64a7e954bb50ca8d19da7e09531c65a43ecfe"
@@ -18030,6 +19103,11 @@ xcode@^2.1.0:
   dependencies:
     simple-plist "^1.0.0"
     uuid "^3.3.2"
+
+xdg-basedir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
+  integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
 
 xdg-basedir@^5.0.1, xdg-basedir@^5.1.0:
   version "5.1.0"
@@ -18209,6 +19287,19 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yup@^0.32.11:
+  version "0.32.11"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.11.tgz#d67fb83eefa4698607982e63f7ca4c5ed3cf18c5"
+  integrity sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/lodash" "^4.14.175"
+    lodash "^4.17.21"
+    lodash-es "^4.17.21"
+    nanoclone "^0.2.1"
+    property-expr "^2.0.4"
+    toposort "^2.0.2"
 
 zen-observable-ts@0.8.19:
   version "0.8.19"


### PR DESCRIPTION
Float numbers ending in .0 where being parsed as integers in an OpenSearch instance when using the @searchable directive. If this data was the first being uploaded to the instance, searching queries wouldn't work as expected. The change creates a JSON file which is uploaded with the Python streaming function to lambda. The JSON has all the schema data types of the @searchable model fields. A modified version of the Python streaming function enables the DynamoDB event fields to be correctly parsed to the correct data type described in the schema.

✅ Closes: #866, #371

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### Changes
1. `graphql-searchable-transformer.ts`
This file had the following change:

>Original file
```js
// creates streaming lambda
const lambda = createLambda(
stack,
context.api,
parameterMap,
lambdaRole,
domain.domainEndpoint,
isProjectUsingDataStore,
region,
);
```
>New file
```js
// creates streaming lambda
const lambda = createLambda(
stack,
context.api,
parameterMap,
lambdaRole,
domain.domainEndpoint,
isProjectUsingDataStore,
region,
this.searchableObjectTypeDefinitions, //Added parameter
);
```

Notice that `this.searchableObjectTypeDefinitions` was added as a parameter. This was needed as the `searchableObjectTypeDefinitions` has the schema that the user wants to create with its corresponding attributes and data types.

2. `create-streaming-lambda.ts`
The `createLambda` function resides in this file and it had to be changed to create a JSON file with the following structure:
```json
{
	"model1name": {
		"attr1": "dataType1",
		"attr2": "dataType2",
		...
		"attrN": "dataTypeN"
	},
	"model2name": {
		"attr1": "dataType1",
		"attr2": "dataType2",
		...
		"attrN": "dataTypeN"
	},
	...
	"modelNname": {
		"attr1": "dataType1",
		"attr2": "dataType2",
		...
		"attrN": "dataTypeN"
	}
}
```
This is later used to map the Schema data types to the corresponding Python data types, which solves the bug described in the [issue](https://github.com/aws-amplify/amplify-category-api/issues/866)

To create it, the `searchableObjectTypeDefinition`s was added as a parameter:
```js
export const createLambda = (
  stack: Stack,
  apiGraphql: GraphQLAPIProvider,
  parameterMap: Map<string, CfnParameter>,
  lambdaRole: IRole,
  endpoint: string,
  isProjectUsingDataStore: boolean,
  region: string,
  searchableObjectTypeDefinitions: { node: ObjectTypeDefinitionNode; 
                                     fieldName: string }[],
): IFunction
```
Inside that function, just before the return statement, a helper function was created:
```js
generateSchemaDataTypes(searchableObjectTypeDefinitions);

return apiGraphql.host.addLambdaFunction(
    ...
```
The helper function looks as follows:
```js
const generateSchemaDataTypes = (searchableObjectTypeDefinitions:
								{ node: ObjectTypeDefinitionNode;
								  fieldName: string; }[]): void => {
  const schemaDataTypes: SchemaDataTypes = {};
  for (const def of searchableObjectTypeDefinitions) {
    const modelName = def.node.name.value.toLowerCase();

    const attributeTypes: AttributeTypes = {};
    def.node.fields?.forEach((f) => {
      attributeTypes[f.name.value] = findNamedType(f.type);
    });
    schemaDataTypes[modelName] = attributeTypes;
  }

  // Paths to export JSON file and lambda function script
  const libPath = path.join(__dirname, '..', '..', 'lib');
  const schemaPath = path.join(libPath, DATA_TYPE_SCHEMA_FILENAME);
  const streamingFunctionPath = path.join(libPath, STREAMING_FUNCTION_FILENAME);
  fs.writeFileSync(schemaPath, JSON.stringify(schemaDataTypes));

  // Zip the file
  const zip = new AdmZip();
  zip.addLocalFile(schemaPath);
  zip.addLocalFile(streamingFunctionPath);
  zip.writeZip(path.join(libPath, STREAMING_LAMBDA_ZIP_FILENAME));
};
```
Initially every model needs to be analyzed to find its corresponding name and attributes with their data types. Then for each of the fields in the model the data types must be extracted. To do that a helper function `findNamedType` needed to be created. The function looks like this:
```js
const findNamedType = (typeNode: TypeNode) : string => {
  switch (typeNode.kind) {
    case 'NamedType':
      return typeNode.name.value;
    case 'ListType':
    case 'NonNullType':
      return findNamedType(typeNode.type);
    default:
      throw new Error(`Unknown type ${typeNode}`);
  }
};
```
Recursion was needed for this function as the `TypeNode` interface permits nested `TypesNodes` inside of it according to its definition:

```js
// ast.d.ts

// Name

export interface NameNode {
  readonly kind: 'Name';
  readonly loc?: Location;
  readonly value: string;
}

...

// Type Reference

export type TypeNode = NamedTypeNode | ListTypeNode | NonNullTypeNode;

export interface NamedTypeNode {
  readonly kind: 'NamedType';
  readonly loc?: Location;
  readonly name: NameNode;
}

export interface ListTypeNode {
  readonly kind: 'ListType';
  readonly loc?: Location;
  readonly type: TypeNode;
}

export interface NonNullTypeNode {
  readonly kind: 'NonNullType';
  readonly loc?: Location;
  readonly type: NamedTypeNode | ListTypeNode;
}
```
Notice that the nesting ends with a `NamedTypeNode` as it doesn't allow more `ListTypeNode` which allow `TypeNode` themselves. Whenever the `NamedTypeNode` is found, it extracts the attribute's data type and returns it.

After every field and its data type has been extracted from its model it is added to the model's name and that happens for every model. After that a JSON file is generated and exported to the lib folder. Finally it is zipped with the `python_streaming_function.py` file to then be uploaded to the lambda function.

 3. `package.json`
The `package.json` needed to be changed as the `python_streaming_function.py` was being zipped during `yarn build` time. 

>Original file
```json
"scripts": {
    "build": "tsc && cd streaming-lambda && bestzip --force node ../lib/streaming-lambda.zip python_streaming_function.py",
    "watch": "tsc -w",
    "clean": "rimraf ./lib",
    "test": "jest"
  },
```
>New file
```json
"scripts": {
    "build": "tsc && cd streaming-lambda && cp python_streaming_function.py ../lib",
    "watch": "tsc -w",
    "clean": "rimraf ./lib",
    "test": "jest"
  },
```
`adm-zip` dependencies where also added.

 4. `python_streaming_function.py`
 This file had to be changed to read the JSON file passed to the lambda and map to the corresponding GraphQL types found in the schema, which solves the issue of floats ending in .0 being parsed to int.
 This new functions where added:
 ```python
# Custom mapper to match Python types to GraphQL Schema types
def map_to_gql_types(fields):
	mapped_fields = {}
	# Get GraphQL schema types
	schema_types = getGQLSchema()
	for field in fields:
		v = fields[field]		
		data_type = schema_types[field] if field != '__typename' else None
		if data_type == 'Float' and isinstance(v, int):
			mapped_fields[field] = float(v)
		else:
			mapped_fields[field] = v
	return mapped_fields

# Gets schema from json file
def getGQLSchema():
	with open('schema_datatypes.json') as f:
		schema = json.load(f)	
	return schema
```
The `map_to_gql_types` function can be extended to solve other issues, such as when a `AWSDate` is used with a timezone with the @serchable directive. For now it just fixes the Float being parsed to int issue. The function gets the serialized DynamoDB event fields and compares it with the fields data types in the JSON file. If it finds that there is a mismatch between data types, then it serializes it to the correct type found in the schema. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->
This PR closes issues #866 and #371

#### Description of how you validated changes

Made a sample app without the changes implemented and used the same app with the changes implemented and tested both locally and in the cloud. Before the changes, whenever a register with a Float type ending with .0 was send, the index created in the OpenSearch instance would have a data type long. When making use of the searchable queries both through the app and directly through AppSync, the {eq: number} filter wouldn't work as expected. After the changes, the index created in the OpenSearch instance would have a data type float and the searchable queries would work as expected.

This was tested using different schemas with different data types and making use of relationships and other models with and without the @searchable directive.   

All previous tests are running successfully, but no new tests where created.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
