### PR TITLE
fix: resolution of nested stack template url

### DIFF
--- a/packages/amplify-graphql-transformer-core/src/cdk-compat/nested-stack.ts
+++ b/packages/amplify-graphql-transformer-core/src/cdk-compat/nested-stack.ts
@@ -47,7 +47,7 @@ export class TransformerNestedStack extends TransformerRootStack {
     this.parameters = props.parameters || {};
 
     this.resource = new CfnStack(parentScope, `${id}.NestedStackResource`, {
-      templateUrl: Lazy.string({
+      templateUrl: Lazy.uncachedString({
         produce: () => this._templateUrl || '<unresolved>',
       }),
       parameters: Lazy.any({


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Do not cache nested stack template urls. 
The nested stack processing goes through two stage resolution.
1. it resolves root stack (template urls are "<unresolved"> by this time).
2. for each nested stack it invokes `_prepareTemplateAsset` which populates templateUrl.
3. runs root stack resolution again. it's expected that template urls resolve here (if not cached).


See for reference:
https://github.com/aws/aws-cdk/blob/5a0595edb1c5345552acbacefe2d09ec0bea31c1/packages/%40aws-cdk/core/lib/private/prepare-app.ts#L30-L56

Sample error caused by this.
![image](https://user-images.githubusercontent.com/5849952/196514883-be24570e-595f-4332-9453-61ce8db36c9e.png)


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] PR description included
- [ x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
