### PR TITLE
chore: use AmplifyError for overrides failure

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -631,7 +631,7 @@ commands:
                   source .circleci/local_publish_helpers.sh
                   amplify version
                   retry runE2eTest
-                no_output_timeout: 60m
+                no_output_timeout: 90m
   scan_e2e_test_artifacts:
     description: "Scan And Cleanup E2E Test Artifacts"
     parameters:

--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -72,12 +72,12 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "@aws-amplify/amplify-environment-parameters": "^1.2.0-beta.1",
-    "amplify-cli-core": "^4.0.0-beta.1",
-    "amplify-headless-interface": "^1.15.0-beta.1",
-    "amplify-prompts": "^2.2.0-beta.1",
-    "amplify-provider-awscloudformation": "^7.0.0-beta.1",
-    "amplify-util-headless-input": "^1.9.5-beta.1"
+    "@aws-amplify/amplify-environment-parameters": "^1.2.0-beta.2",
+    "amplify-cli-core": "^4.0.0-beta.2",
+    "amplify-headless-interface": "^1.16.0-beta.1",
+    "amplify-prompts": "^2.6.2-beta.1",
+    "amplify-provider-awscloudformation": "^7.0.0-beta.2",
+    "amplify-util-headless-input": "^1.9.7-beta.1"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.0",

--- a/packages/amplify-category-api/resources/awscloudformation/overrides-resource/APIGW/package.json
+++ b/packages/amplify-category-api/resources/awscloudformation/overrides-resource/APIGW/package.json
@@ -7,7 +7,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@aws-amplify/cli-extensibility-helper": "^3.0.0-beta.1"
+    "@aws-amplify/cli-extensibility-helper": "^3.0.0-beta.2"
   },
   "devDependencies": {
     "typescript": "^4.2.4"

--- a/packages/amplify-category-api/resources/awscloudformation/overrides-resource/AppSync/package.json
+++ b/packages/amplify-category-api/resources/awscloudformation/overrides-resource/AppSync/package.json
@@ -7,7 +7,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@aws-amplify/cli-extensibility-helper": "^3.0.0-beta.1"
+    "@aws-amplify/cli-extensibility-helper": "^3.0.0-beta.2"
   },
   "devDependencies": {
     "typescript": "^4.2.4"

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-transform.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-transform.ts
@@ -3,6 +3,7 @@ import {
   $TSContext,
   $TSObject,
   AmplifyCategories,
+  AmplifyError,
   buildOverrideDir,
   getAmplifyResourceByCategories,
   JSONUtilities,
@@ -214,10 +215,11 @@ export class ApigwStackTransform {
         try {
           await sandboxNode.run(overrideCode, overrideJSFilePath).override(this.resourceTemplateObj as AmplifyApigwResourceStack);
         } catch (err) {
-          // this is a workaround for the API repo until we can import AmplifyError without creating a circular dependency
-          const amplifyError = new Error("Executing overrides failed. There may be runtime errors in your overrides file. If so, fix the errors and try again.");
-          (amplifyError as any)['_amplifyErrorType'] = 'InvalidOverrideError';
-          throw amplifyError;
+          throw new AmplifyError('InvalidOverrideError', {
+            message: 'Executing overrides failed.',
+            details: err.message,
+            resolution: 'There may be runtime errors in your overrides file. If so, fix the errors and try again.',
+          }, err);
         }
       }
     }

--- a/packages/amplify-dynamodb-simulator/package.json
+++ b/packages/amplify-dynamodb-simulator/package.json
@@ -32,7 +32,7 @@
     "which": "^2.0.2"
   },
   "peerDependencies": {
-    "amplify-cli-core": "^4.0.0-beta.1"
+    "amplify-cli-core": "^4.0.0-beta.2"
   },
   "devDependencies": {
     "get-port": "^5.1.1",

--- a/packages/amplify-e2e-core/package.json
+++ b/packages/amplify-e2e-core/package.json
@@ -22,7 +22,7 @@
     "clean": "rimraf ./lib"
   },
   "dependencies": {
-    "amplify-headless-interface": "^1.15.0",
+    "amplify-headless-interface": "^1.16.0-beta.1",
     "chalk": "^4.1.1",
     "execa": "^5.1.1",
     "fs-extra": "^8.1.0",
@@ -38,6 +38,6 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "amplify-cli-core": "^4.0.0-beta.1"
+    "amplify-cli-core": "^4.0.0-beta.2"
   }
 }

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@aws-amplify/graphql-transformer-core": "1.1.0-beta.1",
-    "amplify-app": "4.3.4-beta.1",
+    "amplify-app": "4.3.4-beta.2",
     "amplify-category-api-e2e-core": "4.0.9-beta.1",
     "aws-amplify": "^4.2.8",
     "aws-appsync": "^4.1.1",
@@ -43,7 +43,7 @@
     "yargs": "^15.1.0"
   },
   "peerDependencies": {
-    "amplify-cli-core": "^4.0.0-beta.1"
+    "amplify-cli-core": "^4.0.0-beta.2"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.149",

--- a/packages/amplify-e2e-tests/src/__tests__/api_7.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_7.test.ts
@@ -74,12 +74,11 @@ describe('amplify add api (GraphQL)', () => {
     const srcInvalidOverrideCompileError = path.join(__dirname, '..', '..', 'overrides', 'override-compile-error.txt');
     fs.copyFileSync(srcInvalidOverrideCompileError, destOverrideFilePath);
     await expect(amplifyPushOverride(projRoot)).rejects.toThrowError();
-    
-    // Commenting the following test out, pending CLI release
-    // // test override file in runtime error state
-    // const srcInvalidOverrideRuntimeError = path.join(__dirname, '..', '..', 'overrides', 'override-runtime-error.txt');
-    // fs.copyFileSync(srcInvalidOverrideRuntimeError, destOverrideFilePath);
-    // await expect(amplifyPushOverride(projRoot)).rejects.toThrowError();
+
+    // test override file in runtime error state
+    const srcInvalidOverrideRuntimeError = path.join(__dirname, '..', '..', 'overrides', 'override-runtime-error.txt');
+    fs.copyFileSync(srcInvalidOverrideRuntimeError, destOverrideFilePath);
+    await expect(amplifyPushOverride(projRoot)).rejects.toThrowError();
 
     // test happy path
     const srcOverrideFilePath = path.join(__dirname, '..', '..', 'overrides', 'override-api-gql.ts');

--- a/packages/amplify-e2e-tests/src/__tests__/apigw.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/apigw.test.ts
@@ -119,12 +119,11 @@ describe('API Gateway e2e tests', () => {
     const srcInvalidOverrideCompileError = path.join(__dirname, '..', '..', 'overrides', 'override-compile-error.txt');
     fs.copyFileSync(srcInvalidOverrideCompileError, destOverrideTsFilePath);
     await expect(amplifyPushAuth(projRoot)).rejects.toThrowError();
-    
-    // Commenting the following test out, pending CLI release
-    // // test override file in runtime error state
-    // const srcInvalidOverrideRuntimeError = path.join(__dirname, '..', '..', 'overrides', 'override-runtime-error.txt');
-    // fs.copyFileSync(srcInvalidOverrideRuntimeError, destOverrideTsFilePath);
-    // await expect(amplifyPushAuth(projRoot)).rejects.toThrowError();
+
+    // test override file in runtime error state
+    const srcInvalidOverrideRuntimeError = path.join(__dirname, '..', '..', 'overrides', 'override-runtime-error.txt');
+    fs.copyFileSync(srcInvalidOverrideRuntimeError, destOverrideTsFilePath);
+    await expect(amplifyPushAuth(projRoot)).rejects.toThrowError();
 
     // test happy path
     const srcOverrideFilePath = path.join(__dirname, '..', '..', 'overrides', 'override-api-rest.ts');

--- a/packages/amplify-e2e-tests/src/__tests__/migration/node.function.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/migration/node.function.test.ts
@@ -57,7 +57,7 @@ describe('nodejs version migration tests', () => {
     );
     let authStackContent = fs.readFileSync(authStackFileName).toString();
 
-    authStackContent = authStackContent.replace('nodejs14.x', 'nodejs10.x');
+    authStackContent = authStackContent.replace('nodejs16.x', 'nodejs10.x');
 
     fs.writeFileSync(authStackFileName, authStackContent, 'utf-8');
 
@@ -72,7 +72,7 @@ describe('nodejs version migration tests', () => {
     );
     let functionStackContent = fs.readFileSync(functionStackFileName).toString();
 
-    functionStackContent = functionStackContent.replace('nodejs14.x', 'nodejs10.x');
+    functionStackContent = functionStackContent.replace('nodejs16.x', 'nodejs10.x');
 
     fs.writeFileSync(functionStackFileName, functionStackContent, 'utf-8');
 
@@ -84,8 +84,8 @@ describe('nodejs version migration tests', () => {
     functionStackContent = fs.readFileSync(functionStackFileName).toString();
 
     expect(projectConfigContent.indexOf('3.1')).toBeGreaterThan(0);
-    expect(authStackContent.indexOf('nodejs14.x')).toBeGreaterThan(0);
-    expect(functionStackContent.indexOf('nodejs14.x')).toBeGreaterThan(0);
+    expect(authStackContent.indexOf('nodejs16.x')).toBeGreaterThan(0);
+    expect(functionStackContent.indexOf('nodejs16.x')).toBeGreaterThan(0);
   });
 
   function amplifyNodeMigrationAndPush(cwd: string) {

--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -41,7 +41,7 @@
     "md5": "^2.3.0"
   },
   "peerDependencies": {
-    "amplify-prompts": "^2.0.0"
+    "amplify-prompts": "^2.6.2-beta.1"
   },
   "devDependencies": {
     "@aws-amplify/graphql-index-transformer": "1.1.0-beta.1",

--- a/packages/amplify-graphql-index-transformer/package.json
+++ b/packages/amplify-graphql-index-transformer/package.json
@@ -38,7 +38,7 @@
     "graphql-transformer-common": "4.24.1-beta.0"
   },
   "peerDependencies": {
-    "amplify-cli-core": "^4.0.0-beta.1"
+    "amplify-cli-core": "^4.0.0-beta.2"
   },
   "jest": {
     "transform": {

--- a/packages/amplify-graphql-migration-tests/package.json
+++ b/packages/amplify-graphql-migration-tests/package.json
@@ -58,6 +58,6 @@
     "graphql-versioned-transformer": "5.2.44-beta.1"
   },
   "peerDependencies": {
-    "amplify-prompts": "^2.0.1"
+    "amplify-prompts": "^2.6.2-beta.1"
   }
 }

--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -41,6 +41,7 @@
     "vm2": "^3.9.8"
   },
   "peerDependencies": {
+    "amplify-cli-core": "^4.0.0-beta.2",
     "amplify-prompts": "^2.6.2-beta.1"
   },
   "devDependencies": {

--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -41,7 +41,7 @@
     "vm2": "^3.9.8"
   },
   "peerDependencies": {
-    "amplify-prompts": "^2.0.1"
+    "amplify-prompts": "^2.6.2-beta.1"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.1",

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -32,6 +32,7 @@ import _ from 'lodash';
 import os from 'os';
 import * as path from 'path';
 import * as vm from 'vm2';
+import { AmplifyError } from 'amplify-cli-core';
 import { ResolverConfig, TransformConfig } from '../config/transformer-config';
 import { InvalidTransformerError, SchemaValidationError, UnknownDirectiveError } from '../errors';
 import { GraphQLApi } from '../graphql-api';
@@ -363,10 +364,11 @@ export class GraphQLTransform {
       try {
         sandboxNode.run(overrideCode, path.join(this.overrideConfig!.overrideDir, 'build', 'override.js')).override(appsyncResourceObj);
       } catch (err) {
-        // this is a workaround for the API repo until we can import AmplifyError without creating a circular dependency
-        const amplifyError = new Error("Executing overrides failed. There may be runtime errors in your overrides file. If so, fix the errors and try again.");
-        (amplifyError as any)['_amplifyErrorType'] = 'InvalidOverrideError';
-        throw amplifyError;
+        throw new AmplifyError('InvalidOverrideError', {
+          message: 'Executing overrides failed.',
+          details: err.message,
+          resolution: 'There may be runtime errors in your overrides file. If so, fix the errors and try again.',
+        }, err);
       }
     }
     return appsyncResourceObj;

--- a/packages/amplify-graphql-transformer-migrator/package.json
+++ b/packages/amplify-graphql-transformer-migrator/package.json
@@ -34,8 +34,8 @@
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "amplify-cli-core": "^4.0.0-beta.1",
-    "amplify-prompts": "^2.0.1"
+    "amplify-cli-core": "^4.0.0-beta.2",
+    "amplify-prompts": "^2.6.2-beta.1"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.1",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -32,10 +32,10 @@
     "@hapi/topo": "^5.0.0",
     "amplify-appsync-simulator": "^2.3.12",
     "amplify-category-api-dynamodb-simulator": "2.4.4-beta.1",
-    "amplify-category-function": "4.2.0-beta.1",
+    "amplify-category-function": "4.2.0-beta.2",
     "amplify-codegen": "^3.1.0",
-    "amplify-provider-awscloudformation": "7.0.0-beta.1",
-    "amplify-storage-simulator": "^1.7.0-beta.1",
+    "amplify-provider-awscloudformation": "7.0.0-beta.2",
+    "amplify-storage-simulator": "^1.7.0-beta.2",
     "chokidar": "^3.5.3",
     "detect-port": "^1.3.0",
     "dotenv": "^8.2.0",
@@ -48,7 +48,7 @@
     "which": "^2.0.2"
   },
   "peerDependencies": {
-    "amplify-cli-core": "^4.0.0-beta.1"
+    "amplify-cli-core": "^4.0.0-beta.2"
   },
   "devDependencies": {
     "@aws-amplify/graphql-auth-transformer": "2.1.0-beta.1",
@@ -65,8 +65,8 @@
     "@types/node": "^12.12.6",
     "@types/semver": "^7.1.0",
     "@types/which": "^1.3.2",
-    "amplify-function-plugin-interface": "^1.9.5",
-    "amplify-nodejs-function-runtime-provider": "2.3.4-beta.1",
+    "amplify-function-plugin-interface": "^1.9.6-beta.0",
+    "amplify-nodejs-function-runtime-provider": "2.3.4-beta.2",
     "aws-appsync": "^2.0.2",
     "aws-sdk": "^2.1113.0",
     "aws-sdk-mock": "^5.6.2",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -33,7 +33,7 @@
     "amplify-appsync-simulator": "^2.3.12",
     "amplify-category-api-dynamodb-simulator": "2.4.4-beta.1",
     "amplify-category-function": "4.2.0-beta.2",
-    "amplify-codegen": "^3.1.0",
+    "amplify-codegen": "^3.3.3",
     "amplify-provider-awscloudformation": "7.0.0-beta.2",
     "amplify-storage-simulator": "^1.7.0-beta.2",
     "chokidar": "^3.5.3",

--- a/packages/graphql-transformer-core/package.json
+++ b/packages/graphql-transformer-core/package.json
@@ -33,7 +33,7 @@
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "amplify-cli-core": "^4.0.0-beta.1"
+    "amplify-cli-core": "^4.0.0-beta.2"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,13 +40,13 @@
     signedsource "^1.0.0"
     yargs "^15.3.1"
 
-"@aws-amplify/amplify-category-custom@3.0.0-beta.1":
-  version "3.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/amplify-category-custom/-/amplify-category-custom-3.0.0-beta.1.tgz#d383c9d4f2025107f065b118d239e0702e27f1db"
-  integrity sha512-HMfrI82ZCL34Wnbh3vOqet7KYE6vVTkuaoVyConYK7WIZ/8uW5PHkZy0C80/WHKH9kRfeROUQjkT3o/sJhQ55A==
+"@aws-amplify/amplify-category-custom@3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/amplify-category-custom/-/amplify-category-custom-3.0.0-beta.2.tgz#b6c298e8dde2da5634a698401f0e11fe14c49ee5"
+  integrity sha512-Vd7T1pEDTFAhNOYOskXVjq9DW2yPiM+DI/17bNaeeYWXJ0mgpULRrXicZlF7MTQYDZyr59TZabBA1heXlc7zNg==
   dependencies:
-    amplify-cli-core "4.0.0-beta.1"
-    amplify-prompts "2.6.2-beta.0"
+    amplify-cli-core "4.0.0-beta.2"
+    amplify-prompts "2.6.2-beta.1"
     aws-cdk-lib "~2.44.0"
     execa "^5.1.1"
     fs-extra "^8.1.0"
@@ -55,12 +55,12 @@
     ora "^4.0.3"
     uuid "^8.3.2"
 
-"@aws-amplify/amplify-environment-parameters@1.2.0-beta.1":
-  version "1.2.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/amplify-environment-parameters/-/amplify-environment-parameters-1.2.0-beta.1.tgz#897b8fe18f8781cd898a15f47deb36a1257a2669"
-  integrity sha512-TJVe0oE5J4YeJECdsgCKVvMurKxUqXt8uWGHQdA3AN7VMG5dEvUetqit/tq3RZa55UakygDQX3FsJlklT1Zvlw==
+"@aws-amplify/amplify-environment-parameters@1.2.0-beta.2":
+  version "1.2.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/amplify-environment-parameters/-/amplify-environment-parameters-1.2.0-beta.2.tgz#e0a170a8fb4a7eb8cee2dec93ccd02eb99ae064d"
+  integrity sha512-P2BYWVcdD7boWHG7xf3Q5IaNT6ZiYwy8nguMJBcbeKoiYbygGHcPU5wlCPlN7sY/Xa6uOCsbZLhl0mxfsAqXXg==
   dependencies:
-    amplify-cli-core "4.0.0-beta.1"
+    amplify-cli-core "4.0.0-beta.2"
     lodash "^4.17.21"
 
 "@aws-amplify/analytics@5.2.28":
@@ -126,6 +126,24 @@
     strip-indent "^3.0.0"
     ts-dedent "^1.1.0"
 
+"@aws-amplify/appsync-modelgen-plugin@2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.3.1.tgz#b785afdc66572c1a5312a4c836eb1729527ab36e"
+  integrity sha512-bAj2d7Pa0isFAH3qqxDfIeMTu+8yYbmbOkKhh0TGBWkT6Ce8RZWdV7zeBP7txrJpWjauAcu/jjDZ8p18oa+fiQ==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^1.18.8"
+    "@graphql-codegen/visitor-plugin-common" "^1.22.0"
+    "@graphql-tools/utils" "^6.0.18"
+    "@types/node" "^12.12.6"
+    "@types/pluralize" "0.0.29"
+    chalk "^3.0.0"
+    change-case "^4.1.1"
+    dart-style "1.3.2-dev"
+    lower-case-first "^2.0.1"
+    pluralize "^8.0.0"
+    strip-indent "^3.0.0"
+    ts-dedent "^1.1.0"
+
 "@aws-amplify/auth@4.6.14":
   version "4.6.14"
   resolved "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.6.14.tgz#561997e6e9d3d80db140a193d363473e86114483"
@@ -143,13 +161,13 @@
   dependencies:
     "@aws-amplify/core" "4.7.12"
 
-"@aws-amplify/cli-extensibility-helper@3.0.0-beta.1":
-  version "3.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/cli-extensibility-helper/-/cli-extensibility-helper-3.0.0-beta.1.tgz#fb1bccc5463069a91bb7af4ffce8b8411e1578ed"
-  integrity sha512-SqzXh2KQcDq8/rKyaNsMMVmZauT6W8vQGXAQluEfYeWMXgY2U/Oo79f/OG1CtHH/p3tSSNaFEi452BVW6FuAbg==
+"@aws-amplify/cli-extensibility-helper@3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/cli-extensibility-helper/-/cli-extensibility-helper-3.0.0-beta.2.tgz#41f63419899efe38b9fff0ba3d4ecac37413feb7"
+  integrity sha512-RWOhKueVS8WRrotIW2IKhS1cE2/JkKR2p0C4tctH/NpXBcYc6OEw1CAqpHmTiWRbTNRHyeoASw4aPZXxn5dNWA==
   dependencies:
-    "@aws-amplify/amplify-category-custom" "3.0.0-beta.1"
-    amplify-cli-core "4.0.0-beta.1"
+    "@aws-amplify/amplify-category-custom" "3.0.0-beta.2"
+    amplify-cli-core "4.0.0-beta.2"
     aws-cdk-lib "~2.44.0"
 
 "@aws-amplify/core@4.7.12":
@@ -211,34 +229,6 @@
     handlebars "4.7.7"
     prettier "^1.19.1"
     yargs "^15.1.0"
-
-"@aws-amplify/graphql-transformer-core@^1.1.0-cdkv2.2":
-  version "1.1.0-cdkv2.2"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/graphql-transformer-core/-/graphql-transformer-core-1.1.0-cdkv2.2.tgz#b0731750462ce2629fde3fae43598a0388106332"
-  integrity sha512-3OyHEeeelldJ+z09tXpsMCX3dTRIYAbRDeTYnTVAOFanhDhmuLO/MB91BruqMBUA8EqZcYb0oL6CX315jdTXTQ==
-  dependencies:
-    "@aws-amplify/graphql-transformer-interfaces" "2.1.0-cdkv2.2"
-    "@aws-cdk/aws-appsync-alpha" "~2.44.0-alpha.0"
-    aws-cdk-lib "~2.44.0"
-    constructs "^10.0.5"
-    fs-extra "^8.1.0"
-    graphql "^14.5.8"
-    graphql-transformer-common "4.24.0"
-    lodash "^4.17.21"
-    md5 "^2.3.0"
-    object-hash "^3.0.0"
-    ts-dedent "^2.0.0"
-    vm2 "^3.9.8"
-
-"@aws-amplify/graphql-transformer-interfaces@2.1.0-cdkv2.2", "@aws-amplify/graphql-transformer-interfaces@^2.1.0-cdkv2.2":
-  version "2.1.0-cdkv2.2"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/graphql-transformer-interfaces/-/graphql-transformer-interfaces-2.1.0-cdkv2.2.tgz#838d40474fdc94517d3d461f730a0002a6b88fcf"
-  integrity sha512-/mmnZgWd/JACxytgnafKiVR+oO0MbKEKVVeng7xLy/vefdPM+RDb8qCqix8MqIx9yPjXItydpBOyP3G20+vvGQ==
-  dependencies:
-    "@aws-cdk/aws-appsync-alpha" "~2.44.0-alpha.0"
-    aws-cdk-lib "~2.44.0"
-    constructs "^10.0.5"
-    graphql "^14.5.8"
 
 "@aws-amplify/graphql-types-generator@3.0.0":
   version "3.0.0"
@@ -6268,15 +6258,15 @@ amazon-cognito-identity-js@5.2.12:
     isomorphic-unfetch "^3.0.0"
     js-cookie "^2.2.1"
 
-amplify-app@4.3.4-beta.1:
-  version "4.3.4-beta.1"
-  resolved "https://registry.yarnpkg.com/amplify-app/-/amplify-app-4.3.4-beta.1.tgz#30a21d5ec04fb6a600c0ba3645e55cad02ea7c26"
-  integrity sha512-6mKyliCpNUSPTwYu+zrVS0WHwFcS+WNXXtrug+u3EtnyHCkIokcZxxPGKySAaTXltLmDuMqfoKp9CYm+onPOlg==
+amplify-app@4.3.4-beta.2:
+  version "4.3.4-beta.2"
+  resolved "https://registry.yarnpkg.com/amplify-app/-/amplify-app-4.3.4-beta.2.tgz#55b5fed45469dad10c15090262441956dff927e7"
+  integrity sha512-r4qcHfr/pDXC18au5ccXY6eYANA6xJpU+avbcWpfHcectylbPj2PktPrtIzjC0ZxJq9uqNqAXIcOg69DVLD2jQ==
   dependencies:
     amplify-frontend-android "3.4.0"
     amplify-frontend-flutter "1.3.5"
-    amplify-frontend-ios "3.5.4-beta.1"
-    amplify-frontend-javascript "3.7.0-beta.1"
+    amplify-frontend-ios "3.5.4-beta.2"
+    amplify-frontend-javascript "3.7.0-beta.2"
     chalk "^4.1.1"
     execa "^5.1.1"
     fs-extra "^8.1.0"
@@ -6325,15 +6315,15 @@ amplify-appsync-simulator@^2.3.12:
     uuid "^8.3.2"
     ws "^7.5.7"
 
-amplify-category-function@4.2.0-beta.1:
-  version "4.2.0-beta.1"
-  resolved "https://registry.yarnpkg.com/amplify-category-function/-/amplify-category-function-4.2.0-beta.1.tgz#f09812bbb70f566224bdbff52c73eb507a42072e"
-  integrity sha512-fRhChO1InJ+HGgHknJiImPTStRAxoHSw1kXkhbDyt6CCsotFwUjRtndzvA3qLR9hXkYSwhmfC+HZVdzq2P7HpA==
+amplify-category-function@4.2.0-beta.2:
+  version "4.2.0-beta.2"
+  resolved "https://registry.yarnpkg.com/amplify-category-function/-/amplify-category-function-4.2.0-beta.2.tgz#c222dfd4e597e1282d859f04614bde881812c8eb"
+  integrity sha512-GX+C21I5hcbNeOrZPq09S7BqQOle4BDYsohUIP+h0qc5I7hn50SjEe/vcVGf3MxaJ+gC/yJF2a9MXGoElUOFXg==
   dependencies:
-    "@aws-amplify/amplify-environment-parameters" "1.2.0-beta.1"
-    amplify-cli-core "4.0.0-beta.1"
-    amplify-function-plugin-interface "1.9.5"
-    amplify-prompts "2.6.2-beta.0"
+    "@aws-amplify/amplify-environment-parameters" "1.2.0-beta.2"
+    amplify-cli-core "4.0.0-beta.2"
+    amplify-function-plugin-interface "1.9.6-beta.0"
+    amplify-prompts "2.6.2-beta.1"
     archiver "^5.3.0"
     aws-sdk "^2.1233.0"
     chalk "^4.1.1"
@@ -6342,7 +6332,7 @@ amplify-category-function@4.2.0-beta.1:
     folder-hash "^4.0.2"
     fs-extra "^8.1.0"
     globby "^11.0.3"
-    graphql-transformer-core "^7.6.6"
+    graphql-transformer-core "8.0.0-beta.1"
     inquirer "^7.3.3"
     inquirer-datepicker "^2.0.0"
     jstreemap "^1.28.2"
@@ -6351,16 +6341,15 @@ amplify-category-function@4.2.0-beta.1:
     promise-sequential "^1.1.1"
     uuid "^8.3.2"
 
-amplify-cli-core@4.0.0-beta.1:
-  version "4.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/amplify-cli-core/-/amplify-cli-core-4.0.0-beta.1.tgz#78b37e7bd4d74475fcb75b58a780a7cfddc83889"
-  integrity sha512-4j7vjApqM73F9lbzaJ0ogEiWg1ja/cFTms6voaf74Ri0a0uvcEvQGQ63AW1hoaaKB+RyqcCEuPMqbqqdVQEyxg==
+amplify-cli-core@4.0.0-beta.2:
+  version "4.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/amplify-cli-core/-/amplify-cli-core-4.0.0-beta.2.tgz#ff14e67338b3c917df0764b8ef84320f3303d217"
+  integrity sha512-4xNLjh1fqPfVWZ1Znc8lEt2n00tmscXWZKFZj6BOm1B+KlNu8nElLB1rOaMcbgbMfJ8EEgTJY4YE/LCaKok6Gw==
   dependencies:
-    "@aws-amplify/graphql-transformer-core" "^1.1.0-beta.0"
-    "@aws-amplify/graphql-transformer-interfaces" "^2.1.0-beta.0"
+    "@aws-amplify/graphql-transformer-interfaces" "2.1.0-beta.1"
     ajv "^6.12.6"
-    amplify-cli-logger "1.2.1"
-    amplify-prompts "2.6.2-beta.0"
+    amplify-cli-logger "1.2.2-beta.0"
+    amplify-prompts "2.6.2-beta.1"
     chalk "^4.1.1"
     ci-info "^2.0.0"
     cloudform-types "^4.2.0"
@@ -6368,7 +6357,6 @@ amplify-cli-core@4.0.0-beta.1:
     execa "^5.1.1"
     fs-extra "^8.1.0"
     globby "^11.0.3"
-    graphql-transformer-core "^7.6.6"
     hjson "^3.2.1"
     js-yaml "^4.0.0"
     lodash "^4.17.21"
@@ -6380,25 +6368,46 @@ amplify-cli-core@4.0.0-beta.1:
     typescript-json-schema "~0.52.0"
     which "^2.0.2"
 
-amplify-cli-logger@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/amplify-cli-logger/-/amplify-cli-logger-1.2.1.tgz#57e25f489950af9dfc1e5ef55da6eafcd2ec49ed"
-  integrity sha512-zdHKufDNVc2XhYBFv87d/l8NRBEqm2aHfPV1YbuanUoHQHowV3P8Gx5qLbGbTmC8xra2FbISpyUv12DCadgwJg==
+amplify-cli-logger@1.2.2-beta.0:
+  version "1.2.2-beta.0"
+  resolved "https://registry.yarnpkg.com/amplify-cli-logger/-/amplify-cli-logger-1.2.2-beta.0.tgz#1b19aaa6351c6584897d109c11f79daa61cdabc9"
+  integrity sha512-GdYtGHgozbtcFxfWcFH07As2bvfhKVNasUB5iS6OJNW4phQE76hcpZsOBmhFJHzTq2jMypfkf/L77u13cXMe4w==
   dependencies:
     winston "^3.3.3"
     winston-daily-rotate-file "^4.5.0"
 
-amplify-cli-shared-interfaces@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/amplify-cli-shared-interfaces/-/amplify-cli-shared-interfaces-1.1.0.tgz#105c8645c50bb469272badf2501505793c3974de"
-  integrity sha512-lN5Y4PfyY5SSCZLxRSfv3qhYYSEwEsFG9T+SbQIf05o6Yfim93Xy9f+1pAAlGc3f/HWjEqdegAH3HG496/BGeg==
+amplify-cli-shared-interfaces@1.1.1-beta.0:
+  version "1.1.1-beta.0"
+  resolved "https://registry.yarnpkg.com/amplify-cli-shared-interfaces/-/amplify-cli-shared-interfaces-1.1.1-beta.0.tgz#7f10398c38ccd5cedc70f8ac7e35af68fff8397e"
+  integrity sha512-x23Wxcy1GWcjx0rFj9dgKw0lFYB/BCvVN4uTbGaGLa+iE2mNcBTJJKgZ+KiposdYm8FFlVfZ2feXoBPNHISR6w==
 
-amplify-codegen@^3.1.0, amplify-codegen@^3.3.1:
+amplify-codegen@^3.1.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/amplify-codegen/-/amplify-codegen-3.3.2.tgz#25711da17f32b06936699ba1fcf926c86933884b"
   integrity sha512-Jq2fNH6dUQTtEZxX6fJ/uu4MF+JRoFVFIpidaehBe6ZE+YPSNqoETqUwu+xtNDYhrT3XHPy5kCStDxXgK31uQQ==
   dependencies:
     "@aws-amplify/appsync-modelgen-plugin" "2.3.0"
+    "@aws-amplify/graphql-docs-generator" "3.0.2"
+    "@aws-amplify/graphql-types-generator" "3.0.0"
+    "@graphql-codegen/core" "1.8.3"
+    chalk "^3.0.0"
+    fs-extra "^8.1.0"
+    glob-all "^3.1.0"
+    glob-parent "^6.0.2"
+    graphql "^14.5.8"
+    graphql-config "^2.2.1"
+    inquirer "^7.3.3"
+    js-yaml "^4.0.0"
+    ora "^4.0.3"
+    semver "^7.3.5"
+    slash "^3.0.0"
+
+amplify-codegen@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/amplify-codegen/-/amplify-codegen-3.3.3.tgz#47b30826801149c01cac8dd341516fdf5a8cf87a"
+  integrity sha512-mVyT4yYq3sY48YtcTXp1R1sTGGkyDhsu23Xubz9kbmhixqSj8wlkfqUTbGhlgpk44fysvzsKBp1d0TNMgLTEjA==
+  dependencies:
+    "@aws-amplify/appsync-modelgen-plugin" "2.3.1"
     "@aws-amplify/graphql-docs-generator" "3.0.2"
     "@aws-amplify/graphql-types-generator" "3.0.0"
     "@graphql-codegen/core" "1.8.3"
@@ -6432,25 +6441,25 @@ amplify-frontend-flutter@1.3.5:
     graphql-config "^2.2.1"
     inquirer "^7.3.3"
 
-amplify-frontend-ios@3.5.4-beta.1:
-  version "3.5.4-beta.1"
-  resolved "https://registry.yarnpkg.com/amplify-frontend-ios/-/amplify-frontend-ios-3.5.4-beta.1.tgz#26af0bf0f663d46f306204407d3b41ef88eeff6d"
-  integrity sha512-H634RTBzIJ/c3l28ChVO7CcnCC8KmacFnb6fZsHQH/v9V+nVChKYvwYN1l9U8h08pCGSpV1m6y2WGctDJwPwWg==
+amplify-frontend-ios@3.5.4-beta.2:
+  version "3.5.4-beta.2"
+  resolved "https://registry.yarnpkg.com/amplify-frontend-ios/-/amplify-frontend-ios-3.5.4-beta.2.tgz#2a45cbae6788287512b554ba02c6035db32f7c89"
+  integrity sha512-asitUxwJ3CPXu0xVcgpJtcFtpUbdk9jQfrqLys8NQJhzl/lfT5PyiXfwQ3F172vRwkxt0PsnXnDhsuaAHayK8Q==
   dependencies:
-    amplify-cli-core "4.0.0-beta.1"
+    amplify-cli-core "4.0.0-beta.2"
     execa "^5.1.1"
     fs-extra "^8.1.0"
     graphql-config "^2.2.1"
     lodash "^4.17.21"
 
-amplify-frontend-javascript@3.7.0-beta.1:
-  version "3.7.0-beta.1"
-  resolved "https://registry.yarnpkg.com/amplify-frontend-javascript/-/amplify-frontend-javascript-3.7.0-beta.1.tgz#740a4d0de42d47d29d4b0b8dde997228b35e8cfd"
-  integrity sha512-CPlVdcrTZcIXiUUpVDXqAxJPQov4bqi68UeQG9tkJO2mcOwD6vN4f+yls6jQd0Sx5PPmF4GhPfHngDVClElf4g==
+amplify-frontend-javascript@3.7.0-beta.2:
+  version "3.7.0-beta.2"
+  resolved "https://registry.yarnpkg.com/amplify-frontend-javascript/-/amplify-frontend-javascript-3.7.0-beta.2.tgz#ffc4c725f5a0470e6f7944bd05cffe58eb927232"
+  integrity sha512-Nd5KnORcDNRy6csMvBbSQL7WtGbMmgDMnQSxWAuQ1zhugyzNxCZqRsLyS7iBZ3bsc3L54lti9KdGvwYf3+SHoQ==
   dependencies:
     "@babel/core" "^7.10.5"
     "@babel/plugin-transform-modules-commonjs" "7.10.4"
-    amplify-cli-core "4.0.0-beta.1"
+    amplify-cli-core "4.0.0-beta.2"
     chalk "^4.1.1"
     execa "^5.1.1"
     fs-extra "^8.1.0"
@@ -6458,52 +6467,62 @@ amplify-frontend-javascript@3.7.0-beta.1:
     inquirer "^7.3.3"
     lodash "^4.17.21"
 
-amplify-function-plugin-interface@1.9.5, amplify-function-plugin-interface@^1.9.5:
-  version "1.9.5"
-  resolved "https://registry.npmjs.org/amplify-function-plugin-interface/-/amplify-function-plugin-interface-1.9.5.tgz#caa95891f7976d29a3d43c51f7c6a372178b9a81"
-  integrity sha512-x49gI8U1863JC7akkUTQ5WrAhOPD8/PRx9LCwRshl1RJNMH4AaF40Gx+ueDVV/SLAsFc2GM0xoigxsvX+Cu4qQ==
+amplify-function-plugin-interface@1.9.6-beta.0:
+  version "1.9.6-beta.0"
+  resolved "https://registry.yarnpkg.com/amplify-function-plugin-interface/-/amplify-function-plugin-interface-1.9.6-beta.0.tgz#bb8b5ea78192b695de3591494fcedb8f9e1d8d3f"
+  integrity sha512-1fc5I269SJZXBcka0GTxMaw/Euz48KrpsYOK4bgYB6DUt7EK3MWFBs440Ci69gpAo2wqG1ITTEgCI9YpPuBQTw==
 
-amplify-headless-interface@1.15.0, amplify-headless-interface@^1.15.0:
+amplify-function-plugin-interface@^1.9.6-beta.0:
+  version "1.9.6-searchable-mocking-test.0"
+  resolved "https://registry.yarnpkg.com/amplify-function-plugin-interface/-/amplify-function-plugin-interface-1.9.6-searchable-mocking-test.0.tgz#a1d420d75f279919b080060be3a939604639c92a"
+  integrity sha512-M6+t3T188pjtGe/zR90dKv6Z3gpX8kCuWCAndsf0u29bQVEWnXIXVt6r8MUHWPYsFFjkqSI1eMtGVZoYMZ6mWA==
+
+amplify-headless-interface@1.15.0:
   version "1.15.0"
   resolved "https://registry.npmjs.org/amplify-headless-interface/-/amplify-headless-interface-1.15.0.tgz#a72d001d11d230ab48844b6e57b5f5c9f1cb030e"
   integrity sha512-6U22nhKLu67i6/zbBXZO+1TYmLXym+/e9fnwqeOhnctMCybU56RdWvj4/MhQIywn4DyOTHvYBkRT5o4f1hFSPg==
 
-amplify-nodejs-function-runtime-provider@2.3.4-beta.1:
-  version "2.3.4-beta.1"
-  resolved "https://registry.yarnpkg.com/amplify-nodejs-function-runtime-provider/-/amplify-nodejs-function-runtime-provider-2.3.4-beta.1.tgz#2a99df0fbe7fb53e6b512954b4a9b639b1a17a95"
-  integrity sha512-6zDK8sFTugw/3dpg+pB5M64b4oWgErMzagzNM8q5pRwt668RAYgEQwJTA35koKMsiVU06D7nCKToT/5wbxkwwQ==
+amplify-headless-interface@^1.16.0-beta.1:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/amplify-headless-interface/-/amplify-headless-interface-1.16.0.tgz#a97ca61d5c135744ac1e54b548c029d3ff5c42fa"
+  integrity sha512-sJugHcCnRiQXDib37mM9de9YjBkvwtHG95DGsnX1KvdjcjPcSMQPEGtQJUhWOVzFM2i3pwWwaw0vDZpAaMohZA==
+
+amplify-nodejs-function-runtime-provider@2.3.4-beta.2:
+  version "2.3.4-beta.2"
+  resolved "https://registry.yarnpkg.com/amplify-nodejs-function-runtime-provider/-/amplify-nodejs-function-runtime-provider-2.3.4-beta.2.tgz#030b6d13886b48f9cebd4c6790b1f984092436d3"
+  integrity sha512-042qlCk2feYktElCgDOR4o2qHd2NxvxuwPL/k62BFHPEtIS1E/t596Y/8qNmRd0/Mr18xkObvgrrKbGOoUydSA==
   dependencies:
-    amplify-cli-core "4.0.0-beta.1"
-    amplify-function-plugin-interface "1.9.5"
+    amplify-cli-core "4.0.0-beta.2"
+    amplify-function-plugin-interface "1.9.6-beta.0"
     execa "^5.1.1"
     exit "^0.1.2"
     fs-extra "^8.1.0"
     glob "^7.2.0"
 
-amplify-prompts@2.6.2-beta.0:
-  version "2.6.2-beta.0"
-  resolved "https://registry.yarnpkg.com/amplify-prompts/-/amplify-prompts-2.6.2-beta.0.tgz#82630b300eaaa1f4c89c604c9052ad2b65892632"
-  integrity sha512-0reapL93Tn3jh5dd0XlW9ccBJRimxEEITCtCpq/CUxJj8g0vfhlJ520T39/zF72RMLx7qNXEYYrwstYoMIroyw==
+amplify-prompts@2.6.2-beta.1:
+  version "2.6.2-beta.1"
+  resolved "https://registry.yarnpkg.com/amplify-prompts/-/amplify-prompts-2.6.2-beta.1.tgz#25722eb1a86dd7b4ed33c181b57b884985eea8eb"
+  integrity sha512-d8/ee+5FqLCvjbhXl29FBBSxAUlx7R2KZALdcXOmGufs6/96xA7h8UotMDIj+dHW2Ys8VCBJzl6S3UT3R3MCnA==
   dependencies:
-    amplify-cli-shared-interfaces "1.1.0"
+    amplify-cli-shared-interfaces "1.1.1-beta.0"
     chalk "^4.1.1"
     enquirer "^2.3.6"
 
-amplify-provider-awscloudformation@7.0.0-beta.1:
-  version "7.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/amplify-provider-awscloudformation/-/amplify-provider-awscloudformation-7.0.0-beta.1.tgz#dde20061059f7bddf51162b54c07259bcee22fb1"
-  integrity sha512-V5tpI9E+WsgDvO+BcXVpFHgL3YwDjQKgxGDGC5QEr7//wCBlOdGWkDTs7DPEqas+17+O288AI9JLMMylw+845Q==
+amplify-provider-awscloudformation@7.0.0-beta.2:
+  version "7.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/amplify-provider-awscloudformation/-/amplify-provider-awscloudformation-7.0.0-beta.2.tgz#e835badb6ede9a6873ae36a13526ebb9c8f77489"
+  integrity sha512-j8ezRxVQ17tZ2qe1t7LBGuWKN3aCPeFa3yisixVGcBjkkx3bzrjo92+e7RvoMPmb4cpSLcA8wPjwvptMx8nDfQ==
   dependencies:
-    "@aws-amplify/amplify-category-custom" "3.0.0-beta.1"
-    "@aws-amplify/amplify-environment-parameters" "1.2.0-beta.1"
-    "@aws-amplify/cli-extensibility-helper" "3.0.0-beta.1"
-    "@aws-amplify/graphql-transformer-core" "^1.1.0-beta.0"
-    "@aws-amplify/graphql-transformer-interfaces" "^2.1.0-beta.0"
-    amplify-cli-core "4.0.0-beta.1"
-    amplify-cli-logger "1.2.1"
-    amplify-codegen "^3.3.1"
-    amplify-prompts "2.6.2-beta.0"
-    amplify-util-import "2.3.0-beta.0"
+    "@aws-amplify/amplify-category-custom" "3.0.0-beta.2"
+    "@aws-amplify/amplify-environment-parameters" "1.2.0-beta.2"
+    "@aws-amplify/cli-extensibility-helper" "3.0.0-beta.2"
+    "@aws-amplify/graphql-transformer-core" "1.1.0-beta.1"
+    "@aws-amplify/graphql-transformer-interfaces" "2.1.0-beta.1"
+    amplify-cli-core "4.0.0-beta.2"
+    amplify-cli-logger "1.2.2-beta.0"
+    amplify-codegen "^3.3.3"
+    amplify-prompts "2.6.2-beta.1"
+    amplify-util-import "2.3.0-beta.1"
     archiver "^5.3.0"
     aws-cdk-lib "~2.44.0"
     aws-sdk "^2.1233.0"
@@ -6520,7 +6539,7 @@ amplify-provider-awscloudformation@7.0.0-beta.1:
     fs-extra "^8.1.0"
     glob "^7.2.0"
     graphql "^14.5.8"
-    graphql-transformer-core "^7.6.6"
+    graphql-transformer-core "8.0.0-beta.1"
     ignore "^5.2.0"
     ini "^1.3.5"
     inquirer "^7.3.3"
@@ -6538,7 +6557,7 @@ amplify-provider-awscloudformation@7.0.0-beta.1:
     vm2 "^3.9.8"
     xstate "^4.14.0"
 
-amplify-storage-simulator@^1.7.0-beta.1:
+amplify-storage-simulator@^1.7.0-beta.2:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/amplify-storage-simulator/-/amplify-storage-simulator-1.7.0.tgz#ddefbe7bf1f074ed247c36269c70ff55f844047b"
   integrity sha512-4l/0wFHWZIlqtzv54mzKt9JsdhP5aIBGfoPjMG0tTjUKbzDOQHawNtHgix34rpy8gldodtmFBzAw94G+K5eDNg==
@@ -6564,10 +6583,10 @@ amplify-util-headless-input@^1.9.6:
     ajv "^6.12.6"
     amplify-headless-interface "1.15.0"
 
-amplify-util-import@2.3.0-beta.0:
-  version "2.3.0-beta.0"
-  resolved "https://registry.yarnpkg.com/amplify-util-import/-/amplify-util-import-2.3.0-beta.0.tgz#f1f29c9234880a6d14efbbef6dff3efe662e070e"
-  integrity sha512-koaoUYldgdCb0lSCnhqAIMzKAwWBWUyBamxWlYc1TN2WpQVW/g5cvwRZ2NyVYnXUfbETUn30nEcms1G8fGt2kQ==
+amplify-util-import@2.3.0-beta.1:
+  version "2.3.0-beta.1"
+  resolved "https://registry.yarnpkg.com/amplify-util-import/-/amplify-util-import-2.3.0-beta.1.tgz#66f3fe6a1d6787c03aa6925508ec4d0041aab5eb"
+  integrity sha512-gkDYgL+XHLaRhC1zTT9r32etAb83LzcX/hy+G8xau7iU16hgU4GNq6mOuJKAqzL8VLUJXfH2gjgKQuGoHueUYA==
   dependencies:
     aws-sdk "^2.1233.0"
 
@@ -10513,19 +10532,6 @@ graphql-tag@^2.10.1, graphql-tag@^2.11.0:
   integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
   dependencies:
     tslib "^2.1.0"
-
-graphql-transformer-core@^7.6.6:
-  version "7.6.6"
-  resolved "https://registry.yarnpkg.com/graphql-transformer-core/-/graphql-transformer-core-7.6.6.tgz#dcd92976e11aab71bdd2609e1b1f1a376b798b73"
-  integrity sha512-9oDYyQ8fOewNIJ9+cAUdQ0VbuVnIISNFgvlxalNepdolskjbBvf6n71JpNDympjCXk8aITqAGWNWnbu/JsDb7A==
-  dependencies:
-    cloudform-types "^4.2.0"
-    deep-diff "^1.0.2"
-    fs-extra "^8.1.0"
-    glob "^7.2.0"
-    graphql "^14.5.8"
-    graphql-transformer-common "4.24.0"
-    lodash "^4.17.21"
 
 graphql@0.13.0:
   version "0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,24 +108,6 @@
     "@aws-amplify/api-graphql" "2.3.25"
     "@aws-amplify/api-rest" "2.0.61"
 
-"@aws-amplify/appsync-modelgen-plugin@2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.3.0.tgz#7a1ce65fce338f26f48256807fb7775d10bd25e8"
-  integrity sha512-8228aL1CrJVkxfqX64U44G/Kjw0pnpWM8W4p8x9vHYhsuzTvPyH08ZS/elzytQxkDjumrxL7yhIlweRRuO8zwA==
-  dependencies:
-    "@graphql-codegen/plugin-helpers" "^1.18.8"
-    "@graphql-codegen/visitor-plugin-common" "^1.22.0"
-    "@graphql-tools/utils" "^6.0.18"
-    "@types/node" "^12.12.6"
-    "@types/pluralize" "0.0.29"
-    chalk "^3.0.0"
-    change-case "^4.1.1"
-    dart-style "1.3.2-dev"
-    lower-case-first "^2.0.1"
-    pluralize "^8.0.0"
-    strip-indent "^3.0.0"
-    ts-dedent "^1.1.0"
-
 "@aws-amplify/appsync-modelgen-plugin@2.3.1":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.3.1.tgz#b785afdc66572c1a5312a4c836eb1729527ab36e"
@@ -6380,27 +6362,6 @@ amplify-cli-shared-interfaces@1.1.1-beta.0:
   version "1.1.1-beta.0"
   resolved "https://registry.yarnpkg.com/amplify-cli-shared-interfaces/-/amplify-cli-shared-interfaces-1.1.1-beta.0.tgz#7f10398c38ccd5cedc70f8ac7e35af68fff8397e"
   integrity sha512-x23Wxcy1GWcjx0rFj9dgKw0lFYB/BCvVN4uTbGaGLa+iE2mNcBTJJKgZ+KiposdYm8FFlVfZ2feXoBPNHISR6w==
-
-amplify-codegen@^3.1.0:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/amplify-codegen/-/amplify-codegen-3.3.2.tgz#25711da17f32b06936699ba1fcf926c86933884b"
-  integrity sha512-Jq2fNH6dUQTtEZxX6fJ/uu4MF+JRoFVFIpidaehBe6ZE+YPSNqoETqUwu+xtNDYhrT3XHPy5kCStDxXgK31uQQ==
-  dependencies:
-    "@aws-amplify/appsync-modelgen-plugin" "2.3.0"
-    "@aws-amplify/graphql-docs-generator" "3.0.2"
-    "@aws-amplify/graphql-types-generator" "3.0.0"
-    "@graphql-codegen/core" "1.8.3"
-    chalk "^3.0.0"
-    fs-extra "^8.1.0"
-    glob-all "^3.1.0"
-    glob-parent "^6.0.2"
-    graphql "^14.5.8"
-    graphql-config "^2.2.1"
-    inquirer "^7.3.3"
-    js-yaml "^4.0.0"
-    ora "^4.0.3"
-    semver "^7.3.5"
-    slash "^3.0.0"
 
 amplify-codegen@^3.3.3:
   version "3.3.3"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR:
- uses AmplifyError instead of workaround to emit override error.
- bumps cli versions needed for this change
- brings back tests that were commented out earlier

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
