### PR TITLE
fix: cleanup script does not run if tests fail

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -364,6 +364,19 @@ jobs:
           path: ~/repo/packages/amplify-e2e-tests/amplify-e2e-reports
     working_directory: ~/repo
 
+  wait_for_all:
+    <<: *linux-e2e-executor
+    steps:
+      - run:
+          name: 'Wait for all required jobs to finish'
+          command: |
+              while [[ $(curl --location --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job" --header "Circle-Token: $CIRCLECI_TOKEN"| jq -r '.items[]|select(.name != "wait_for_all")|.status' | grep -c "running") -gt 0 ]]
+                do
+                  sleep 60
+                done
+          no_output_timeout: 180m
+    working_directory: ~/repo
+
 workflows:
   version: 2
   e2e_resource_cleanup:
@@ -493,16 +506,31 @@ workflows:
                 - /run-e2e\/.*/
           requires:
             - publish_to_local_registry
+      - wait_for_all:
+          context:
+            - api-cleanup-resources
+            - api-e2e-test-context
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - main
+                - /tagged-release\/.*/
+                - /run-e2e\/.*/
+
       - cleanup_resources_after_e2e_runs:
           context:
             - api-cleanup-resources
             - api-e2e-test-context
           requires:
-            - amplify_e2e_tests
-            - client_e2e_tests
-            - graphql_e2e_tests
-            - amplify_migration_tests_v6
-            - amplify_migration_tests_v5
+            - wait_for_all
+          filters:
+            branches:
+              only:
+                - main
+                - /tagged-release\/.*/
+                - /run-e2e\/.*/
       - deploy:
           context:
             - e2e-auth-credentials

--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -10,6 +10,7 @@ import { deleteS3Bucket } from 'amplify-category-api-e2e-core';
 
 // Ensure to update scripts/split-e2e-tests.ts is also updated this gets updated
 const AWS_REGIONS_TO_RUN_TESTS = [
+  'us-east-1',
   'us-east-2',
   'us-west-2',
   'eu-west-2',

--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -58,6 +58,11 @@ type S3BucketInfo = {
   cciInfo?: CircleCIJobDetails;
 };
 
+type IamRoleInfo = {
+  name: string;
+  cciInfo?: CircleCIJobDetails;
+};
+
 type ReportEntry = {
   jobId?: string;
   workflowId?: string;
@@ -66,6 +71,7 @@ type ReportEntry = {
   amplifyApps: Record<string, AmplifyAppInfo>;
   stacks: Record<string, StackInfo>;
   buckets: Record<string, S3BucketInfo>;
+  roles: Record<string, IamRoleInfo>;
 };
 
 type JobFilterPredicate = (job: ReportEntry) => boolean;
@@ -84,10 +90,57 @@ type AWSAccountInfo = {
   sessionToken: string;
 };
 
+const BUCKET_TEST_REGEX = /test/;
+const IAM_TEST_REGEX = /!RotateE2eAwsToken-e2eTestContextRole|-integtest$|^amplify-|^eu-|^us-|^ap-/;
+const STALE_DURATION_MS = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
+
+/*
+ * Exit on expired token as all future requests will fail.
+ */
+const handleExpiredTokenException = (): void => {
+  console.log('Token expired. Exiting...');
+  process.exit();
+};
+
+/**
+ * We define a resource as viable for deletion if it matches TEST_REGEX in the name, and if it is > STALE_DURATION_MS old.
+ */
+const testBucketStalenessFilter = (resource: aws.S3.Bucket): boolean => {
+  const isTestResource = resource.Name.match(BUCKET_TEST_REGEX);
+  const isStaleResource = (Date.now() - resource.CreationDate.getMilliseconds()) > STALE_DURATION_MS;
+  return isTestResource && isStaleResource;
+};
+
+const testRoleStalenessFilter = (resource: aws.IAM.Role): boolean => {
+  const isTestResource = resource.RoleName.match(IAM_TEST_REGEX);
+  const isStaleResource = (Date.now() - resource.CreateDate.getMilliseconds()) > STALE_DURATION_MS;
+  return isTestResource && isStaleResource;
+};
+
+/**
+ * Get all S3 buckets in the account, and filter down to the ones we consider stale.
+ */
+const getOrphanS3TestBuckets = async (account: AWSAccountInfo): Promise<S3BucketInfo[]> => {
+  const s3Client = new aws.S3(getAWSConfig(account));
+  const listBucketResponse = await s3Client.listBuckets().promise();
+  const staleBuckets = listBucketResponse.Buckets.filter(testBucketStalenessFilter);
+  return staleBuckets.map(it => ({ name: it.Name }));
+};
+
+/**
+ * Get all iam roles in the account, and filter down to the ones we consider stale.
+ */
+const getOrphanTestIamRoles = async (account: AWSAccountInfo): Promise<IamRoleInfo[]> => {
+  const iamClient = new aws.IAM(getAWSConfig(account));
+  const listRoleResponse = await iamClient.listRoles({ MaxItems: 1000 }).promise();
+  const staleRoles = listRoleResponse.Roles.filter(testRoleStalenessFilter);
+  return staleRoles.map(it => ({ name: it.RoleName }));
+};
+
 /**
  * Get the relevant AWS config object for a given account and region.
  */
-const getAWSConfig = ({ accessKeyId, secretAccessKey, sessionToken }: AWSAccountInfo, region?: string): any => ({
+ const getAWSConfig = ({ accessKeyId, secretAccessKey, sessionToken }: AWSAccountInfo, region?: string): unknown => ({
   credentials: {
     accessKeyId,
     secretAccessKey,
@@ -100,6 +153,7 @@ const getAWSConfig = ({ accessKeyId, secretAccessKey, sessionToken }: AWSAccount
 /**
  * Returns a list of Amplify Apps in the region. The apps includes information about the CircleCI build that created the app
  * This is determined by looking at tags of the backend environments that are associated with the Apps
+ * @param account aws account to query for amplify Apps
  * @param region aws region to query for amplify Apps
  * @returns Promise<AmplifyAppInfo[]> a list of Amplify Apps in the region with build info
  */
@@ -146,6 +200,7 @@ const getJobId = (tags: aws.CloudFormation.Tags = []): number | undefined => {
  * deletion failures
  *
  * @param stackName name of the stack
+ * @param account account
  * @param region region
  * @returns stack details
  */
@@ -197,7 +252,9 @@ const getStacks = async (account: AWSAccountInfo, region: string): Promise<Stack
   for (const stack of rootStacks) {
     try {
       const details = await getStackDetails(stack.StackName, account, region);
-      details && results.push(details);
+      if (details) {
+        results.push(details);
+      }
     } catch {
       // don't want to barf and fail e2e tests
     }
@@ -282,6 +339,8 @@ const mergeResourcesByCCIJob = (
   amplifyApp: AmplifyAppInfo[],
   cfnStacks: StackInfo[],
   s3Buckets: S3BucketInfo[],
+  orphanS3Buckets: S3BucketInfo[],
+  orphanIamRoles: IamRoleInfo[],
 ): Record<string, ReportEntry> => {
   const result: Record<string, ReportEntry> = {};
 
@@ -304,7 +363,7 @@ const mergeResourcesByCCIJob = (
 
   _.mergeWith(
     result,
-    _.pickBy(amplifyAppByJobId, (_, key) => key !== MULTI_JOB_APP),
+    _.pickBy(amplifyAppByJobId, (__, key) => key !== MULTI_JOB_APP),
     (val, src, key) => ({
       ...val,
       ...extractCCIJobInfo(src),
@@ -316,7 +375,7 @@ const mergeResourcesByCCIJob = (
   _.mergeWith(
     result,
     stacksByJobId,
-    (_, key) => key !== ORPHAN,
+    (__: unknown, key: string) => key !== ORPHAN,
     (val, src, key) => ({
       ...val,
       ...extractCCIJobInfo(src),
@@ -330,6 +389,26 @@ const mergeResourcesByCCIJob = (
     ...extractCCIJobInfo(src),
     jobId: key,
     buckets: src,
+  }));
+  
+  const orphanBuckets = {
+    [ORPHAN]: orphanS3Buckets,
+  };
+
+  _.mergeWith(result, orphanBuckets, (val, src, key) => ({
+    ...val,
+    jobId: key,
+    buckets: src,
+  }));
+
+  const orphanIamRolesGroup = {
+    [ORPHAN]: orphanIamRoles,
+  };
+
+  _.mergeWith(result, orphanIamRolesGroup, (val, src, key) => ({
+    ...val,
+    jobId: key,
+    roles: src,
   }));
 
   return result;
@@ -347,6 +426,85 @@ const deleteAmplifyApp = async (account: AWSAccountInfo, accountIndex: number, a
     await amplifyClient.deleteApp({ appId }).promise();
   } catch (e) {
     console.log(`[ACCOUNT ${accountIndex}] Deleting Amplify App ${appId} failed with the following error`, e);
+    if (e.code === 'ExpiredTokenException') {
+      handleExpiredTokenException();
+    }
+  }
+};
+
+const deleteIamRoles = async (account: AWSAccountInfo, accountIndex: number, roles: IamRoleInfo[]): Promise<void> => {
+  await Promise.all(roles.map(role => deleteIamRole(account, accountIndex, role)));
+};
+
+const deleteIamRole = async (account: AWSAccountInfo, accountIndex: number, role: IamRoleInfo): Promise<void> => {
+  const { name: roleName } = role;
+  try {
+    console.log(`[ACCOUNT ${accountIndex}] Deleting Iam Role ${roleName}`);
+    const iamClient = new aws.IAM(getAWSConfig(account));
+    await deleteAttachedRolePolicies(account, accountIndex, roleName);
+    await deleteRolePolicies(account, accountIndex, roleName);
+    await iamClient.deleteRole({ RoleName: roleName }).promise();
+  } catch (e) {
+    console.log(`[ACCOUNT ${accountIndex}] Deleting iam role ${roleName} failed with error ${e.message}`);
+    if (e.code === 'ExpiredTokenException') {
+      handleExpiredTokenException();
+    }
+  }
+};
+
+const deleteAttachedRolePolicies = async (
+  account: AWSAccountInfo,
+  accountIndex: number,
+  roleName: string,
+): Promise<void> => {
+  const iamClient = new aws.IAM(getAWSConfig(account));
+  const rolePolicies = await iamClient.listAttachedRolePolicies({ RoleName: roleName }).promise();
+  await Promise.all(rolePolicies.AttachedPolicies.map(policy => detachIamAttachedRolePolicy(account, accountIndex, roleName, policy)));
+};
+
+const detachIamAttachedRolePolicy = async (
+  account: AWSAccountInfo,
+  accountIndex: number,
+  roleName: string,
+  policy: aws.IAM.AttachedPolicy,
+): Promise<void> => {
+  try {
+    console.log(`[ACCOUNT ${accountIndex}] Detach Iam Attached Role Policy ${policy.PolicyName}`);
+    const iamClient = new aws.IAM(getAWSConfig(account));
+    await iamClient.detachRolePolicy({ RoleName: roleName, PolicyArn: policy.PolicyArn }).promise();
+  } catch (e) {
+    console.log(`[ACCOUNT ${accountIndex}] Detach iam role policy ${policy.PolicyName} failed with error ${e.message}`);
+    if (e.code === 'ExpiredTokenException') {
+      handleExpiredTokenException();
+    }
+  }
+};
+
+const deleteRolePolicies = async (
+  account: AWSAccountInfo,
+  accountIndex: number,
+  roleName: string,
+): Promise<void> => {
+  const iamClient = new aws.IAM(getAWSConfig(account));
+  const rolePolicies = await iamClient.listRolePolicies({ RoleName: roleName }).promise();
+  await Promise.all(rolePolicies.PolicyNames.map(policy => deleteIamRolePolicy(account, accountIndex, roleName, policy)));
+};
+
+const deleteIamRolePolicy = async (
+  account: AWSAccountInfo,
+  accountIndex: number,
+  roleName: string,
+  policyName: string,
+): Promise<void> => {
+  try {
+    console.log(`[ACCOUNT ${accountIndex}] Deleting Iam Role Policy ${policyName}`);
+    const iamClient = new aws.IAM(getAWSConfig(account));
+    await iamClient.deleteRolePolicy({ RoleName: roleName, PolicyName: policyName }).promise();
+  } catch (e) {
+    console.log(`[ACCOUNT ${accountIndex}] Deleting iam role policy ${policyName} failed with error ${e.message}`);
+    if (e.code === 'ExpiredTokenException') {
+      handleExpiredTokenException();
+    }
   }
 };
 
@@ -362,6 +520,9 @@ const deleteBucket = async (account: AWSAccountInfo, accountIndex: number, bucke
     await deleteS3Bucket(name, s3);
   } catch (e) {
     console.log(`[ACCOUNT ${accountIndex}] Deleting bucket ${name} failed with error ${e.message}`);
+    if (e.code === 'ExpiredTokenException') {
+      handleExpiredTokenException();
+    }
   }
 };
 
@@ -379,10 +540,13 @@ const deleteCfnStack = async (account: AWSAccountInfo, accountIndex: number, sta
     await cfnClient.waitFor('stackDeleteComplete', { StackName: stackName }).promise();
   } catch (e) {
     console.log(`Deleting CloudFormation stack ${stackName} failed with error ${e.message}`);
+    if (e.code === 'ExpiredTokenException') {
+      handleExpiredTokenException();
+    }
   }
 };
 
-const generateReport = (jobs): void => {
+const generateReport = (jobs: _.Dictionary<ReportEntry>): void => {
   fs.ensureFileSync(reportPath);
   fs.writeFileSync(reportPath, JSON.stringify(jobs, null, 4));
 };
@@ -409,12 +573,17 @@ const deleteResources = async (
     if (resources.buckets) {
       await deleteBuckets(account, accountIndex, Object.values(resources.buckets));
     }
+
+    if (resources.roles) {
+      await deleteIamRoles(account, accountIndex, Object.values(resources.roles));
+    }
   }
 };
 
 /**
  * Grab the right CircleCI filter based on args passed in.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getFilterPredicate = (args: any): JobFilterPredicate => {
   const filterByJobId = (jobId: string) => (job: ReportEntry) => job.jobId === jobId;
   const filterByWorkflowId = (workflowId: string) => (job: ReportEntry) => job.workflowId === workflowId;
@@ -496,13 +665,18 @@ const cleanupAccount = async (account: AWSAccountInfo, accountIndex: number, fil
   const appPromises = AWS_REGIONS_TO_RUN_TESTS.map(region => getAmplifyApps(account, region));
   const stackPromises = AWS_REGIONS_TO_RUN_TESTS.map(region => getStacks(account, region));
   const bucketPromise = getS3Buckets(account);
+  const orphanBucketPromise = getOrphanS3TestBuckets(account);
+  const orphanIamRolesPromise = getOrphanTestIamRoles(account);
 
   const apps = (await Promise.all(appPromises)).flat();
   const stacks = (await Promise.all(stackPromises)).flat();
   const buckets = await bucketPromise;
+  const orphanBuckets = await orphanBucketPromise;
+  const orphanIamRoles = await orphanIamRolesPromise;
 
-  const allResources = mergeResourcesByCCIJob(apps, stacks, buckets);
+  const allResources = mergeResourcesByCCIJob(apps, stacks, buckets, orphanBuckets, orphanIamRoles);
   const staleResources = _.pickBy(allResources, filterPredicate);
+
   generateReport(staleResources);
   await deleteResources(account, accountIndex, staleResources);
   console.log(`[ACCOUNT ${accountIndex}] Cleanup done!`);
@@ -511,22 +685,22 @@ const cleanupAccount = async (account: AWSAccountInfo, accountIndex: number, fil
 /**
  * Execute the cleanup script.
  * Cleanup will happen in parallel across all accounts within a given organization,
- * based on the requested filter parameters (i.e. for a given workfow, job, or all stale resources).
+ * based on the requested filter parameters (i.e. for a given workflow, job, or all stale resources).
  * Logs are emitted for given account ids anywhere we've fanned out, but we use an indexing scheme instead
  * of account ids since the logs these are written to will be effectively public.
  */
 const cleanup = async (): Promise<void> => {
   const args = yargs
     .command('*', 'clean up all the stale resources')
-    .command('workflow <workflow-id>', 'clean all the resources created by workflow', yargs => {
-      yargs.positional('workflowId', {
+    .command('workflow <workflow-id>', 'clean all the resources created by workflow', _yargs => {
+      _yargs.positional('workflowId', {
         describe: 'Workflow Id of the workflow',
         type: 'string',
         demandOption: '',
       });
     })
-    .command('job <jobId>', 'clean all the resource created by a job', yargs => {
-      yargs.positional('jobId', {
+    .command('job <jobId>', 'clean all the resource created by a job', _yargs => {
+      _yargs.positional('jobId', {
         describe: 'job id of the job',
         type: 'number',
       });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This change ensures that we are cleaning up correctly after each test run, even if a test fails.
For example, in this run you can see that the cleanup script does not run because of some tests failing:
![image](https://user-images.githubusercontent.com/110861985/201997891-01b731d6-442b-46a1-9f82-b64386745d0e.png)


Solution: use a job awaiter task

As you can see below, some tests failed, but the cleanup script is still able to run, thanks to its dependency on the wait_for_all task that doesn't rely on passing tests.

![image](https://user-images.githubusercontent.com/110861985/201997557-887e3efa-4030-4bb7-9fb3-5aed3c90d24a.png)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
