### PR TITLE
chore: bump timeout for e2e tests

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -613,7 +613,7 @@ commands:
                   source .circleci/local_publish_helpers.sh
                   amplify version
                   retry runE2eTest
-                no_output_timeout: 60m
+                no_output_timeout: 90m
   scan_e2e_test_artifacts:
     description: "Scan And Cleanup E2E Test Artifacts"
     parameters:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Undo part of https://github.com/aws-amplify/amplify-category-api/pull/994/files . I.e. increase timeout back to 90m for e2e tests.
The `searchable-migration-l` test keeps timing out consistently. So bumping timeout back to original value until better solution is put in place.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
