### PR TITLE
feat: add github action to automatically remove pending-response label

### DIFF
--- a/.github/workflows/issue-pending-response.yml
+++ b/.github/workflows/issue-pending-response.yml
@@ -2,7 +2,8 @@ name: issue-pending-response
 on:
   issue_comment:
     types: [created]
-
+permissions:
+  issues: write
 jobs:
   issue_commented:
     if: ${{ !github.event.issue.pull_request  && contains(github.event.issue.labels.*.name, 'pending-response') }}

--- a/.github/workflows/issue-pending-response.yml
+++ b/.github/workflows/issue-pending-response.yml
@@ -1,0 +1,14 @@
+name: issue-pending-response
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  issue_commented:
+    if: ${{ !github.event.issue.pull_request  && contains(github.event.issue.labels.*.name, 'pending-response') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: siegerts/pending-author-response@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pending-response-label: pending-response


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

adds GitHub Action to automatically remove the `pending-response` label when the author of the issue responds. This will also adjust how we look at issues that have not yet been triaged by further defining an entrypoint:

https://github.com/aws-amplify/amplify-category-api/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-asc+-label%3Abug%2Cfeature-request%2Crfc%2Cregion-support+-label%3Apending-response

#### Issue #, if available

n/a

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

piloted on CLI repository

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
