### PR TITLE
fix: 🐛 Prevent not defined fields being added as owner fields

### DIFF
--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -32,6 +32,7 @@
     "@aws-amplify/graphql-relational-transformer": "0.12.4",
     "@aws-amplify/graphql-transformer-core": "0.17.15",
     "@aws-amplify/graphql-transformer-interfaces": "1.14.9",
+    "@aws-cdk/aws-iam": "^1.181.0",
     "@aws-cdk/core": "~1.172.0",
     "constructs": "^3.3.125",
     "graphql": "^14.5.8",

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
@@ -75,6 +75,7 @@ const getSchema = (authDirective: string): string => `
     type Post @model ${authDirective} {
         id: ID!
         title: String!
+        editors: String
         createdAt: String
         updatedAt: String
     }`;
@@ -342,7 +343,7 @@ describe('schema generation directive tests', () => {
     });
 
     // Check that owner argument is present when only using owner auth rules
-    subscriptionType?.fields?.forEach(field => {
+    subscriptionType?.fields?.forEach((field) => {
       expect(field.arguments).toHaveLength(2);
       const ownerArg: InputValueDefinitionNode = field?.arguments![1];
       expect(ownerArg.name.value).toEqual('owner');

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -119,6 +119,35 @@ import { showDefaultIdentityClaimWarning, showOwnerCanReassignWarning } from './
 // resolver.ts for auth pipeline slots
 
 /**
+ * util to get allowed roles for field
+ * if we have a rule like cognito private we can remove all other related roles from the field since it has top level
+ * access by the provider
+ */
+const getReadRolesForField = (acm: AccessControlMatrix, readRoles: Array<string>, fieldName: string): Array<string> => {
+  const hasCognitoPrivateRole = readRoles.some((r) => r === 'userPools:private')
+    && acm.isAllowed('userPools:private', fieldName, 'get')
+    && acm.isAllowed('userPools:private', fieldName, 'list')
+    && acm.isAllowed('userPools:private', fieldName, 'sync')
+    && acm.isAllowed('userPools:private', fieldName, 'search')
+    && acm.isAllowed('userPools:private', fieldName, 'listen');
+  const hasOIDCPrivateRole = readRoles.some((r) => r === 'oidc:private')
+    && acm.isAllowed('oidc:private', fieldName, 'get')
+    && acm.isAllowed('oidc:private', fieldName, 'list')
+    && acm.isAllowed('oidc:private', fieldName, 'sync')
+    && acm.isAllowed('oidc:private', fieldName, 'search')
+    && acm.isAllowed('oidc:private', fieldName, 'listen');
+  let allowedRoles = [...readRoles];
+
+  if (hasCognitoPrivateRole) {
+    allowedRoles = allowedRoles.filter((r) => !(r.startsWith('userPools:') && r !== 'userPools:private'));
+  }
+  if (hasOIDCPrivateRole) {
+    allowedRoles = allowedRoles.filter((r) => !(r.startsWith('oidc:') && r !== 'oidc:private'));
+  }
+  return allowedRoles;
+};
+
+/**
  * The class for running the @auth transformer
  */
 export class AuthTransformer extends TransformerAuthBase implements TransformerAuthProvider {
@@ -162,7 +191,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
   };
 
   object = (def: ObjectTypeDefinitionNode, directive: DirectiveNode, context: TransformerSchemaVisitStepContextProvider): void => {
-    const modelDirective = def.directives?.find(dir => dir.name.value === 'model');
+    const modelDirective = def.directives?.find((dir) => dir.name.value === 'model');
     if (!modelDirective) {
       throw new TransformerContractError('Types annotated with @auth must also be annotated with @model.');
     }
@@ -190,7 +219,8 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     this.addTypeToResourceReferences(def.name.value, this.rules);
     // turn rules into roles and add into acm and roleMap
     this.convertRulesToRoles(acm, this.rules, isJoinType, undefined, undefined, context);
-    this.modelDirectiveConfig.set(typeName, getModelConfig(modelDirective, typeName, context.featureFlags, context.isProjectUsingDataStore()));
+    this.modelDirectiveConfig.set(typeName, getModelConfig(modelDirective, typeName, context.featureFlags,
+      context.isProjectUsingDataStore()));
     this.authModelConfig.set(typeName, acm);
   };
 
@@ -225,12 +255,13 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     // context.resolver -> resolver manager -> dynamodb, relation directives, searchable
     // creates field resolver
 
-    const modelDirective = parent.directives?.find(dir => dir.name.value === 'model');
+    const modelDirective = parent.directives?.find((dir) => dir.name.value === 'model');
     const typeName = parent.name.value;
     const fieldName = field.name.value;
     const getAuthRulesOptions = merge({ isField: true }, generateGetArgumentsInput(context.featureFlags));
     const rules: AuthRule[] = getAuthDirectiveRules(new DirectiveWrapper(directive), getAuthRulesOptions);
-    validateFieldRules(new DirectiveWrapper(directive), isParentTypeBuiltinType, modelDirective !== undefined, field.name.value, context.featureFlags);
+    validateFieldRules(new DirectiveWrapper(directive), isParentTypeBuiltinType, modelDirective !== undefined, field.name.value,
+      context.featureFlags);
     validateRules(rules, this.configuredAuthProviders, field.name.value);
 
     // regardless if a model directive is used we generate the policy for iam auth
@@ -243,7 +274,8 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
       let acm: AccessControlMatrix;
       // check if the parent is already in the model config if not add it
       if (!this.modelDirectiveConfig.has(typeName)) {
-        this.modelDirectiveConfig.set(typeName, getModelConfig(modelDirective, typeName, context.featureFlags, context.isProjectUsingDataStore()));
+        this.modelDirectiveConfig.set(typeName, getModelConfig(modelDirective, typeName, context.featureFlags,
+          context.isProjectUsingDataStore()));
         acm = new AccessControlMatrix({
           name: parent.name.value,
           operations: MODEL_OPERATIONS,
@@ -280,14 +312,14 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     this.removeAuthFieldsFromSubscriptionFilter(context);
     this.authModelConfig.forEach((acm, modelName) => {
       const def = context.output.getObject(modelName)!;
-      const modelHasSearchable = def.directives.some(dir => dir.name.value === 'searchable');
+      const modelHasSearchable = def.directives.some((dir) => dir.name.value === 'searchable');
       // collect ownerFields and them in the model
       this.addFieldsToObject(context, modelName, getOwnerFields(acm));
       // Get the directives we need to add to the GraphQL nodes
       const providers = this.getAuthProviders(acm.getRoles());
       const directives = this.getServiceDirectives(providers, providers.length === 0 ? this.shouldAddDefaultServiceDirective() : false);
       if (modelHasSearchable) {
-        providers.forEach(p => searchableAggregateServiceDirectives.add(p));
+        providers.forEach((p) => searchableAggregateServiceDirectives.add(p));
       }
       if (directives.length > 0) {
         extendTypeWithDirectives(context, modelName, directives);
@@ -307,7 +339,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     // add the service directives to the searchable aggregate types
     if (searchableAggregateServiceDirectives.size > 0) {
       const serviceDirectives = this.getServiceDirectives(Array.from(searchableAggregateServiceDirectives), false);
-      SEARCHABLE_AGGREGATE_TYPES.forEach(aggType => {
+      SEARCHABLE_AGGREGATE_TYPES.forEach((aggType) => {
         extendTypeWithDirectives(context, aggType, serviceDirectives);
       });
     }
@@ -321,10 +353,10 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
       const indexKeyName = `${modelName}:indicies`;
       const def = context.output.getObject(modelName)!;
       const modelNameConfig = this.modelDirectiveConfig.get(modelName);
-      const searchableDirective = def.directives.find(dir => dir.name.value === 'searchable');
+      const searchableDirective = def.directives.find((dir) => dir.name.value === 'searchable');
 
       const queryFields = getQueryFieldNames(this.modelDirectiveConfig.get(modelName)!);
-      queryFields.forEach(query => {
+      queryFields.forEach((query) => {
         switch (query.type) {
           case QueryFieldType.GET:
             this.protectGetResolver(context, def, query.typeName, query.fieldName, acm);
@@ -341,7 +373,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
       });
       // protect additional query fields if they exist
       if (context.metadata.has(indexKeyName)) {
-        context.metadata.get<Set<string>>(indexKeyName)!.forEach(index => {
+        context.metadata.get<Set<string>>(indexKeyName)!.forEach((index) => {
           const [indexName, indexQueryName] = index.split(':');
           this.protectListResolver(context, def, def.name.value, indexQueryName, acm, indexName);
         });
@@ -355,12 +387,12 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
       // get fields specified in the schema
       // if there is a role that does not have read access on the field then we create a field resolver
       // or there is a relational directive on the field then we should protect that as well
-      const readRoles = [...new Set(...READ_MODEL_OPERATIONS.map(op => acm.getRolesPerOperation(op)))];
+      const readRoles = [...new Set(...READ_MODEL_OPERATIONS.map((op) => acm.getRolesPerOperation(op)))];
       const modelFields = def.fields?.filter((f: { name: { value: string; }; }) => acm.hasResource(f.name.value)) ?? [];
       const errorFields = new Array<string>();
       modelFields.forEach((field: FieldDefinitionNode) => {
         const fieldReadRoles = getReadRolesForField(acm, readRoles, field.name.value);
-        const allowedRoles = fieldReadRoles.filter(r => READ_MODEL_OPERATIONS.some(op => acm.isAllowed(r, field.name.value, op)));
+        const allowedRoles = fieldReadRoles.filter((r) => READ_MODEL_OPERATIONS.some((op) => acm.isAllowed(r, field.name.value, op)));
 
         const needsFieldResolver = allowedRoles.length < fieldReadRoles.length;
         if (needsFieldResolver && field.type.kind === Kind.NON_NULL_TYPE) {
@@ -381,7 +413,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
         );
       }
       const mutationFields = getMutationFieldNames(this.modelDirectiveConfig.get(modelName)!);
-      mutationFields.forEach(mutation => {
+      mutationFields.forEach((mutation) => {
         switch (mutation.type) {
           case MutationFieldType.CREATE:
             this.protectCreateResolver(context, def, mutation.typeName, mutation.fieldName, acm);
@@ -400,15 +432,15 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
       const subscriptionFieldNames = getSubscriptionFieldNames(this.modelDirectiveConfig.get(modelName)!);
       const subscriptionRoles = acm
         .getRolesPerOperation('listen')
-        .map((role) => this.roleMap.get(role)!)
+        .map((role) => this.roleMap.get(role)!);
       subscriptionFieldNames.forEach((subscription) => {
         this.protectSubscriptionResolver(context, subscription.typeName, subscription.fieldName, subscriptionRoles);
       });
 
       if (context.featureFlags.getBoolean('useSubUsernameForDefaultIdentityClaim')) {
-        const roleDefinitions = acm.getRoles().map(role => this.roleMap.get(role)!);
+        const roleDefinitions = acm.getRoles().map((role) => this.roleMap.get(role)!);
 
-        roleDefinitions.forEach(role => {
+        roleDefinitions.forEach((role) => {
           const hasMultiClaims = role.claim?.split(IDENTITY_CLAIM_DELIMITER)?.length > 1;
           const createOwnerFieldResolver = role.strategy === 'owner' && hasMultiClaims;
 
@@ -435,7 +467,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
    */
   removeAuthFieldsFromSubscriptionFilter = (context: TransformerTransformSchemaStepContextProvider): void => {
     this.authModelConfig.forEach((acm, modelName) => {
-      acm.getRoles().map(role => this.roleMap.get(role)).forEach(role => {
+      acm.getRoles().map((role) => this.roleMap.get(role)).forEach((role) => {
         if (!role.static && (role.provider === 'userPools' || role.provider === 'oidc')) {
           removeSubscriptionFilterInputAttribute(context, modelName, role.entity);
         }
@@ -461,7 +493,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
         ),
       );
     } else {
-      const hasModelDirective = def.directives.some(dir => dir.name.value === 'model');
+      const hasModelDirective = def.directives.some((dir) => dir.name.value === 'model');
       const stack = getStackForField(ctx, def, fieldName, hasModelDirective);
 
       resolver = ctx.resolvers.addResolver(
@@ -489,7 +521,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
   ): void => {
     const modelConfig = this.modelDirectiveConfig.get(def.name.value)!;
     const indexKeyName = `${def.name.value}:indicies`;
-    const searchableDirective = def.directives.find(dir => dir.name.value === 'searchable');
+    const searchableDirective = def.directives.find((dir) => dir.name.value === 'searchable');
     const addServiceDirective = (typeName: string, operation: ModelOperation, operationName: string | null = null): void => {
       if (operationName) {
         const includeDefault = this.doesTypeHaveRulesForOperation(acm, operation);
@@ -510,7 +542,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     addServiceDirective(ctx.output.getMutationTypeName()!, 'delete', modelConfig?.mutations?.delete);
     // @index queries
     if (ctx.metadata.has(indexKeyName)) {
-      ctx.metadata.get<Set<string>>(indexKeyName)!.forEach(index => {
+      ctx.metadata.get<Set<string>>(indexKeyName)!.forEach((index) => {
         addServiceDirective(ctx.output.getQueryTypeName(), 'list', index.split(':')[1]);
         addServiceDirective(ctx.output.getQueryTypeName(), 'get', index.split(':')[1]);
       });
@@ -525,22 +557,22 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     if (subscriptions?.level === SubscriptionLevel.on) {
       const subscriptionArguments = acm
         .getRolesPerOperation('listen')
-        .map(role => this.roleMap.get(role)!)
-        .filter(roleDef => roleDef.strategy === 'owner' && !fieldIsList(def.fields ?? [], roleDef.entity!));
+        .map((role) => this.roleMap.get(role)!)
+        .filter((roleDef) => roleDef.strategy === 'owner' && !fieldIsList(def.fields ?? [], roleDef.entity!));
       if (subscriptions.onCreate && modelConfig?.mutations?.create) {
-        subscriptions.onCreate.forEach(onCreateSub => {
+        subscriptions.onCreate.forEach((onCreateSub) => {
           addServiceDirective(ctx.output.getSubscriptionTypeName()!, 'listen', onCreateSub);
           addSubscriptionArguments(ctx, onCreateSub, subscriptionArguments);
         });
       }
       if (subscriptions.onUpdate && modelConfig?.mutations?.update) {
-        subscriptions.onUpdate.forEach(onUpdateSub => {
+        subscriptions.onUpdate.forEach((onUpdateSub) => {
           addServiceDirective(ctx.output.getSubscriptionTypeName()!, 'listen', onUpdateSub);
           addSubscriptionArguments(ctx, onUpdateSub, subscriptionArguments);
         });
       }
       if (subscriptions.onDelete && modelConfig?.mutations?.delete) {
-        subscriptions.onDelete.forEach(onDeleteSub => {
+        subscriptions.onDelete.forEach((onDeleteSub) => {
           addServiceDirective(ctx.output.getSubscriptionTypeName()!, 'listen', onDeleteSub);
           addSubscriptionArguments(ctx, onDeleteSub, subscriptionArguments);
         });
@@ -556,9 +588,9 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     acm: AccessControlMatrix,
   ): void => {
     const resolver = ctx.resolvers.getResolver(typeName, fieldName) as TransformerResolverProvider;
-    const roleDefinitions = acm.getRolesPerOperation('get').map(r => this.roleMap.get(r)!);
+    const roleDefinitions = acm.getRolesPerOperation('get').map((r) => this.roleMap.get(r)!);
     const tableKeySchema = getTable(ctx, def).keySchema;
-    const primaryFields = tableKeySchema.map(att => att.attributeName);
+    const primaryFields = tableKeySchema.map((att) => att.attributeName);
     const primaryKey = getPartitionKey(tableKeySchema);
     const authExpression = generateAuthExpressionForQueries(
       this.configuredAuthProviders,
@@ -583,7 +615,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     indexName?: string,
   ): void => {
     const resolver = ctx.resolvers.getResolver(typeName, fieldName) as TransformerResolverProvider;
-    const roleDefinitions = acm.getRolesPerOperation('list').map(r => this.roleMap.get(r)!);
+    const roleDefinitions = acm.getRolesPerOperation('list').map((r) => this.roleMap.get(r)!);
     let primaryFields: Array<string>;
     let partitionKey: string;
     const table = getTable(ctx, def);
@@ -633,7 +665,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
         ...acm.getRolesPerOperation('sync'),
         ...acm.getRolesPerOperation('search'),
         ...acm.getRolesPerOperation('listen'),
-      ])].map(r => this.roleMap.get(r)!);
+      ])].map((r) => this.roleMap.get(r)!);
       const relationalPrimaryMap = getRelationalPrimaryMap(ctx, def, field, relatedModelObject);
       relatedAuthExpression = generateAuthExpressionForRelationQuery(
         this.configuredAuthProviders,
@@ -648,7 +680,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     // if there is field auth on the relational query then we need to add field auth read rules first
     // in the request we then add the rules of the related type
     if (fieldRoles) {
-      const roleDefinitions = fieldRoles.map(r => this.roleMap.get(r)!);
+      const roleDefinitions = fieldRoles.map((r) => this.roleMap.get(r)!);
       const hasSubsEnabled = this.modelDirectiveConfig.get(typeName)!.subscriptions?.level === 'on';
       relatedAuthExpression = `${setDeniedFieldFlag('Mutation', hasSubsEnabled)}\n${relatedAuthExpression}`;
       fieldAuthExpression = generateAuthExpressionForField(this.configuredAuthProviders, roleDefinitions, def.fields ?? []);
@@ -683,8 +715,8 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
   ): void => {
     if (ctx.isProjectUsingDataStore()) {
       const resolver = ctx.resolvers.getResolver(typeName, fieldName) as TransformerResolverProvider;
-      const roleDefinitions = acm.getRolesPerOperation('sync').map(r => this.roleMap.get(r)!);
-      const primaryFields = getTable(ctx, def).keySchema.map(att => att.attributeName);
+      const roleDefinitions = acm.getRolesPerOperation('sync').map((r) => this.roleMap.get(r)!);
+      const primaryFields = getTable(ctx, def).keySchema.map((att) => att.attributeName);
       const authExpression = generateAuthExpressionForQueries(
         this.configuredAuthProviders,
         roleDefinitions,
@@ -714,19 +746,19 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     const acmFields = acm.getResources();
     const modelFields = def.fields ?? [];
     // only add readonly fields if they exist
-    const allowedAggFields = modelFields.map(f => f.name.value).filter(f => !acmFields.includes(f));
+    const allowedAggFields = modelFields.map((f) => f.name.value).filter((f) => !acmFields.includes(f));
     let leastAllowedFields = acmFields;
     const resolver = ctx.resolvers.getResolver(typeName, fieldName) as TransformerResolverProvider;
     // to protect search and aggregation queries we need to collect all the roles which can query
     // and the allowed fields to run field auth on aggregation queries
-    const readRoleDefinitions = acm.getRolesPerOperation('search').map(role => {
-      const allowedFields = acmFields.filter(resource => acm.isAllowed(role, resource, 'search'));
+    const readRoleDefinitions = acm.getRolesPerOperation('search').map((role) => {
+      const allowedFields = acmFields.filter((resource) => acm.isAllowed(role, resource, 'search'));
       const roleDefinition = this.roleMap.get(role)!;
       // we add the allowed fields if the role does not have full access
       // or if the rule is a dynamic rule (ex. ownerField, groupField)
       if (allowedFields.length !== acmFields.length || !roleDefinition.static) {
         roleDefinition.allowedFields = allowedFields;
-        leastAllowedFields = leastAllowedFields.filter(f => allowedFields.includes(f));
+        leastAllowedFields = leastAllowedFields.filter((f) => allowedFields.includes(f));
       } else {
         roleDefinition.allowedFields = null;
       }
@@ -762,8 +794,8 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     fieldName: string,
     roles: Array<string>,
   ): void => {
-    const roleDefinitions = roles.map(r => this.roleMap.get(r)!);
-    const hasModelDirective = def.directives.some(dir => dir.name.value === 'model');
+    const roleDefinitions = roles.map((r) => this.roleMap.get(r)!);
+    const hasModelDirective = def.directives.some((dir) => dir.name.value === 'model');
     const stack = getStackForField(ctx, def, fieldName, hasModelDirective);
     if (ctx.api.host.hasResolver(typeName, fieldName)) {
       // TODO: move pipeline resolvers created in the api host to the resolver manager
@@ -817,9 +849,9 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
   ): void => {
     const resolver = ctx.resolvers.getResolver(typeName, fieldName) as TransformerResolverProvider;
     const fields = acm.getResources();
-    const createRoles = acm.getRolesPerOperation('create').map(role => {
+    const createRoles = acm.getRolesPerOperation('create').map((role) => {
       const roleDefinition = this.roleMap.get(role)!;
-      const allowedFields = fields.filter(resource => acm.isAllowed(role, resource, 'create'));
+      const allowedFields = fields.filter((resource) => acm.isAllowed(role, resource, 'create'));
       roleDefinition.areAllFieldsAllowed = allowedFields.length === fields.length;
       roleDefinition.allowedFields = this.addAutoGeneratedFields(ctx, def, allowedFields, fields);
       return roleDefinition;
@@ -842,9 +874,9 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     const fields = acm.getResources();
     const updateDeleteRoles = [...new Set([...acm.getRolesPerOperation('update'), ...acm.getRolesPerOperation('delete')])];
     // protect fields to be updated and fields that can't be set to null (partial delete on fields)
-    const totalRoles = updateDeleteRoles.map(role => {
-      const allowedFields = fields.filter(resource => acm.isAllowed(role, resource, 'update'));
-      const nullAllowedFields = fields.filter(resource => acm.isAllowed(role, resource, 'delete'));
+    const totalRoles = updateDeleteRoles.map((role) => {
+      const allowedFields = fields.filter((resource) => acm.isAllowed(role, resource, 'update'));
+      const nullAllowedFields = fields.filter((resource) => acm.isAllowed(role, resource, 'delete'));
       const roleDefinition = this.roleMap.get(role)!;
       roleDefinition.areAllFieldsAllowed = allowedFields.length === fields.length;
       roleDefinition.areAllFieldsNullAllowed = nullAllowedFields.length === fields.length;
@@ -873,7 +905,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
   ): void => {
     const resolver = ctx.resolvers.getResolver(typeName, fieldName) as TransformerResolverProvider;
     // only roles with full delete on every field can delete
-    const deleteRoles = acm.getRolesPerOperation('delete', true).map(role => this.roleMap.get(role)!);
+    const deleteRoles = acm.getRolesPerOperation('delete', true).map((role) => this.roleMap.get(role)!);
     const dataSource = ctx.api.host.getDataSource(`${def.name.value}Table`) as DataSourceProvider;
     const requestExpression = generateAuthRequestExpression();
     const authExpression = generateAuthExpressionForDelete(this.configuredAuthProviders, deleteRoles, def.fields ?? []);
@@ -910,10 +942,10 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     overrideOperations?: ModelOperation[],
     context?: TransformerSchemaVisitStepContextProvider,
   ): void {
-    authRules.forEach(rule => {
+    authRules.forEach((rule) => {
       const operations: ModelOperation[] = overrideOperations || rule.operations || MODEL_OPERATIONS;
       if (rule.groups && !rule.groupsField) {
-        rule.groups.forEach(group => {
+        rule.groups.forEach((group) => {
           const groupClaim = rule.groupClaim || DEFAULT_GROUP_CLAIM;
           const roleName = `${rule.provider}:staticGroup:${group}:${groupClaim}`;
           if (!(roleName in this.roleMap)) {
@@ -955,7 +987,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
             if (rule.allow === 'groups') {
               const groupClaim = rule.groupClaim || DEFAULT_GROUP_CLAIM;
               const groupsField = rule.groupsField || DEFAULT_GROUPS_FIELD;
-              const fieldType = (context.output.getType(acm.getName()) as any).fields.find(f => f.name.value === groupsField);
+              const fieldType = (context.output.getType(acm.getName()) as any).fields.find((f) => f.name.value === groupsField);
               const isGroupFieldList = fieldType ? isListType(fieldType.type) : false;
               roleName = `${rule.provider}:dynamicGroup:${groupsField}:${groupClaim}`;
               roleDefinition = {
@@ -968,7 +1000,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
               };
             } else if (rule.allow === 'owner') {
               const ownerField = rule.ownerField || DEFAULT_OWNER_FIELD;
-              const fieldType = (context.output.getType(acm.getName()) as any).fields.find(f => f.name.value === ownerField);
+              const fieldType = (context.output.getType(acm.getName()) as any).fields.find((f) => f.name.value === ownerField);
               const isOwnerFieldList = fieldType ? isListType(fieldType.type) : false;
               const useSub = context.featureFlags.getBoolean('useSubUsernameForDefaultIdentityClaim');
               const ownerClaim = rule.identityClaim || (useSub ? DEFAULT_UNIQUE_IDENTITY_CLAIM : DEFAULT_IDENTITY_CLAIM);
@@ -1007,7 +1039,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
 
   private doesTypeHaveRulesForOperation(acm: AccessControlMatrix, operation: ModelOperation): boolean {
     const rolesHasDefaultProvider = (roles: Array<string>): boolean => roles.some(
-      r => this.roleMap.get(r)!.provider! === this.configuredAuthProviders.default,
+      (r) => this.roleMap.get(r)!.provider! === this.configuredAuthProviders.default,
     );
     const roles = acm.getRolesPerOperation(operation, operation === 'delete');
     return rolesHasDefaultProvider(roles) || (roles.length === 0 && this.shouldAddDefaultServiceDirective());
@@ -1016,7 +1048,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
   private getAuthProviders(roles: Array<string>): Array<AuthProvider> {
     const providers: Set<AuthProvider> = new Set();
     // get the roles created for type
-    roles.forEach(role => providers.add(this.roleMap.get(role)!.provider));
+    roles.forEach((role) => providers.add(this.roleMap.get(role)!.provider));
     if (this.configuredAuthProviders.hasAdminRolesEnabled) {
       providers.add('iam');
     }
@@ -1043,11 +1075,13 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
   addFieldsToObject = (ctx: TransformerTransformSchemaStepContextProvider, modelName: string, ownerFields: Array<string>): void => {
     const modelObject = ctx.output.getObject(modelName)!;
     const existingFields = collectFieldNames(modelObject);
-    const ownerFieldsToAdd = ownerFields.filter(field => !existingFields.includes(field));
-    ownerFieldsToAdd.forEach(ownerField => {
-      /* eslint-disable @typescript-eslint/no-explicit-any */
-      (modelObject as any).fields.push(makeField(ownerField, [], makeNamedType('String')));
-      /* eslint-enable */
+    const ownerFieldsToAdd = ownerFields.filter((field) => !existingFields.includes(field));
+    ownerFieldsToAdd.forEach((ownerField) => {
+      if (ownerField === DEFAULT_OWNER_FIELD) {
+        (modelObject as any).fields.push(makeField(ownerField, [], makeNamedType('String')));
+      } else {
+        throw new TransformerContractError(`ownerField "${ownerField}" is not defined in model ${modelName}.`);
+      }
     });
     ctx.output.putType(modelObject);
   }
@@ -1062,31 +1096,31 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
         if (fieldType.kind !== 'ObjectTypeDefinition') {
           return undefined;
         }
-        const typeModel = fieldType.directives!.find(dir => dir.name.value === 'model');
+        const typeModel = fieldType.directives!.find((dir) => dir.name.value === 'model');
         return typeModel !== undefined ? undefined : fieldType;
       }
       return fieldType;
     };
     const nonModelFieldTypes = def
-      .fields!.map(f => ctx.output.getType(getBaseType(f.type)) as TypeDefinitionNode)
+      .fields!.map((f) => ctx.output.getType(getBaseType(f.type)) as TypeDefinitionNode)
       .filter(nonModelTypePredicate);
 
-    nonModelFieldTypes.forEach(nonModelFieldType => {
+    nonModelFieldTypes.forEach((nonModelFieldType) => {
       const nonModelName = nonModelFieldType.name.value;
       const hasSeenType = this.seenNonModelTypes.has(nonModelFieldType.name.value);
       let directives = this.getServiceDirectives(providers, hasSeenType);
       if (!hasSeenType) {
-        this.seenNonModelTypes.set(nonModelName, new Set<string>([...directives.map(dir => dir.name.value)]));
+        this.seenNonModelTypes.set(nonModelName, new Set<string>([...directives.map((dir) => dir.name.value)]));
         // since we haven't seen this type before we add it to the iam policy resource sets
-        const hasIAM = directives.some(dir => dir.name.value === 'aws_iam') || this.configuredAuthProviders.default === 'iam';
+        const hasIAM = directives.some((dir) => dir.name.value === 'aws_iam') || this.configuredAuthProviders.default === 'iam';
         if (hasIAM) {
           this.unauthPolicyResources.add(`${nonModelFieldType.name.value}/null`);
           this.authPolicyResources.add(`${nonModelFieldType.name.value}/null`);
         }
       } else {
         const currentDirectives = this.seenNonModelTypes.get(nonModelName)!;
-        directives = directives.filter(dir => !currentDirectives.has(dir.name.value));
-        this.seenNonModelTypes.set(nonModelName, new Set<string>([...directives.map(dir => dir.name.value), ...currentDirectives]));
+        directives = directives.filter((dir) => !currentDirectives.has(dir.name.value));
+        this.seenNonModelTypes.set(nonModelName, new Set<string>([...directives.map((dir) => dir.name.value), ...currentDirectives]));
       }
       // we continue to check the nested types if we find that directives list is not empty or if haven't seen the type before
       if (directives.length > 0 || !hasSeenType) {
@@ -1108,8 +1142,8 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     */
     const addDirectiveIfNeeded = (provider: AuthProvider, directiveName: string): void => {
       if (
-        (this.configuredAuthProviders.default !== provider && providers.some(p => p === provider))
-        || (this.configuredAuthProviders.default === provider && providers.some(p => p !== provider && addDefaultIfNeeded === true))
+        (this.configuredAuthProviders.default !== provider && providers.some((p) => p === provider))
+        || (this.configuredAuthProviders.default === provider && providers.some((p) => p !== provider && addDefaultIfNeeded === true))
       ) {
         directives.push(makeDirective(directiveName, []));
       }
@@ -1121,17 +1155,15 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     /*
       If we have any rules for the default provider AND those with other providers,
       we add the default provider directive, regardless of the addDefaultDirective value
-
       For example if we have this rule and the default is API_KEY
       @auth(rules: [{ allow: owner }, { allow: public, operations: [read] }])
-
       Then we need to add @aws_api_key on the queries along with @aws_cognito_user_pools, but we
       cannot add @aws_api_key to other operations since their is no rule granted access to it
     */
     if (
-      providers.some(p => p === this.configuredAuthProviders.default)
-      && providers.some(p => p !== this.configuredAuthProviders.default)
-      && !directives.some(d => d.name.value === AUTH_PROVIDER_DIRECTIVE_MAP.get(this.configuredAuthProviders.default))
+      providers.some((p) => p === this.configuredAuthProviders.default)
+      && providers.some((p) => p !== this.configuredAuthProviders.default)
+      && !directives.some((d) => d.name.value === AUTH_PROVIDER_DIRECTIVE_MAP.get(this.configuredAuthProviders.default))
     ) {
       directives.push(makeDirective(AUTH_PROVIDER_DIRECTIVE_MAP.get(this.configuredAuthProviders.default) as string, []));
     }
@@ -1214,19 +1246,19 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     if (rules.length === 0 || this.generateIAMPolicyForAuthRole === true) {
       return;
     }
-    this.generateIAMPolicyForAuthRole = rules.some(rule => (rule.allow === 'private' || rule.allow === 'public') && rule.provider === 'iam');
+    this.generateIAMPolicyForAuthRole = rules.some((rule) => (rule.allow === 'private' || rule.allow === 'public') && rule.provider === 'iam');
   }
 
   private setUnauthPolicyFlag(rules: AuthRule[]): void {
     if (rules.length === 0 || this.generateIAMPolicyForUnauthRole === true) {
       return;
     }
-    this.generateIAMPolicyForUnauthRole = rules.some(rule => (rule.allow === 'public' && rule.provider === 'iam'));
+    this.generateIAMPolicyForUnauthRole = rules.some((rule) => (rule.allow === 'public' && rule.provider === 'iam'));
   }
 
   private addOperationToResourceReferences(operationName: string, fieldName: string, roles: Array<string>): void {
-    const iamPublicRolesExist = roles.some(r => this.roleMap.get(r)!.provider === 'iam' && this.roleMap.get(r)!.strategy === 'public');
-    const iamPrivateRolesExist = roles.some(r => this.roleMap.get(r)!.provider === 'iam' && this.roleMap.get(r)!.strategy === 'private');
+    const iamPublicRolesExist = roles.some((r) => this.roleMap.get(r)!.provider === 'iam' && this.roleMap.get(r)!.strategy === 'public');
+    const iamPrivateRolesExist = roles.some((r) => this.roleMap.get(r)!.provider === 'iam' && this.roleMap.get(r)!.strategy === 'private');
 
     if (iamPublicRolesExist) {
       this.unauthPolicyResources.add(`${operationName}/${fieldName}`);
@@ -1241,8 +1273,8 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
    * TODO: Change Resource Ref Object/Field Functions to work with roles
    */
   private addTypeToResourceReferences(typeName: string, rules: AuthRule[]): void {
-    const iamPublicRulesExist = rules.some(r => r.allow === 'public' && r.provider === 'iam' && r.generateIAMPolicy);
-    const iamPrivateRulesExist = rules.some(r => r.allow === 'private' && r.provider === 'iam' && r.generateIAMPolicy);
+    const iamPublicRulesExist = rules.some((r) => r.allow === 'public' && r.provider === 'iam' && r.generateIAMPolicy);
+    const iamPrivateRulesExist = rules.some((r) => r.allow === 'private' && r.provider === 'iam' && r.generateIAMPolicy);
 
     if (iamPublicRulesExist) {
       this.unauthPolicyResources.add(`${typeName}/null`);
@@ -1254,8 +1286,8 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
   }
 
   private addFieldToResourceReferences(typeName: string, fieldName: string, rules: AuthRule[]): void {
-    const iamPublicRulesExist = rules.some(r => r.allow === 'public' && r.provider === 'iam' && r.generateIAMPolicy);
-    const iamPrivateRulesExist = rules.some(r => r.allow === 'private' && r.provider === 'iam' && r.generateIAMPolicy);
+    const iamPublicRulesExist = rules.some((r) => r.allow === 'public' && r.provider === 'iam' && r.generateIAMPolicy);
+    const iamPrivateRulesExist = rules.some((r) => r.allow === 'private' && r.provider === 'iam' && r.generateIAMPolicy);
 
     if (iamPublicRulesExist) {
       this.unauthPolicyResources.add(`${typeName}/${fieldName}`);
@@ -1290,7 +1322,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     allowedFields: Set<string>,
     fields: readonly string[],
   ): void => {
-    const typeDefinitions = ctx.inputDocument.definitions.filter(it => it.kind === 'ObjectTypeDefinition') as ObjectTypeDefinitionNode[];
+    const typeDefinitions = ctx.inputDocument.definitions.filter((it) => it.kind === 'ObjectTypeDefinition') as ObjectTypeDefinitionNode[];
 
     this.addAutoGeneratedHasManyFields(ctx, typeDefinitions, def, allowedFields);
     this.addAutoGeneratedHasOneFields(ctx, typeDefinitions, fields, def, allowedFields);
@@ -1298,20 +1330,20 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
 
   addAutoGeneratedIndexFields = (definition: ObjectTypeDefinitionNode, allowedFields: Set<string>): void => {
     const sortKeyFieldValues: ListValueNode[] = definition.fields
-      ?.map(it => it.directives)
+      ?.map((it) => it.directives)
       .flat()
-      .filter(it => it.name.value === 'primaryKey' || it.name.value === 'index')
-      .map(it => it.arguments)
+      .filter((it) => it.name.value === 'primaryKey' || it.name.value === 'index')
+      .map((it) => it.arguments)
       .flat()
-      .filter(it => it.name.value === 'sortKeyFields' && it.value.kind === 'ListValue' && it.value.values.length > 1)
-      .map(it => it.value)
+      .filter((it) => it.name.value === 'sortKeyFields' && it.value.kind === 'ListValue' && it.value.values.length > 1)
+      .map((it) => it.value)
       .flat() as ListValueNode[];
 
-    sortKeyFieldValues.forEach(sortKeyFieldValue => {
-      const accessOnAllKeys = !sortKeyFieldValue.values.some(it => it.kind !== 'StringValue' || !allowedFields.has(it.value));
+    sortKeyFieldValues.forEach((sortKeyFieldValue) => {
+      const accessOnAllKeys = !sortKeyFieldValue.values.some((it) => it.kind !== 'StringValue' || !allowedFields.has(it.value));
       if (accessOnAllKeys) {
         const keyName = sortKeyFieldValue.values
-          .map(it => (it as StringValueNode).value)
+          .map((it) => (it as StringValueNode).value)
           .join(ModelResourceIDs.ModelCompositeKeySeparator());
         allowedFields.add(keyName);
       }
@@ -1325,11 +1357,11 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     allowedFields: Set<string>,
   ): void => {
     const hasManyRelatedFields = typeDefinitions
-      .map(it => it.fields.map(field => ({ ...field, relatedType: it })))
+      .map((it) => it.fields.map((field) => ({ ...field, relatedType: it })))
       .flat()
-      .filter(it => getBaseType(it.type) === def.name.value && it.directives?.some(d => d.name.value === 'hasMany'));
+      .filter((it) => getBaseType(it.type) === def.name.value && it.directives?.some((d) => d.name.value === 'hasMany'));
 
-    hasManyRelatedFields.forEach(relatedField => {
+    hasManyRelatedFields.forEach((relatedField) => {
       allowedFields.add(
         getConnectionAttributeName(
           ctx.featureFlags,
@@ -1338,7 +1370,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
           getObjectPrimaryKey(relatedField.relatedType).name.value,
         ),
       );
-      getSortKeyFieldNames(relatedField.relatedType).forEach(sortKeyFieldName => {
+      getSortKeyFieldNames(relatedField.relatedType).forEach((sortKeyFieldName) => {
         allowedFields.add(
           getSortKeyConnectionAttributeName(
             relatedField.relatedType.name.value,
@@ -1360,19 +1392,20 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     def: ObjectTypeDefinitionNode,
     allowedFields: Set<string>,
   ): void => {
-    fields.forEach(field => {
-      const modelField = def.fields.find(it => it.name.value === field);
+    fields.forEach((field) => {
+      const modelField = def.fields.find((it) => it.name.value === field);
 
       const directives = modelField.directives?.filter(
-        dir => !dir.arguments?.some(it => it.name.value === 'fields') && (dir.name.value === 'hasOne' || dir.name.value === 'belongsTo'),
+        (dir) => !dir.arguments?.some((it) => it.name.value === 'fields') && (dir.name.value === 'hasOne' || dir.name.value === 'belongsTo'),
       );
-      directives.forEach(directive => {
-        const relatedType = typeDefinitions.find(it => it.name.value === getBaseType(modelField.type));
-        if (directive.name.value === 'hasOne' ||
-           (directive.name.value === 'belongsTo' &&
-            relatedType.fields.some(f => getBaseType(f.type) === def.name.value && f.directives?.some(d => d.name.value === 'hasOne')))) {
-          allowedFields.add(getConnectionAttributeName(ctx.featureFlags, def.name.value, field, getObjectPrimaryKey(relatedType).name.value));
-          getSortKeyFieldNames(def).forEach(sortKeyFieldName => {
+      directives.forEach((directive) => {
+        const relatedType = typeDefinitions.find((it) => it.name.value === getBaseType(modelField.type));
+        if (directive.name.value === 'hasOne'
+           || (directive.name.value === 'belongsTo'
+            && relatedType.fields.some((f) => getBaseType(f.type) === def.name.value && f.directives?.some((d) => d.name.value === 'hasOne')))) {
+          allowedFields.add(getConnectionAttributeName(ctx.featureFlags, def.name.value, field,
+            getObjectPrimaryKey(relatedType).name.value));
+          getSortKeyFieldNames(def).forEach((sortKeyFieldName) => {
             allowedFields.add(
               getSortKeyConnectionAttributeName(
                 def.name.value,
@@ -1388,35 +1421,6 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
 
   addAutoGeneratedDataStoreFields = (ctx: TransformerContextProvider, allowedFields: Set<string>): void => {
     const dataStoreFields = ctx.isProjectUsingDataStore() ? ['_version', '_deleted', '_lastChangedAt'] : [];
-    dataStoreFields.forEach(item => allowedFields.add(item));
+    dataStoreFields.forEach((item) => allowedFields.add(item));
   };
 }
-
-/**
- * util to get allowed roles for field
- * if we have a rule like cognito private we can remove all other related roles from the field since it has top level
- * access by the provider
- */
-const getReadRolesForField = (acm: AccessControlMatrix, readRoles: Array<string>, fieldName: string): Array<string> => {
-  const hasCognitoPrivateRole = readRoles.some(r => r === 'userPools:private')
-    && acm.isAllowed('userPools:private', fieldName, 'get')
-    && acm.isAllowed('userPools:private', fieldName, 'list')
-    && acm.isAllowed('userPools:private', fieldName, 'sync')
-    && acm.isAllowed('userPools:private', fieldName, 'search')
-    && acm.isAllowed('userPools:private', fieldName, 'listen');
-  const hasOIDCPrivateRole = readRoles.some(r => r === 'oidc:private')
-    && acm.isAllowed('oidc:private', fieldName, 'get')
-    && acm.isAllowed('oidc:private', fieldName, 'list')
-    && acm.isAllowed('oidc:private', fieldName, 'sync')
-    && acm.isAllowed('oidc:private', fieldName, 'search')
-    && acm.isAllowed('oidc:private', fieldName, 'listen');
-  let allowedRoles = [...readRoles];
-
-  if (hasCognitoPrivateRole) {
-    allowedRoles = allowedRoles.filter(r => !(r.startsWith('userPools:') && r !== 'userPools:private'));
-  }
-  if (hasOIDCPrivateRole) {
-    allowedRoles = allowedRoles.filter(r => !(r.startsWith('oidc:') && r !== 'oidc:private'));
-  }
-  return allowedRoles;
-};

--- a/packages/amplify-util-mock/src/__tests__/velocity/model-auth.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/velocity/model-auth.test.ts
@@ -1,42 +1,43 @@
-import { AuthTransformer } from "@aws-amplify/graphql-auth-transformer";
-import { IndexTransformer, PrimaryKeyTransformer } from "@aws-amplify/graphql-index-transformer";
-import { ModelTransformer } from "@aws-amplify/graphql-model-transformer";
-import { GraphQLTransform } from "@aws-amplify/graphql-transformer-core";
-import { AppSyncAuthConfiguration } from "@aws-amplify/graphql-transformer-interfaces";
-import { AmplifyAppSyncSimulatorAuthenticationType, AppSyncGraphQLExecutionContext } from "amplify-appsync-simulator";
-import { VelocityTemplateSimulator, AppSyncVTLContext, getJWTToken } from "../../velocity";
-import { featureFlags } from "./test-helper";
+import { TransformerContractError } from 'graphql-transformer-core';
+import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { IndexTransformer, PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
+import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-interfaces';
+import { AmplifyAppSyncSimulatorAuthenticationType, AppSyncGraphQLExecutionContext } from 'amplify-appsync-simulator';
+import { VelocityTemplateSimulator, AppSyncVTLContext, getJWTToken } from '../../velocity';
+import { featureFlags } from './test-helper';
 
-jest.mock("amplify-prompts");
+jest.mock('amplify-prompts');
 
-const USER_POOL_ID = "us-fake-1ID";
+const USER_POOL_ID = 'us-fake-1ID';
 
-describe("@model owner mutation checks", () => {
+describe('@model owner mutation checks', () => {
   let vtlTemplate: VelocityTemplateSimulator;
   let transformer: GraphQLTransform;
   const ownerRequest: AppSyncGraphQLExecutionContext = {
     requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
-    jwt: getJWTToken(USER_POOL_ID, "user1", "user1@test.com"),
+    jwt: getJWTToken(USER_POOL_ID, 'user1', 'user1@test.com'),
     headers: {},
-    sourceIp: ""
+    sourceIp: '',
   };
 
   beforeEach(() => {
     const authConfig: AppSyncAuthConfiguration = {
       defaultAuthentication: {
-        authenticationType: "AMAZON_COGNITO_USER_POOLS"
+        authenticationType: 'AMAZON_COGNITO_USER_POOLS',
       },
-      additionalAuthenticationProviders: []
+      additionalAuthenticationProviders: [],
     };
     transformer = new GraphQLTransform({
       authConfig,
       transformers: [new ModelTransformer(), new AuthTransformer()],
-      featureFlags
+      featureFlags,
     });
     vtlTemplate = new VelocityTemplateSimulator({ authConfig });
   });
 
-  test("implicit owner with default owner field", () => {
+  test('implicit owner with default owner field', () => {
     const validSchema = `
       type Post @model @auth(rules: [{ allow: owner }]) {
         id: ID!
@@ -48,21 +49,21 @@ describe("@model owner mutation checks", () => {
     expect(out).toBeDefined();
     // create the owner type
     const ownerContext: AppSyncVTLContext = {
-      arguments: { input: { id: "001", title: "sample" } }
+      arguments: { input: { id: '001', title: 'sample' } },
     };
 
     // expect the query resolver to contain a filter for the owner
-    const queryTemplate = out.resolvers["Query.listPosts.auth.1.req.vtl"];
+    const queryTemplate = out.resolvers['Query.listPosts.auth.1.req.vtl'];
     const queryResponse = vtlTemplate.render(queryTemplate, { context: {}, requestParameters: ownerRequest });
     expect(queryResponse).toBeDefined();
     expect(queryResponse.stash.hasAuth).toEqual(true);
     expect(queryResponse.stash.authFilter).toEqual(
       expect.objectContaining({
-        or: [{ owner: { eq: `${ownerRequest.jwt.sub}::user1` } }, { owner: { eq: `${ownerRequest.jwt.sub}` } }, { owner: { eq: "user1" } }]
-      })
+        or: [{ owner: { eq: `${ownerRequest.jwt.sub}::user1` } }, { owner: { eq: `${ownerRequest.jwt.sub}` } }, { owner: { eq: 'user1' } }],
+      }),
     );
 
-    const createRequestTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
+    const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
     const createVTLRequest = vtlTemplate.render(createRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
     expect(createVTLRequest).toBeDefined();
     expect(createVTLRequest.stash.hasAuth).toEqual(true);
@@ -71,24 +72,24 @@ describe("@model owner mutation checks", () => {
     // since we have an owner rule we expect the owner field to be defined in the argument input
     expect(createVTLRequest.args.input.owner).toEqual(`${ownerRequest.jwt.sub}::user1`);
 
-    const updateRequestTemplate = out.resolvers["Mutation.updatePost.auth.1.req.vtl"];
+    const updateRequestTemplate = out.resolvers['Mutation.updatePost.auth.1.req.vtl'];
     const updateVTLRequest = vtlTemplate.render(updateRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
     expect(updateVTLRequest).toBeDefined();
     // here we expect a get item payload to verify the owner making the update request is valid
     expect(updateVTLRequest.result).toEqual(
       expect.objectContaining({
-        key: { id: { S: "001" } },
-        operation: "GetItem",
-        version: "2018-05-29"
-      })
+        key: { id: { S: '001' } },
+        operation: 'GetItem',
+        version: '2018-05-29',
+      }),
     );
     // atm there is there is nothing in the stash yet
     expect(updateVTLRequest.stash).toEqual({});
-    const updateResponseTemplate = out.resolvers["Mutation.updatePost.auth.1.res.vtl"];
+    const updateResponseTemplate = out.resolvers['Mutation.updatePost.auth.1.res.vtl'];
     // response where the owner is indeed the owner
     const updateVTLResponse = vtlTemplate.render(updateResponseTemplate, {
-      context: { ...ownerContext, result: { id: "001", owner: "user1" } },
-      requestParameters: ownerRequest
+      context: { ...ownerContext, result: { id: '001', owner: 'user1' } },
+      requestParameters: ownerRequest,
     });
     expect(updateVTLResponse).toBeDefined();
 
@@ -96,46 +97,32 @@ describe("@model owner mutation checks", () => {
     expect(updateVTLResponse.stash.hasAuth).toEqual(true);
     // response where there is an error
     const updateVTLWithError = vtlTemplate.render(updateResponseTemplate, {
-      context: { ...ownerContext, result: { id: "001", owner: "user2" } },
-      requestParameters: ownerRequest
+      context: { ...ownerContext, result: { id: '001', owner: 'user2' } },
+      requestParameters: ownerRequest,
     });
     expect(updateVTLWithError).toBeDefined();
     expect(updateVTLWithError.hadException).toEqual(true);
     expect(updateVTLWithError.errors).toHaveLength(1);
     expect(updateVTLWithError.errors[0]).toEqual(
       expect.objectContaining({
-        errorType: "Unauthorized",
-        message: expect.stringContaining("Unauthorized on $util.unauthorized()")
-      })
+        errorType: 'Unauthorized',
+        message: expect.stringContaining('Unauthorized on $util.unauthorized()'),
+      }),
     );
   });
 
-  test("implicit owner with custom field", () => {
+  test("implicit owner with custom field doesn't get added", () => {
     const validSchema = `
-      type Post @model @auth(rules: [{ allow: owner, ownerField: "editor" }]) {
-        id: ID!
-        title: String!
-        createdAt: String
-        updatedAt: String
-      }`;
-    const out = transformer.transform(validSchema);
-    expect(out).toBeDefined();
-    // create context and request
-    const ownerContext: AppSyncVTLContext = {
-      arguments: { input: { id: "001", title: "sample" } }
-    };
-
-    const createRequestTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
-    const createVTLRequest = vtlTemplate.render(createRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
-    expect(createVTLRequest).toBeDefined();
-    expect(createVTLRequest.stash.hasAuth).toEqual(true);
-    expect(createVTLRequest.args).toBeDefined();
-    expect(createVTLRequest.hadException).toEqual(false);
-    // since we have an owner rule we expect the owner field to be defined in the argument input
-    expect(createVTLRequest.args.input.editor).toEqual(`${ownerRequest.jwt.sub}::user1`);
+        type Post @model @auth(rules: [{ allow: owner, ownerField: "editor" }]) {
+          id: ID!
+          title: String!
+          createdAt: String
+          updatedAt: String
+        }`;
+    expect(() => transformer.transform(validSchema)).toThrowError(new TransformerContractError('ownerField "editor" is not defined in model Post.'));
   });
 
-  test("explicit owner with default field", () => {
+  test('explicit owner with default field', () => {
     const validSchema = `
       type Post @model @auth(rules: [{ allow: owner }]) {
         id: ID!
@@ -148,10 +135,10 @@ describe("@model owner mutation checks", () => {
     expect(out).toBeDefined();
     // create context and request
     const ownerContext: AppSyncVTLContext = {
-      arguments: { input: { id: "001", title: "sample" } }
+      arguments: { input: { id: '001', title: 'sample' } },
     };
 
-    const createRequestTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
+    const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
     const createVTLRequest = vtlTemplate.render(createRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
     expect(createVTLRequest).toBeDefined();
     expect(createVTLRequest.stash.hasAuth).toEqual(true);
@@ -161,7 +148,7 @@ describe("@model owner mutation checks", () => {
     expect(createVTLRequest.args.input.owner).toEqual(`${ownerRequest.jwt.sub}::user1`);
   });
 
-  test("explicit owner with custom field", () => {
+  test('explicit owner with custom field', () => {
     const validSchema = `
       type Post @model @auth(rules: [{ allow: owner, ownerField: "editor" }]) {
         id: ID!
@@ -174,10 +161,10 @@ describe("@model owner mutation checks", () => {
     expect(out).toBeDefined();
     // create context and request
     const ownerContext: AppSyncVTLContext = {
-      arguments: { input: { id: "001", title: "sample" } }
+      arguments: { input: { id: '001', title: 'sample' } },
     };
 
-    const createRequestTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
+    const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
     const createVTLRequest = vtlTemplate.render(createRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
     expect(createVTLRequest).toBeDefined();
     expect(createVTLRequest.stash.hasAuth).toEqual(true);
@@ -186,10 +173,10 @@ describe("@model owner mutation checks", () => {
     // since we have an owner rule we expect the owner field to be defined in the argument input
     expect(createVTLRequest.args.input.editor).toEqual(`${ownerRequest.jwt.sub}::user1`);
 
-    const differentOwnerContext: AppSyncVTLContext = { arguments: { input: { id: "001", title: "sample", editor: "user2" } } };
+    const differentOwnerContext: AppSyncVTLContext = { arguments: { input: { id: '001', title: 'sample', editor: 'user2' } } };
     const createVTLRequestWithErrors = vtlTemplate.render(createRequestTemplate, {
       context: differentOwnerContext,
-      requestParameters: ownerRequest
+      requestParameters: ownerRequest,
     });
     expect(createVTLRequestWithErrors).toBeDefined();
     expect(createVTLRequestWithErrors.hadException).toEqual(true);
@@ -197,13 +184,13 @@ describe("@model owner mutation checks", () => {
     // should fail since the owner in the input is different than what is in the
     expect(createVTLRequestWithErrors.errors[0]).toEqual(
       expect.objectContaining({
-        errorType: "Unauthorized",
-        message: expect.stringContaining("Unauthorized on $util.unauthorized()")
-      })
+        errorType: 'Unauthorized',
+        message: expect.stringContaining('Unauthorized on $util.unauthorized()'),
+      }),
     );
   });
 
-  test("explicit owner using a custom list field", () => {
+  test('explicit owner using a custom list field', () => {
     const validSchema = `
       type Post @model @auth(rules: [{ allow: owner, ownerField: "editors" }]) {
         id: ID!
@@ -216,10 +203,10 @@ describe("@model owner mutation checks", () => {
     expect(out).toBeDefined();
     // create context and request
     const ownerContext: AppSyncVTLContext = {
-      arguments: { input: { id: "001", title: "sample" } }
+      arguments: { input: { id: '001', title: 'sample' } },
     };
 
-    const createRequestTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
+    const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
     expect(createRequestTemplate).toBeDefined();
     const createVTLRequest = vtlTemplate.render(createRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
     expect(createVTLRequest).toBeDefined();
@@ -232,68 +219,68 @@ describe("@model owner mutation checks", () => {
     // should fail if the list of users does not contain the currently signed user
     const failedCreateVTLRequest = vtlTemplate.render(createRequestTemplate, {
       context: {
-        arguments: { input: { id: "001", title: "sample", editors: ["user2"] } }
+        arguments: { input: { id: '001', title: 'sample', editors: ['user2'] } },
       },
-      requestParameters: ownerRequest
+      requestParameters: ownerRequest,
     });
     expect(failedCreateVTLRequest.hadException).toEqual(true);
     // should fail since the owner in the input is different than what is in the
     expect(failedCreateVTLRequest.errors[0]).toEqual(
       expect.objectContaining({
-        errorType: "Unauthorized",
-        message: expect.stringContaining("Unauthorized on $util.unauthorized()")
-      })
+        errorType: 'Unauthorized',
+        message: expect.stringContaining('Unauthorized on $util.unauthorized()'),
+      }),
     );
   });
 });
 
-describe("@model operations", () => {
+describe('@model operations', () => {
   let vtlTemplate: VelocityTemplateSimulator;
   let transformer: GraphQLTransform;
   const ownerRequest: AppSyncGraphQLExecutionContext = {
     requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
-    jwt: getJWTToken(USER_POOL_ID, "user1", "user1@test.com"),
+    jwt: getJWTToken(USER_POOL_ID, 'user1', 'user1@test.com'),
     headers: {},
-    sourceIp: ""
+    sourceIp: '',
   };
   const adminGroupRequest: AppSyncGraphQLExecutionContext = {
     requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
-    jwt: getJWTToken(USER_POOL_ID, "user2", "user2@test.com", ["admin"]),
+    jwt: getJWTToken(USER_POOL_ID, 'user2', 'user2@test.com', ['admin']),
     headers: {},
-    sourceIp: ""
+    sourceIp: '',
   };
   const editorGroupRequest: AppSyncGraphQLExecutionContext = {
     requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
-    jwt: getJWTToken(USER_POOL_ID, "user3", "user3@test.com", ["editor"]),
+    jwt: getJWTToken(USER_POOL_ID, 'user3', 'user3@test.com', ['editor']),
     headers: {},
-    sourceIp: ""
+    sourceIp: '',
   };
   const createPostInput = (owner?: string): AppSyncVTLContext => ({
     arguments: {
       input: {
-        id: "001",
-        name: "sample",
-        owner
-      }
-    }
+        id: '001',
+        name: 'sample',
+        owner,
+      },
+    },
   });
 
   beforeEach(() => {
     const authConfig: AppSyncAuthConfiguration = {
       defaultAuthentication: {
-        authenticationType: "AMAZON_COGNITO_USER_POOLS"
+        authenticationType: 'AMAZON_COGNITO_USER_POOLS',
       },
-      additionalAuthenticationProviders: []
+      additionalAuthenticationProviders: [],
     };
     transformer = new GraphQLTransform({
       authConfig,
       transformers: [new ModelTransformer(), new AuthTransformer()],
-      featureFlags
+      featureFlags,
     });
     vtlTemplate = new VelocityTemplateSimulator({ authConfig });
   });
 
-  test("explicit operations where create/delete restricted", () => {
+  test('explicit operations where create/delete restricted', () => {
     const validSchema = `
       type Post @model @auth(rules: [
         { allow: owner, operations: [create, read] },
@@ -305,31 +292,31 @@ describe("@model operations", () => {
     const out = transformer.transform(validSchema);
     expect(out).toBeDefined();
     // load vtl templates
-    const createRequestTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
-    const readRequestTemplate = out.resolvers["Query.listPosts.auth.1.req.vtl"];
-    const updateResponseTemplate = out.resolvers["Mutation.updatePost.auth.1.res.vtl"];
-    const deleteResponseTemplate = out.resolvers["Mutation.deletePost.auth.1.res.vtl"];
+    const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
+    const readRequestTemplate = out.resolvers['Query.listPosts.auth.1.req.vtl'];
+    const updateResponseTemplate = out.resolvers['Mutation.updatePost.auth.1.res.vtl'];
+    const deleteResponseTemplate = out.resolvers['Mutation.deletePost.auth.1.res.vtl'];
 
     // run create request as owner and admin
     // even though they are not the owner it will still pass as they one making the request is in the admin group
     const createRequestAsAdmin = vtlTemplate.render(createRequestTemplate, {
-      context: createPostInput("owner2"),
-      requestParameters: adminGroupRequest
+      context: createPostInput('owner2'),
+      requestParameters: adminGroupRequest,
     });
     expect(createRequestAsAdmin).toBeDefined();
     expect(createRequestAsAdmin.hadException).toEqual(false);
     expect(createRequestAsAdmin.stash.hasAuth).toEqual(true);
     // run the create request as owner should fail if the input is different the signed in owner
     const createRequestAsOwner = vtlTemplate.render(createRequestTemplate, {
-      context: createPostInput("user2"),
-      requestParameters: ownerRequest
+      context: createPostInput('user2'),
+      requestParameters: ownerRequest,
     });
     expect(createRequestAsOwner.hadException).toEqual(true);
     expect(createRequestAsOwner.errors[0]).toEqual(
       expect.objectContaining({
-        errorType: "Unauthorized",
-        message: expect.stringContaining("Unauthorized on $util.unauthorized()")
-      })
+        errorType: 'Unauthorized',
+        message: expect.stringContaining('Unauthorized on $util.unauthorized()'),
+      }),
     );
     // read request for admin should not contain the filter
     const readRequestAsAdmin = vtlTemplate.render(readRequestTemplate, { context: {}, requestParameters: adminGroupRequest });
@@ -339,38 +326,38 @@ describe("@model operations", () => {
     expect(readRequestAsOwner.stash.hasAuth).toEqual(true);
     expect(readRequestAsOwner.stash.authFilter).toEqual(
       expect.objectContaining({
-        or: [{ owner: { eq: `${ownerRequest.jwt.sub}::user1` } }, { owner: { eq: `${ownerRequest.jwt.sub}` } }, { owner: { eq: "user1" } }]
-      })
+        or: [{ owner: { eq: `${ownerRequest.jwt.sub}::user1` } }, { owner: { eq: `${ownerRequest.jwt.sub}` } }, { owner: { eq: 'user1' } }],
+      }),
     );
-    const ddbResponseResult: AppSyncVTLContext = { result: { id: "001", title: "sample", owner: "user1" } };
+    const ddbResponseResult: AppSyncVTLContext = { result: { id: '001', title: 'sample', owner: 'user1' } };
     // update should pass for admin even if they are not the owner of the record
     const updateResponseAsAdmin = vtlTemplate.render(updateResponseTemplate, {
       context: ddbResponseResult,
-      requestParameters: adminGroupRequest
+      requestParameters: adminGroupRequest,
     });
     expect(updateResponseAsAdmin.hadException).toEqual(false);
     expect(updateResponseAsAdmin.stash.hasAuth).toEqual(true);
     // update should fail for owner even though they are the owner of the record
     const updateResponseAsOwner = vtlTemplate.render(updateResponseTemplate, {
       context: ddbResponseResult,
-      requestParameters: ownerRequest
+      requestParameters: ownerRequest,
     });
     expect(updateResponseAsOwner.hadException).toEqual(true);
     // delete should pass for admin even if they are not the owner of the record
     const deleteResponseAsAdmin = vtlTemplate.render(deleteResponseTemplate, {
       context: ddbResponseResult,
-      requestParameters: adminGroupRequest
+      requestParameters: adminGroupRequest,
     });
     expect(deleteResponseAsAdmin.hadException).toEqual(false);
     // delete should fail for owner even though they are the owner of the record
     const deleteResponseAsOwner = vtlTemplate.render(deleteResponseTemplate, {
       context: ddbResponseResult,
-      requestParameters: ownerRequest
+      requestParameters: ownerRequest,
     });
     expect(deleteResponseAsOwner.hadException).toEqual(true);
   });
 
-  test("owner restricts create/read and group restricts read/update/delete", () => {
+  test('owner restricts create/read and group restricts read/update/delete', () => {
     // NOTE: this means that you can only create a record for the same owner
     // you can't create a record for other owners even if your in the editor group
     const validSchema = `
@@ -384,15 +371,15 @@ describe("@model operations", () => {
     `;
     const out = transformer.transform(validSchema);
     // load vtl templates
-    const createRequestTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
-    const readRequestTemplate = out.resolvers["Query.listPosts.auth.1.req.vtl"];
-    const updateResponseTemplate = out.resolvers["Mutation.updatePost.auth.1.res.vtl"];
-    const deleteResponseTemplate = out.resolvers["Mutation.deletePost.auth.1.res.vtl"];
+    const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
+    const readRequestTemplate = out.resolvers['Query.listPosts.auth.1.req.vtl'];
+    const updateResponseTemplate = out.resolvers['Mutation.updatePost.auth.1.res.vtl'];
+    const deleteResponseTemplate = out.resolvers['Mutation.deletePost.auth.1.res.vtl'];
 
     // check that a editor member can't create a post under another owner
     const createPostAsEditor = vtlTemplate.render(createRequestTemplate, {
-      context: createPostInput("user1"),
-      requestParameters: editorGroupRequest
+      context: createPostInput('user1'),
+      requestParameters: editorGroupRequest,
     });
     expect(createPostAsEditor.hadException).toEqual(true);
     // check that editor can read posts with no filter
@@ -404,34 +391,34 @@ describe("@model operations", () => {
     expect(readPostsAsOwner.hadException).toEqual(false);
     expect(readPostsAsOwner.stash.authFilter).toEqual(
       expect.objectContaining({
-        or: [{ owner: { eq: `${ownerRequest.jwt.sub}::user1` } }, { owner: { eq: `${ownerRequest.jwt.sub}` } }, { owner: { eq: "user1" } }]
-      })
+        or: [{ owner: { eq: `${ownerRequest.jwt.sub}::user1` } }, { owner: { eq: `${ownerRequest.jwt.sub}` } }, { owner: { eq: 'user1' } }],
+      }),
     );
     // expect owner can't run update or delete
     const updateResponseAsOwner = vtlTemplate.render(updateResponseTemplate, {
-      context: createPostInput("user1"),
-      requestParameters: ownerRequest
+      context: createPostInput('user1'),
+      requestParameters: ownerRequest,
     });
     expect(updateResponseAsOwner.hadException).toEqual(true);
     const deleteResponseAsOwner = vtlTemplate.render(deleteResponseTemplate, {
-      context: createPostInput("user1"),
-      requestParameters: ownerRequest
+      context: createPostInput('user1'),
+      requestParameters: ownerRequest,
     });
     expect(deleteResponseAsOwner.hadException).toEqual(true);
     // expect editor to be able to run update and delete
     const updateResponseAsEditor = vtlTemplate.render(updateResponseTemplate, {
-      context: createPostInput("user1"),
-      requestParameters: editorGroupRequest
+      context: createPostInput('user1'),
+      requestParameters: editorGroupRequest,
     });
     expect(updateResponseAsEditor.hadException).toEqual(false);
     const deleteResponseAsEditor = vtlTemplate.render(deleteResponseTemplate, {
-      context: createPostInput("user1"),
-      requestParameters: editorGroupRequest
+      context: createPostInput('user1'),
+      requestParameters: editorGroupRequest,
     });
     expect(deleteResponseAsEditor.hadException).toEqual(false);
   });
 
-  test("explicit operations where update restricted", () => {
+  test('explicit operations where update restricted', () => {
     const validSchema = `
       type Post @model @auth(rules: [
         { allow: owner, operations: [create, read, delete] },
@@ -443,21 +430,21 @@ describe("@model operations", () => {
     const out = transformer.transform(validSchema);
     expect(out).toBeDefined();
     // load vtl templates
-    const createRequestTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
-    const readRequestTemplate = out.resolvers["Query.listPosts.auth.1.req.vtl"];
-    const updateResponseTemplate = out.resolvers["Mutation.updatePost.auth.1.res.vtl"];
-    const deleteResponseTemplate = out.resolvers["Mutation.deletePost.auth.1.res.vtl"];
+    const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
+    const readRequestTemplate = out.resolvers['Query.listPosts.auth.1.req.vtl'];
+    const updateResponseTemplate = out.resolvers['Mutation.updatePost.auth.1.res.vtl'];
+    const deleteResponseTemplate = out.resolvers['Mutation.deletePost.auth.1.res.vtl'];
 
     // run the create request as owner should fail if the input is different the signed in owner
     const createRequestAsNonOwner = vtlTemplate.render(createRequestTemplate, {
-      context: createPostInput("user2"),
-      requestParameters: ownerRequest
+      context: createPostInput('user2'),
+      requestParameters: ownerRequest,
     });
     expect(createRequestAsNonOwner.hadException).toEqual(true);
 
     const createRequestAsOwner = vtlTemplate.render(createRequestTemplate, {
-      context: createPostInput("user1"),
-      requestParameters: ownerRequest
+      context: createPostInput('user1'),
+      requestParameters: ownerRequest,
     });
     expect(createRequestAsOwner.hadException).toEqual(false);
 
@@ -466,8 +453,8 @@ describe("@model operations", () => {
     expect(readRequestAsOwner.stash.hasAuth).toEqual(true);
     expect(readRequestAsOwner.stash.authFilter).toEqual(
       expect.objectContaining({
-        or: [{ owner: { eq: `${ownerRequest.jwt.sub}::user1` } }, { owner: { eq: `${ownerRequest.jwt.sub}` } }, { owner: { eq: "user1" } }]
-      })
+        or: [{ owner: { eq: `${ownerRequest.jwt.sub}::user1` } }, { owner: { eq: `${ownerRequest.jwt.sub}` } }, { owner: { eq: 'user1' } }],
+      }),
     );
 
     // read should have filter
@@ -477,85 +464,85 @@ describe("@model operations", () => {
         or: [
           { owner: { eq: `${adminGroupRequest.jwt.sub}::user2` } },
           { owner: { eq: `${adminGroupRequest.jwt.sub}` } },
-          { owner: { eq: "user2" } }
-        ]
-      })
+          { owner: { eq: 'user2' } },
+        ],
+      }),
     );
 
     // update should fail for owner
     const ddbUpdateResult: AppSyncVTLContext = {
-      result: { id: "001", name: "sample", owner: "user1" },
+      result: { id: '001', name: 'sample', owner: 'user1' },
       arguments: {
         input: {
-          id: "001",
-          name: "sample"
-        }
-      }
+          id: '001',
+          name: 'sample',
+        },
+      },
     };
     const updateResponseAsOwner = vtlTemplate.render(updateResponseTemplate, {
       context: ddbUpdateResult,
-      requestParameters: ownerRequest
+      requestParameters: ownerRequest,
     });
     expect(updateResponseAsOwner.hadException).toEqual(true);
 
     // update should fail for NON owner
     const updateResponseAsNonOwner = vtlTemplate.render(updateResponseTemplate, {
       context: ddbUpdateResult,
-      requestParameters: adminGroupRequest
+      requestParameters: adminGroupRequest,
     });
     expect(updateResponseAsNonOwner.hadException).toEqual(true);
 
     // delete should fail for non owner
     const ddbDeleteResult: AppSyncVTLContext = {
-      result: { id: "001", name: "sample", owner: "user1" }
+      result: { id: '001', name: 'sample', owner: 'user1' },
     };
     const deleteResponseAsNonOwner = vtlTemplate.render(deleteResponseTemplate, {
       context: ddbDeleteResult,
-      requestParameters: adminGroupRequest
+      requestParameters: adminGroupRequest,
     });
     expect(deleteResponseAsNonOwner.hadException).toEqual(true);
 
     // delete should pass for owner
     const deleteResponseAsOwner = vtlTemplate.render(deleteResponseTemplate, {
       context: ddbDeleteResult,
-      requestParameters: ownerRequest
+      requestParameters: ownerRequest,
     });
     expect(deleteResponseAsOwner.hadException).toEqual(false);
     expect(deleteResponseAsOwner.stash.hasAuth).toEqual(true);
   });
 });
 
-describe("@model field auth", () => {
+describe('@model field auth', () => {
   let vtlTemplate: VelocityTemplateSimulator;
   let transformer: GraphQLTransform;
   const ownerRequest: AppSyncGraphQLExecutionContext = {
     requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
-    jwt: getJWTToken(USER_POOL_ID, "user1", "user1@test.com"),
+    jwt: getJWTToken(USER_POOL_ID, 'user1', 'user1@test.com'),
     headers: {},
-    sourceIp: ""
+    sourceIp: '',
   };
   const adminGroupRequest: AppSyncGraphQLExecutionContext = {
     requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
-    jwt: getJWTToken(USER_POOL_ID, "user2", "user2@test.com", ["admin"]),
+    jwt: getJWTToken(USER_POOL_ID, 'user2', 'user2@test.com', ['admin']),
     headers: {},
-    sourceIp: ""
+    sourceIp: '',
   };
   beforeEach(() => {
     const authConfig: AppSyncAuthConfiguration = {
       defaultAuthentication: {
-        authenticationType: "AMAZON_COGNITO_USER_POOLS"
+        authenticationType: 'AMAZON_COGNITO_USER_POOLS',
       },
-      additionalAuthenticationProviders: []
+      additionalAuthenticationProviders: [],
     };
     transformer = new GraphQLTransform({
       authConfig,
       transformers: [new ModelTransformer(), new AuthTransformer()],
-      featureFlags
+      featureFlags,
     });
     vtlTemplate = new VelocityTemplateSimulator({ authConfig });
   });
 
-  test("object level group auth + field level owner auth", () => {
+  test('object level group auth + field level owner auth', () => {
     const validSchema = `
       type Student @model @auth(rules:[{ allow: groups, groups: ["admin"] }]) {
         id: ID @auth(rules: [{ allow: groups, groups: ["admin"] }, { allow: owner, operations: [read, update], identityClaim: "username" }])
@@ -564,66 +551,66 @@ describe("@model field auth", () => {
         ssn: String
       }`;
     const out = transformer.transform(validSchema);
-    const updateResponseTemplate = out.resolvers["Mutation.updateStudent.auth.1.res.vtl"];
+    const updateResponseTemplate = out.resolvers['Mutation.updateStudent.auth.1.res.vtl'];
     const updateContext: AppSyncVTLContext = {
       arguments: {
         input: {
-          id: "001",
-          email: "myNewEmail",
-          name: "newName"
-        }
+          id: '001',
+          email: 'myNewEmail',
+          name: 'newName',
+        },
       },
       result: {
-        id: "001",
-        email: "user1@test.com",
+        id: '001',
+        email: 'user1@test.com',
         name: "samplename", // eslint-disable-line
-        owner: "user1"
-      }
+        owner: 'user1',
+      },
     };
     const updateContextOwnerPass: AppSyncVTLContext = {
       ...updateContext,
       arguments: {
         input: {
-          id: "001",
-          email: "newEmail@user1.com"
-        }
-      }
+          id: '001',
+          email: 'newEmail@user1.com',
+        },
+      },
     };
     // update request should fail
     const updateResponseAsOwnerFailed = vtlTemplate.render(updateResponseTemplate, {
       context: updateContext,
-      requestParameters: ownerRequest
+      requestParameters: ownerRequest,
     });
     expect(updateResponseAsOwnerFailed.hadException).toEqual(true);
     expect(updateResponseAsOwnerFailed.errors[0].extensions).toEqual(
       expect.objectContaining({
-        errorType: "Unauthorized",
-        message: "Unauthorized on [name]"
-      })
+        errorType: 'Unauthorized',
+        message: 'Unauthorized on [name]',
+      }),
     );
     // update request should pass if the owner is only modifying the allowed fields
     const updateResponseAsOwner = vtlTemplate.render(updateResponseTemplate, {
       context: updateContextOwnerPass,
-      requestParameters: ownerRequest
+      requestParameters: ownerRequest,
     });
     expect(updateResponseAsOwner.hadException).toEqual(false);
     // update request should pass for admin user
     const updateResponseAsAdmin = vtlTemplate.render(updateResponseTemplate, {
       context: updateContext,
-      requestParameters: adminGroupRequest
+      requestParameters: adminGroupRequest,
     });
     expect(updateResponseAsAdmin.hadException).toEqual(false);
 
     // field read checks
     const readFieldContext: AppSyncVTLContext = {
       source: {
-        id: "001",
-        owner: "user1",
-        name: "nameSample",
-        ssn: "000111111"
-      }
+        id: '001',
+        owner: 'user1',
+        name: 'nameSample',
+        ssn: '000111111',
+      },
     };
-    ["name", "ssn"].forEach(field => {
+    ['name', 'ssn'].forEach((field) => {
       // expect owner to get denied on these fields
       const readFieldTemplate = out.resolvers[`Student.${field}.req.vtl`];
       const ownerReadResponse = vtlTemplate.render(readFieldTemplate, { context: readFieldContext, requestParameters: ownerRequest });
@@ -633,13 +620,13 @@ describe("@model field auth", () => {
       expect(adminReadResponse.hadException).toEqual(false);
     });
 
-    ["id", "email"].forEach(field => {
+    ['id', 'email'].forEach((field) => {
       // since the only two roles have access to these fields there are no field resolvers
       expect(out.resolvers?.[`Student.${field}.req.vtl`]).not.toBeDefined();
     });
   });
 
-  test("should allow setting name to null field", () => {
+  test('should allow setting name to null field', () => {
     const validSchema = `
       type Post @model @auth(rules: [{ allow: owner, operations: [create, read] }]) {
         id: ID @auth(rules: [{ allow: owner, operations: [create, read, update, delete] }])
@@ -651,38 +638,38 @@ describe("@model field auth", () => {
     expect(out).toBeDefined();
 
     // load vtl templates
-    const createPostTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
-    const updatePostTemplate = out.resolvers["Mutation.updatePost.auth.1.res.vtl"];
+    const createPostTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
+    const updatePostTemplate = out.resolvers['Mutation.updatePost.auth.1.res.vtl'];
 
     const createPostContext = {
       arguments: {
         input: {
-          id: "001",
-          name: "sample"
-        }
-      }
+          id: '001',
+          name: 'sample',
+        },
+      },
     };
     const createPostRequest = vtlTemplate.render(createPostTemplate, {
       context: createPostContext,
-      requestParameters: ownerRequest
+      requestParameters: ownerRequest,
     });
     expect(createPostRequest.hadException).toEqual(false);
 
     const updatePostContext = {
       result: {
-        id: "001",
+        id: '001',
         name: null,
-        owner: "user1"
-      }
+        owner: 'user1',
+      },
     };
     const updatePostRequest = vtlTemplate.render(updatePostTemplate, {
       context: updatePostContext,
-      requestParameters: ownerRequest
+      requestParameters: ownerRequest,
     });
     expect(updatePostRequest.hadException).toEqual(false);
   });
 
-  test("should allow owner to update", () => {
+  test('should allow owner to update', () => {
     const validSchema = `
     type Post @model @auth(rules: [{ allow: owner, operations: [create, update, read] }]) {
       id: ID!
@@ -694,79 +681,69 @@ describe("@model field auth", () => {
     expect(out).toBeDefined();
 
     // load vtl templates
-    const createPostTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
-    const updatePostTemplate = out.resolvers["Mutation.updatePost.auth.1.res.vtl"];
+    const createPostTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
+    const updatePostTemplate = out.resolvers['Mutation.updatePost.auth.1.res.vtl'];
 
     const createPostContext = {
       arguments: {
         input: {
-          id: "001",
-          name: "sample"
-        }
-      }
+          id: '001',
+          name: 'sample',
+        },
+      },
     };
     const createPostRequest = vtlTemplate.render(createPostTemplate, {
       context: createPostContext,
-      requestParameters: ownerRequest
+      requestParameters: ownerRequest,
     });
     expect(createPostRequest.hadException).toEqual(false);
 
     const updatePostContext = {
       result: {
-        id: "001",
-        name: "updated",
-        owner: "user1"
-      }
+        id: '001',
+        name: 'updated',
+        owner: 'user1',
+      },
     };
     const updatePostRequest = vtlTemplate.render(updatePostTemplate, {
       context: updatePostContext,
-      requestParameters: ownerRequest
+      requestParameters: ownerRequest,
     });
     expect(updatePostRequest.hadException).toEqual(false);
   });
 });
 
-describe("@model @primaryIndex @index auth", () => {
-  let vtlTemplate: VelocityTemplateSimulator;
+describe('@model @primaryIndex @index auth', () => {
   let transformer: GraphQLTransform;
-
-  const ownerRequest: AppSyncGraphQLExecutionContext = {
-    requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
-    jwt: getJWTToken(USER_POOL_ID, "user1", "user1@test.com"),
-    headers: {},
-    sourceIp: ""
-  };
 
   beforeEach(() => {
     const authConfig: AppSyncAuthConfiguration = {
       defaultAuthentication: {
-        authenticationType: "AMAZON_COGNITO_USER_POOLS"
+        authenticationType: 'AMAZON_COGNITO_USER_POOLS',
       },
-      additionalAuthenticationProviders: []
+      additionalAuthenticationProviders: [],
     };
     transformer = new GraphQLTransform({
       authConfig,
       featureFlags: {
         getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
-          if (name === "secondaryKeyAsGSI") {
+          if (name === 'secondaryKeyAsGSI') {
             return true;
           }
-          if (name === "useSubUsernameForDefaultIdentityClaim") {
+          if (name === 'useSubUsernameForDefaultIdentityClaim') {
             return true;
           }
           return defaultValue;
         }),
         getNumber: jest.fn(),
         getObject: jest.fn(),
-       
 
       },
-      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer(), new AuthTransformer()]
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer(), new AuthTransformer()],
     });
-    vtlTemplate = new VelocityTemplateSimulator({ authConfig });
   });
 
-  test("listX operations", () => {
+  test('listX operations', () => {
     const validSchema = `
     type FamilyMember @model @auth(rules: [
       { allow: owner, ownerField: "parent", operations: [read] },
@@ -786,36 +763,36 @@ describe("@model @primaryIndex @index auth", () => {
   });
 });
 
-describe("with identity claim feature flag disabled", () => {
-  describe("@model owner mutation checks", () => {
+describe('with identity claim feature flag disabled', () => {
+  describe('@model owner mutation checks', () => {
     let vtlTemplate: VelocityTemplateSimulator;
     let transformer: GraphQLTransform;
     const ownerRequest: AppSyncGraphQLExecutionContext = {
       requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
-      jwt: getJWTToken(USER_POOL_ID, "user1", "user1@test.com"),
+      jwt: getJWTToken(USER_POOL_ID, 'user1', 'user1@test.com'),
       headers: {},
-      sourceIp: ""
+      sourceIp: '',
     };
 
     beforeEach(() => {
       const authConfig: AppSyncAuthConfiguration = {
         defaultAuthentication: {
-          authenticationType: "AMAZON_COGNITO_USER_POOLS"
+          authenticationType: 'AMAZON_COGNITO_USER_POOLS',
         },
-        additionalAuthenticationProviders: []
+        additionalAuthenticationProviders: [],
       };
       transformer = new GraphQLTransform({
         authConfig,
         transformers: [new ModelTransformer(), new AuthTransformer()],
         featureFlags: {
           ...featureFlags,
-          ...{ getBoolean: () => false }
-        }
+          ...{ getBoolean: () => false },
+        },
       });
       vtlTemplate = new VelocityTemplateSimulator({ authConfig });
     });
 
-    test("implicit owner with default owner field", () => {
+    test('implicit owner with default owner field', () => {
       const validSchema = `
         type Post @model @auth(rules: [{ allow: owner }]) {
           id: ID!
@@ -827,68 +804,68 @@ describe("with identity claim feature flag disabled", () => {
       expect(out).toBeDefined();
       // create the owner type
       const ownerContext: AppSyncVTLContext = {
-        arguments: { input: { id: "001", title: "sample" } }
+        arguments: { input: { id: '001', title: 'sample' } },
       };
 
       // expect the query resolver to contain a filter for the owner
-      const queryTemplate = out.resolvers["Query.listPosts.auth.1.req.vtl"];
+      const queryTemplate = out.resolvers['Query.listPosts.auth.1.req.vtl'];
       const queryResponse = vtlTemplate.render(queryTemplate, { context: {}, requestParameters: ownerRequest });
       expect(queryResponse).toBeDefined();
       expect(queryResponse.stash.hasAuth).toEqual(true);
       expect(queryResponse.stash.authFilter).toEqual(
         expect.objectContaining({
-          or: [{ owner: { eq: "user1" } }]
-        })
+          or: [{ owner: { eq: 'user1' } }],
+        }),
       );
 
-      const createRequestTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
+      const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
       const createVTLRequest = vtlTemplate.render(createRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
       expect(createVTLRequest).toBeDefined();
       expect(createVTLRequest.stash.hasAuth).toEqual(true);
       expect(createVTLRequest.args).toBeDefined();
       expect(createVTLRequest.hadException).toEqual(false);
       // since we have an owner rule we expect the owner field to be defined in the argument input
-      expect(createVTLRequest.args.input.owner).toEqual("user1");
+      expect(createVTLRequest.args.input.owner).toEqual('user1');
 
-      const updateRequestTemplate = out.resolvers["Mutation.updatePost.auth.1.req.vtl"];
+      const updateRequestTemplate = out.resolvers['Mutation.updatePost.auth.1.req.vtl'];
       const updateVTLRequest = vtlTemplate.render(updateRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
       expect(updateVTLRequest).toBeDefined();
       // here we expect a get item payload to verify the owner making the update request is valid
       expect(updateVTLRequest.result).toEqual(
         expect.objectContaining({
-          key: { id: { S: "001" } },
-          operation: "GetItem",
-          version: "2018-05-29"
-        })
+          key: { id: { S: '001' } },
+          operation: 'GetItem',
+          version: '2018-05-29',
+        }),
       );
       // atm there is there is nothing in the stash yet
       expect(updateVTLRequest.stash).toEqual({});
-      const updateResponseTemplate = out.resolvers["Mutation.updatePost.auth.1.res.vtl"];
+      const updateResponseTemplate = out.resolvers['Mutation.updatePost.auth.1.res.vtl'];
       // response where the owner is indeed the owner
       const updateVTLResponse = vtlTemplate.render(updateResponseTemplate, {
-        context: { ...ownerContext, result: { id: "001", owner: "user1" } },
-        requestParameters: ownerRequest
+        context: { ...ownerContext, result: { id: '001', owner: 'user1' } },
+        requestParameters: ownerRequest,
       });
       expect(updateVTLResponse).toBeDefined();
       expect(updateVTLResponse.hadException).toEqual(false);
       expect(updateVTLResponse.stash.hasAuth).toEqual(true);
       // response where there is an error
       const updateVTLWithError = vtlTemplate.render(updateResponseTemplate, {
-        context: { ...ownerContext, result: { id: "001", owner: "user2" } },
-        requestParameters: ownerRequest
+        context: { ...ownerContext, result: { id: '001', owner: 'user2' } },
+        requestParameters: ownerRequest,
       });
       expect(updateVTLWithError).toBeDefined();
       expect(updateVTLWithError.hadException).toEqual(true);
       expect(updateVTLWithError.errors).toHaveLength(1);
       expect(updateVTLWithError.errors[0]).toEqual(
         expect.objectContaining({
-          errorType: "Unauthorized",
-          message: expect.stringContaining("Unauthorized on $util.unauthorized()")
-        })
+          errorType: 'Unauthorized',
+          message: expect.stringContaining('Unauthorized on $util.unauthorized()'),
+        }),
       );
     });
 
-    test("implicit owner with custom field", () => {
+    test("implicit owner with custom field doesn't get added", () => {
       const validSchema = `
         type Post @model @auth(rules: [{ allow: owner, ownerField: "editor" }]) {
           id: ID!
@@ -896,24 +873,10 @@ describe("with identity claim feature flag disabled", () => {
           createdAt: String
           updatedAt: String
         }`;
-      const out = transformer.transform(validSchema);
-      expect(out).toBeDefined();
-      // create context and request
-      const ownerContext: AppSyncVTLContext = {
-        arguments: { input: { id: "001", title: "sample" } }
-      };
-
-      const createRequestTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
-      const createVTLRequest = vtlTemplate.render(createRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
-      expect(createVTLRequest).toBeDefined();
-      expect(createVTLRequest.stash.hasAuth).toEqual(true);
-      expect(createVTLRequest.args).toBeDefined();
-      expect(createVTLRequest.hadException).toEqual(false);
-      // since we have an owner rule we expect the owner field to be defined in the argument input
-      expect(createVTLRequest.args.input.editor).toEqual("user1");
+      expect(() => transformer.transform(validSchema)).toThrowError(new TransformerContractError('ownerField "editor" is not defined in model Post.'));
     });
 
-    test("explicit owner with default field", () => {
+    test('explicit owner with default field', () => {
       const validSchema = `
         type Post @model @auth(rules: [{ allow: owner }]) {
           id: ID!
@@ -926,20 +889,20 @@ describe("with identity claim feature flag disabled", () => {
       expect(out).toBeDefined();
       // create context and request
       const ownerContext: AppSyncVTLContext = {
-        arguments: { input: { id: "001", title: "sample" } }
+        arguments: { input: { id: '001', title: 'sample' } },
       };
 
-      const createRequestTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
+      const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
       const createVTLRequest = vtlTemplate.render(createRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
       expect(createVTLRequest).toBeDefined();
       expect(createVTLRequest.stash.hasAuth).toEqual(true);
       expect(createVTLRequest.args).toBeDefined();
       expect(createVTLRequest.hadException).toEqual(false);
       // since we have an owner rule we expect the owner field to be defined in the argument input
-      expect(createVTLRequest.args.input.owner).toEqual("user1");
+      expect(createVTLRequest.args.input.owner).toEqual('user1');
     });
 
-    test("explicit owner with custom field", () => {
+    test('explicit owner with custom field', () => {
       const validSchema = `
         type Post @model @auth(rules: [{ allow: owner, ownerField: "editor" }]) {
           id: ID!
@@ -952,22 +915,22 @@ describe("with identity claim feature flag disabled", () => {
       expect(out).toBeDefined();
       // create context and request
       const ownerContext: AppSyncVTLContext = {
-        arguments: { input: { id: "001", title: "sample" } }
+        arguments: { input: { id: '001', title: 'sample' } },
       };
 
-      const createRequestTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
+      const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
       const createVTLRequest = vtlTemplate.render(createRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
       expect(createVTLRequest).toBeDefined();
       expect(createVTLRequest.stash.hasAuth).toEqual(true);
       expect(createVTLRequest.args).toBeDefined();
       expect(createVTLRequest.hadException).toEqual(false);
       // since we have an owner rule we expect the owner field to be defined in the argument input
-      expect(createVTLRequest.args.input.editor).toEqual("user1");
+      expect(createVTLRequest.args.input.editor).toEqual('user1');
 
-      const differentOwnerContext: AppSyncVTLContext = { arguments: { input: { id: "001", title: "sample", editor: "user2" } } };
+      const differentOwnerContext: AppSyncVTLContext = { arguments: { input: { id: '001', title: 'sample', editor: 'user2' } } };
       const createVTLRequestWithErrors = vtlTemplate.render(createRequestTemplate, {
         context: differentOwnerContext,
-        requestParameters: ownerRequest
+        requestParameters: ownerRequest,
       });
       expect(createVTLRequestWithErrors).toBeDefined();
       expect(createVTLRequestWithErrors.hadException).toEqual(true);
@@ -975,13 +938,13 @@ describe("with identity claim feature flag disabled", () => {
       // should fail since the owner in the input is different than what is in the
       expect(createVTLRequestWithErrors.errors[0]).toEqual(
         expect.objectContaining({
-          errorType: "Unauthorized",
-          message: expect.stringContaining("Unauthorized on $util.unauthorized()")
-        })
+          errorType: 'Unauthorized',
+          message: expect.stringContaining('Unauthorized on $util.unauthorized()'),
+        }),
       );
     });
 
-    test("explicit owner using a custom list field", () => {
+    test('explicit owner using a custom list field', () => {
       const validSchema = `
         type Post @model @auth(rules: [{ allow: owner, ownerField: "editors" }]) {
           id: ID!
@@ -994,10 +957,10 @@ describe("with identity claim feature flag disabled", () => {
       expect(out).toBeDefined();
       // create context and request
       const ownerContext: AppSyncVTLContext = {
-        arguments: { input: { id: "001", title: "sample" } }
+        arguments: { input: { id: '001', title: 'sample' } },
       };
 
-      const createRequestTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
+      const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
       expect(createRequestTemplate).toBeDefined();
       const createVTLRequest = vtlTemplate.render(createRequestTemplate, { context: ownerContext, requestParameters: ownerRequest });
       expect(createVTLRequest).toBeDefined();
@@ -1005,76 +968,76 @@ describe("with identity claim feature flag disabled", () => {
       expect(createVTLRequest.args).toBeDefined();
       expect(createVTLRequest.hadException).toEqual(false);
       // since we have an owner rule we expect the owner field to be defined in the argument input
-      expect(createVTLRequest.args.input.editors).toEqual(["user1"]);
+      expect(createVTLRequest.args.input.editors).toEqual(['user1']);
 
       // should fail if the list of users does not contain the currently signed user
       const failedCreateVTLRequest = vtlTemplate.render(createRequestTemplate, {
         context: {
-          arguments: { input: { id: "001", title: "sample", editors: ["user2"] } }
+          arguments: { input: { id: '001', title: 'sample', editors: ['user2'] } },
         },
-        requestParameters: ownerRequest
+        requestParameters: ownerRequest,
       });
       expect(failedCreateVTLRequest.hadException).toEqual(true);
       // should fail since the owner in the input is different than what is in the
       expect(failedCreateVTLRequest.errors[0]).toEqual(
         expect.objectContaining({
-          errorType: "Unauthorized",
-          message: expect.stringContaining("Unauthorized on $util.unauthorized()")
-        })
+          errorType: 'Unauthorized',
+          message: expect.stringContaining('Unauthorized on $util.unauthorized()'),
+        }),
       );
     });
   });
 
-  describe("@model operations", () => {
+  describe('@model operations', () => {
     let vtlTemplate: VelocityTemplateSimulator;
     let transformer: GraphQLTransform;
     const ownerRequest: AppSyncGraphQLExecutionContext = {
       requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
-      jwt: getJWTToken(USER_POOL_ID, "user1", "user1@test.com"),
+      jwt: getJWTToken(USER_POOL_ID, 'user1', 'user1@test.com'),
       headers: {},
-      sourceIp: ""
+      sourceIp: '',
     };
     const adminGroupRequest: AppSyncGraphQLExecutionContext = {
       requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
-      jwt: getJWTToken(USER_POOL_ID, "user2", "user2@test.com", ["admin"]),
+      jwt: getJWTToken(USER_POOL_ID, 'user2', 'user2@test.com', ['admin']),
       headers: {},
-      sourceIp: ""
+      sourceIp: '',
     };
     const editorGroupRequest: AppSyncGraphQLExecutionContext = {
       requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
-      jwt: getJWTToken(USER_POOL_ID, "user3", "user3@test.com", ["editor"]),
+      jwt: getJWTToken(USER_POOL_ID, 'user3', 'user3@test.com', ['editor']),
       headers: {},
-      sourceIp: ""
+      sourceIp: '',
     };
     const createPostInput = (owner?: string): AppSyncVTLContext => ({
       arguments: {
         input: {
-          id: "001",
-          name: "sample",
-          owner
-        }
-      }
+          id: '001',
+          name: 'sample',
+          owner,
+        },
+      },
     });
 
     beforeEach(() => {
       const authConfig: AppSyncAuthConfiguration = {
         defaultAuthentication: {
-          authenticationType: "AMAZON_COGNITO_USER_POOLS"
+          authenticationType: 'AMAZON_COGNITO_USER_POOLS',
         },
-        additionalAuthenticationProviders: []
+        additionalAuthenticationProviders: [],
       };
       transformer = new GraphQLTransform({
         authConfig,
         transformers: [new ModelTransformer(), new AuthTransformer()],
         featureFlags: {
           ...featureFlags,
-          ...{ getBoolean: () => false }
-        }
+          ...{ getBoolean: () => false },
+        },
       });
       vtlTemplate = new VelocityTemplateSimulator({ authConfig });
     });
 
-    test("explicit operations where create/delete restricted", () => {
+    test('explicit operations where create/delete restricted', () => {
       const validSchema = `
         type Post @model @auth(rules: [
           { allow: owner, operations: [create, read] },
@@ -1086,31 +1049,31 @@ describe("with identity claim feature flag disabled", () => {
       const out = transformer.transform(validSchema);
       expect(out).toBeDefined();
       // load vtl templates
-      const createRequestTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
-      const readRequestTemplate = out.resolvers["Query.listPosts.auth.1.req.vtl"];
-      const updateResponseTemplate = out.resolvers["Mutation.updatePost.auth.1.res.vtl"];
-      const deleteResponseTemplate = out.resolvers["Mutation.deletePost.auth.1.res.vtl"];
+      const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
+      const readRequestTemplate = out.resolvers['Query.listPosts.auth.1.req.vtl'];
+      const updateResponseTemplate = out.resolvers['Mutation.updatePost.auth.1.res.vtl'];
+      const deleteResponseTemplate = out.resolvers['Mutation.deletePost.auth.1.res.vtl'];
 
       // run create request as owner and admin
       // even though they are not the owner it will still pass as they one making the request is in the admin group
       const createRequestAsAdmin = vtlTemplate.render(createRequestTemplate, {
-        context: createPostInput("owner2"),
-        requestParameters: adminGroupRequest
+        context: createPostInput('owner2'),
+        requestParameters: adminGroupRequest,
       });
       expect(createRequestAsAdmin).toBeDefined();
       expect(createRequestAsAdmin.hadException).toEqual(false);
       expect(createRequestAsAdmin.stash.hasAuth).toEqual(true);
       // run the create request as owner should fail if the input is different the signed in owner
       const createRequestAsOwner = vtlTemplate.render(createRequestTemplate, {
-        context: createPostInput("user2"),
-        requestParameters: ownerRequest
+        context: createPostInput('user2'),
+        requestParameters: ownerRequest,
       });
       expect(createRequestAsOwner.hadException).toEqual(true);
       expect(createRequestAsOwner.errors[0]).toEqual(
         expect.objectContaining({
-          errorType: "Unauthorized",
-          message: expect.stringContaining("Unauthorized on $util.unauthorized()")
-        })
+          errorType: 'Unauthorized',
+          message: expect.stringContaining('Unauthorized on $util.unauthorized()'),
+        }),
       );
       // read request for admin should not contain the filter
       const readRequestAsAdmin = vtlTemplate.render(readRequestTemplate, { context: {}, requestParameters: adminGroupRequest });
@@ -1120,38 +1083,38 @@ describe("with identity claim feature flag disabled", () => {
       expect(readRequestAsOwner.stash.hasAuth).toEqual(true);
       expect(readRequestAsOwner.stash.authFilter).toEqual(
         expect.objectContaining({
-          or: [{ owner: { eq: "user1" } }]
-        })
+          or: [{ owner: { eq: 'user1' } }],
+        }),
       );
-      const ddbResponseResult: AppSyncVTLContext = { result: { id: "001", title: "sample", owner: "user1" } };
+      const ddbResponseResult: AppSyncVTLContext = { result: { id: '001', title: 'sample', owner: 'user1' } };
       // update should pass for admin even if they are not the owner of the record
       const updateResponseAsAdmin = vtlTemplate.render(updateResponseTemplate, {
         context: ddbResponseResult,
-        requestParameters: adminGroupRequest
+        requestParameters: adminGroupRequest,
       });
       expect(updateResponseAsAdmin.hadException).toEqual(false);
       expect(updateResponseAsAdmin.stash.hasAuth).toEqual(true);
       // update should fail for owner even though they are the owner of the record
       const updateResponseAsOwner = vtlTemplate.render(updateResponseTemplate, {
         context: ddbResponseResult,
-        requestParameters: ownerRequest
+        requestParameters: ownerRequest,
       });
       expect(updateResponseAsOwner.hadException).toEqual(true);
       // delete should pass for admin even if they are not the owner of the record
       const deleteResponseAsAdmin = vtlTemplate.render(deleteResponseTemplate, {
         context: ddbResponseResult,
-        requestParameters: adminGroupRequest
+        requestParameters: adminGroupRequest,
       });
       expect(deleteResponseAsAdmin.hadException).toEqual(false);
       // delete should fail for owner even though they are the owner of the record
       const deleteResponseAsOwner = vtlTemplate.render(deleteResponseTemplate, {
         context: ddbResponseResult,
-        requestParameters: ownerRequest
+        requestParameters: ownerRequest,
       });
       expect(deleteResponseAsOwner.hadException).toEqual(true);
     });
 
-    test("owner restricts create/read and group restricts read/update/delete", () => {
+    test('owner restricts create/read and group restricts read/update/delete', () => {
       // NOTE: this means that you can only create a record for the same owner
       // you can't create a record for other owners even if your in the editor group
       const validSchema = `
@@ -1165,15 +1128,15 @@ describe("with identity claim feature flag disabled", () => {
       `;
       const out = transformer.transform(validSchema);
       // load vtl templates
-      const createRequestTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
-      const readRequestTemplate = out.resolvers["Query.listPosts.auth.1.req.vtl"];
-      const updateResponseTemplate = out.resolvers["Mutation.updatePost.auth.1.res.vtl"];
-      const deleteResponseTemplate = out.resolvers["Mutation.deletePost.auth.1.res.vtl"];
+      const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
+      const readRequestTemplate = out.resolvers['Query.listPosts.auth.1.req.vtl'];
+      const updateResponseTemplate = out.resolvers['Mutation.updatePost.auth.1.res.vtl'];
+      const deleteResponseTemplate = out.resolvers['Mutation.deletePost.auth.1.res.vtl'];
 
       // check that a editor member can't create a post under another owner
       const createPostAsEditor = vtlTemplate.render(createRequestTemplate, {
-        context: createPostInput("user1"),
-        requestParameters: editorGroupRequest
+        context: createPostInput('user1'),
+        requestParameters: editorGroupRequest,
       });
       expect(createPostAsEditor.hadException).toEqual(true);
       // check that editor can read posts with no filter
@@ -1185,34 +1148,34 @@ describe("with identity claim feature flag disabled", () => {
       expect(readPostsAsOwner.hadException).toEqual(false);
       expect(readPostsAsOwner.stash.authFilter).toEqual(
         expect.objectContaining({
-          or: [{ owner: { eq: "user1" } }]
-        })
+          or: [{ owner: { eq: 'user1' } }],
+        }),
       );
       // expect owner can't run update or delete
       const updateResponseAsOwner = vtlTemplate.render(updateResponseTemplate, {
-        context: createPostInput("user1"),
-        requestParameters: ownerRequest
+        context: createPostInput('user1'),
+        requestParameters: ownerRequest,
       });
       expect(updateResponseAsOwner.hadException).toEqual(true);
       const deleteResponseAsOwner = vtlTemplate.render(deleteResponseTemplate, {
-        context: createPostInput("user1"),
-        requestParameters: ownerRequest
+        context: createPostInput('user1'),
+        requestParameters: ownerRequest,
       });
       expect(deleteResponseAsOwner.hadException).toEqual(true);
       // expect editor to be able to run update and delete
       const updateResponseAsEditor = vtlTemplate.render(updateResponseTemplate, {
-        context: createPostInput("user1"),
-        requestParameters: editorGroupRequest
+        context: createPostInput('user1'),
+        requestParameters: editorGroupRequest,
       });
       expect(updateResponseAsEditor.hadException).toEqual(false);
       const deleteResponseAsEditor = vtlTemplate.render(deleteResponseTemplate, {
-        context: createPostInput("user1"),
-        requestParameters: editorGroupRequest
+        context: createPostInput('user1'),
+        requestParameters: editorGroupRequest,
       });
       expect(deleteResponseAsEditor.hadException).toEqual(false);
     });
 
-    test("explicit operations where update restricted", () => {
+    test('explicit operations where update restricted', () => {
       const validSchema = `
         type Post @model @auth(rules: [
           { allow: owner, operations: [create, read, delete] },
@@ -1224,21 +1187,21 @@ describe("with identity claim feature flag disabled", () => {
       const out = transformer.transform(validSchema);
       expect(out).toBeDefined();
       // load vtl templates
-      const createRequestTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
-      const readRequestTemplate = out.resolvers["Query.listPosts.auth.1.req.vtl"];
-      const updateResponseTemplate = out.resolvers["Mutation.updatePost.auth.1.res.vtl"];
-      const deleteResponseTemplate = out.resolvers["Mutation.deletePost.auth.1.res.vtl"];
+      const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
+      const readRequestTemplate = out.resolvers['Query.listPosts.auth.1.req.vtl'];
+      const updateResponseTemplate = out.resolvers['Mutation.updatePost.auth.1.res.vtl'];
+      const deleteResponseTemplate = out.resolvers['Mutation.deletePost.auth.1.res.vtl'];
 
       // run the create request as owner should fail if the input is different the signed in owner
       const createRequestAsNonOwner = vtlTemplate.render(createRequestTemplate, {
-        context: createPostInput("user2"),
-        requestParameters: ownerRequest
+        context: createPostInput('user2'),
+        requestParameters: ownerRequest,
       });
       expect(createRequestAsNonOwner.hadException).toEqual(true);
 
       const createRequestAsOwner = vtlTemplate.render(createRequestTemplate, {
-        context: createPostInput("user1"),
-        requestParameters: ownerRequest
+        context: createPostInput('user1'),
+        requestParameters: ownerRequest,
       });
       expect(createRequestAsOwner.hadException).toEqual(false);
 
@@ -1247,95 +1210,95 @@ describe("with identity claim feature flag disabled", () => {
       expect(readRequestAsOwner.stash.hasAuth).toEqual(true);
       expect(readRequestAsOwner.stash.authFilter).toEqual(
         expect.objectContaining({
-          or: [{ owner: { eq: "user1" } }]
-        })
+          or: [{ owner: { eq: 'user1' } }],
+        }),
       );
 
       // read should have filter
       const readRequestAsNonOwner = vtlTemplate.render(readRequestTemplate, { context: {}, requestParameters: adminGroupRequest });
       expect(readRequestAsNonOwner.stash.authFilter).toEqual(
         expect.objectContaining({
-          or: [{ owner: { eq: "user2" } }]
-        })
+          or: [{ owner: { eq: 'user2' } }],
+        }),
       );
 
       // update should fail for owner
       const ddbUpdateResult: AppSyncVTLContext = {
-        result: { id: "001", name: "sample", owner: "user1" },
+        result: { id: '001', name: 'sample', owner: 'user1' },
         arguments: {
           input: {
-            id: "001",
-            name: "sample"
-          }
-        }
+            id: '001',
+            name: 'sample',
+          },
+        },
       };
       const updateResponseAsOwner = vtlTemplate.render(updateResponseTemplate, {
         context: ddbUpdateResult,
-        requestParameters: ownerRequest
+        requestParameters: ownerRequest,
       });
       expect(updateResponseAsOwner.hadException).toEqual(true);
 
       // update should fail for NON owner
       const updateResponseAsNonOwner = vtlTemplate.render(updateResponseTemplate, {
         context: ddbUpdateResult,
-        requestParameters: adminGroupRequest
+        requestParameters: adminGroupRequest,
       });
       expect(updateResponseAsNonOwner.hadException).toEqual(true);
 
       // delete should fail for non owner
       const ddbDeleteResult: AppSyncVTLContext = {
-        result: { id: "001", name: "sample", owner: "user1" }
+        result: { id: '001', name: 'sample', owner: 'user1' },
       };
       const deleteResponseAsNonOwner = vtlTemplate.render(deleteResponseTemplate, {
         context: ddbDeleteResult,
-        requestParameters: adminGroupRequest
+        requestParameters: adminGroupRequest,
       });
       expect(deleteResponseAsNonOwner.hadException).toEqual(true);
 
       // delete should pass for owner
       const deleteResponseAsOwner = vtlTemplate.render(deleteResponseTemplate, {
         context: ddbDeleteResult,
-        requestParameters: ownerRequest
+        requestParameters: ownerRequest,
       });
       expect(deleteResponseAsOwner.hadException).toEqual(false);
       expect(deleteResponseAsOwner.stash.hasAuth).toEqual(true);
     });
   });
 
-  describe("@model field auth", () => {
+  describe('@model field auth', () => {
     let vtlTemplate: VelocityTemplateSimulator;
     let transformer: GraphQLTransform;
     const ownerRequest: AppSyncGraphQLExecutionContext = {
       requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
-      jwt: getJWTToken(USER_POOL_ID, "user1", "user1@test.com"),
+      jwt: getJWTToken(USER_POOL_ID, 'user1', 'user1@test.com'),
       headers: {},
-      sourceIp: ""
+      sourceIp: '',
     };
     const adminGroupRequest: AppSyncGraphQLExecutionContext = {
       requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
-      jwt: getJWTToken(USER_POOL_ID, "user2", "user2@test.com", ["admin"]),
+      jwt: getJWTToken(USER_POOL_ID, 'user2', 'user2@test.com', ['admin']),
       headers: {},
-      sourceIp: ""
+      sourceIp: '',
     };
     beforeEach(() => {
       const authConfig: AppSyncAuthConfiguration = {
         defaultAuthentication: {
-          authenticationType: "AMAZON_COGNITO_USER_POOLS"
+          authenticationType: 'AMAZON_COGNITO_USER_POOLS',
         },
-        additionalAuthenticationProviders: []
+        additionalAuthenticationProviders: [],
       };
       transformer = new GraphQLTransform({
         authConfig,
         transformers: [new ModelTransformer(), new AuthTransformer()],
         featureFlags: {
           ...featureFlags,
-          ...{ getBoolean: () => false }
-        }
+          ...{ getBoolean: () => false },
+        },
       });
       vtlTemplate = new VelocityTemplateSimulator({ authConfig });
     });
 
-    test("object level group auth + field level owner auth", () => {
+    test('object level group auth + field level owner auth', () => {
       const validSchema = `
         type Student @model @auth(rules:[{ allow: groups, groups: ["admin"] }]) {
           id: ID @auth(rules: [{ allow: groups, groups: ["admin"] }, { allow: owner, operations: [read, update] }])
@@ -1344,66 +1307,66 @@ describe("with identity claim feature flag disabled", () => {
           ssn: String
         }`;
       const out = transformer.transform(validSchema);
-      const updateResponseTemplate = out.resolvers["Mutation.updateStudent.auth.1.res.vtl"];
+      const updateResponseTemplate = out.resolvers['Mutation.updateStudent.auth.1.res.vtl'];
       const updateContext: AppSyncVTLContext = {
         arguments: {
           input: {
-            id: "001",
-            email: "myNewEmail",
-            name: "newName"
-          }
+            id: '001',
+            email: 'myNewEmail',
+            name: 'newName',
+          },
         },
         result: {
-          id: "001",
-          email: "user1@test.com",
+          id: '001',
+          email: 'user1@test.com',
           name: "samplename", // eslint-disable-line
-          owner: "user1"
-        }
+          owner: 'user1',
+        },
       };
       const updateContextOwnerPass: AppSyncVTLContext = {
         ...updateContext,
         arguments: {
           input: {
-            id: "001",
-            email: "newEmail@user1.com"
-          }
-        }
+            id: '001',
+            email: 'newEmail@user1.com',
+          },
+        },
       };
       // update request should fail
       const updateResponseAsOwnerFailed = vtlTemplate.render(updateResponseTemplate, {
         context: updateContext,
-        requestParameters: ownerRequest
+        requestParameters: ownerRequest,
       });
       expect(updateResponseAsOwnerFailed.hadException).toEqual(true);
       expect(updateResponseAsOwnerFailed.errors[0].extensions).toEqual(
         expect.objectContaining({
-          errorType: "Unauthorized",
-          message: "Unauthorized on [name]"
-        })
+          errorType: 'Unauthorized',
+          message: 'Unauthorized on [name]',
+        }),
       );
       // update request should pass if the owner is only modifying the allowed fields
       const updateResponseAsOwner = vtlTemplate.render(updateResponseTemplate, {
         context: updateContextOwnerPass,
-        requestParameters: ownerRequest
+        requestParameters: ownerRequest,
       });
       expect(updateResponseAsOwner.hadException).toEqual(false);
       // update request should pass for admin user
       const updateResponseAsAdmin = vtlTemplate.render(updateResponseTemplate, {
         context: updateContext,
-        requestParameters: adminGroupRequest
+        requestParameters: adminGroupRequest,
       });
       expect(updateResponseAsAdmin.hadException).toEqual(false);
 
       // field read checks
       const readFieldContext: AppSyncVTLContext = {
         source: {
-          id: "001",
-          owner: "user1",
-          name: "nameSample",
-          ssn: "000111111"
-        }
+          id: '001',
+          owner: 'user1',
+          name: 'nameSample',
+          ssn: '000111111',
+        },
       };
-      ["name", "ssn"].forEach(field => {
+      ['name', 'ssn'].forEach((field) => {
         // expect owner to get denied on these fields
         const readFieldTemplate = out.resolvers[`Student.${field}.req.vtl`];
         const ownerReadResponse = vtlTemplate.render(readFieldTemplate, { context: readFieldContext, requestParameters: ownerRequest });
@@ -1411,18 +1374,18 @@ describe("with identity claim feature flag disabled", () => {
         // expect admin to be allowed
         const adminReadResponse = vtlTemplate.render(readFieldTemplate, {
           context: readFieldContext,
-          requestParameters: adminGroupRequest
+          requestParameters: adminGroupRequest,
         });
         expect(adminReadResponse.hadException).toEqual(false);
       });
 
-      ["id", "email"].forEach(field => {
+      ['id', 'email'].forEach((field) => {
         // since the only two roles have access to these fields there are no field resolvers
         expect(out.resolvers?.[`Student.${field}.req.vtl`]).not.toBeDefined();
       });
     });
 
-    test("should allow setting name to null field", () => {
+    test('should allow setting name to null field', () => {
       const validSchema = `
         type Post @model @auth(rules: [{ allow: owner, operations: [create, read] }]) {
           id: ID @auth(rules: [{ allow: owner, operations: [create, read, update, delete] }])
@@ -1434,38 +1397,38 @@ describe("with identity claim feature flag disabled", () => {
       expect(out).toBeDefined();
 
       // load vtl templates
-      const createPostTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
-      const updatePostTemplate = out.resolvers["Mutation.updatePost.auth.1.res.vtl"];
+      const createPostTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
+      const updatePostTemplate = out.resolvers['Mutation.updatePost.auth.1.res.vtl'];
 
       const createPostContext = {
         arguments: {
           input: {
-            id: "001",
-            name: "sample"
-          }
-        }
+            id: '001',
+            name: 'sample',
+          },
+        },
       };
       const createPostRequest = vtlTemplate.render(createPostTemplate, {
         context: createPostContext,
-        requestParameters: ownerRequest
+        requestParameters: ownerRequest,
       });
       expect(createPostRequest.hadException).toEqual(false);
 
       const updatePostContext = {
         result: {
-          id: "001",
+          id: '001',
           name: null,
-          owner: "user1"
-        }
+          owner: 'user1',
+        },
       };
       const updatePostRequest = vtlTemplate.render(updatePostTemplate, {
         context: updatePostContext,
-        requestParameters: ownerRequest
+        requestParameters: ownerRequest,
       });
       expect(updatePostRequest.hadException).toEqual(false);
     });
 
-    test("should allow owner to update", () => {
+    test('should allow owner to update', () => {
       const validSchema = `
       type Post @model @auth(rules: [{ allow: owner, operations: [create, update, read] }]) {
         id: ID!
@@ -1477,79 +1440,78 @@ describe("with identity claim feature flag disabled", () => {
       expect(out).toBeDefined();
 
       // load vtl templates
-      const createPostTemplate = out.resolvers["Mutation.createPost.auth.1.req.vtl"];
-      const updatePostTemplate = out.resolvers["Mutation.updatePost.auth.1.res.vtl"];
+      const createPostTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
+      const updatePostTemplate = out.resolvers['Mutation.updatePost.auth.1.res.vtl'];
 
       const createPostContext = {
         arguments: {
           input: {
-            id: "001",
-            name: "sample"
-          }
-        }
+            id: '001',
+            name: 'sample',
+          },
+        },
       };
       const createPostRequest = vtlTemplate.render(createPostTemplate, {
         context: createPostContext,
-        requestParameters: ownerRequest
+        requestParameters: ownerRequest,
       });
       expect(createPostRequest.hadException).toEqual(false);
 
       const updatePostContext = {
         result: {
-          id: "001",
-          name: "updated",
-          owner: "user1"
-        }
+          id: '001',
+          name: 'updated',
+          owner: 'user1',
+        },
       };
       const updatePostRequest = vtlTemplate.render(updatePostTemplate, {
         context: updatePostContext,
-        requestParameters: ownerRequest
+        requestParameters: ownerRequest,
       });
       expect(updatePostRequest.hadException).toEqual(false);
     });
   });
 
-  describe("@model @primaryIndex @index auth", () => {
+  describe('@model @primaryIndex @index auth', () => {
     let vtlTemplate: VelocityTemplateSimulator;
     let transformer: GraphQLTransform;
 
     const ownerRequest: AppSyncGraphQLExecutionContext = {
       requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
-      jwt: getJWTToken(USER_POOL_ID, "user1", "user1@test.com"),
+      jwt: getJWTToken(USER_POOL_ID, 'user1', 'user1@test.com'),
       headers: {},
-      sourceIp: ""
+      sourceIp: '',
     };
 
     beforeEach(() => {
       const authConfig: AppSyncAuthConfiguration = {
         defaultAuthentication: {
-          authenticationType: "AMAZON_COGNITO_USER_POOLS"
+          authenticationType: 'AMAZON_COGNITO_USER_POOLS',
         },
-        additionalAuthenticationProviders: []
+        additionalAuthenticationProviders: [],
       };
       transformer = new GraphQLTransform({
         authConfig,
         featureFlags: {
           getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
-            if (name === "secondaryKeyAsGSI") {
+            if (name === 'secondaryKeyAsGSI') {
               return true;
             }
-            if (name === "useSubUsernameForDefaultIdentityClaim") {
+            if (name === 'useSubUsernameForDefaultIdentityClaim') {
               return false;
             }
             return defaultValue;
           }),
           getNumber: jest.fn(),
           getObject: jest.fn(),
-         
 
         },
-        transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer(), new AuthTransformer()]
+        transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer(), new AuthTransformer()],
       });
       vtlTemplate = new VelocityTemplateSimulator({ authConfig });
     });
 
-    test("listX operations", () => {
+    test('listX operations', () => {
       const validSchema = `
       type FamilyMember @model @auth(rules: [
         { allow: owner, ownerField: "parent", operations: [read] },
@@ -1565,20 +1527,20 @@ describe("with identity claim feature flag disabled", () => {
       expect(out).toBeDefined();
 
       // should expect no errors and there should be an auth filter
-      const listAuthRequestTemplate = out.resolvers["Query.listFamilyMembers.auth.1.req.vtl"];
+      const listAuthRequestTemplate = out.resolvers['Query.listFamilyMembers.auth.1.req.vtl'];
       expect(listAuthRequestTemplate).toBeDefined();
       let listAuthVTLRequest = vtlTemplate.render(listAuthRequestTemplate, {
         context: {},
-        requestParameters: ownerRequest
+        requestParameters: ownerRequest,
       });
       expect(listAuthVTLRequest.hadException).toEqual(false);
       expect(listAuthVTLRequest.stash.authFilter).toEqual(
         expect.objectContaining({
           or: expect.arrayContaining([
-            expect.objectContaining({ child: { eq: ownerRequest.jwt["cognito:username"] } }),
-            expect.objectContaining({ parent: { eq: ownerRequest.jwt["cognito:username"] } })
-          ])
-        })
+            expect.objectContaining({ child: { eq: ownerRequest.jwt['cognito:username'] } }),
+            expect.objectContaining({ parent: { eq: ownerRequest.jwt['cognito:username'] } }),
+          ]),
+        }),
       );
 
       // should still change model query expression if the partition key is provided
@@ -1586,23 +1548,23 @@ describe("with identity claim feature flag disabled", () => {
       listAuthVTLRequest = vtlTemplate.render(listAuthRequestTemplate, {
         context: {
           arguments: {
-            parent: "user10"
+            parent: 'user10',
           },
           stash: {
             modelQueryExpression: {
-              expression: "#parent = :parent",
+              expression: '#parent = :parent',
               expressionNames: {
-                "#parent": "parent"
+                '#parent': 'parent',
               },
               expressionValues: {
-                ":parent": {
-                  S: "$ctx.args.parent"
-                }
-              }
-            }
-          }
+                ':parent': {
+                  S: '$ctx.args.parent',
+                },
+              },
+            },
+          },
         },
-        requestParameters: ownerRequest
+        requestParameters: ownerRequest,
       });
       expect(listAuthVTLRequest.hadException).toEqual(false);
       expect(listAuthVTLRequest.stash.authFilter).not.toBeDefined();


### PR DESCRIPTION
A new error is raised when trying to add owner fields not defined in the schema to improve developer experience, be consistent with the docs and other developer experience features.

BREAKING CHANGE: 🧨  No implicit owner fields for models

The reasons to support this changes can be found in #957

✅ Closes: #957

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

A new error is raised when trying to add owner fields not defined in the schema to improve developer experience, be consistent with the docs and other developer experience features. 


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Closes #957 
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
`yarn test` passes with modified tests and custom app with the following schema:
```graphql
type Invoice
  @model
  @auth(
    rules: [
      {
        allow: owner
        ownerField: "storeID"
        operations: [create, read, update, delete]
      }
      {
        allow: owner
        ownerField: "customerID"
        operations: [create, read, update, delete]
      }
    ]
  ) {
  id: ID!
  items: [String]
  storeID: ID!
  # note bad capitalization for "customerID"
  customerId: ID!
}
```

`amplify-dev api gql-compile` produces the following error message:
![image](https://user-images.githubusercontent.com/66692533/204369296-f474cd05-9b8f-4ae6-963a-bb71087b4a74.png)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
