### PR TITLE
chore: validate cdk version

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -100,6 +100,18 @@ jobs:
     environment:
       NODE_OPTIONS: --max-old-space-size=4096
 
+  validate_cdk_version:
+    <<: *linux-e2e-executor
+    steps:
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: amplify-category-api-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{ arch }}
+      - run:
+          name: Validate cdk version
+          command: |
+            yarn ts-node .circleci/validate_cdk_version.ts
+
   lint:
     <<: *linux-e2e-executor
     steps:
@@ -414,6 +426,9 @@ workflows:
                 - l
                 - w
       - lint:
+          requires:
+            - build
+      - validate_cdk_version:
           requires:
             - build
       - test:

--- a/.circleci/validate_cdk_version.ts
+++ b/.circleci/validate_cdk_version.ts
@@ -1,0 +1,14 @@
+import { exec } from 'child_process';
+
+// @aws-cdk/core indicates CDK v1.
+exec('yarn why @aws-cdk/core', (err, stdout, stderr) => {
+
+  const cdkV1AbsenceIndicator = 'We couldn\'t find a match'
+  if (stdout.toString().includes(cdkV1AbsenceIndicator) || stderr.toString().includes(cdkV1AbsenceIndicator)) {
+    console.log('Success! CDK V1 not found');
+  } else {
+    console.log('Failure! Found CDK V1 references');
+    console.log(stdout.toString());
+    process.exit(1);
+  }
+});


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR adds validation that checks for presence of @aws-cdk/core which indicates presence of V1 CDK somewhere in dependency tree. This is to make sure we don't regress to V1 during merges from dev.

Similar change in CLI repo:
https://github.com/aws-amplify/amplify-cli/pull/11434

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
