### PR TITLE
fix: suppress CDK deprecation warnings

### DIFF
--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -246,7 +246,8 @@ export const executeAmplifyCommand = async (context: $TSContext): Promise<void> 
   }
 
   //TODO: This is a temporary suppression for CDK deprecation warnings, which should be removed after the migration is complete
-  // This is not diabled in CI or debug mode
+  // Most of these warning messages are targetting searchable directive, which needs to migrate from elastic search to open search
+  // This is not diabled in debug mode
   disableCDKDeprecationWarning();
 
   const commandModule = await import(commandPath);
@@ -367,9 +368,8 @@ const canResourceBeTransformed = (
  * Disable the CDK deprecation warning in production but not in CI/debug mode
  */
 const disableCDKDeprecationWarning = () => {
-  const isCI = process.env.CI && process.env.CIRCLECI;
   const isDebug = process.argv.includes('--debug') || process.env.AMPLIFY_ENABLE_DEBUG_OUTPUT === 'true';
-  if (!(isCI || isDebug)) {
+  if (!isDebug) {
     process.env.JSII_DEPRECATED = 'quiet';
   }
 }

--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -363,11 +363,12 @@ const canResourceBeTransformed = (
 ): boolean => stateManager.resourceInputsJsonExists(undefined, AmplifyCategories.API, resourceName);
 
 /**
- * Disable the CDK deprecation warning in production but not in CI
+ * Disable the CDK deprecation warning in production but not in CI/debug mode
  */
 const disableCDKDeprecationWarning = () => {
-  const isCI = () => process.env.CI && process.env.CIRCLECI;
-  if (!isCI()) {
+  const isCI = process.env.CI && process.env.CIRCLECI;
+  const isDebug = process.argv.includes('--debug') || process.env.AMPLIFY_ENABLE_DEBUG_OUTPUT === 'true';
+  if (!(isCI || isDebug)) {
     process.env.JSII_DEPRECATED = 'quiet';
   }
 }

--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -244,7 +244,10 @@ export const executeAmplifyCommand = async (context: $TSContext): Promise<void> 
   } else {
     commandPath = path.join(commandPath, category, context.input.command);
   }
+
+  //TODO: This is a temporary suppression for CDK deprecation warnings, which should be removed after the migration is complete
   disableCDKDeprecationWarning();
+
   const commandModule = await import(commandPath);
   try {
     await commandModule.run(context);

--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -246,6 +246,7 @@ export const executeAmplifyCommand = async (context: $TSContext): Promise<void> 
   }
 
   //TODO: This is a temporary suppression for CDK deprecation warnings, which should be removed after the migration is complete
+  // This is not diabled in CI or debug mode
   disableCDKDeprecationWarning();
 
   const commandModule = await import(commandPath);

--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -244,7 +244,7 @@ export const executeAmplifyCommand = async (context: $TSContext): Promise<void> 
   } else {
     commandPath = path.join(commandPath, category, context.input.command);
   }
-
+  disableCDKDeprecationWarning();
   const commandModule = await import(commandPath);
   try {
     await commandModule.run(context);
@@ -358,3 +358,13 @@ export const transformCategoryStack = async (context: $TSContext, resource: $TSO
 const canResourceBeTransformed = (
   resourceName: string,
 ): boolean => stateManager.resourceInputsJsonExists(undefined, AmplifyCategories.API, resourceName);
+
+/**
+ * Disable the CDK deprecation warning in production but not in CI
+ */
+const disableCDKDeprecationWarning = () => {
+  const isCI = () => process.env.CI && process.env.CIRCLECI;
+  if (!isCI()) {
+    process.env.JSII_DEPRECATED = 'quiet';
+  }
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Disable the CDK deprecation warning msg. This will be removed once the migration to CDK V2 is complete. The msg can still be seen on the CI/debug environment.

Refer https://github.com/aws/aws-cdk-rfcs/blob/master/text/287-cli-deprecation-warnings.md#cdk-cli-deprecation-warnings
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
`amplify-dev api gql-compile`
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
