### PR TITLE
fix(graphql): protect relational fields when fields rules are restrictive

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/resolvers/field.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/field.ts
@@ -196,7 +196,7 @@ export const setDeniedFieldFlag = (operation: string, subscriptionsEnabled: bool
       compoundExpression([
         iff(
           equals(methodCall(ref('util.defaultIfNull'), methodCall(ref('ctx.source.get'), str(OPERATION_KEY)), nul()), str(operation)),
-          qref(methodCall(ref('ctx.result.put'), str('deniedField'), bool(true))),
+          qref(methodCall(ref('ctx.stash.put'), str('deniedField'), bool(true))),
         ),
       ]),
     );

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
@@ -10450,7 +10450,7 @@ Object {
 
 exports[`validates VTL of a complex schema 1`] = `
 Object {
-  "Child.parents.req.vtl": "#if( $ctx.source.deniedField )
+  "Child.parents.req.vtl": "#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.id) )
@@ -10564,7 +10564,7 @@ $util.error($ctx.error.message, $ctx.error.type)
   #end
   $util.toJson($result)
 #end",
-  "Friendship.friend.req.vtl": "#if( $ctx.source.deniedField )
+  "Friendship.friend.req.vtl": "#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.friendID) )
@@ -13436,7 +13436,7 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
   $util.toJson($ctx.result)
 #end
 ## [End] ResponseTemplate. **",
-  "Parent.child.req.vtl": "#if( $ctx.source.deniedField )
+  "Parent.child.req.vtl": "#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.childID) || $util.isNull($ctx.source.childName) )
@@ -13474,7 +13474,7 @@ $util.unauthorized()
     $util.toJson(null)
   #end
 #end",
-  "Post.authors.req.vtl": "#if( $ctx.source.deniedField )
+  "Post.authors.req.vtl": "#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.authorID) )
@@ -13610,7 +13610,7 @@ $util.error($ctx.error.message, $ctx.error.type)
   #end
   $util.toJson($result)
 #end",
-  "PostAuthor.post.req.vtl": "#if( $ctx.source.deniedField )
+  "PostAuthor.post.req.vtl": "#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.postID) )
@@ -13646,7 +13646,7 @@ $util.unauthorized()
     $util.toJson(null)
   #end
 #end",
-  "PostModel.authors.req.vtl": "#if( $ctx.source.deniedField )
+  "PostModel.authors.req.vtl": "#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.authorID) )
@@ -13724,7 +13724,7 @@ $util.error($ctx.error.message, $ctx.error.type)
   #end
   $util.toJson($result)
 #end",
-  "PostModel.singleAuthor.req.vtl": "#if( $ctx.source.deniedField )
+  "PostModel.singleAuthor.req.vtl": "#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.authorID) || $util.isNull($ctx.source.authorName) || $util.isNull($ctx.source.authorSurname) )
@@ -15375,7 +15375,7 @@ $extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args
 #end
 $util.toJson(null)
 ## [End] Subscription Response template. **",
-  "User.friendships.req.vtl": "#if( $ctx.source.deniedField )
+  "User.friendships.req.vtl": "#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.id) )
@@ -15489,7 +15489,7 @@ $util.error($ctx.error.message, $ctx.error.type)
   #end
   $util.toJson($result)
 #end",
-  "UserModel.authorPosts.req.vtl": "#if( $ctx.source.deniedField )
+  "UserModel.authorPosts.req.vtl": "#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.id) )

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
@@ -366,7 +366,7 @@ input ModelIDKeyConditionInput {
 
 exports[`both models with sort key 2`] = `
 Object {
-  "ModelA.models.req.vtl": "#if( $ctx.source.deniedField )
+  "ModelA.models.req.vtl": "#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.id) )
@@ -444,7 +444,7 @@ $util.error($ctx.error.message, $ctx.error.type)
   #end
   $util.toJson($result)
 #end",
-  "ModelAModelB.modelA.req.vtl": "#if( $ctx.source.deniedField )
+  "ModelAModelB.modelA.req.vtl": "#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.modelAID) || $util.isNull($ctx.source.modelAsortId) )
@@ -482,7 +482,7 @@ $util.unauthorized()
     $util.toJson(null)
   #end
 #end",
-  "ModelAModelB.modelB.req.vtl": "#if( $ctx.source.deniedField )
+  "ModelAModelB.modelB.req.vtl": "#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.modelBID) || $util.isNull($ctx.source.modelBsortId) )
@@ -520,7 +520,7 @@ $util.unauthorized()
     $util.toJson(null)
   #end
 #end",
-  "ModelB.models.req.vtl": "#if( $ctx.source.deniedField )
+  "ModelB.models.req.vtl": "#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.id) )
@@ -4367,7 +4367,7 @@ input ModelSubscriptionFooBarFilterInput {
 
 exports[`valid schema 2`] = `
 Object {
-  "Bar.foos.req.vtl": "#if( $ctx.source.deniedField )
+  "Bar.foos.req.vtl": "#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.id) )
@@ -4443,7 +4443,7 @@ $util.error($ctx.error.message, $ctx.error.type)
   #end
   $util.toJson($result)
 #end",
-  "Foo.bars.req.vtl": "#if( $ctx.source.deniedField )
+  "Foo.bars.req.vtl": "#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.id) )
@@ -4519,7 +4519,7 @@ $util.error($ctx.error.message, $ctx.error.type)
   #end
   $util.toJson($result)
 #end",
-  "FooBar.bar.req.vtl": "#if( $ctx.source.deniedField )
+  "FooBar.bar.req.vtl": "#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.barID) )
@@ -4555,7 +4555,7 @@ $util.unauthorized()
     $util.toJson(null)
   #end
 #end",
-  "FooBar.foo.req.vtl": "#if( $ctx.source.deniedField )
+  "FooBar.foo.req.vtl": "#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.fooID) )

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-relations-with-custom-primary-key.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-relations-with-custom-primary-key.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Resolvers for custom primary key and relational directives should generate correct dynamoDB partition key and sort key for CPK schema in resolver VTL when CPK feature is enabled 1`] = `
-"#if( $ctx.source.deniedField )
+"#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.postId) )
@@ -74,7 +74,7 @@ null
 `;
 
 exports[`Resolvers for custom primary key and relational directives should generate correct dynamoDB partition key and sort key for CPK schema in resolver VTL when CPK feature is enabled 2`] = `
-"#if( $ctx.source.deniedField )
+"#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.postId) )
@@ -147,7 +147,7 @@ null
 `;
 
 exports[`Resolvers for custom primary key and relational directives should generate correct dynamoDB partition key and sort key for CPK schema in resolver VTL when CPK feature is enabled 3`] = `
-"#if( $ctx.source.deniedField )
+"#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.postId) )
@@ -220,7 +220,7 @@ null
 `;
 
 exports[`Resolvers for custom primary key and relational directives should generate correct dynamoDB partition key and sort key for CPK schema in resolver VTL when CPK feature is enabled 4`] = `
-"#if( $ctx.source.deniedField )
+"#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.postId) )
@@ -293,7 +293,7 @@ null
 `;
 
 exports[`Resolvers for custom primary key and relational directives should generate correct dynamoDB partition key and sort key for CPK schema in resolver VTL when CPK feature is enabled 5`] = `
-"#if( $ctx.source.deniedField )
+"#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.postId) )
@@ -366,7 +366,7 @@ null
 `;
 
 exports[`Resolvers for custom primary key and relational directives should generate correct dynamoDB partition key and sort key for CPK schema in resolver VTL when CPK feature is enabled 6`] = `
-"#if( $ctx.source.deniedField )
+"#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.postId) )
@@ -439,7 +439,7 @@ null
 `;
 
 exports[`Resolvers for custom primary key and relational directives should generate correct dynamoDB partition key and sort key for CPK schema in resolver VTL when CPK feature is enabled 7`] = `
-"#if( $ctx.source.deniedField )
+"#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.customPostId) )
@@ -512,7 +512,7 @@ null
 `;
 
 exports[`Resolvers for custom primary key and relational directives should generate correct dynamoDB partition key and sort key for CPK schema in resolver VTL when CPK feature is enabled 8`] = `
-"#if( $ctx.source.deniedField )
+"#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.customTagId) )
@@ -585,7 +585,7 @@ null
 `;
 
 exports[`Resolvers for custom primary key and relational directives should not generate sort key field in implicit hasMany relation when CPK feature is disabled 1`] = `
-"#if( $ctx.source.deniedField )
+"#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.postId) )
@@ -656,7 +656,7 @@ null
 `;
 
 exports[`Resolvers for custom primary key and relational directives should not generate sort key field in implicit hasMany relation when CPK feature is disabled 2`] = `
-"#if( $ctx.source.deniedField )
+"#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.postId) )
@@ -727,7 +727,7 @@ null
 `;
 
 exports[`Resolvers for custom primary key and relational directives should not generate sort key field in implicit hasMany relation when CPK feature is disabled 3`] = `
-"#if( $ctx.source.deniedField )
+"#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.postId) )
@@ -798,7 +798,7 @@ null
 `;
 
 exports[`Resolvers for custom primary key and relational directives should not generate sort key field in implicit hasMany relation when CPK feature is disabled 4`] = `
-"#if( $ctx.source.deniedField )
+"#if( $ctx.stash.deniedField )
   #return($util.toJson(null))
 #end
 #if( $util.isNull($ctx.source.postId) )

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -113,7 +113,7 @@ export function makeGetItemConnectionWithKeyResolver(config: HasOneDirectiveConf
     MappingTemplate.s3MappingTemplateFromString(
       print(
         compoundExpression([
-          iff(ref('ctx.source.deniedField'), raw('#return($util.toJson(null))')),
+          iff(ref('ctx.stash.deniedField'), raw('#return($util.toJson(null))')),
           ifElse(
             or(localFields.map(f => raw(`$util.isNull($ctx.source.${f})`))),
             raw('#return'),
@@ -262,7 +262,7 @@ export function makeQueryConnectionWithKeyResolver(config: HasManyDirectiveConfi
     MappingTemplate.s3MappingTemplateFromString(
       print(
         compoundExpression([
-          iff(ref('ctx.source.deniedField'), raw('#return($util.toJson(null))')),
+          iff(ref('ctx.stash.deniedField'), raw('#return($util.toJson(null))')),
           ifElse(
             raw(`$util.isNull($ctx.source.${connectionAttributes[0]})`),
             compoundExpression([set(ref('result'), obj({ items: list([]) })), raw('#return($result)')]),

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts
@@ -156,32 +156,11 @@ interface CreateTaskInput {
   description?: string;
 }
 
-interface UpdateTaskInput {
-  id: string;
-  name?: string;
-  description?: string;
-}
-
-interface DeleteTaskInput {
-  id: string;
-}
-
 interface CreateNoteInput {
   id?: string;
   content: string;
   secretNote?: string;
   taskNotesId?: string;
-}
-
-interface UpdateNoteInput {
-  id: string;
-  content?: string;
-  secretNote?: string;
-  taskNotesId?: string;
-}
-
-interface DeleteNoteInput {
-  id: string;
 }
 
 beforeEach(async () => {


### PR DESCRIPTION
#### Description of changes

Protect relational fields when field rules are more restrictive than the model auth rules.

#### Issue #, if available

NA.

#### Description of how you validated changes
- manual testing
- added new e2e tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
