### PR TITLE
Javascript Resolver Support for overrides

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/graphql-v2/custom-slot-js-resolver.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/graphql-v2/custom-slot-js-resolver.test.ts
@@ -1,0 +1,127 @@
+import {
+  initJSProjectWithProfile,
+  deleteProject,
+  amplifyPush,
+  addApiWithBlankSchema,
+  updateApiSchema,
+  createNewProjectDir,
+  deleteProjectDir,
+  getProjectMeta,
+} from 'amplify-category-api-e2e-core';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
+import gql from 'graphql-tag';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+// to deal with subscriptions in node env
+(global as any).WebSocket = require('ws');
+
+const projectName = 'jsslotoverride';
+const providerName = 'awscloudformation';
+
+const writeOverrideResolver = (projRoot: string, resolverName: string, contents: string) => fs.writeFileSync(
+  path.join(projRoot, 'amplify', 'backend', 'api', projectName, 'resolvers', resolverName),
+  contents,
+);
+
+const createAndRetrieveEmptyTodoContent = async (projRoot: string): Promise<void> => {
+  const meta = getProjectMeta(projRoot);
+  const region = meta.providers[providerName].Region as string;
+  const { output } = meta.api[projectName];
+  const url = output.GraphQLAPIEndpointOutput as string;
+  const apiKey = output.GraphQLAPIKeyOutput as string;
+
+  const api = new AWSAppSyncClient({
+    url,
+    region,
+    disableOffline: true,
+    auth: { type: AUTH_TYPE.API_KEY, apiKey },
+  });
+
+  const fetchPolicy = 'no-cache';
+
+  const createdTodoResponse = await api.mutate({
+    mutation: gql(/* GraphQL */ `
+      mutation CreateTodo($input: CreateTodoInput!) {
+        createTodo(input: $input) { id }
+      }
+    `),
+    fetchPolicy,
+    variables: { input: {} },
+  });
+
+  const createdTodoId = (createdTodoResponse as any).data.createTodo.id;
+
+  const retrievedTodoContentResponse = await api.query({
+    query: gql(/* GraphQL */ `
+      query GetTodo($id: ID!) {
+        getTodo(id: $id) {
+          content
+        }
+      }
+    `),
+    fetchPolicy,
+    variables: { id: createdTodoId },
+  });
+
+  return (retrievedTodoContentResponse as any).data.getTodo.content;
+};
+
+describe('JS Resolver Overrides for Slots', () => {
+  let projRoot: string;
+
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir(projectName);
+    await initJSProjectWithProfile(projRoot, {
+      name: projectName,
+    });
+
+    await addApiWithBlankSchema(projRoot, { transformerVersion: 2 });
+    updateApiSchema(projRoot, projectName, 'model_with_sandbox_mode.graphql');
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('Allows adding custom resolvers into an unused slot', async () => {
+    const overrideContentMessage = 'I was set by an overridden resolver';
+    writeOverrideResolver(projRoot, 'Query.getTodo.postDataLoad.0.js', `
+      export function request() {
+        return {};
+      }
+
+      export function response(ctx) {
+        const data = ctx.prev.result;
+        data.content = '${overrideContentMessage}';
+        return data;
+      }
+    `);
+
+    await amplifyPush(projRoot);
+    const retrievedTodoContent = await createAndRetrieveEmptyTodoContent(projRoot);
+
+    expect(retrievedTodoContent).toEqual(overrideContentMessage)
+  });
+
+  it('Allows overriding generated VTL resolvers with a JS resolver', async () => {
+    writeOverrideResolver(projRoot, 'Query.getTodo.postAuth.1.js', `
+      import { util } from '@aws-appsync/utils'
+
+      export function request() {
+        util.unauthorized();
+        return {};
+      }
+
+      export function response(ctx) {
+        {}
+      }
+    `);
+
+    await amplifyPush(projRoot);
+    await expect(async () => await createAndRetrieveEmptyTodoContent(projRoot)).rejects.toThrow('Not Authorized to access getTodo on type Todo');
+  });
+});

--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -9,6 +9,7 @@ import { ApiKeyConfig } from 'aws-cdk-lib/aws-appsync';
 import { App } from 'aws-cdk-lib';
 import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-interfaces';
 import { AppSyncDataSourceType } from '@aws-amplify/graphql-transformer-interfaces';
+import { AppSyncExecutionStrategy } from '@aws-amplify/graphql-transformer-interfaces';
 import { AppSyncFunctionConfigurationProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { AuthorizationConfig } from 'aws-cdk-lib/aws-appsync';
 import { AuthorizationType } from 'aws-cdk-lib/aws-appsync';
@@ -609,23 +610,46 @@ export interface TransformerProjectConfig {
 
 // @public (undocumented)
 export class TransformerResolver implements TransformerResolverProvider {
-    constructor(typeName: string, fieldName: string, resolverLogicalId: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider, requestSlots: string[], responseSlots: string[], datasource?: DataSourceProvider | undefined);
+    constructor(typeName: string, fieldName: string, resolverLogicalId: string, requestMappingTemplate: MappingTemplateProvider | undefined, responseMappingTemplate: MappingTemplateProvider | undefined, requestSlots: string[], responseSlots: string[], datasource?: DataSourceProvider | undefined, strategy?: AppSyncExecutionStrategy);
     // (undocumented)
     addToSlot: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider, dataSource?: DataSourceProvider) => void;
+    // (undocumented)
+    addToSlotWithStrategy: (slotName: string, strategy: AppSyncExecutionStrategy, dataSource?: DataSourceProvider) => void;
     // Warning: (ae-forgotten-export) The symbol "Slot" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
     findSlot: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider) => Slot | undefined;
     // (undocumented)
+    findSlotForStrategy: ({ slotName, strategy, }: {
+        slotName: string;
+        strategy: AppSyncExecutionStrategy;
+    }) => Slot | undefined;
+    // (undocumented)
+    static fromStrategy: ({ typeName, fieldName, resolverLogicalId, requestSlots, responseSlots, datasource, strategy, }: {
+        typeName: string;
+        fieldName: string;
+        resolverLogicalId: string;
+        requestSlots: string[];
+        responseSlots: string[];
+        datasource?: DataSourceProvider | undefined;
+        strategy: AppSyncExecutionStrategy;
+    }) => TransformerResolver;
+    // (undocumented)
+    getStackName: () => string;
+    // (undocumented)
     mapToStack: (stack: Stack) => void;
     // (undocumented)
     slotExists: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider) => boolean;
+    // (undocumented)
+    slotExistsForStrategy: (slotName: string, strategy: AppSyncExecutionStrategy) => boolean;
     // (undocumented)
     synthesize: (context: TransformerContextProvider, api: GraphQLAPIProvider) => void;
     // (undocumented)
     synthesizeResolvers: (stack: Stack, api: GraphQLAPIProvider, slotsNames: string[]) => AppSyncFunctionConfigurationProvider[];
     // (undocumented)
     updateSlot: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider) => void;
+    // (undocumented)
+    updateSlotForStrategy: (slotName: string, strategy: AppSyncExecutionStrategy) => void;
 }
 
 // @public (undocumented)

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transform-host.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transform-host.test.ts
@@ -1,39 +1,164 @@
-import { App } from 'aws-cdk-lib';
+import { App, Stack } from 'aws-cdk-lib';
 import { DefaultTransformHost } from '../transform-host';
-import { GraphQLApi, TransformerAPIProps } from '../graphql-api';
+import { GraphQLApi } from '../graphql-api';
 import { InlineTemplate } from '../cdk-compat/template-asset';
 import { TransformerRootStack } from '../cdk-compat/root-stack';
+import { AppSyncExecutionStrategy } from '@aws-amplify/graphql-transformer-interfaces';
 
-describe('addResolver', () => {
-  const app = new App();
-  const stack = new TransformerRootStack(app, 'test-root-stack');
-  const transformHost = new DefaultTransformHost({ api: new GraphQLApi(stack, 'testId', { name: 'testApiName' }) });
+const NONE_DS = 'NONE_DS';
 
-  it('generates resolver name with hash for non-alphanumeric type names', () => {
-    const cfnResolver = transformHost.addResolver(
-      'test_type',
-      'testField',
-      new InlineTemplate('testTemplate'),
-      new InlineTemplate('testTemplate'),
-      undefined,
-      undefined,
-      ['testPipelineConfig'],
-      stack,
-    );
-    expect(cfnResolver.logicalId).toMatch('testtype4c79TestFieldResolver.LogicalID'); // have to use match instead of equals because the logicalId is a CDK token that has some non-deterministic stuff in it
+describe('DefaultTransformHost', () => {
+  describe('addResolver', () => {
+    const app = new App();
+    const stack = new TransformerRootStack(app, 'test-root-stack');
+    const transformHost = new DefaultTransformHost({ api: new GraphQLApi(stack, 'testId', { name: 'testApiName' }) });
+
+    it('generates resolver name with hash for non-alphanumeric type names', () => {
+      const cfnResolver = transformHost.addResolver(
+        'test_type',
+        'testField',
+        new InlineTemplate('testTemplate'),
+        new InlineTemplate('testTemplate'),
+        undefined,
+        undefined,
+        ['testPipelineConfig'],
+        stack,
+      );
+      expect(cfnResolver.logicalId).toMatch('testtype4c79TestFieldResolver.LogicalID'); // have to use match instead of equals because the logicalId is a CDK token that has some non-deterministic stuff in it
+    });
+
+    it('generates resolver name with hash for non-alphanumeric field names', () => {
+      const cfnResolver = transformHost.addResolver(
+        'testType',
+        'test_field',
+        new InlineTemplate('testTemplate'),
+        new InlineTemplate('testTemplate'),
+        undefined,
+        undefined,
+        ['testPipelineConfig'],
+        stack,
+      );
+      expect(cfnResolver.logicalId).toMatch('testTypeTestfield6a0fResolver.LogicalID'); // have to use match instead of equals because the logicalId is a CDK token that has some non-deterministic stuff in it
+    });
   });
 
-  it('generates resolver name with hash for non-alphanumeric field names', () => {
-    const cfnResolver = transformHost.addResolver(
-      'testType',
-      'test_field',
-      new InlineTemplate('testTemplate'),
-      new InlineTemplate('testTemplate'),
-      undefined,
-      undefined,
-      ['testPipelineConfig'],
-      stack,
-    );
-    expect(cfnResolver.logicalId).toMatch('testTypeTestfield6a0fResolver.LogicalID'); // have to use match instead of equals because the logicalId is a CDK token that has some non-deterministic stuff in it
+  describe('addResolverWithStrategy', () => {
+    const app = new App();
+    const stack = new TransformerRootStack(app, 'test-root-stack');
+    const transformHost = new DefaultTransformHost({ api: new GraphQLApi(stack, 'testId', { name: 'testApiName' }) });
+
+    it('generates resolver name with hash for non-alphanumeric type names', () => {
+      const cfnResolver = transformHost.addResolverWithStrategy(
+        'test_type',
+        'testField',
+        {
+          type: 'TEMPLATE',
+          requestMappingTemplate: new InlineTemplate('testTemplate'),
+          responseMappingTemplate: new InlineTemplate('testTemplate'),
+        },
+        undefined,
+        undefined,
+        ['testPipelineConfig'],
+        stack,
+      );
+      expect(cfnResolver.logicalId).toMatch('testtype4c79TestFieldResolver.LogicalID'); // have to use match instead of equals because the logicalId is a CDK token that has some non-deterministic stuff in it
+    });
+
+    it('generates resolver name with hash for non-alphanumeric field names', () => {
+      const cfnResolver = transformHost.addResolverWithStrategy(
+        'testType',
+        'test_field',
+        {
+          type: 'TEMPLATE',
+          requestMappingTemplate: new InlineTemplate('testTemplate'),
+          responseMappingTemplate: new InlineTemplate('testTemplate'),
+        },
+        undefined,
+        undefined,
+        ['testPipelineConfig'],
+        stack,
+      );
+      expect(cfnResolver.logicalId).toMatch('testTypeTestfield6a0fResolver.LogicalID'); // have to use match instead of equals because the logicalId is a CDK token that has some non-deterministic stuff in it
+    });
+
+    it('throws on CODE strategy type', () => {
+      expect(() => {
+        transformHost.addResolverWithStrategy(
+          'testType',
+          'test_field',
+          {
+            type: 'CODE',
+            code: new InlineTemplate('testTemplate'),
+            runtime: { name: '', runtimeVersion: '' },
+          },
+          undefined,
+          undefined,
+          ['testPipelineConfig'],
+          stack,
+        );
+      }).toThrowErrorMatchingInlineSnapshot('"Code Execution strategies are not yet supported for top-level resolvers."');
+    });
+  });
+
+  describe('addAppSyncFunctionWithStrategy', () => {
+    const noopTemplateStrategy: AppSyncExecutionStrategy = {
+      type: 'TEMPLATE',
+      requestMappingTemplate: new InlineTemplate('testTemplate'),
+      responseMappingTemplate: new InlineTemplate('testTemplate'),
+    };
+    const setupHostWithNoneDSAndFns = (
+      ...strategies: AppSyncExecutionStrategy[]
+    ): { stack: Stack, transformHost: DefaultTransformHost } => {
+      const app = new App();
+      const stack = new TransformerRootStack(app, 'test-root-stack');
+      const transformHost = new DefaultTransformHost({ api: new GraphQLApi(stack, 'testId', { name: 'testApiName' }) });
+      transformHost.addNoneDataSource(NONE_DS);
+      strategies.forEach((strategy, i) => transformHost.addAppSyncFunctionWithStrategy(
+        `Function${i}`,
+        strategy,
+        NONE_DS,
+        stack,
+      ));
+      return { stack, transformHost };
+    };
+
+    it('throws for unknown dataSourceName', () => {
+      const { stack, transformHost } = setupHostWithNoneDSAndFns();
+
+      expect(() => {
+        transformHost.addAppSyncFunctionWithStrategy(
+          'TestFunction',
+          noopTemplateStrategy,
+          'UndefinedDataSource',
+          stack,
+        );
+      }).toThrowErrorMatchingInlineSnapshot('"DataSource UndefinedDataSource is missing in the API"');
+    });
+
+    it('adds a template-based function without error', () => {
+      const { stack, transformHost } = setupHostWithNoneDSAndFns();
+
+      transformHost.addAppSyncFunctionWithStrategy(
+        'TestFunction',
+        noopTemplateStrategy,
+        NONE_DS,
+        stack,
+      );
+    });
+
+    it('adds a code-based function without error', () => {
+      const { stack, transformHost } = setupHostWithNoneDSAndFns();
+
+      transformHost.addAppSyncFunctionWithStrategy(
+        'TestFunction',
+        {
+          type: 'CODE',
+          code: new InlineTemplate('I am code'),
+          runtime: { name: '', runtimeVersion: '' },
+        },
+        NONE_DS,
+        stack,
+      );
+    });
   });
 });

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transformer-context/resolver.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transformer-context/resolver.test.ts
@@ -1,0 +1,256 @@
+import { AppSyncExecutionStrategy, DataSourceProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { App, Stack } from '@aws-cdk/core';
+import { InlineTemplate, S3MappingTemplate, TransformerRootStack } from '../../cdk-compat';
+import { GraphQLApi } from '../../graphql-api';
+import { DefaultTransformHost } from '../../transform-host';
+import { ResolverManager, TransformerResolver } from '../../transformer-context/resolver';
+
+const NONE_DS = 'NONE_DS';
+const noopDataSourceProvider = {} as DataSourceProvider;
+const noopTemplate = new InlineTemplate('mylogic');
+const noopTemplateStrategy: AppSyncExecutionStrategy = {
+  type: 'TEMPLATE',
+  requestMappingTemplate: noopTemplate,
+  responseMappingTemplate: noopTemplate,
+};
+const noopCodeStrategy: AppSyncExecutionStrategy = {
+  type: 'CODE',
+  code: noopTemplate,
+  runtime: { name: '', runtimeVersion: '' },
+};
+
+describe('ResolverManager', () => {
+  describe('generateQueryResolver', () => {
+    it('can be invoked, and generates a TransformerResolver', () => {
+      const manager = new ResolverManager();
+
+      const resolver = manager.generateQueryResolver(
+        'Query',
+        'getTodo',
+        'QuerygetTodoResolver',
+        noopDataSourceProvider,
+        noopTemplate,
+        noopTemplate,
+      );
+
+      expect(resolver).toBeDefined();
+    });
+  });
+
+  describe('generateQueryResolverWithStrategy', () => {
+    it('can be invoked with a Code execution strategy, and generates a TransformerResolver', () => {
+      const manager = new ResolverManager();
+
+      const resolver = manager.generateQueryResolverWithStrategy(
+        'Query',
+        'getTodo',
+        'QuerygetTodoResolver',
+        noopDataSourceProvider,
+        noopCodeStrategy,
+      );
+
+      expect(resolver).toBeDefined();
+    });
+  });
+
+  describe('generateMutationResolver', () => {
+    it('can be invoked, and generates a TransformerResolver', () => {
+      const manager = new ResolverManager();
+
+      const resolver = manager.generateMutationResolver(
+        'Mutation',
+        'createTodo',
+        'MutationcreateTodoResolver',
+        noopDataSourceProvider,
+        new InlineTemplate('mylogic'),
+        new InlineTemplate('mylogic'),
+      );
+
+      expect(resolver).toBeDefined();
+    });
+  });
+
+  describe('generateMutationResolverWithStrategy', () => {
+    it('can be invoked with a Code execution strategy, and generates a TransformerResolver', () => {
+      const manager = new ResolverManager();
+
+      const resolver = manager.generateMutationResolverWithStrategy(
+        'Mutation',
+        'createTodo',
+        'MutationcreateTodoResolver',
+        noopDataSourceProvider,
+        noopCodeStrategy,
+      );
+
+      expect(resolver).toBeDefined();
+    });
+  });
+
+  describe('generateSubscriptionResolver', () => {
+    it('can be invoked, and generates a TransformerResolver', () => {
+      const manager = new ResolverManager();
+
+      const resolver = manager.generateSubscriptionResolver(
+        'Subscription',
+        'onTodoUpdate',
+        'SubscriptionOnTodoUpdateResolver',
+        new InlineTemplate('mylogic'),
+        new InlineTemplate('mylogic'),
+      );
+
+      expect(resolver).toBeDefined();
+    });
+  });
+
+  describe('generateSubscriptionResolverWithStrategy', () => {
+    it('can be invoked with a Code execution strategy, and generates a TransformerResolver', () => {
+      const manager = new ResolverManager();
+
+      const resolver = manager.generateSubscriptionResolverWithStrategy(
+        'Subscription',
+        'onTodoUpdate',
+        'SubscriptionOnTodoUpdateResolver',
+        noopCodeStrategy,
+      );
+
+      expect(resolver).toBeDefined();
+    });
+  });
+});
+
+describe('TransformerResolver', () => {
+  const slotName = 'init';
+  let resolver: TransformerResolver;
+
+  const setupSynthState = (): { stack: Stack, api: GraphQLApi } => {
+    const app = new App();
+    const stack = new TransformerRootStack(app, 'test-root-stack');
+
+    // This is weird, but the transformHost must take in an api in it's constructor
+    // that API also needs the transformHost, which can't be set after initialization
+    // So we do this two-round create w/ a dummy, then update the referances
+    const dummyApi = new GraphQLApi(stack, 'dummyApi', { name: 'dummyApiName' });
+    const transformHost = new DefaultTransformHost({ api: dummyApi });
+    const api = new GraphQLApi(stack, 'testId2', { name: 'testApiName', host: transformHost });
+    transformHost.setAPI(api);
+
+    transformHost.addNoneDataSource(NONE_DS);
+
+    return { stack, api };
+  };
+
+  beforeEach(() => {
+    resolver = TransformerResolver.fromStrategy({
+      typeName: 'Query',
+      fieldName: 'getTodo',
+      resolverLogicalId: 'QuerygetTodoResolver',
+      requestSlots: [slotName],
+      responseSlots: [],
+      strategy: noopCodeStrategy,
+    });
+  });
+
+  describe('addToSlot', () => {
+    it('can be invoked as a proxy to addToSlotWithStrategy', () => {
+      resolver.addToSlot(slotName, noopTemplate, noopTemplate, noopDataSourceProvider);
+      
+      const { stack, api } = setupSynthState();
+
+      const synthesizedResolvers = resolver.synthesizeResolvers(stack, api, [slotName]);
+      expect(synthesizedResolvers.length).toEqual(1);
+    });
+  });
+
+  describe('addToSlotWithStrategy', () => {
+    it('can add a new template function to an empty slot', () => {
+      resolver.addToSlotWithStrategy(
+        slotName,
+        noopTemplateStrategy,
+        noopDataSourceProvider,
+      );
+      
+      const { stack, api } = setupSynthState();
+
+      const synthesizedResolvers = resolver.synthesizeResolvers(stack, api, [slotName]);
+      expect(synthesizedResolvers.length).toEqual(1);
+    });
+
+    it('can add a new code function to an empty slot', () => {
+      resolver.addToSlotWithStrategy(
+        slotName,
+        noopCodeStrategy,
+        noopDataSourceProvider,
+      );
+      
+      const { stack, api } = setupSynthState();
+
+      const synthesizedResolvers = resolver.synthesizeResolvers(stack, api, [slotName]);
+      expect(synthesizedResolvers.length).toEqual(1);
+    });
+
+    it('will append a function for inline functions regardless of type', () => {
+      resolver.addToSlotWithStrategy(slotName, noopTemplateStrategy);
+      resolver.addToSlotWithStrategy(slotName, noopTemplateStrategy);
+      resolver.addToSlotWithStrategy(slotName, noopCodeStrategy);
+      resolver.addToSlotWithStrategy(slotName, noopCodeStrategy);
+      
+      const { stack, api } = setupSynthState();
+
+      const synthesizedResolvers = resolver.synthesizeResolvers(stack, api, [slotName]);
+      expect(synthesizedResolvers.length).toEqual(4);
+    });
+
+    it('will update request and response override templates', () => {
+      const requestMappingTemplate1 = new InlineTemplate('myrequestmappinglogic');
+      (requestMappingTemplate1 as any).name = 'Query.getTodo.init.1.req.vtl';
+      const responseMappingTemplate1 = new InlineTemplate('myresponsemappinglogic');
+      (responseMappingTemplate1 as any).name = 'Query.getTodo.init.1.res.vtl';
+      const requestMappingTemplate2 = new InlineTemplate('myupdatedrequestmappinglogic');
+      (requestMappingTemplate2 as any).name = 'Query.getTodo.init.1.req.vtl';
+      const responseMappingTemplate2 = new InlineTemplate('myupdatedresponsemappinglogic');
+      (responseMappingTemplate2 as any).name = 'Query.getTodo.init.1.res.vtl';
+      resolver.addToSlotWithStrategy(slotName, {
+        type: 'TEMPLATE',
+        requestMappingTemplate: requestMappingTemplate1,
+        responseMappingTemplate: responseMappingTemplate1,
+      });
+      resolver.addToSlotWithStrategy(slotName, {
+        type: 'TEMPLATE',
+        requestMappingTemplate: requestMappingTemplate2,
+        responseMappingTemplate: responseMappingTemplate2,
+      });
+
+      const { stack, api } = setupSynthState();
+
+      const synthesizedResolvers = resolver.synthesizeResolvers(stack, api, [slotName]);
+      expect(synthesizedResolvers.length).toEqual(1);
+      expect((synthesizedResolvers[0] as any).function.requestMappingTemplate).toEqual('myupdatedrequestmappinglogic');
+      expect((synthesizedResolvers[0] as any).function.responseMappingTemplate).toEqual('myupdatedresponsemappinglogic');
+    });
+
+    it('will update request and response override templates with code', () => {
+      const requestMappingTemplate = new InlineTemplate('myrequestmappinglogic');
+      (requestMappingTemplate as any).name = 'Query.getTodo.init.1.req.vtl';
+      const responseMappingTemplate = new InlineTemplate('myresponsemappinglogic');
+      (responseMappingTemplate as any).name = 'Query.getTodo.init.1.res.vtl';
+      const code = new InlineTemplate('myupdatedcode');
+      (code as any).name = 'Query.getTodo.init.1.js';
+      resolver.addToSlotWithStrategy(slotName, {
+        type: 'TEMPLATE',
+        requestMappingTemplate,
+        responseMappingTemplate,
+      });
+      resolver.addToSlotWithStrategy(slotName, {
+        type: 'CODE',
+        code,
+        runtime: { name: 'APP_SYNC_JS', runtimeVersion: '1.0.0' },
+      });
+
+      const { stack, api } = setupSynthState();
+
+      const synthesizedResolvers = resolver.synthesizeResolvers(stack, api, [slotName]);
+      expect(synthesizedResolvers.length).toEqual(1);
+      expect((synthesizedResolvers[0] as any).function._cfnProperties.Code).toEqual('myupdatedcode');
+    });
+  });
+});

--- a/packages/amplify-graphql-transformer-core/src/appsync-function.ts
+++ b/packages/amplify-graphql-transformer-core/src/appsync-function.ts
@@ -1,41 +1,33 @@
-import { MappingTemplateProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { BackedDataSource, BaseDataSource } from 'aws-cdk-lib/aws-appsync';
-import { CfnFunctionConfiguration } from 'aws-cdk-lib/aws-appsync';
+import { BackedDataSource, BaseDataSource, CfnFunctionConfiguration } from 'aws-cdk-lib/aws-appsync';
 import { Construct } from 'constructs';
+import { AppSyncExecutionStrategy } from '@aws-amplify/graphql-transformer-interfaces';
+import { CfnResource } from 'aws-cdk-lib';
 import { InlineTemplate } from './cdk-compat/template-asset';
 import { GraphQLApi } from './graphql-api';
-export interface BaseFunctionConfigurationProps {
-  /**
-   * The request mapping template for this resolver
-   *
-   * @default - No mapping template
-   */
-  readonly requestMappingTemplate: MappingTemplateProvider;
-  /**
-   * The response mapping template for this resolver
-   *
-   * @default - No mapping template
-   */
-  readonly responseMappingTemplate: MappingTemplateProvider;
-
-  readonly description?: string;
-}
 
 /**
  * Additional properties for an AppSync resolver like GraphQL API reference and datasource
  */
-export interface FunctionConfigurationProps extends BaseFunctionConfigurationProps {
+type FunctionConfigurationProps = {
+  /**
+   * Resolvers and code for the given function.
+   */
+  readonly strategy: AppSyncExecutionStrategy;
+
   /**
    * The API this resolver is attached to
    */
   readonly api: GraphQLApi;
+
   /**
-   * The data source this resolver is using
-   *
-   * @default - No datasource
-   */
+  * The data source this resolver is using
+  *
+  * @default - No datasource
+  */
   readonly dataSource: BaseDataSource | string;
-}
+
+  readonly description?: string;
+};
 
 export class AppSyncFunctionConfiguration extends Construct {
   /**
@@ -44,32 +36,90 @@ export class AppSyncFunctionConfiguration extends Construct {
   public readonly arn: string;
   public readonly functionId: string;
 
-  private function: CfnFunctionConfiguration;
+  private function: CfnFunctionConfiguration | CfnResource;
 
   constructor(scope: Construct, id: string, props: FunctionConfigurationProps) {
     super(scope, id);
 
-    const requestTemplate = props.requestMappingTemplate.bind(this);
-    const responseTemplate = props.responseMappingTemplate.bind(this);
-    this.function = new CfnFunctionConfiguration(this, `${id}.AppSyncFunction`, {
-      name: id,
-      apiId: props.api.apiId,
-      functionVersion: '2018-05-29',
-      description: props.description,
-      dataSourceName: props.dataSource instanceof BaseDataSource ? props.dataSource.ds.attrName : props.dataSource,
-      ...(props.requestMappingTemplate instanceof InlineTemplate
-        ? { requestMappingTemplate: requestTemplate }
-        : { requestMappingTemplateS3Location: requestTemplate }),
-      ...(props.responseMappingTemplate instanceof InlineTemplate
-        ? { responseMappingTemplate: responseTemplate }
-        : { responseMappingTemplateS3Location: responseTemplate }),
-    });
+    this.function = this.generateFunction(id, props);
 
     props.api.addSchemaDependency(this.function);
     if (props.dataSource instanceof BackedDataSource) {
       this.function.addDependency(props.dataSource?.ds);
     }
-    this.arn = this.function.attrFunctionArn;
-    this.functionId = this.function.attrFunctionId;
+
+    this.arn = this.getFunctionArn();
+    this.functionId = this.getFunctionId();
+  }
+
+  private getFunctionArn = (): string => {
+    if (this.function instanceof CfnFunctionConfiguration) {
+      return this.function.attrFunctionArn;
+    }
+
+    return this.function.getAtt('FunctionArn').toString();
+  };
+
+  private getFunctionId = (): string => {
+    if (this.function instanceof CfnFunctionConfiguration) {
+      return this.function.attrFunctionId;
+    }
+
+    return this.function.getAtt('FunctionId').toString();
+  };
+
+  generateFunction(id: string, props: FunctionConfigurationProps): CfnFunctionConfiguration | CfnResource {
+    switch (props.strategy.type) {
+      case 'TEMPLATE':
+        return this.generateTemplateFunction(id, props);
+      case 'CODE':
+        return this.generateCodeFunction(id, props);
+    }
+  }
+
+  generateTemplateFunction(id: string, props: FunctionConfigurationProps): CfnFunctionConfiguration {
+    if (props.strategy.type !== 'TEMPLATE') {
+      throw new Error(`Expected strategy with type TEMPLATE, got ${props.strategy.type}`);
+    }
+    const requestTemplate = props.strategy.requestMappingTemplate?.bind(this);
+    const responseTemplate = props.strategy.responseMappingTemplate?.bind(this);
+
+    return new CfnFunctionConfiguration(this, `${id}.AppSyncFunction`, {
+      name: id,
+      apiId: props.api.apiId,
+      functionVersion: '2018-05-29',
+      description: props.description,
+      dataSourceName: props.dataSource instanceof BaseDataSource ? props.dataSource.ds.attrName : props.dataSource,
+      ...(props.strategy.requestMappingTemplate instanceof InlineTemplate
+        ? { requestMappingTemplate: requestTemplate }
+        : { requestMappingTemplateS3Location: requestTemplate }),
+      ...(props.strategy.responseMappingTemplate instanceof InlineTemplate
+        ? { responseMappingTemplate: responseTemplate }
+        : { responseMappingTemplateS3Location: responseTemplate }),
+    });
+  }
+
+  generateCodeFunction(id: string, props: FunctionConfigurationProps): CfnResource {
+    if (props.strategy.type !== 'CODE') {
+      throw new Error(`Expected strategy with type CODE, got ${props.strategy.type}`);
+    }
+
+    const code = props.strategy.code.bind(this);
+
+    return new CfnResource(this, `${id}.AppSyncFunctinon`, {
+      type: 'AWS::AppSync::FunctionConfiguration',
+      properties: {
+        ApiId: props.api.apiId,
+        ...(props.strategy.code instanceof InlineTemplate
+          ? { Code: code }
+          : { CodeS3Location: code }),
+        DataSourceName: props.dataSource instanceof BaseDataSource ? props.dataSource.ds.attrName : props.dataSource,
+        Name: id,
+        Runtime: {
+          Name: props.strategy.runtime.name,
+          RuntimeVersion: props.strategy.runtime.runtimeVersion,
+        },
+      },
+    });
   }
 }

--- a/packages/amplify-graphql-transformer-core/src/transform-host.ts
+++ b/packages/amplify-graphql-transformer-core/src/transform-host.ts
@@ -1,7 +1,9 @@
 import {
   DynamoDbDataSourceOptions,
-  InlineMappingTemplateProvider,
-  MappingTemplateProvider, MappingTemplateType, S3MappingTemplateProvider, SearchableDataSourceOptions, TransformHostProvider,
+  SearchableDataSourceOptions,
+  TransformHostProvider,
+  AppSyncExecutionStrategy,
+  MappingTemplateProvider,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import {
   BaseDataSource,
@@ -25,12 +27,6 @@ import { AppSyncFunctionConfiguration } from './appsync-function';
 import { SearchableDataSource } from './cdk-compat/searchable-datasource';
 import { InlineTemplate, S3MappingFunctionCode } from './cdk-compat/template-asset';
 import { GraphQLApi } from './graphql-api';
-
-type Slot = {
-  requestMappingTemplate?: string;
-  responseMappingTemplate?: string;
-  dataSource?: string;
-};
 
 export interface DefaultTransformHostOptions {
   readonly api: GraphQLApi;
@@ -119,10 +115,25 @@ export class DefaultTransformHost implements TransformHostProvider {
     return dataSource;
   }
 
+  /**
+   * @deprecated Use addAppSyncFunctionWithStrategy, which adds support for all AppSync runtimes.
+   */
   public addAppSyncFunction = (
     name: string,
     requestMappingTemplate: MappingTemplateProvider,
     responseMappingTemplate: MappingTemplateProvider,
+    dataSourceName: string,
+    stack?: Stack,
+  ): AppSyncFunctionConfiguration => this.addAppSyncFunctionWithStrategy(
+    name,
+    { type: 'TEMPLATE', requestMappingTemplate, responseMappingTemplate },
+    dataSourceName,
+    stack
+  );
+
+  public addAppSyncFunctionWithStrategy = (
+    name: string,
+    strategy: AppSyncExecutionStrategy,
     dataSourceName: string,
     stack?: Stack,
   ): AppSyncFunctionConfiguration => {
@@ -130,36 +141,55 @@ export class DefaultTransformHost implements TransformHostProvider {
       throw new Error(`DataSource ${dataSourceName} is missing in the API`);
     }
 
-    // calculate hash of the slot object
-    // if the slot exists for the hash, then return same fn else create function
-
     const dataSource = this.dataSources.get(dataSourceName);
 
-    const obj :Slot = {
-      dataSource: dataSourceName,
-      requestMappingTemplate: requestMappingTemplate.getTemplateHash(),
-      responseMappingTemplate: responseMappingTemplate.getTemplateHash(),
-    };
-
-    const slotHash = hash(obj);
-    if (!this.api.disableResolverDeduping && this.appsyncFunctions.has(slotHash)) {
-      const appsyncFunction = this.appsyncFunctions.get(slotHash)!;
-      // generating duplicate appsync functions vtl files to help in custom overrides
-      requestMappingTemplate.bind(appsyncFunction);
-      responseMappingTemplate.bind(appsyncFunction);
-      return appsyncFunction;
+    // calculate hash of the slot object
+    // if the slot exists for the hash, then return same fn else create function
+    const slotHash: string = this.computeSlotHash({ dataSource: dataSourceName, strategy });
+    const existingFunction = this.appsyncFunctions.get(slotHash);
+    if (existingFunction) {
+      // generating duplicate appsync functions to help in custom overrides
+      switch(strategy.type) {
+        case 'TEMPLATE':
+          strategy.requestMappingTemplate?.bind(existingFunction);
+          strategy.responseMappingTemplate?.bind(existingFunction);
+          break;
+        case 'CODE':
+          strategy.code.bind(existingFunction);
+          break;
+      }
+      return existingFunction;
     }
 
-    const fn = new AppSyncFunctionConfiguration(stack || this.api, name, {
+    const appSyncFunction = new AppSyncFunctionConfiguration(stack || this.api, name, {
       api: this.api,
       dataSource: dataSource || dataSourceName,
-      requestMappingTemplate,
-      responseMappingTemplate,
-    });
-    this.appsyncFunctions.set(slotHash, fn);
-    return fn;
+      strategy
+    })
+
+    this.appsyncFunctions.set(slotHash, appSyncFunction);
+    return appSyncFunction;
   }
 
+  private computeSlotHash = ({ strategy, dataSource }: { strategy: AppSyncExecutionStrategy, dataSource: string}): string => {
+    switch (strategy.type) {
+      case 'TEMPLATE':
+        return hash({
+          dataSource,
+          requestMappingTemplate: strategy.requestMappingTemplate?.getTemplateHash(),
+          responseMappingTemplate: strategy.responseMappingTemplate?.getTemplateHash(),
+        });
+      case 'CODE':
+        return hash({
+          dataSource,
+          requestMappingTemplate: strategy.code.getTemplateHash(),
+        });
+    }
+  };
+
+  /**
+   * @deprecated Use addResolverWithStrategy, which supports all AppSync runtimes.
+   */
   public addResolver = (
     typeName: string,
     fieldName: string,
@@ -169,13 +199,35 @@ export class DefaultTransformHost implements TransformHostProvider {
     dataSourceName?: string,
     pipelineConfig?: string[],
     stack?: Stack,
+  ): CfnResolver => this.addResolverWithStrategy(
+    typeName,
+    fieldName,
+    { type: 'TEMPLATE', requestMappingTemplate, responseMappingTemplate },
+    resolverLogicalId,
+    dataSourceName,
+    pipelineConfig,
+    stack,
+  );
+
+  public addResolverWithStrategy = (
+    typeName: string,
+    fieldName: string,
+    strategy: AppSyncExecutionStrategy,
+    resolverLogicalId?: string,
+    dataSourceName?: string,
+    pipelineConfig?: string[],
+    stack?: Stack,
   ): CfnResolver => {
     if (dataSourceName && !Token.isUnresolved(dataSourceName) && !this.dataSources.has(dataSourceName)) {
       throw new Error(`DataSource ${dataSourceName} is missing in the API`);
     }
 
-    const requestTemplateLocation = requestMappingTemplate.bind(this.api);
-    const responseTemplateLocation = responseMappingTemplate.bind(this.api);
+    if (strategy.type !== 'TEMPLATE') {
+      throw new Error('Code Execution strategies are not yet supported for top-level resolvers.');
+    }
+
+    const requestTemplateLocation = strategy.requestMappingTemplate?.bind(this.api);
+    const responseTemplateLocation = strategy.responseMappingTemplate?.bind(this.api);
     const resolverName = toCamelCase([resourceName(typeName), resourceName(fieldName), 'Resolver']);
     const resourceId = resolverLogicalId ?? ResolverResourceIDs.ResolverResourceID(typeName, fieldName);
 
@@ -187,10 +239,10 @@ export class DefaultTransformHost implements TransformHostProvider {
         typeName,
         kind: 'UNIT',
         dataSourceName: dataSource?.ds.attrName || dataSourceName,
-        ...(requestMappingTemplate instanceof InlineTemplate
+        ...(strategy.requestMappingTemplate instanceof InlineTemplate
           ? { requestMappingTemplate: requestTemplateLocation }
           : { requestMappingTemplateS3Location: requestTemplateLocation }),
-        ...(responseMappingTemplate instanceof InlineTemplate
+        ...(strategy.responseMappingTemplate instanceof InlineTemplate
           ? { responseMappingTemplate: responseTemplateLocation }
           : { responseMappingTemplateS3Location: responseTemplateLocation }),
       });
@@ -203,10 +255,10 @@ export class DefaultTransformHost implements TransformHostProvider {
         fieldName,
         typeName,
         kind: 'PIPELINE',
-        ...(requestMappingTemplate instanceof InlineTemplate
+        ...(strategy.requestMappingTemplate instanceof InlineTemplate
           ? { requestMappingTemplate: requestTemplateLocation }
           : { requestMappingTemplateS3Location: requestTemplateLocation }),
-        ...(responseMappingTemplate instanceof InlineTemplate
+        ...(strategy.responseMappingTemplate instanceof InlineTemplate
           ? { responseMappingTemplate: responseTemplateLocation }
           : { responseMappingTemplateS3Location: responseTemplateLocation }),
         pipelineConfig: {

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -104,6 +104,13 @@ export type AppSyncAuthConfigurationUserPoolEntry = {
 export type AppSyncAuthMode = 'API_KEY' | 'AMAZON_COGNITO_USER_POOLS' | 'AWS_IAM' | 'OPENID_CONNECT' | 'AWS_LAMBDA';
 
 // @public (undocumented)
+export type AppSyncCodeExecutionStrategy = {
+    type: 'CODE';
+    code: MappingTemplateProvider;
+    runtime: AppSyncRuntime;
+};
+
+// @public (undocumented)
 export enum AppSyncDataSourceType {
     // (undocumented)
     AMAZON_DYNAMODB = "AMAZON_DYNAMODB",
@@ -120,12 +127,28 @@ export enum AppSyncDataSourceType {
 }
 
 // @public (undocumented)
+export type AppSyncExecutionStrategy = AppSyncTemplateExecutionStrategy | AppSyncCodeExecutionStrategy;
+
+// @public (undocumented)
 export interface AppSyncFunctionConfigurationProvider extends IConstruct {
     // (undocumented)
     readonly arn: string;
     // (undocumented)
     readonly functionId: string;
 }
+
+// @public (undocumented)
+export type AppSyncRuntime = {
+    name: string;
+    runtimeVersion: string;
+};
+
+// @public (undocumented)
+export type AppSyncTemplateExecutionStrategy = {
+    type: 'TEMPLATE';
+    requestMappingTemplate?: MappingTemplateProvider;
+    responseMappingTemplate?: MappingTemplateProvider;
+};
 
 // Warning: (ae-forgotten-export) The symbol "NoneDataSourceProvider" needs to be exported by the entry point index.d.ts
 //
@@ -619,6 +642,8 @@ export interface TransformerResolverProvider {
     // (undocumented)
     addToSlot: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider, dataSource?: DataSourceProvider) => void;
     // (undocumented)
+    addToSlotWithStrategy: (slotName: string, strategy: AppSyncExecutionStrategy, dataSource?: DataSourceProvider) => void;
+    // (undocumented)
     mapToStack: (stack: Stack) => void;
     // (undocumented)
     synthesize: (context: TransformerContextProvider, api: GraphQLAPIProvider) => void;
@@ -633,9 +658,15 @@ export interface TransformerResolversManagerProvider {
     // (undocumented)
     generateMutationResolver: (typeName: string, fieldName: string, resolverLogicalId: string, dataSource: DataSourceProvider, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider) => TransformerResolverProvider;
     // (undocumented)
+    generateMutationResolverWithStrategy: (typeName: string, fieldName: string, resolverLogicalId: string, dataSource: DataSourceProvider, strategy: AppSyncExecutionStrategy) => TransformerResolverProvider;
+    // (undocumented)
     generateQueryResolver: (typeName: string, fieldName: string, resolverLogicalId: string, dataSource: DataSourceProvider, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider) => TransformerResolverProvider;
     // (undocumented)
+    generateQueryResolverWithStrategy: (typeName: string, fieldName: string, resolverLogicalId: string, dataSource: DataSourceProvider, strategy: AppSyncExecutionStrategy) => TransformerResolverProvider;
+    // (undocumented)
     generateSubscriptionResolver: (typeName: string, fieldName: string, resolverLogicalId: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider) => TransformerResolverProvider;
+    // (undocumented)
+    generateSubscriptionResolverWithStrategy: (typeName: string, fieldName: string, resolverLogicalId: string, strategy: AppSyncExecutionStrategy) => TransformerResolverProvider;
     // (undocumented)
     getResolver: (typeName: string, fieldName: string) => TransformerResolverProvider | void;
     // (undocumented)
@@ -690,6 +721,8 @@ export interface TransformHostProvider {
     // (undocumented)
     addAppSyncFunction: (name: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider, dataSourceName: string, stack?: Stack) => AppSyncFunctionConfigurationProvider;
     // (undocumented)
+    addAppSyncFunctionWithStrategy: (name: string, strategy: AppSyncExecutionStrategy, dataSourceName: string, stack?: Stack) => AppSyncFunctionConfigurationProvider;
+    // (undocumented)
     addDynamoDbDataSource(name: string, table: ITable, options?: DynamoDbDataSourceOptions, stack?: Stack): DynamoDbDataSource;
     // (undocumented)
     addHttpDataSource(name: string, endpoint: string, options?: DataSourceOptions, stack?: Stack): HttpDataSource;
@@ -703,6 +736,8 @@ export interface TransformHostProvider {
     addNoneDataSource(name: string, options?: DataSourceOptions, stack?: Stack): NoneDataSource;
     // (undocumented)
     addResolver: (typeName: string, fieldName: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider, resolverLogicalId?: string, dataSourceName?: string, pipelineConfig?: string[], stack?: Stack) => CfnResolver;
+    // (undocumented)
+    addResolverWithStrategy: (typeName: string, fieldName: string, strategy: AppSyncExecutionStrategy, resolverLogicalId?: string, dataSourceName?: string, pipelineConfig?: string[], stack?: Stack) => CfnResolver;
     // (undocumented)
     addSearchableDataSource(name: string, endpoint: string, region: string, options?: SearchableDataSourceOptions, stack?: Stack): BaseDataSource;
     // (undocumented)

--- a/packages/amplify-graphql-transformer-interfaces/src/appsync-execution-strategy.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/appsync-execution-strategy.ts
@@ -1,0 +1,20 @@
+import { MappingTemplateProvider } from "./graphql-api-provider";
+
+export type AppSyncRuntime = {
+  name: string;
+  runtimeVersion: string;
+};
+
+export type AppSyncTemplateExecutionStrategy = {
+  type: 'TEMPLATE',
+  requestMappingTemplate?: MappingTemplateProvider,
+  responseMappingTemplate?: MappingTemplateProvider,
+};
+
+export type AppSyncCodeExecutionStrategy = {
+  type: 'CODE',
+  code: MappingTemplateProvider,
+  runtime: AppSyncRuntime,
+};
+
+export type AppSyncExecutionStrategy = AppSyncTemplateExecutionStrategy | AppSyncCodeExecutionStrategy;

--- a/packages/amplify-graphql-transformer-interfaces/src/index.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/index.ts
@@ -9,7 +9,7 @@ export {
   TransformerAuthProvider,
 } from './transformer-model-provider';
 export { FeatureFlagProvider } from './feature-flag-provider';
-
+export * from './appsync-execution-strategy';
 export {
   GraphQLAPIProvider,
   AppSyncFunctionConfigurationProvider,

--- a/packages/amplify-graphql-transformer-interfaces/src/transform-host-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transform-host-provider.ts
@@ -17,6 +17,7 @@ import {
   SearchableDataSourceOptions,
   MappingTemplateProvider,
 } from './graphql-api-provider';
+import { AppSyncExecutionStrategy } from './appsync-execution-strategy';
 
 export interface DynamoDbDataSourceOptions extends DataSourceOptions {
   /**
@@ -40,6 +41,9 @@ export interface TransformHostProvider {
     stack?: Stack,
   ): BaseDataSource;
 
+  /**
+   * @deprecated Use addAppSyncFunctionWithStrategy, which adds support for all AppSync runtimes.
+   */
   addAppSyncFunction: (
     name: string,
     requestMappingTemplate: MappingTemplateProvider,
@@ -48,11 +52,31 @@ export interface TransformHostProvider {
     stack?: Stack,
   ) => AppSyncFunctionConfigurationProvider;
 
+  addAppSyncFunctionWithStrategy: (
+    name: string,
+    strategy: AppSyncExecutionStrategy,
+    dataSourceName: string,
+    stack?: Stack,
+  ) => AppSyncFunctionConfigurationProvider;
+
+  /**
+   * @deprecated Use addResolverWithStrategy, which supports all AppSync runtimes.
+   */
   addResolver: (
     typeName: string,
     fieldName: string,
     requestMappingTemplate: MappingTemplateProvider,
     responseMappingTemplate: MappingTemplateProvider,
+    resolverLogicalId?: string,
+    dataSourceName?: string,
+    pipelineConfig?: string[],
+    stack?: Stack,
+  ) => CfnResolver;
+
+  addResolverWithStrategy: (
+    typeName: string,
+    fieldName: string,
+    strategy: AppSyncExecutionStrategy,
     resolverLogicalId?: string,
     dataSourceName?: string,
     pipelineConfig?: string[],

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-resolver-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-resolver-provider.ts
@@ -2,12 +2,21 @@ import { Stack } from 'aws-cdk-lib';
 import { GraphQLAPIProvider, MappingTemplateProvider } from '../graphql-api-provider';
 import { DataSourceProvider } from './transformer-datasource-provider';
 import { TransformerContextProvider } from './transformer-context-provider';
+import { AppSyncExecutionStrategy } from '../appsync-execution-strategy';
 
 export interface TransformerResolverProvider {
+  /**
+   * @deprecated use addToSlotWithStrategy, which supports all appsync runtimes
+   */
   addToSlot: (
     slotName: string,
     requestMappingTemplate?: MappingTemplateProvider,
     responseMappingTemplate?: MappingTemplateProvider,
+    dataSource?: DataSourceProvider,
+  ) => void;
+  addToSlotWithStrategy: (
+    slotName: string,
+    strategy: AppSyncExecutionStrategy,
     dataSource?: DataSourceProvider,
   ) => void;
   synthesize: (context: TransformerContextProvider, api: GraphQLAPIProvider) => void;
@@ -21,6 +30,9 @@ export interface TransformerResolversManagerProvider {
   removeResolver: (typeName: string, fieldName: string) => TransformerResolverProvider;
   collectResolvers: () => Map<string, TransformerResolverProvider>;
 
+  /**
+   * @deprecated use generateQueryResolverWithStrategy, which supports all appsync runtimes
+   */
   generateQueryResolver: (
     typeName: string,
     fieldName: string,
@@ -30,6 +42,17 @@ export interface TransformerResolversManagerProvider {
     responseMappingTemplate: MappingTemplateProvider,
   ) => TransformerResolverProvider;
 
+  generateQueryResolverWithStrategy: (
+    typeName: string,
+    fieldName: string,
+    resolverLogicalId: string,
+    dataSource: DataSourceProvider,
+    strategy: AppSyncExecutionStrategy,
+  ) => TransformerResolverProvider;
+
+  /**
+   * @deprecated use generateMutationResolverWithStrategy, which supports all appsync runtimes
+   */
   generateMutationResolver: (
     typeName: string,
     fieldName: string,
@@ -39,11 +62,29 @@ export interface TransformerResolversManagerProvider {
     responseMappingTemplate: MappingTemplateProvider,
   ) => TransformerResolverProvider;
 
+  generateMutationResolverWithStrategy: (
+    typeName: string,
+    fieldName: string,
+    resolverLogicalId: string,
+    dataSource: DataSourceProvider,
+    strategy: AppSyncExecutionStrategy,
+  ) => TransformerResolverProvider;
+
+  /**
+   * @deprecated use generateSubscriptionResolverWithStrategy, which supports all appsync runtimes
+   */
   generateSubscriptionResolver: (
     typeName: string,
     fieldName: string,
     resolverLogicalId: string,
     requestMappingTemplate: MappingTemplateProvider,
     responseMappingTemplate: MappingTemplateProvider,
+  ) => TransformerResolverProvider;
+
+  generateSubscriptionResolverWithStrategy: (
+    typeName: string,
+    fieldName: string,
+    resolverLogicalId: string,
+    strategy: AppSyncExecutionStrategy,
   ) => TransformerResolverProvider;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6211,9 +6211,9 @@
     "@octokit/openapi-types" "^12.11.0"
 
 "@octokit/types@^9.0.0":
-  version "9.1.1"
-  resolved "https://registry.npmjs.org/@octokit/types/-/types-9.1.1.tgz#8a71f05c4e72fe51aac2c66ed71999abdd7e2777"
-  integrity sha512-hFheiHJEZzE5qn/u4R2IeMLXqUzXgd1vSokHS5x4oq+klHhXNFLL69kanAtrlTqj3K9Dps9XhOqOtDhDmPdlxQ==
+  version "9.1.2"
+  resolved "https://registry.npmjs.org/@octokit/types/-/types-9.1.2.tgz#1a8d35b1f4a3d2ad386e223f249dd5f7506979c1"
+  integrity sha512-LPbJIuu1WNoRHbN4UMysEdlissRFpTCWyoKT7kHPufI8T+XX33/qilfMWJo3mCOjNIKu0+43oSQPf+HJa0+TTQ==
   dependencies:
     "@octokit/openapi-types" "^17.0.0"
 
@@ -8058,9 +8058,9 @@ aws-sdk-mock@^5.6.2:
     traverse "^0.6.6"
 
 aws-sdk@2.518.0, aws-sdk@^2.1113.0, aws-sdk@^2.1141.0, aws-sdk@^2.1231.0, aws-sdk@^2.1233.0:
-  version "2.1362.0"
-  resolved "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1362.0.tgz#e7a65b5db9dfa40dd5b968a456ac7ad903c721bc"
-  integrity sha512-Cqv0khSv13xBGKOdErArCdyT0/W3cxQ3Xr9Oa0Lwt43xb24gbad+9lvtNMkbQGQusX3PSk95o+gcAaWreYAlYg==
+  version "2.1363.0"
+  resolved "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1363.0.tgz#30c3b7fe999ee2ba1103a533ea27e1b0f5708e1f"
+  integrity sha512-M2MZZXehgi/EMQv5GlzRkn3TlhoOYHg2cYdSAAqhjv67WaEG50MjaQy5vRvfN1i8XvB24aJFJ5pCrx69TaCaIg==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
#### Description of changes
Add new construct `AppSyncExecutionStrategy` to the transformer interfaces, which allow the input of either TEMPLATE based functions or resolvers, which accept a RequestMappingTemplate, and ResponseMappingTemplate, and a CODE based function or resolver, which accepts the code for the functions, and the runtime configuration required by AppSync.

 Tested manually using this test app https://github.com/alharris-at/override-resolvers, and verified via added unit and integration tests.

This adds a few new APIs to the system, but is implemented to be fully backwards-compatible. All existing APIs continue to work, and just proxy to the new methods, creating the TEMPLATE based strategy.

#### Issue #, if available
Related to https://github.com/aws-amplify/amplify-category-api/issues/1015

#### Description of how you validated changes
Verified w/ a test app, added unit tests for core components, and e2e tests to cover the use case of adding a new slot-based js resolver, and overriding an internally generated VTL-based resolver.

[E2E Run](https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api/3016/workflows/7191aca0-81ef-4bd0-8775-3a69b1a4b902)

##### Override File

![Screenshot 2022-11-29 at 11 21 18 AM](https://user-images.githubusercontent.com/91494052/204628291-f01ae057-9346-4384-a155-17a94c48befb.png)

##### Config in AppSync Pipeline

![Screenshot 2022-11-29 at 11 22 52 AM](https://user-images.githubusercontent.com/91494052/204628069-a83f97c1-8b9f-4d68-84ca-58efc30dcd88.png)

##### Query Results

![Screenshot 2022-11-29 at 11 21 01 AM](https://user-images.githubusercontent.com/91494052/204627025-b40460af-67c9-45ca-8571-2b1c69cf1000.png)

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
