### PR TITLE
fix: replace deprecated cdk methods

### DIFF
--- a/packages/amplify-graphql-transformer-core/src/cdk-compat/nested-stack.ts
+++ b/packages/amplify-graphql-transformer-core/src/cdk-compat/nested-stack.ts
@@ -47,12 +47,12 @@ export class TransformerNestedStack extends TransformerRootStack {
     this.parameters = props.parameters || {};
 
     this.resource = new CfnStack(parentScope, `${id}.NestedStackResource`, {
-      templateUrl: Lazy.stringValue({
+      templateUrl: Lazy.uncachedString({
         produce: () => {
           return this._templateUrl || '<unresolved>';
         },
       }),
-      parameters: Lazy.anyValue({
+      parameters: Lazy.any({
         produce: () => (Object.keys(this.parameters).length > 0 ? this.parameters : undefined),
       }),
       notificationArns: props.notificationArns,

--- a/packages/amplify-graphql-transformer-core/src/cdk-compat/schema-asset.ts
+++ b/packages/amplify-graphql-transformer-core/src/cdk-compat/schema-asset.ts
@@ -15,7 +15,7 @@ export class TransformerSchema {
       this.api = api;
       this.schemaConstruct = new CfnGraphQLSchema(api, 'TransformerSchema', {
         apiId: api.apiId,
-        definitionS3Location: Lazy.stringValue({
+        definitionS3Location: Lazy.string({
           produce: () => {
             const asset = schema.addAsset();
             return asset.s3Url;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Replaced the deprecated methods which are indicated by the upgrade of CDK.
For the `uncachedString`, please refer https://github.com/aws-amplify/amplify-category-api/pull/893 and https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_core.Lazy.html#static-uncachedwbrstringproducer-options

Not in scope: the deprecated methods/modules for `@searchable`
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Running `amplify-dev api gql-compile` and check the console output
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
