### PR TITLE
fix(e2e): set longer timeout for searchable migration

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/searchable-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/searchable-migration.test.ts
@@ -13,6 +13,8 @@ import gql from 'graphql-tag';
 import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
 (global as any).fetch = require('node-fetch');
 
+jest.setTimeout(120 * 60 * 1000); // Set timeout to 2 hour because of creating/deleting searchable instance
+
 describe('transformer model searchable migration test', () => {
   let projRoot: string;
   let projectName: string;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Set 2 hour for `searchable-migration` test to avoid the timeout error
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Run the e2e test locally. The test is passed and takes 3800 seconds (more than 1 hour)
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
