### PR TITLE
chore: split containers-api tests

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/containers-api-1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/containers-api-1.test.ts
@@ -6,8 +6,6 @@ import {
   deleteProject,
   deleteProjectDir,
   initJSProjectWithProfile,
-  getProjectMeta,
-  modifyRestAPI,
   retry,
 } from 'amplify-category-api-e2e-core';
 import fetch from 'node-fetch';
@@ -59,18 +57,5 @@ describe('amplify api add', () => {
       },
     );
     expect(result).toEqual(expected);
-  });
-
-  it('init project, enable containers and add multicontainer api push, edit and push', async () => {
-    const envName = 'devtest';
-    const apiName = 'containermodifyapi';
-    await initJSProjectWithProfile(projRoot, { name: 'multicontainer', envName });
-    await setupAmplifyProject(projRoot);
-    await addRestContainerApi(projRoot, { apiName });
-    await amplifyPushWithoutCodegen(projRoot);
-    const meta = await getProjectMeta(projRoot);
-    const api = Object.keys(meta.api)[0];
-    modifyRestAPI(projRoot, api);
-    await amplifyPushWithoutCodegen(projRoot);
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/containers-api-2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/containers-api-2.test.ts
@@ -1,0 +1,45 @@
+import {
+  addRestContainerApi,
+  amplifyConfigureProject,
+  amplifyPushWithoutCodegen,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  initJSProjectWithProfile,
+  getProjectMeta,
+  modifyRestAPI,
+} from 'amplify-category-api-e2e-core';
+import fetch from 'node-fetch';
+import { getAWSExports } from '../aws-exports/awsExports';
+
+async function setupAmplifyProject(cwd: string) {
+  await amplifyConfigureProject({
+    cwd,
+    enableContainers: true,
+  });
+}
+
+describe('amplify api add', () => {
+  let projRoot: string;
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir('containers');
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('init project, enable containers and add multicontainer api push, edit and push', async () => {
+    const envName = 'devtest';
+    const apiName = 'containermodifyapi';
+    await initJSProjectWithProfile(projRoot, { name: 'multicontainer', envName });
+    await setupAmplifyProject(projRoot);
+    await addRestContainerApi(projRoot, { apiName });
+    await amplifyPushWithoutCodegen(projRoot);
+    const meta = await getProjectMeta(projRoot);
+    const api = Object.keys(meta.api)[0];
+    modifyRestAPI(projRoot, api);
+    await amplifyPushWithoutCodegen(projRoot);
+  });
+});

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -89,7 +89,8 @@ const KNOWN_SUITES_SORTED_ACCORDING_TO_RUNTIME = [
   'src/__tests__/schema-predictions.test.ts',
   'src/__tests__/amplify-app.test.ts',
   'src/__tests__/schema-iterative-update-2.test.ts',
-  'src/__tests__/containers-api.test.ts',
+  'src/__tests__/containers-api-1.test.ts',
+  'src/__tests__/containers-api-2.test.ts',
   //<25m
   'src/__tests__/schema-auth-10.test.ts',
   'src/__tests__/schema-key.test.ts',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This splits two long running tests in order to:
- decrease total load
- increase stability and retryability (they both running in same job compounds chance of failed attempt)

FWIW this has been split in CLI repo for the same reason
See https://github.com/aws-amplify/amplify-cli/blob/dev/packages/amplify-e2e-tests/src/__tests__/containers-api-1.test.ts
and https://github.com/aws-amplify/amplify-cli/blob/dev/packages/amplify-e2e-tests/src/__tests__/containers-api-2.test.ts

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

E2E tests run https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api/1940/workflows/77347e4a-bf0e-4441-83c0-928d111f7fe3

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] PR description included
- [ x] `yarn test` passes
- [ x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
