### PR TITLE
fix: aggregate fields access for iam auth with admin roles

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/resolvers/helpers.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/helpers.ts
@@ -168,19 +168,23 @@ export const iamExpression = (
 /**
  * Creates iam admin role check helper
  */
-export const iamAdminRoleCheckExpression = (adminRoles: Array<string>, fieldName?: string): Expression => compoundExpression([
-  set(ref('adminRoles'), raw(JSON.stringify(adminRoles))),
-  forEach(/* for */ ref('adminRole'), /* in */ ref('adminRoles'), [
-    iff(
-      and([
-        methodCall(ref('ctx.identity.userArn.contains'), ref('adminRole')),
-        notEquals(ref('ctx.identity.userArn'), ref('ctx.stash.authRole')),
-        notEquals(ref('ctx.identity.userArn'), ref('ctx.stash.unauthRole')),
-      ]),
-      fieldName ? raw(`#return($context.source.${fieldName})`) : raw('#return($util.toJson({}))'),
-    ),
-  ]),
-]);
+export const iamAdminRoleCheckExpression = (adminRoles: Array<string>, fieldName?: string, adminCheckExpression?: Expression): Expression => {
+  const returnStatement = fieldName ? raw(`#return($context.source.${fieldName})`) : raw('#return($util.toJson({}))');
+  const fullReturnExpression = adminCheckExpression ? compoundExpression([ adminCheckExpression, returnStatement ]) : returnStatement;
+  return compoundExpression([
+    set(ref('adminRoles'), raw(JSON.stringify(adminRoles))),
+    forEach(/* for */ ref('adminRole'), /* in */ ref('adminRoles'), [
+      iff(
+        and([
+          methodCall(ref('ctx.identity.userArn.contains'), ref('adminRole')),
+          notEquals(ref('ctx.identity.userArn'), ref('ctx.stash.authRole')),
+          notEquals(ref('ctx.identity.userArn'), ref('ctx.stash.unauthRole')),
+        ]),
+        fullReturnExpression
+      ),
+    ]),
+  ])
+};
 
 /**
  * Creates generate auth request helper

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/search.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/search.ts
@@ -20,7 +20,6 @@ import {
   set,
   ifElse,
 } from 'graphql-mapping-template';
-import { NONE_VALUE } from 'graphql-transformer-common';
 import {
   getIdentityClaimExp,
   emptyPayload,
@@ -88,7 +87,11 @@ const iamExpression = (
   const expression = new Array<Expression>();
   // allow if using an admin role
   if (hasAdminRolesEnabled) {
-    expression.push(iamAdminRoleCheckExpression(adminRoles));
+    const adminCheckExpression = compoundExpression([
+      set(ref(allowedAggFieldsList), ref(totalFields)),
+      qref(methodCall(ref('ctx.stash.put'), str(allowedAggFieldsList), ref(allowedAggFieldsList)))
+    ]);
+    expression.push(iamAdminRoleCheckExpression(adminRoles, undefined, adminCheckExpression));
   }
   if (roles.length === 0) {
     expression.push(ref('util.unauthorized()'));


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes the Auth transformer to properly set the allowed aggregate fields in the stash for Search query auth resolvers with IAM auth and having admin roles.

#### Issue #, if available
https://github.com/aws-amplify/amplify-category-api/issues/73

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Added unit test and JS sample app.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
