### PR TITLE
chore: reduce timeouts on circleci tasks

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -35,7 +35,7 @@ defaults: &defaults
 
 scan_e2e_test_artifacts: &scan_e2e_test_artifacts
   name: Scan And Cleanup E2E Test Artifacts
-  no_output_timeout: 90m
+  no_output_timeout: 60m
   command: |
     if ! yarn ts-node .circleci/scan_artifacts.ts; then
       echo "Cleaning the repository"
@@ -120,7 +120,7 @@ jobs:
             source .circleci/local_publish_helpers.sh
             cd packages/amplify-util-mock/
             yarn e2e
-          no_output_timeout: 90m
+          no_output_timeout: 60m
           environment:
             JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
       - store_test_results:
@@ -178,7 +178,7 @@ jobs:
             retry yarn e2e --maxWorkers=3 $TEST_SUITE
           environment:
             AMPLIFY_CLI_DISABLE_LOGGING: "true"
-          no_output_timeout: 90m
+          no_output_timeout: 60m
       - store_test_results:
           path: packages/graphql-transformers-e2e-tests/
 
@@ -272,7 +272,7 @@ jobs:
             changeNpmGlobalPath
             cd packages/amplify-migration-tests
             retry yarn run migration_v5.2.0 --maxWorkers=3 $TEST_SUITE
-          no_output_timeout: 90m
+          no_output_timeout: 60m
       - run: *scan_e2e_test_artifacts
       - store_test_results:
           path: packages/amplify-migration-tests/
@@ -297,7 +297,7 @@ jobs:
             changeNpmGlobalPath
             cd packages/amplify-migration-tests
             retry yarn run migration_v6.1.0 --maxWorkers=3 $TEST_SUITE
-          no_output_timeout: 90m
+          no_output_timeout: 60m
       - run: *scan_e2e_test_artifacts
       - store_test_results:
           path: packages/amplify-migration-tests/
@@ -334,7 +334,7 @@ jobs:
           command: |
             cd packages/amplify-e2e-tests
             yarn clean-e2e-resources
-          no_output_timeout: 90m
+          no_output_timeout: 60m
       - run:
           name: "Cleanup Stale Buckets"
           command: |
@@ -358,7 +358,7 @@ jobs:
           command: |
             cd packages/amplify-e2e-tests
             yarn clean-e2e-resources workflow ${CIRCLE_WORKFLOW_ID}
-          no_output_timeout: 90m
+          no_output_timeout: 60m
       - run: *scan_e2e_test_artifacts
       - store_artifacts:
           path: ~/repo/packages/amplify-e2e-tests/amplify-e2e-reports
@@ -572,7 +572,7 @@ commands:
                   source .circleci/local_publish_helpers.sh
                   cd packages/amplify-e2e-tests
                   retry yarn run e2e --detectOpenHandles --maxWorkers=3 $TEST_SUITE
-                no_output_timeout: 90m
+                no_output_timeout: 60m
       - when:
           condition:
             equal: [*linux-e2e-executor, << parameters.os >>]
@@ -585,7 +585,7 @@ commands:
                   source .circleci/local_publish_helpers.sh
                   amplify version
                   retry runE2eTest
-                no_output_timeout: 90m
+                no_output_timeout: 60m
   scan_e2e_test_artifacts:
     description: "Scan And Cleanup E2E Test Artifacts"
     parameters:
@@ -595,7 +595,7 @@ commands:
     steps:
       - run:
           name: Scan E2E artifacts
-          no_output_timeout: 90m
+          no_output_timeout: 60m
           command: |
             if ! yarn ts-node .circleci/scan_artifacts.ts; then
               echo "Cleaning the repository"
@@ -623,7 +623,7 @@ commands:
                   cd client-test-apps/js/api-model-relationship-app
                   npm install
                   retry npm run test:ci
-                no_output_timeout: 90m
+                no_output_timeout: 60m
       - when:
           condition:
             equal: [*linux-e2e-executor, << parameters.os >>]
@@ -638,4 +638,4 @@ commands:
                   cd client-test-apps/js/api-model-relationship-app
                   npm install
                   retry npm run test:ci
-                no_output_timeout: 90m
+                no_output_timeout: 60m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,4 +257,4 @@ commands:
             cd client-test-apps/js/api-model-relationship-app
             npm install
             retry npm run test:ci
-          no_output_timeout: 90m
+          no_output_timeout: 60m


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Currently, jobs are allowed to hang up to 90 minutes (for each retry) if there is no output from the test. Usually, this happens if there are resource limits or other errors that cause the process to hang.
Also, if a test hangs for 90 minutes, it will fail at 90 minutes and re-try; and if it fails again, you've got 3 hours spent waiting on this test. We can at least shave an hour off the worst case scenario by doing this.

The longest running test during a successful run completes in about 1 hour as shown [here](https://app.circleci.com/pipelines/gh/aws-amplify/amplify-category-api/1784/workflows/c2720418-7aa6-4412-9d79-811c9dd57c91). So 60 minutes is a reasonable timeout.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
