### PR TITLE
feat: add utils for parameter store interactions

### DIFF
--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -83,6 +83,7 @@
     "@aws-cdk/custom-resources": "~1.172.0",
     "@aws-cdk/cx-api": "~1.172.0",
     "@aws-cdk/region-info": "~1.172.0",
+    "aws-sdk": "^2.1113.0",
     "@graphql-tools/merge": "^6.0.18",
     "@octokit/rest": "^18.0.9",
     "chalk": "^4.1.1",

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/rds-secrets/ssmClient.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/rds-secrets/ssmClient.test.ts
@@ -1,0 +1,53 @@
+import { $TSAny, $TSContext } from 'amplify-cli-core';
+import { SSMClient } from '../../../../../provider-utils/awscloudformation/utils/rds-secrets/ssmClient';
+import aws from 'aws-sdk';
+
+const mockPutParameter = jest.fn(({ Name, Value, Type, Overwrite }) => {
+  return {
+    promise: () => {},
+  };
+});
+
+jest.mock('aws-sdk', () => {
+  return {
+    config: {
+      update() {
+        return {};
+      },
+    },
+    SSM: jest.fn(() => {
+      return {
+        putParameter: mockPutParameter
+      };
+    }),
+  };
+});
+
+describe('SSM client configuration', () => {
+  const mockContext = {
+    amplify: {
+      invokePluginMethod: jest.fn().mockResolvedValue({ client: new aws.SSM()})
+    }
+  } as $TSAny as $TSContext;
+
+  test('able to get the configured SSM instance via provider plugin', async () => {
+    const ssmClient = await SSMClient.getInstance(mockContext);
+    expect(ssmClient).toBeDefined();
+    expect(mockContext.amplify.invokePluginMethod).toBeCalledTimes(1);
+    expect(mockContext.amplify.invokePluginMethod).toBeCalledWith(mockContext, 'awscloudformation', undefined, 'getConfiguredSSMClient', [mockContext]);
+  });
+
+  test('able to set the secret value', async () => {
+    const ssmClient = await SSMClient.getInstance(mockContext);
+    const secretName = 'mock-test-secret-name';
+    const secretValue = 'mock-test-secret-value';
+    
+    ssmClient.setSecret(secretName, secretValue);
+    expect(mockPutParameter).toBeCalledWith({
+      Name: secretName,
+      Overwrite: true,
+      Type: 'SecureString',
+      Value: secretValue
+    });
+  });
+});

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/rds-secrets/ssmClient.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/rds-secrets/ssmClient.test.ts
@@ -2,11 +2,12 @@ import { $TSAny, $TSContext } from 'amplify-cli-core';
 import { SSMClient } from '../../../../../provider-utils/awscloudformation/utils/rds-secrets/ssmClient';
 import aws from 'aws-sdk';
 
-const mockPutParameter = jest.fn(({ Name, Value, Type, Overwrite }) => {
-  return {
-    promise: () => {},
-  };
-});
+const secretName = 'mock-test-secret-name';
+const secretValue = 'mock-test-secret-value';
+const mockPutParameter = jest.fn(({ Name, Value, Type, Overwrite }) => { return { promise: () => {} }; });
+const mockDeleteParameter = jest.fn(({ Name }) => { return { promise: () => {} }; });
+const mockDeleteParameters = jest.fn(({ Names }) => { return { promise: () => {} }; });
+const mockGetParameters = jest.fn(({ Names }) => { return { promise: () => Promise.resolve({ Parameters: [{ Name: secretName, Value: secretValue }] }) }; });
 
 jest.mock('aws-sdk', () => {
   return {
@@ -17,7 +18,10 @@ jest.mock('aws-sdk', () => {
     },
     SSM: jest.fn(() => {
       return {
-        putParameter: mockPutParameter
+        putParameter: mockPutParameter,
+        deleteParameter: mockDeleteParameter,
+        deleteParameters: mockDeleteParameters,
+        getParameters: mockGetParameters
       };
     }),
   };
@@ -39,8 +43,6 @@ describe('SSM client configuration', () => {
 
   test('able to set the secret value', async () => {
     const ssmClient = await SSMClient.getInstance(mockContext);
-    const secretName = 'mock-test-secret-name';
-    const secretValue = 'mock-test-secret-value';
     
     ssmClient.setSecret(secretName, secretValue);
     expect(mockPutParameter).toBeCalledWith({
@@ -48,6 +50,33 @@ describe('SSM client configuration', () => {
       Overwrite: true,
       Type: 'SecureString',
       Value: secretValue
+    });
+  });
+
+  test('able to get the secret value', async () => {
+    const ssmClient = await SSMClient.getInstance(mockContext);
+    const result = await ssmClient.getSecrets([secretName]);
+
+    expect(mockGetParameters).toBeCalledWith({
+      Names: [secretName],
+      WithDecryption: true
+    });
+    expect(result).toEqual([{"secretName": secretName, "secretValue": secretValue}]);
+  });
+
+  test('able to delete the secret', async () => {
+    const ssmClient = await SSMClient.getInstance(mockContext);
+    ssmClient.deleteSecret(secretName);
+    expect(mockDeleteParameter).toBeCalledWith({
+      Name: secretName
+    });
+  });
+
+  test('able to delete multiple secrets', async () => {
+    const ssmClient = await SSMClient.getInstance(mockContext);
+    ssmClient.deleteSecrets([secretName]);
+    expect(mockDeleteParameters).toBeCalledWith({
+      Names: [secretName]
     });
   });
 });

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-secrets/ssmClient.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-secrets/ssmClient.ts
@@ -1,0 +1,115 @@
+import { $TSAny, $TSContext } from 'amplify-cli-core';
+import aws from 'aws-sdk';
+
+/**
+ *  SSM client provider for AWS SDK calls
+ */
+export class SSMClient {
+  private static instance: SSMClient;
+
+  static getInstance = async (context: $TSContext): Promise<SSMClient> => {
+    if (!SSMClient?.instance) {
+      SSMClient.instance = new SSMClient(await getSSMClient(context));
+    }
+    return SSMClient.instance;
+  };
+
+  private constructor(private readonly ssmClient: aws.SSM) {}
+
+  /**
+   * Returns a list of secret name value pairs
+   */
+  getSecrets = async (secretNames: string[]): Promise<$TSAny> => {
+    if (!secretNames || secretNames?.length === 0) {
+      return [];
+    }
+    const result = await this.ssmClient
+      .getParameters({
+        Names: secretNames,
+        WithDecryption: true,
+      })
+      .promise();
+
+    return result?.Parameters?.map(({ Name, Value }) => ({ secretName: Name, secretValue: Value }));
+  };
+
+  /**
+   * Returns all secret names under a path. Does NOT decrypt any secrets
+   */
+  getSecretNamesByPath = async (secretPath: string): Promise<string[]> => {
+    let nextToken: string|undefined;
+    const secretNames: string[] = [];
+    do {
+      const result = await this.ssmClient
+        .getParametersByPath({
+          Path: secretPath,
+          MaxResults: 10,
+          ParameterFilters: [
+            {
+              Key: 'Type',
+              Option: 'Equals',
+              Values: ['SecureString'],
+            },
+          ],
+          NextToken: nextToken
+        })
+        .promise();
+      secretNames.push(...result?.Parameters?.map(param => param?.Name));
+      nextToken = result?.NextToken;
+    } while (nextToken);
+    return secretNames;
+  };
+
+  /**
+   * Sets the given secretName to the secretValue. If secretName is already present, it is overwritten.
+   */
+  setSecret = async (secretName: string, secretValue: string): Promise<void> => {
+    await this.ssmClient
+      .putParameter({
+        Name: secretName,
+        Value: secretValue,
+        Type: 'SecureString',
+        Overwrite: true,
+      })
+      .promise();
+  };
+
+  /**
+   * Deletes secretName. If it already doesn't exist, this is treated as success. All other errors will throw.
+   */
+  deleteSecret = async (secretName: string): Promise<void> => {
+    await this.ssmClient
+      .deleteParameter({
+        Name: secretName,
+      })
+      .promise()
+      .catch(err => {
+        if (err?.code !== 'ParameterNotFound') {
+          // if the value didn't exist in the first place, consider it deleted
+          throw err;
+        }
+      });
+  };
+
+  /**
+   * Deletes all secrets in secretNames.If secret doesn't exist, this is treated as success. All other errors will throw.
+   */
+  deleteSecrets = async (secretNames: string[]): Promise<void> => {
+    try {
+      await this.ssmClient.deleteParameters({ Names: secretNames }).promise();
+    } catch (err) {
+      // if the value didn't exist in the first place, consider it deleted
+      if (err?.code !== 'ParameterNotFound') {
+        throw err;
+      }
+    }
+  };
+}
+
+// The Provider plugin holds all the configured service clients. Fetch from there.
+const getSSMClient = async (context: $TSContext): Promise<aws.SSM> => {
+  const { client } = await context.amplify.invokePluginMethod(context, 'awscloudformation', undefined, 'getConfiguredSSMClient', [
+    context,
+  ]) as $TSAny;
+  return client as aws.SSM;
+};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds utility methods to be used to store DB connection secrets in AWS SSM managed parameter store.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Added unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
