### PR TITLE
fix: preserve logical id patterns for dynamodb tables and search domain

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
@@ -6,7 +6,7 @@
 import * as apigw from 'aws-cdk-lib/aws-apigateway';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
-import * as cdk from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { $TSObject, JSONUtilities } from 'amplify-cli-core';
 import _ from 'lodash';

--- a/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-many-to-many.test.ts
+++ b/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-many-to-many.test.ts
@@ -52,7 +52,7 @@ const transformSchema = (schema: string): DeploymentResources => {
 describe('mapsTo with manyToMany', () => {
   it('creates resources with original GSIs and field names', () => {
     const out = transformSchema(manyToManyMapped);
-    expect(out.stacks.EmployeeTask!.Resources!.EmployeeTaskTable09DF6270.Properties.GlobalSecondaryIndexes).toMatchSnapshot();
+    expect(out.stacks.EmployeeTask!.Resources!.EmployeeTaskTable.Properties.GlobalSecondaryIndexes).toMatchSnapshot();
     const outSchema = parse(out.schema);
     const EmployeeTaskFields = (
       outSchema.definitions.find((def) => (def as any)?.name.value === 'EmployeeTask')! as ObjectTypeDefinitionNode

--- a/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-model.test.ts
+++ b/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-model.test.ts
@@ -15,7 +15,7 @@ describe('@mapsTo directive on model type', () => {
       sandboxModeEnabled: true,
     });
     const out = transformer.transform(basicSchema);
-    expect(out.stacks.Task.Resources!.TaskTable22070546!.Properties.TableName).toMatchInlineSnapshot(`
+    expect(out.stacks.Task.Resources!.TaskTable!.Properties.TableName).toMatchInlineSnapshot(`
       Object {
         "Fn::Join": Array [
           "",

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer-override.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer-override.test.ts.snap
@@ -237,7 +237,7 @@ $util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
               "\\"))
 $util.qr($ctx.stash.put(\\"tableName\\", \\"",
               Object {
-                "Ref": "PostTable197E3F68",
+                "Ref": "PostTable",
               },
               "\\"))
 $util.toJson({})",
@@ -288,7 +288,7 @@ $util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
               "\\"))
 $util.qr($ctx.stash.put(\\"tableName\\", \\"",
               Object {
-                "Ref": "PostTable197E3F68",
+                "Ref": "PostTable",
               },
               "\\"))
 $util.toJson({})",
@@ -414,7 +414,7 @@ $util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
               "\\"))
 $util.qr($ctx.stash.put(\\"tableName\\", \\"",
               Object {
-                "Ref": "PostTable197E3F68",
+                "Ref": "PostTable",
               },
               "\\"))
 $util.toJson({})",
@@ -465,7 +465,7 @@ $util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
               "\\"))
 $util.qr($ctx.stash.put(\\"tableName\\", \\"",
               Object {
-                "Ref": "PostTable197E3F68",
+                "Ref": "PostTable",
               },
               "\\"))
 $util.toJson({})",
@@ -703,7 +703,7 @@ $util.toJson({})",
             "Ref": "AWS::Region",
           },
           "TableName": Object {
-            "Ref": "PostTable197E3F68",
+            "Ref": "PostTable",
           },
         },
         "Name": "PostTable",
@@ -772,7 +772,7 @@ $util.toJson({})",
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "PostTable197E3F68",
+                    "PostTable",
                     "Arn",
                   ],
                 },
@@ -793,7 +793,7 @@ $util.toJson({})",
       },
       "Type": "AWS::IAM::Policy",
     },
-    "PostTable197E3F68": Object {
+    "PostTable": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "AttributeDefinitions": Array [
@@ -1212,7 +1212,7 @@ $util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
               "\\"))
 $util.qr($ctx.stash.put(\\"tableName\\", \\"",
               Object {
-                "Ref": "PostTable197E3F68",
+                "Ref": "PostTable",
               },
               "\\"))
 $util.toJson({})",
@@ -1410,7 +1410,7 @@ Object {
             "Ref": "AWS::Region",
           },
           "TableName": Object {
-            "Ref": "CommentTableE9F84112",
+            "Ref": "CommentTable",
           },
         },
         "Name": "CommentTable",
@@ -1479,7 +1479,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "CommentTableE9F84112",
+                    "CommentTable",
                     "Arn",
                   ],
                 },
@@ -1500,7 +1500,7 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "CommentTableE9F84112": Object {
+    "CommentTable": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
         "AttributeDefinitions": Array [
@@ -1613,7 +1613,7 @@ $util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
               "\\"))
 $util.qr($ctx.stash.put(\\"tableName\\", \\"",
               Object {
-                "Ref": "CommentTableE9F84112",
+                "Ref": "CommentTable",
               },
               "\\"))
 $util.toJson({})",
@@ -1661,7 +1661,7 @@ $util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
               "\\"))
 $util.qr($ctx.stash.put(\\"tableName\\", \\"",
               Object {
-                "Ref": "CommentTableE9F84112",
+                "Ref": "CommentTable",
               },
               "\\"))
 $util.toJson({})",
@@ -1784,7 +1784,7 @@ $util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
               "\\"))
 $util.qr($ctx.stash.put(\\"tableName\\", \\"",
               Object {
-                "Ref": "CommentTableE9F84112",
+                "Ref": "CommentTable",
               },
               "\\"))
 $util.toJson({})",
@@ -1832,7 +1832,7 @@ $util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
               "\\"))
 $util.qr($ctx.stash.put(\\"tableName\\", \\"",
               Object {
-                "Ref": "CommentTableE9F84112",
+                "Ref": "CommentTable",
               },
               "\\"))
 $util.toJson({})",
@@ -2261,7 +2261,7 @@ $util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
               "\\"))
 $util.qr($ctx.stash.put(\\"tableName\\", \\"",
               Object {
-                "Ref": "CommentTableE9F84112",
+                "Ref": "CommentTable",
               },
               "\\"))
 $util.toJson({})",

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -1238,6 +1238,10 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     });
     const cfnTable = table.node.defaultChild as CfnTable;
 
+    // CDK started to append hash to logical id of dynamodb table.
+    // This line overrides that behavior to avoid deletion and re-creation of existing tables.
+    cfnTable.overrideLogicalId(tableLogicalName);
+
     cfnTable.provisionedThroughput = cdk.Fn.conditionIf(usePayPerRequestBilling.logicalId, cdk.Fn.ref('AWS::NoValue'), {
       ReadCapacityUnits: readIops,
       WriteCapacityUnits: writeIops,

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -38,7 +38,7 @@ import {
 } from 'aws-cdk-lib/aws-dynamodb';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { CfnRole } from 'aws-cdk-lib/aws-iam';
-import * as cdk from 'aws-cdk-lib/core';
+import * as cdk from 'aws-cdk-lib';
 import { CfnDataSource } from 'aws-cdk-lib/aws-appsync';
 import {
   DirectiveNode,

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer-override.test.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer-override.test.ts
@@ -57,7 +57,7 @@ test('it overrides expected resources', () => {
               'Fn::Split': [
                 ':',
                 {
-                  'Fn::GetAtt': ['OpenSearchDomain85D65221', 'Arn'],
+                  'Fn::GetAtt': ['OpenSearchDomain', 'Arn'],
                 },
               ],
             },
@@ -69,7 +69,7 @@ test('it overrides expected resources', () => {
             [
               'https://',
               {
-                'Fn::GetAtt': ['OpenSearchDomain85D65221', 'DomainEndpoint'],
+                'Fn::GetAtt': ['OpenSearchDomain', 'DomainEndpoint'],
               },
             ],
           ],

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
@@ -249,7 +249,7 @@ test('it generates expected resources', () => {
               'Fn::Split': [
                 ':',
                 {
-                  'Fn::GetAtt': ['OpenSearchDomain85D65221', 'Arn'],
+                  'Fn::GetAtt': ['OpenSearchDomain', 'Arn'],
                 },
               ],
             },
@@ -261,7 +261,7 @@ test('it generates expected resources', () => {
             [
               'https://',
               {
-                'Fn::GetAtt': ['OpenSearchDomain85D65221', 'DomainEndpoint'],
+                'Fn::GetAtt': ['OpenSearchDomain', 'DomainEndpoint'],
               },
             ],
           ],
@@ -300,7 +300,7 @@ test('it generates expected resources', () => {
             },
             '"))\n$util.qr($ctx.stash.put("endpoint", "https://',
             {
-              'Fn::GetAtt': ['OpenSearchDomain85D65221', 'DomainEndpoint'],
+              'Fn::GetAtt': ['OpenSearchDomain', 'DomainEndpoint'],
             },
             '"))\n$util.toJson({})',
           ],

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
@@ -29,7 +29,13 @@ export const createSearchableDomain = (stack: Construct, parameterMap: Map<strin
     removalPolicy: RemovalPolicy.DESTROY,
   });
 
-  (domain.node.defaultChild as CfnDomain).elasticsearchClusterConfig = {
+  const cfnDomain = domain.node.defaultChild as CfnDomain;
+
+  // CDK started to append hash to logical id of search domain.
+  // This line overrides that behavior to avoid deletion and re-creation of existing domains.
+  cfnDomain.overrideLogicalId(OpenSearchDomainLogicalID);
+
+  cfnDomain.elasticsearchClusterConfig = {
     instanceCount: parameterMap.get(OpenSearchInstanceCount)?.valueAsNumber,
     instanceType: parameterMap.get(OpenSearchInstanceType)?.valueAsString,
   };

--- a/packages/amplify-graphql-transformer-core/src/cdk-compat/nested-stack.ts
+++ b/packages/amplify-graphql-transformer-core/src/cdk-compat/nested-stack.ts
@@ -47,7 +47,7 @@ export class TransformerNestedStack extends TransformerRootStack {
     this.parameters = props.parameters || {};
 
     this.resource = new CfnStack(parentScope, `${id}.NestedStackResource`, {
-      templateUrl: Lazy.string({
+      templateUrl: Lazy.uncachedString({
         produce: () => this._templateUrl || '<unresolved>',
       }),
       parameters: Lazy.any({


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

CDK started to add hash at the end of DynamoDB table and SearchDomain logical ids.
This would mean deletion and creation of these resources for existing customers. Which is destructive without data migration.

Therefore we override logical id at L1 construct level to maintain current behavior.


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] PR description included
- [ x] `yarn test` passes
- [x ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
