### PR TITLE
chore: bump memory for mock_e2e_tests

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -125,6 +125,7 @@ jobs:
           no_output_timeout: 90m
           environment:
             JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
+            NODE_OPTIONS: --max-old-space-size=4096
       - store_test_results:
           path: packages/amplify-util-mock/
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Bump memory setting for `mock_e2e_tests`. It goes over current limit while generating test report.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

After applying the change in the release tag build.

![image](https://user-images.githubusercontent.com/5849952/197601906-ab486714-392d-4e4f-80bb-15e26a9fb5c0.png)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] PR description included
- [ x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
