### PR TITLE
fix: resolve test region dynamically

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/IAMHelper.ts
+++ b/packages/graphql-transformers-e2e-tests/src/IAMHelper.ts
@@ -1,8 +1,11 @@
 import { IAM, Credentials } from 'aws-sdk';
+import { resolveTestRegion } from './testSetup';
+
+const REGION = resolveTestRegion();
 
 export class IAMHelper {
   client: IAM;
-  constructor(region: string = 'us-west-2', credentials?: Credentials) {
+  constructor(region: string = REGION, credentials?: Credentials) {
     this.client = new IAM({
       region,
       credentials

--- a/packages/graphql-transformers-e2e-tests/src/LambdaHelper.ts
+++ b/packages/graphql-transformers-e2e-tests/src/LambdaHelper.ts
@@ -1,10 +1,13 @@
 import { Credentials, Lambda } from 'aws-sdk';
 import * as fs from 'fs';
 import * as path from 'path';
+import { resolveTestRegion } from './testSetup';
+
+const REGION = resolveTestRegion();
 
 export class LambdaHelper {
   client: Lambda;
-  constructor(region: string = 'us-west-2', credentials?: Credentials) {
+  constructor(region: string = REGION, credentials?: Credentials) {
     this.client = new Lambda({
       region,
       credentials

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2Transformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2Transformer.e2e.test.ts
@@ -22,15 +22,18 @@ import {
 } from '../cognitoUtils';
 import { ResourceConstants } from 'graphql-transformer-common';
 import { GraphQLClient } from '../GraphQLClient';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
 describe('@model with @auth', () => {
   // setup clients
-  const cf = new CloudFormationClient('us-west-2');
-  const customS3Client = new S3Client('us-west-2');
-  const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: 'us-west-2' });
-  const awsS3Client = new S3({ region: 'us-west-2' });
+  const cf = new CloudFormationClient(region);
+  const customS3Client = new S3Client(region);
+  const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: region });
+  const awsS3Client = new S3({ region: region });
 
   // stack info
   const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2TransformerWithFF.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2TransformerWithFF.e2e.test.ts
@@ -22,15 +22,18 @@ import {
   signupUser,
 } from '../cognitoUtils';
 import { GraphQLClient } from '../GraphQLClient';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
 describe('@model with @auth', () => {
   // setup clients
-  const cf = new CloudFormationClient('us-west-2');
-  const customS3Client = new S3Client('us-west-2');
-  const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: 'us-west-2' });
-  const awsS3Client = new S3({ region: 'us-west-2' });
+  const cf = new CloudFormationClient(region);
+  const customS3Client = new S3Client(region);
+  const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: region });
+  const awsS3Client = new S3({ region: region });
 
   // stack info
   const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ConnectionsWithAuthTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ConnectionsWithAuthTests.e2e.test.ts
@@ -26,10 +26,13 @@ import 'isomorphic-fetch';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
+const cf = new CloudFormationClient(region);
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
     if (name === 'improvePluralization') {
@@ -79,9 +82,9 @@ const DEVS_GROUP_NAME = 'Devs';
 const PARTICIPANT_GROUP_NAME = 'Participant';
 const WATCHER_GROUP_NAME = 'Watcher';
 
-const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: 'us-west-2' });
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: region });
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 
 function outputValueSelector(key: string) {
   return (outputs: Output[]) => {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/DefaultValueTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/DefaultValueTransformer.e2e.test.ts
@@ -9,12 +9,15 @@ import { CloudFormationClient } from '../CloudFormationClient';
 import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { GraphQLClient } from '../GraphQLClient';
 import { S3Client } from '../S3Client';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
 const STACK_NAME = `DefaultValueTransformerTests-${BUILD_TIMESTAMP}`;
 const BUCKET_NAME = `appsync-default-value-transformer-test-bucket-${BUILD_TIMESTAMP}`;

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/DynamoDBModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/DynamoDBModelTransformer.e2e.test.ts
@@ -9,12 +9,15 @@ import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { S3Client } from '../S3Client';
 import { default as S3 } from 'aws-sdk/clients/s3';
 import { default as moment } from 'moment';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
     if (name === 'improvePluralization') {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/FunctionTransformerTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/FunctionTransformerTests.e2e.test.ts
@@ -12,10 +12,12 @@ import { S3Client } from '../S3Client';
 import { default as S3 } from 'aws-sdk/clients/s3';
 import { LambdaHelper } from '../LambdaHelper';
 import { IAMHelper } from '../IAMHelper';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const region = 'us-west-2';
 const cf = new CloudFormationClient(region);
 const customS3Client = new S3Client(region);
 const awsS3Client = new S3({ region: region });

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/FunctionTransformerTestsV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/FunctionTransformerTestsV2.e2e.test.ts
@@ -15,10 +15,12 @@ import { IAMHelper } from '../IAMHelper';
 import { default as STS } from 'aws-sdk/clients/sts';
 import { default as Organizations } from 'aws-sdk/clients/organizations';
 import AWS from 'aws-sdk';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const region = 'us-west-2';
 const cf = new CloudFormationClient(region);
 const customS3Client = new S3Client(region);
 const awsS3Client = new S3({ region: region });

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/HttpTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/HttpTransformer.e2e.test.ts
@@ -11,11 +11,14 @@ import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { S3Client } from '../S3Client';
 import { default as S3 } from 'aws-sdk/clients/s3';
 import { deployJsonServer, destroyJsonServer } from '../cdkUtils';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
-const customS3Client = new S3Client('us-west-2');
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
     if (name === 'improvePluralization') {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/HttpTransformerV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/HttpTransformerV2.e2e.test.ts
@@ -10,10 +10,12 @@ import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { S3Client } from '../S3Client';
 import { default as S3 } from 'aws-sdk/clients/s3';
 import { deployJsonServer, destroyJsonServer } from '../cdkUtils';
+import { resolveTestRegion } from '../testSetup';
+
+const REGION = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const REGION = 'us-west-2';
 const cf = new CloudFormationClient(REGION);
 const customS3Client = new S3Client(REGION);
 const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/IndexTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/IndexTransformer.e2e.test.ts
@@ -11,12 +11,15 @@ import { CloudFormationClient } from '../CloudFormationClient';
 import { GraphQLClient } from '../GraphQLClient';
 import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { S3Client } from '../S3Client';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 const featureFlags = {
   getBoolean: jest.fn(),
   getNumber: jest.fn(),

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/IndexWithAuthV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/IndexWithAuthV2.e2e.test.ts
@@ -19,10 +19,11 @@ import {
   createUserPoolClient,
   signupUser,
 } from '../cognitoUtils';
+import { resolveTestRegion } from '../testSetup';
+
+const AWS_REGION = resolveTestRegion();
 
 jest.setTimeout(2000000);
-
-const AWS_REGION = 'us-west-2';
 
 const cf = new CloudFormationClient(AWS_REGION);
 const customS3Client = new S3Client(AWS_REGION);

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/IndexWithAuthV2WithFF.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/IndexWithAuthV2WithFF.e2e.test.ts
@@ -19,10 +19,11 @@ import {
   createUserPoolClient,
   signupUser,
 } from '../cognitoUtils';
+import { resolveTestRegion } from '../testSetup';
+
+const AWS_REGION = resolveTestRegion();
 
 jest.setTimeout(2000000);
-
-const AWS_REGION = 'us-west-2';
 
 const cf = new CloudFormationClient(AWS_REGION);
 const customS3Client = new S3Client(AWS_REGION);

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/IndexWithAutoQueryField.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/IndexWithAutoQueryField.e2e.test.ts
@@ -11,12 +11,15 @@ import { CloudFormationClient } from '../CloudFormationClient';
 import { GraphQLClient } from '../GraphQLClient';
 import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { S3Client } from '../S3Client';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
     if (name === 'enableAutoIndexQueryNames') {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyTransformer.e2e.test.ts
@@ -10,12 +10,15 @@ import { default as moment } from 'moment';
 import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { S3Client } from '../S3Client';
 import { default as S3 } from 'aws-sdk/clients/s3';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
     if (name === 'improvePluralization') {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/KeyWithAuth.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/KeyWithAuth.e2e.test.ts
@@ -26,10 +26,13 @@ import 'isomorphic-fetch';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
+const cf = new CloudFormationClient(region);
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
     if (name === 'improvePluralization') {
@@ -83,9 +86,9 @@ const DEVS_GROUP_NAME = 'Devs';
 const PARTICIPANT_GROUP_NAME = 'Participant';
 const WATCHER_GROUP_NAME = 'Watcher';
 
-const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: 'us-west-2' });
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: region });
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 
 function outputValueSelector(key: string) {
   return (outputs: Output[]) => {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelAuthTransformer.e2e.test.ts
@@ -27,6 +27,9 @@ import 'isomorphic-fetch';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 const featureFlags = {
@@ -42,7 +45,7 @@ const featureFlags = {
 
 };
 describe(`ModelAuthTests`, () => {
-  const cf = new CloudFormationClient('us-west-2');
+  const cf = new CloudFormationClient(region);
 
   const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
   const STACK_NAME = `ModelAuthTransformerTest-${BUILD_TIMESTAMP}`;
@@ -86,9 +89,9 @@ describe(`ModelAuthTests`, () => {
   const PARTICIPANT_GROUP_NAME = 'Participant';
   const WATCHER_GROUP_NAME = 'Watcher';
 
-  const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: 'us-west-2' });
-  const customS3Client = new S3Client('us-west-2');
-  const awsS3Client = new S3({ region: 'us-west-2' });
+  const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: region });
+  const customS3Client = new S3Client(region);
+  const awsS3Client = new S3({ region: region });
 
   function outputValueSelector(key: string) {
     return (outputs: Output[]) => {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelConnectionTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelConnectionTransformer.e2e.test.ts
@@ -10,12 +10,15 @@ import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { S3Client } from '../S3Client';
 import { default as S3 } from 'aws-sdk/clients/s3';
 import { default as moment } from 'moment';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
     if (name === 'improvePluralization') {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelConnectionWithKeyTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelConnectionWithKeyTransformer.e2e.test.ts
@@ -11,12 +11,15 @@ import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { S3Client } from '../S3Client';
 import { default as S3 } from 'aws-sdk/clients/s3';
 import { default as moment } from 'moment';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
     if (name === 'improvePluralization') {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelTransformer.e2e.test.ts
@@ -8,12 +8,15 @@ import { CloudFormationClient } from '../CloudFormationClient';
 import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { GraphQLClient } from '../GraphQLClient';
 import { S3Client } from '../S3Client';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
 const STACK_NAME = `ModelTransformerTest-${BUILD_TIMESTAMP}`;
 const BUCKET_NAME = `appsync-model-transformer-test-bucket-${BUILD_TIMESTAMP}`;

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
@@ -26,6 +26,7 @@ import 'isomorphic-fetch';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+import { resolveTestRegion } from '../testSetup';
 
 // To overcome of the way of how AmplifyJS picks up currentUserCredentials
 const anyAWS = AWS as any;
@@ -34,9 +35,10 @@ if (anyAWS && anyAWS.config && anyAWS.config.credentials) {
   delete anyAWS.config.credentials;
 }
 
+const REGION = resolveTestRegion();
+
 jest.setTimeout(2000000);
 
-const REGION = 'us-west-2';
 const cf = new CloudFormationClient(REGION);
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthV2Transformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthV2Transformer.e2e.test.ts
@@ -29,6 +29,9 @@ import 'isomorphic-fetch';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+import { resolveTestRegion } from '../testSetup';
+
+const AWS_REGION = resolveTestRegion();
 
 // To overcome of the way of how AmplifyJS picks up currentUserCredentials
 const anyAWS = AWS as any;
@@ -37,8 +40,6 @@ if (anyAWS && anyAWS.config && anyAWS.config.credentials) {
 }
 
 jest.setTimeout(2000000);
-
-const AWS_REGION = 'us-west-2';
 
 function outputValueSelector(key: string) {
   return (outputs: Output[]) => {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthV2TransformerWithFF.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthV2TransformerWithFF.e2e.test.ts
@@ -29,6 +29,9 @@ import 'isomorphic-fetch';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+import { resolveTestRegion } from '../testSetup';
+
+const AWS_REGION = resolveTestRegion();
 
 // To overcome of the way of how AmplifyJS picks up currentUserCredentials
 const anyAWS = AWS as any;
@@ -37,8 +40,6 @@ if (anyAWS && anyAWS.config && anyAWS.config.credentials) {
 }
 
 jest.setTimeout(2000000);
-
-const AWS_REGION = 'us-west-2';
 
 function outputValueSelector(key: string) {
   return (outputs: Output[]) => {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MutationCondition.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MutationCondition.e2e.test.ts
@@ -32,6 +32,9 @@ import IdentityPool from 'cloudform-types/types/cognito/identityPool';
 import IdentityPoolRoleAttachment from 'cloudform-types/types/cognito/identityPoolRoleAttachment';
 import AWS = require('aws-sdk');
 import 'isomorphic-fetch';
+import { resolveTestRegion } from '../testSetup';
+
+const REGION = resolveTestRegion();
 
 jest.setTimeout(2000000);
 const featureFlags = {
@@ -553,7 +556,6 @@ if (anyAWS && anyAWS.config && anyAWS.config.credentials) {
 }
 
 describe(`Deployed Mutation Condition tests`, () => {
-  const REGION = 'us-west-2';
   const cf = new CloudFormationClient(REGION);
 
   const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/NewConnectionTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/NewConnectionTransformer.e2e.test.ts
@@ -11,12 +11,15 @@ import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { S3Client } from '../S3Client';
 import { default as S3 } from 'aws-sdk/clients/s3';
 import { default as moment } from 'moment';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
     if (name === 'improvePluralization') {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/NewConnectionWithAuth.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/NewConnectionWithAuth.e2e.test.ts
@@ -27,10 +27,13 @@ import 'isomorphic-fetch';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
+const cf = new CloudFormationClient(region);
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
     if (name === 'improvePluralization') {
@@ -79,9 +82,9 @@ const DEVS_GROUP_NAME = 'Devs';
 const PARTICIPANT_GROUP_NAME = 'Participant';
 const WATCHER_GROUP_NAME = 'Watcher';
 
-const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: 'us-west-2' });
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: region });
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 
 function outputValueSelector(key: string) {
   return (outputs: Output[]) => {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/NonModelAuthFunction.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/NonModelAuthFunction.e2e.test.ts
@@ -24,6 +24,9 @@ import 'isomorphic-fetch';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+import { resolveTestRegion } from '../testSetup';
+
+const REGION = resolveTestRegion();
 
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
@@ -46,7 +49,6 @@ if (anyAWS && anyAWS.config && anyAWS.config.credentials) {
 
 jest.setTimeout(2000000);
 
-const REGION = 'us-west-2';
 const cf = new CloudFormationClient(REGION);
 const customS3Client = new S3Client(REGION);
 const awsS3Client = new S3({ region: REGION });

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/NonModelAuthV2Function.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/NonModelAuthV2Function.e2e.test.ts
@@ -21,10 +21,12 @@ import { S3Client } from '../S3Client';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+import { resolveTestRegion } from '../testSetup';
+
+const REGION = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const REGION = 'us-west-2';
 const cf = new CloudFormationClient(REGION);
 const identityClient = new CognitoIdentity({ apiVersion: '2014-06-30', region: REGION });
 const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: REGION });

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/NoneEnvFunctionTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/NoneEnvFunctionTransformer.e2e.test.ts
@@ -12,12 +12,14 @@ import { S3Client } from '../S3Client';
 import { default as S3 } from 'aws-sdk/clients/s3';
 import { LambdaHelper } from '../LambdaHelper';
 import { IAMHelper } from '../IAMHelper';
+import { resolveTestRegion } from '../testSetup';
 
+const region = resolveTestRegion();
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
     if (name === 'improvePluralization') {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthTests.e2e.test.ts
@@ -26,10 +26,13 @@ import 'isomorphic-fetch';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
+const cf = new CloudFormationClient(region);
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
     if (name === 'improvePluralization') {
@@ -79,9 +82,9 @@ const PARTICIPANT_GROUP_NAME = 'Participant';
 const WATCHER_GROUP_NAME = 'Watcher';
 const INSTRUCTOR_GROUP_NAME = 'Instructor';
 
-const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: 'us-west-2' });
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: region });
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 
 function outputValueSelector(key: string) {
   return (outputs: Output[]) => {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthV2Transformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthV2Transformer.e2e.test.ts
@@ -24,12 +24,13 @@ import 'isomorphic-fetch';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const AWS_REGION = 'us-west-2';
-
-const cf = new CloudFormationClient(AWS_REGION);
+const cf = new CloudFormationClient(region);
 const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
 const STACK_NAME = `PerFieldAuthV2Tests-${BUILD_TIMESTAMP}`;
 const BUCKET_NAME = `per-field-authv2-tests-bucket-${BUILD_TIMESTAMP}`;
@@ -67,9 +68,9 @@ const PARTICIPANT_GROUP_NAME = 'Participant';
 const WATCHER_GROUP_NAME = 'Watcher';
 const INSTRUCTOR_GROUP_NAME = 'Instructor';
 
-const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: 'us-west-2' });
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: region });
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 
 function outputValueSelector(key: string) {
   return (outputs: Output[]) => {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthV2TransformerWithFF.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthV2TransformerWithFF.e2e.test.ts
@@ -24,12 +24,12 @@ import 'isomorphic-fetch';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+import { resolveTestRegion } from '../testSetup';
 
+const region = resolveTestRegion();
 jest.setTimeout(2000000);
 
-const AWS_REGION = 'us-west-2';
-
-const cf = new CloudFormationClient(AWS_REGION);
+const cf = new CloudFormationClient(region);
 const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
 const STACK_NAME = `PerFieldAuthV2Tests-${BUILD_TIMESTAMP}`;
 const BUCKET_NAME = `per-field-authv2-tests-bucket-${BUILD_TIMESTAMP}`;
@@ -67,9 +67,9 @@ const PARTICIPANT_GROUP_NAME = 'Participant';
 const WATCHER_GROUP_NAME = 'Watcher';
 const INSTRUCTOR_GROUP_NAME = 'Instructor';
 
-const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: 'us-west-2' });
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: region });
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 
 function outputValueSelector(key: string) {
   return (outputs: Output[]) => {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PredictionsTransformerTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PredictionsTransformerTests.e2e.test.ts
@@ -10,11 +10,13 @@ import { default as moment } from 'moment';
 import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { S3Client } from '../S3Client';
 import { default as S3 } from 'aws-sdk/clients/s3';
+import { resolveTestRegion } from '../testSetup';
+
+const AWS_REGION = resolveTestRegion();
 
 // tslint:disable: no-magic-numbers
 jest.setTimeout(2000000);
 
-const AWS_REGION = 'us-east-2';
 const cf = new CloudFormationClient(AWS_REGION);
 const customS3Client = new S3Client(AWS_REGION);
 const awsS3Client = new S3({ region: AWS_REGION });

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PredictionsTransformerV2Tests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PredictionsTransformerV2Tests.e2e.test.ts
@@ -11,11 +11,13 @@ import { CloudFormationClient } from '../CloudFormationClient';
 import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { GraphQLClient } from '../GraphQLClient';
 import { S3Client } from '../S3Client';
+import { resolveTestRegion } from '../testSetup';
+
+const AWS_REGION = resolveTestRegion();
 
 // tslint:disable: no-magic-numbers
 jest.setTimeout(2000000);
 
-const AWS_REGION = 'us-east-2';
 const cf = new CloudFormationClient(AWS_REGION);
 const customS3Client = new S3Client(AWS_REGION);
 const awsS3Client = new S3({ region: AWS_REGION });

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalTransformers.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalTransformers.e2e.test.ts
@@ -17,12 +17,15 @@ import { CloudFormationClient } from '../CloudFormationClient';
 import { GraphQLClient } from '../GraphQLClient';
 import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { S3Client } from '../S3Client';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2.e2e.test.ts
@@ -27,13 +27,16 @@ import {
 } from '../cognitoUtils';
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
-const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: 'us-west-2' });
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
+const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: region });
 const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
 const STACK_NAME = `RelationalAuthV2TransformersTest-${BUILD_TIMESTAMP}`;
 const BUCKET_NAME = `appsync-relational-auth-transformer-test-${BUILD_TIMESTAMP}`;

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2WithFF.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2WithFF.e2e.test.ts
@@ -27,13 +27,16 @@ import {
 } from '../cognitoUtils';
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
-const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: 'us-west-2' });
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
+const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: region });
 const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
 const STACK_NAME = `RelationalAuthV2TransformersTest-${BUILD_TIMESTAMP}`;
 const BUCKET_NAME = `appsync-relational-auth-transformer-test-${BUILD_TIMESTAMP}`;

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformer.e2e.test.ts
@@ -12,13 +12,16 @@ import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { default as moment } from 'moment';
 import { default as S3 } from 'aws-sdk/clients/s3';
 import addStringSets from '../stringSetMutations';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 // tslint:disable: no-magic-numbers
 jest.setTimeout(60000 * 60);
 
-const cf = new CloudFormationClient('us-west-2');
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 let GRAPHQL_CLIENT: GraphQLClient = undefined;
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformerV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformerV2.e2e.test.ts
@@ -9,13 +9,16 @@ import { GraphQLClient } from '../GraphQLClient';
 import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
 import { default as moment } from 'moment';
 import { default as S3 } from 'aws-sdk/clients/s3';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 // tslint:disable: no-magic-numbers
 jest.setTimeout(60000 * 60);
 
-const cf = new CloudFormationClient('us-east-1');
-const customS3Client = new S3Client('us-east-1');
-const awsS3Client = new S3({ region: 'us-east-1' });
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 let GRAPHQL_CLIENT: GraphQLClient = undefined;
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableWithAuthTests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableWithAuthTests.e2e.test.ts
@@ -49,10 +49,12 @@ if (anyAWS && anyAWS.config && anyAWS.config.credentials) {
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+import { resolveTestRegion } from '../testSetup';
+
+const AWS_REGION = resolveTestRegion();
 
 jest.setTimeout(9700000);
 
-const AWS_REGION = 'us-west-2';
 const cf = new CloudFormationClient(AWS_REGION);
 const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
 const STACK_NAME = `SearchableAuthTests-${BUILD_TIMESTAMP}`;

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableWithAuthV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableWithAuthV2.e2e.test.ts
@@ -26,6 +26,10 @@ import {
 } from '../cognitoUtils';
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+import { resolveTestRegion } from '../testSetup';
+
+const AWS_REGION = resolveTestRegion();
+
 // To overcome of the way of how AmplifyJS picks up currentUserCredentials
 const anyAWS = AWS as any;
 if (anyAWS && anyAWS.config && anyAWS.config.credentials) {
@@ -34,7 +38,6 @@ if (anyAWS && anyAWS.config && anyAWS.config.credentials) {
 
 // tslint:disable: no-magic-numbers
 jest.setTimeout(60000 * 60);
-const AWS_REGION = 'us-west-2';
 
 const cf = new CloudFormationClient(AWS_REGION);
 const customS3Client = new S3Client(AWS_REGION);

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableWithAuthV2WithFF.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableWithAuthV2WithFF.e2e.test.ts
@@ -26,6 +26,10 @@ import {
 } from '../cognitoUtils';
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+import { resolveTestRegion } from '../testSetup';
+
+const AWS_REGION = resolveTestRegion();
+
 // To overcome of the way of how AmplifyJS picks up currentUserCredentials
 const anyAWS = AWS as any;
 if (anyAWS && anyAWS.config && anyAWS.config.credentials) {
@@ -34,7 +38,6 @@ if (anyAWS && anyAWS.config && anyAWS.config.credentials) {
 
 // tslint:disable: no-magic-numbers
 jest.setTimeout(60000 * 60);
-const AWS_REGION = 'us-west-2';
 
 const cf = new CloudFormationClient(AWS_REGION);
 const customS3Client = new S3Client(AWS_REGION);

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts
@@ -27,6 +27,10 @@ import { S3Client } from '../S3Client';
 // to deal with subscriptions in node env
 (global as any).WebSocket = require('ws');
 
+import { resolveTestRegion } from '../testSetup';
+
+const AWS_REGION = resolveTestRegion();
+
 // To overcome of the way of how AmplifyJS picks up currentUserCredentials
 const anyAWS = AWS as any;
 if (anyAWS && anyAWS.config && anyAWS.config.credentials) {
@@ -48,7 +52,6 @@ function outputValueSelector(key: string) {
   };
 }
 
-const AWS_REGION = 'us-west-2';
 const cf = new CloudFormationClient(AWS_REGION);
 const customS3Client = new S3Client(AWS_REGION);
 const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: AWS_REGION });

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts
@@ -54,6 +54,10 @@ const featureFlags = {
 // to deal with subscriptions in node env
 (global as any).WebSocket = require('ws');
 
+import { resolveTestRegion } from '../testSetup';
+
+const AWS_REGION = resolveTestRegion();
+
 // delay times
 const SUBSCRIPTION_DELAY = 10000;
 const PROPAGATION_DELAY = 5000;
@@ -62,7 +66,6 @@ const SUBSCRIPTION_TIMEOUT = 10000;
 
 jest.setTimeout(JEST_TIMEOUT);
 
-const AWS_REGION = 'us-west-2';
 const cf = new CloudFormationClient(AWS_REGION);
 const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
 const STACK_NAME = `SubscriptionAuthTests-${BUILD_TIMESTAMP}`;

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts
@@ -39,6 +39,10 @@ import * as Observable from 'zen-observable';
 // to deal with subscriptions in node env
 (global as any).WebSocket = require('ws');
 
+import { resolveTestRegion } from '../testSetup';
+
+const AWS_REGION = resolveTestRegion();
+
 // To overcome of the way of how AmplifyJS picks up currentUserCredentials
 const anyAWS = AWS as any;
 if (anyAWS && anyAWS.config && anyAWS.config.credentials) {
@@ -60,7 +64,6 @@ function outputValueSelector(key: string) {
   };
 }
 
-const AWS_REGION = 'us-west-2';
 const cf = new CloudFormationClient(AWS_REGION);
 const customS3Client = new S3Client(AWS_REGION);
 const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: AWS_REGION });

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2WithFF.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthV2WithFF.e2e.test.ts
@@ -35,6 +35,10 @@ import * as Observable from 'zen-observable';
 // to deal with subscriptions in node env
 (global as any).WebSocket = require('ws');
 
+import { resolveTestRegion } from '../testSetup';
+
+const AWS_REGION = resolveTestRegion();
+
 // To overcome of the way of how AmplifyJS picks up currentUserCredentials
 const anyAWS = AWS as any;
 if (anyAWS && anyAWS.config && anyAWS.config.credentials) {
@@ -56,7 +60,6 @@ function outputValueSelector(key: string) {
   };
 }
 
-const AWS_REGION = 'us-west-2';
 const cf = new CloudFormationClient(AWS_REGION);
 const customS3Client = new S3Client(AWS_REGION);
 const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: AWS_REGION });

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/TransformerOptionsV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/TransformerOptionsV2.e2e.test.ts
@@ -13,10 +13,11 @@ import moment from 'moment';
 import { createUserPool, createUserPoolClient, configureAmplify } from '../cognitoUtils';
 import { ResourceConstants } from 'graphql-transformer-common';
 import gql from 'graphql-tag';
+import { resolveTestRegion } from '../testSetup';
+
+const AWS_REGION = resolveTestRegion();
 
 jest.setTimeout(2000000);
-
-const AWS_REGION = 'us-west-2';
 
 describe('V2 transformer options', () => {
   const cf = new CloudFormationClient(AWS_REGION);

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/VersionedModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/VersionedModelTransformer.e2e.test.ts
@@ -10,10 +10,13 @@ import { default as moment } from 'moment';
 import { default as S3 } from 'aws-sdk/clients/s3';
 import { S3Client } from '../S3Client';
 import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
+import { resolveTestRegion } from '../testSetup';
+
+const region = resolveTestRegion();
 
 jest.setTimeout(2000000);
 
-const cf = new CloudFormationClient('us-west-2');
+const cf = new CloudFormationClient(region);
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
     if (name === 'improvePluralization') {
@@ -32,8 +35,8 @@ const S3_ROOT_DIR_KEY = 'deployments';
 
 let GRAPHQL_CLIENT = undefined;
 
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 
 function outputValueSelector(key: string) {
   return (outputs: Output[]) => {

--- a/packages/graphql-transformers-e2e-tests/src/authExhaustiveTestUtils.ts
+++ b/packages/graphql-transformers-e2e-tests/src/authExhaustiveTestUtils.ts
@@ -24,8 +24,9 @@ import {
 import { cleanupStackAfterTest, deploy } from './deployNestedStacks';
 import { IAMHelper } from './IAMHelper';
 import { S3Client } from './S3Client';
+import { resolveTestRegion } from './testSetup';
 
-const REGION = 'us-west-2';
+const REGION = resolveTestRegion();
 const IAM_HELPER = new IAMHelper(REGION);
 const CF = new CloudFormationClient(REGION);
 const COGNITO_CLIENT = new CognitoClient({ apiVersion: '2016-04-19', region: REGION });

--- a/packages/graphql-transformers-e2e-tests/src/cognitoUtils.ts
+++ b/packages/graphql-transformers-e2e-tests/src/cognitoUtils.ts
@@ -15,6 +15,9 @@ import { IAM as cfnIAM, Cognito as cfnCognito } from 'cloudform-types';
 import { CognitoIdentityServiceProvider as CognitoClient, CognitoIdentity } from 'aws-sdk';
 import TestStorage from './TestStorage';
 import DeploymentResources from 'graphql-transformer-core/lib/DeploymentResources';
+import { resolveTestRegion } from './testSetup';
+
+const region = resolveTestRegion();
 
 interface E2Econfiguration {
   STACK_NAME?: string;
@@ -26,13 +29,13 @@ interface E2Econfiguration {
   USER_POOL_ID?: string;
 }
 
-const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: 'us-west-2' });
+const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: region });
 
 export function configureAmplify(userPoolId: string, userPoolClientId: string, identityPoolId?: string) {
   Amplify.configure({
     Auth: {
       // REQUIRED - Amazon Cognito Region
-      region: 'us-west-2',
+      region: region,
       userPoolId: userPoolId,
       userPoolWebClientId: userPoolClientId,
       storage: new TestStorage(),

--- a/packages/graphql-transformers-e2e-tests/src/deploySchema.ts
+++ b/packages/graphql-transformers-e2e-tests/src/deploySchema.ts
@@ -10,10 +10,12 @@ import { cleanupStackAfterTest, deploy } from './deployNestedStacks';
 import { Output } from 'aws-sdk/clients/cloudformation';
 import { ResourceConstants } from 'graphql-transformer-common';
 import * as fs from 'fs-extra';
+import { resolveTestRegion } from './testSetup';
 
-const cf = new CloudFormationClient('us-west-2');
-const customS3Client = new S3Client('us-west-2');
-const awsS3Client = new S3({ region: 'us-west-2' });
+const region = resolveTestRegion();
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
 
 /**
  * Interface for object that can manage graphql api deployments and cleanup for e2e tests

--- a/packages/graphql-transformers-e2e-tests/src/emptyBucket.ts
+++ b/packages/graphql-transformers-e2e-tests/src/emptyBucket.ts
@@ -1,5 +1,8 @@
 import { default as S3 } from 'aws-sdk/clients/s3';
-const awsS3Client = new S3({ region: 'us-west-2' });
+import { resolveTestRegion } from './testSetup';
+
+const region = resolveTestRegion();
+const awsS3Client = new S3({ region: region });
 
 const emptyBucket = async (bucket: string) => {
   let listObjects = await awsS3Client

--- a/packages/graphql-transformers-e2e-tests/src/testSetup.ts
+++ b/packages/graphql-transformers-e2e-tests/src/testSetup.ts
@@ -1,0 +1,10 @@
+/**
+ * Resolves the AWS region to run the tests
+ * @param defaultRegion 
+ * @returns 
+ */
+export const resolveTestRegion = (defaultRegion = 'us-west-2') => {
+  const resolvedRegion = process?.env?.CLI_REGION || defaultRegion;
+  console.log('Running in region: ' + resolvedRegion);
+  return resolvedRegion;
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The test setup for most of the tests in the `graphql-transformer-e2e-tests` package is forced to run on fixed AWS region, popularly `us-west-2`. This change attempts to resolve the region to that is supplied as environment variable `CLI_REGION` in the generated CI config with a fallback to `us-west-2`.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
[Full e2e pipeline run](https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api/2551/workflows/9f817078-02b3-4309-aaff-8eaeec8c44f1)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
