### PR TITLE
fix: add proper labels to artifacts in E2E

### DIFF
--- a/packages/amplify-e2e-core/src/nexpect-reporter.js
+++ b/packages/amplify-e2e-core/src/nexpect-reporter.js
@@ -83,7 +83,10 @@ class AmplifyCLIExecutionReporter {
             for(let section of commandAndParams){
               sanitizedSections.push(section.replace(/[^a-z0-9]/gi, '_').toLowerCase());
             }
-            const suffix = sanitizedSections.join('_');
+            let suffix = sanitizedSections.join('_');
+            if(suffix.length > 30){
+              suffix = suffix.substring(0, 30);
+            }
             const castFile = `${new Date().getTime()}_${index}_${suffix}.cast`;
             const castFilePath = path.join(publicPath, castFile);
             fs.writeFileSync(castFilePath, r.recording);

--- a/packages/amplify-e2e-core/src/nexpect-reporter.js
+++ b/packages/amplify-e2e-core/src/nexpect-reporter.js
@@ -74,7 +74,8 @@ class AmplifyCLIExecutionReporter {
           const recordings = mergeCliLog(r, result.CLITestRunner.logs.children, r.ancestorTitles);
 
           const recordingWithPath = recordings.map((r, index) => {
-            const commandAndParams = [r.cmd];
+            // the first command is always 'amplify', but r.cmd is the full path to the cli.. so this is more readable
+            const commandAndParams = ['amplify'];
             if(r.params){
               commandAndParams.push(...r.params);
             }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Often, when tests fail we are unable to playback the artifacts, and must scan through a bunch of .cast files to figure out the error trail. This process is very manual and slow, often there are ten files or more, and they currently don't print in-order, so you have to look through each one to find the error.
Instead, we can use labels that use timestamps, & and order indicator, so that it is easier to find the file that contains the error, usually the first file that occurs before the "amplify delete" teardown step.

So, what does it look like now?
Take this example.. using this change, I can quickly scan the files to see what commands were executed for each test on the right hand side. I can also see that the .cast files are in order. Additionally, I can quickly go to the file that happens before the teardown step 'amplify api gql compile' and find the error in there.
<img width="820" alt="image" src="https://user-images.githubusercontent.com/110861985/202351660-4a5e6f15-103f-40cd-bc62-b9b1a65f11ca.png">

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
