### PR TITLE
chore: add migration test support for v10

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -317,6 +317,7 @@ jobs:
       - run:
           name: Run tests migrating from CLI v10.5.1
           command: |
+            yarn setup-dev
             source .circleci/local_publish_helpers.sh
             changeNpmGlobalPath
             cd packages/amplify-migration-tests

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -259,6 +259,8 @@ jobs:
 
   amplify_migration_tests_v5:
     <<: *defaults
+    environment:
+      AMPLIFY_PATH: /home/circleci/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify
     steps:
       - attach_workspace:
           at: ./
@@ -281,9 +283,9 @@ jobs:
     working_directory: ~/repo
 
   amplify_migration_tests_v6:
+    <<: *defaults
     environment:
       AMPLIFY_PATH: /home/circleci/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify
-    <<: *defaults
     steps:
       - attach_workspace:
           at: ./
@@ -301,6 +303,32 @@ jobs:
       - run: *scan_e2e_test_artifacts
       - store_test_results:
           path: packages/amplify-migration-tests/
+      - store_artifacts:
+          path: ~/repo/packages/amplify-migration-tests/amplify-migration-reports
+    working_directory: ~/repo
+
+  amplify_migration_tests_v10:
+    <<: *defaults
+    environment:
+      AMPLIFY_PATH: /home/circleci/.amplify/bin/amplify
+    steps:
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: amplify-category-api-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{ arch }}
+      - run:
+          name: Run tests migrating from CLI v10.5.1
+          command: |
+            source .circleci/local_publish_helpers.sh
+            changeNpmGlobalPath
+            cd packages/amplify-migration-tests
+            unset IS_AMPLIFY_CI
+            echo $IS_AMPLIFY_CI
+            retry yarn run migration_v10.5.1 --maxWorkers=3 $TEST_SUITE
+          no_output_timeout: 90m
+      - run: *scan_e2e_test_artifacts
+      - store_test_results:
+          path: ~/repo/packages/amplify-migration-tests/
       - store_artifacts:
           path: ~/repo/packages/amplify-migration-tests/amplify-migration-reports
     working_directory: ~/repo
@@ -493,6 +521,19 @@ workflows:
                 - /run-e2e\/.*/
           requires:
             - publish_to_local_registry
+      - amplify_migration_tests_v10:
+          context:
+            - e2e-auth-credentials
+            - api-cleanup-resources
+            - api-e2e-test-context
+          filters:
+            branches:
+              only:
+                - main
+                - /tagged-release\/.*/
+                - /run-e2e\/.*/
+          requires:
+            - publish_to_local_registry
       - amplify_migration_tests_v5:
           context:
             - e2e-auth-credentials
@@ -542,6 +583,7 @@ workflows:
             - graphql_e2e_tests
             - amplify_e2e_tests
             - client_e2e_tests
+            - amplify_migration_tests_v10
             - amplify_migration_tests_v6
             - amplify_migration_tests_v5
           filters:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -13,8 +13,8 @@ executors:
       shell: bash.exe
     working_directory: ~/repo
     environment:
-      AMPLIFY_DIR: C:/home/circleci/repo/out
-      AMPLIFY_PATH: C:/home/circleci/repo/out/amplify.exe
+      AMPLIFY_DIR: C:/home/circleci/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin
+      AMPLIFY_PATH: C:/home/circleci/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify
 
   l: &linux-e2e-executor
     docker:
@@ -22,8 +22,8 @@ executors:
     working_directory: ~/repo
     resource_class: large
     environment:
-      AMPLIFY_DIR: /home/circleci/repo/out
-      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux-x64
+      AMPLIFY_DIR: /home/circleci/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin
+      AMPLIFY_PATH: /home/circleci/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify
 
 defaults: &defaults
   working_directory: ~/repo
@@ -213,8 +213,6 @@ jobs:
           path: packages/amplify-e2e-tests/amplify-e2e-reports
 
   client_e2e_tests:
-    environment:
-      AMPLIFY_PATH: /home/circleci/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify
     parameters:
       os:
         type: executor
@@ -260,7 +258,7 @@ jobs:
   amplify_migration_tests_v5:
     <<: *defaults
     environment:
-      AMPLIFY_PATH: /home/circleci/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify
+      AMPLIFY_PATH: /home/circleci/.npm-global/lib/node_modules/@aws-amplify/cli/bin/amplify
     steps:
       - attach_workspace:
           at: ./
@@ -285,7 +283,7 @@ jobs:
   amplify_migration_tests_v6:
     <<: *defaults
     environment:
-      AMPLIFY_PATH: /home/circleci/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify
+      AMPLIFY_PATH: /home/circleci/.npm-global/lib/node_modules/@aws-amplify/cli/bin/amplify
     steps:
       - attach_workspace:
           at: ./

--- a/packages/amplify-e2e-core/package.json
+++ b/packages/amplify-e2e-core/package.json
@@ -35,6 +35,7 @@
     "rimraf": "^3.0.0",
     "strip-ansi": "^6.0.0",
     "throat": "^5.0.0",
+    "semver": "^7.3.5",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {

--- a/packages/amplify-e2e-core/src/index.ts
+++ b/packages/amplify-e2e-core/src/index.ts
@@ -6,6 +6,7 @@ import * as ini from 'ini';
 import { spawnSync, execSync } from 'child_process';
 import { v4 as uuid } from 'uuid';
 import { pathManager } from 'amplify-cli-core';
+import { gt } from 'semver';
 
 export * from './configure/';
 export * from './init/';
@@ -29,13 +30,14 @@ const amplifyTestsDir = 'amplify-e2e-tests';
 export function getCLIPath(testingWithLatestCodebase = false) {
   if (!testingWithLatestCodebase) {
     if (process.env.AMPLIFY_PATH && fs.existsSync(process.env.AMPLIFY_PATH)) {
+      console.log("CLIPATH 1:", process.env.AMPLIFY_PATH);
       return process.env.AMPLIFY_PATH;
     }
-
+    console.log("CLIPATH 2:", process.platform === 'win32' ? 'amplify.exe' : 'amplify');
     return process.platform === 'win32' ? 'amplify.exe' : 'amplify';
   }
-
   const amplifyScriptPath = path.join(__dirname, '..', '..', '..', 'node_modules', 'amplify-cli-internal', 'bin', 'amplify');
+  console.log("CLIPATH 3:", amplifyScriptPath);
   return amplifyScriptPath;
 }
 
@@ -91,7 +93,7 @@ export async function installAmplifyCLI(version: string = 'latest') {
   });
   
   console.log("SETTING PATH:");
-  if(version === '10.5.1'){
+  if(gt(version, '10.0.0')){
     process.env.AMPLIFY_PATH = process.platform === 'win32'
     ? path.join(os.homedir(), '.amplify', 'bin', 'amplify')
     : path.join(os.homedir(), '.amplify', 'bin', 'amplify');

--- a/packages/amplify-e2e-core/src/index.ts
+++ b/packages/amplify-e2e-core/src/index.ts
@@ -89,10 +89,19 @@ export async function installAmplifyCLI(version: string = 'latest') {
     env: process.env,
     stdio: 'inherit',
   });
-  process.env.AMPLIFY_PATH =
-    process.platform === 'win32'
-      ? path.join(os.homedir(), '..', '..', 'Program` Files', 'nodejs', 'node_modules', '@aws-amplify', 'cli', 'bin', 'amplify')
-      : path.join(os.homedir(), '.npm-global', 'bin', 'amplify');
+  
+  console.log("SETTING PATH:");
+  if(version === '10.5.1'){
+    process.env.AMPLIFY_PATH = process.platform === 'win32'
+    ? path.join(os.homedir(), '.amplify', 'bin', 'amplify')
+    : path.join(os.homedir(), '.amplify', 'bin', 'amplify');
+  } else {
+    process.env.AMPLIFY_PATH = process.platform === 'win32'
+    ? path.join(os.homedir(), '..', '..', 'Program` Files', 'nodejs', 'node_modules', '@aws-amplify', 'cli', 'bin', 'amplify')
+    : path.join(os.homedir(), '.npm-global', 'bin', 'amplify');
+  }
+  
+  console.log("PATH SET:", process.env.AMPLIFY_PATH);
 }
 
 export async function createNewProjectDir(

--- a/packages/amplify-e2e-core/src/index.ts
+++ b/packages/amplify-e2e-core/src/index.ts
@@ -30,14 +30,14 @@ const amplifyTestsDir = 'amplify-e2e-tests';
 export function getCLIPath(testingWithLatestCodebase = false) {
   if (!testingWithLatestCodebase) {
     if (process.env.AMPLIFY_PATH && fs.existsSync(process.env.AMPLIFY_PATH)) {
-      console.log("CLIPATH 1:", process.env.AMPLIFY_PATH);
+      console.log("Resolving CLI path to AMPLIFY_PATH:", process.env.AMPLIFY_PATH);
       return process.env.AMPLIFY_PATH;
     }
-    console.log("CLIPATH 2:", process.platform === 'win32' ? 'amplify.exe' : 'amplify');
+    console.log("Resolving CLI path to present executable:", process.platform === 'win32' ? 'amplify.exe' : 'amplify');
     return process.platform === 'win32' ? 'amplify.exe' : 'amplify';
   }
   const amplifyScriptPath = path.join(__dirname, '..', '..', '..', 'node_modules', 'amplify-cli-internal', 'bin', 'amplify');
-  console.log("CLIPATH 3:", amplifyScriptPath);
+  console.log("Resolving CLI Path to source code:", amplifyScriptPath);
   return amplifyScriptPath;
 }
 

--- a/packages/amplify-migration-tests/package.json
+++ b/packages/amplify-migration-tests/package.json
@@ -18,10 +18,9 @@
   "private": true,
   "scripts": {
     "build-tests": "tsc --build tsconfig.tests.json",
-    "migration_v4.28.2_nonmultienv_layers": "npm run setup-profile 4.28.2 && jest src/__tests__/migration_tests/lambda-layer-migration/layer-migration.test.ts --verbose --passWithNoTests",
-    "migration_v4.52.0_multienv_layers": "npm run setup-profile 4.52.0 && jest src/__tests__/migration_tests/lambda-layer-migration/layer-migration.test.ts --verbose --passWithNoTests",
-    "migration_v5.2.0": "npm run setup-profile 5.2.0 && jest --testPathIgnorePatterns=auth.deployment.secrets\\|layer-migration\\|overrides --verbose --passWithNoTests",
-    "migration_v6.1.0": "npm run setup-profile 6.1.0 && jest --testPathIgnorePatterns=auth.deployment.secrets\\|layer-migration --verbose --passWithNoTests",
+    "migration_v5.2.0": "npm run setup-profile 5.2.0 && jest --verbose",
+    "migration_v6.1.0": "npm run setup-profile 6.1.0 && jest --verbose",
+    "migration_v10.5.1": "npm run setup-profile 10.5.1 && jest --verbose",
     "setup-profile": "ts-node ./src/configure_tests.ts"
   },
   "dependencies": {

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/scaffold.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/scaffold.test.ts
@@ -1,0 +1,34 @@
+import {
+    createNewProjectDir,
+    deleteProject,
+    deleteProjectDir,
+  } from 'amplify-category-api-e2e-core';
+  import { versionCheck, allowedVersionsToMigrateFrom } from '../../migration-helpers';
+  import { initJSProjectWithProfileV10 } from '../../migration-helpers-v10/init';
+  
+  describe('amplify migration test scaffold v10', () => {
+    let projRoot: string;
+  
+    beforeAll(async () => {
+      const migrateFromVersion = { v: 'unintialized' };
+      const migrateToVersion = { v: 'unintialized' };
+      await versionCheck(process.cwd(), false, migrateFromVersion);
+      await versionCheck(process.cwd(), true, migrateToVersion);
+      console.log(`Test migration from: ${migrateFromVersion} to ${migrateToVersion}`);
+      // expect(migrateFromVersion.v).not.toEqual(migrateToVersion.v); // uncomment this once we are in v11 for local codebase
+      expect(allowedVersionsToMigrateFrom).toContain(migrateFromVersion.v);
+    });
+  
+    beforeEach(async () => {
+      projRoot = await createNewProjectDir('scaffoldTest');
+    });
+  
+    afterEach(async () => {
+      await deleteProject(projRoot, null, true);
+      deleteProjectDir(projRoot);
+    });
+  
+    it('...should init a project', async () => {
+      await initJSProjectWithProfileV10(projRoot, { name: 'scaffoldTest' });
+    });
+  });

--- a/packages/amplify-migration-tests/src/configure_tests.ts
+++ b/packages/amplify-migration-tests/src/configure_tests.ts
@@ -10,6 +10,7 @@ async function setupAmplify(version: string = 'latest') {
   // install CLI to be used for migration test initial project
   await installAmplifyCLI(version);
 
+  console.log("INSTALLED CLI:", version);
   if (isCI()) {
     const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
     const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY;

--- a/packages/amplify-migration-tests/src/migration-helpers-v10/init.ts
+++ b/packages/amplify-migration-tests/src/migration-helpers-v10/init.ts
@@ -1,0 +1,94 @@
+
+import { addCircleCITags, getCLIPath, nspawn as spawn } from 'amplify-category-api-e2e-core';
+import { EOL } from 'os';
+
+const defaultSettings = {
+    name: EOL,
+    // eslint-disable-next-line spellcheck/spell-checker
+    envName: 'integtest',
+    editor: EOL,
+    appType: EOL,
+    framework: EOL,
+    srcDir: EOL,
+    distDir: EOL,
+    buildCmd: EOL,
+    startCmd: EOL,
+    useProfile: EOL,
+    profileName: EOL,
+    region: process.env.CLI_REGION,
+    local: false,
+    disableAmplifyAppCreation: true,
+    disableCIDetection: false,
+    providerConfig: undefined,
+    permissionsBoundaryArn: undefined,
+};
+  
+export function initJSProjectWithProfileV10(cwd: string, settings?: Partial<typeof defaultSettings>): Promise<void> {
+    const s = { ...defaultSettings, ...settings };
+    let env;
+  
+    if (s.disableAmplifyAppCreation === true) {
+      env = {
+        CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
+      };
+    }
+  
+    addCircleCITags(cwd);
+  
+    const cliArgs = ['init'];
+    const providerConfigSpecified = !!s.providerConfig && typeof s.providerConfig === 'object';
+    if (providerConfigSpecified) {
+      cliArgs.push('--providers', JSON.stringify(s.providerConfig));
+    }
+  
+    if (s.permissionsBoundaryArn) {
+      cliArgs.push('--permissions-boundary', s.permissionsBoundaryArn);
+    }
+  
+    if (s?.name?.length > 20) console.warn('Project names should not be longer than 20 characters. This may cause tests to break.');
+  
+    return new Promise((resolve, reject) => {
+      const chain = spawn(getCLIPath(), cliArgs, {
+        cwd, stripColors: true, env, disableCIDetection: s.disableCIDetection,
+      })
+        .wait('Enter a name for the project')
+        .sendLine(s.name)
+        .wait('Initialize the project with the above configuration?')
+        .sendConfirmNo()
+        .wait('Enter a name for the environment')
+        .sendLine(s.envName)
+        .wait('Choose your default editor:')
+        .sendLine(s.editor)
+        .wait("Choose the type of app that you're building")
+        .sendLine(s.appType)
+        .wait('What javascript framework are you using')
+        .sendLine(s.framework)
+        .wait('Source Directory Path:')
+        .sendLine(s.srcDir)
+        .wait('Distribution Directory Path:')
+        .sendLine(s.distDir)
+        .wait('Build Command:')
+        .sendLine(s.buildCmd)
+        .wait('Start Command:')
+        .sendCarriageReturn();
+  
+      if (!providerConfigSpecified) {
+        chain
+          .wait('Using default provider  awscloudformation')
+          .wait('Select the authentication method you want to use:')
+          .sendCarriageReturn()
+          .wait('Please choose the profile you want to use')
+          .sendLine(s.profileName);
+      }
+      chain.wait('Help improve Amplify CLI by sharing non sensitive configurations on failures')
+        .sendYes()
+        .wait(/Try "amplify add api" to create a backend API and then "amplify (push|publish)" to deploy everything/).run((err: Error) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+    });
+  }
+  

--- a/packages/amplify-migration-tests/src/migration-helpers/check-version.ts
+++ b/packages/amplify-migration-tests/src/migration-helpers/check-version.ts
@@ -21,4 +21,4 @@ export function versionCheck(cwd: string, testingWithLatestCodebase = false, ver
  *
  * ext migrate flow: https://github.com/aws-amplify/amplify-cli/pull/8806
  */
-export const allowedVersionsToMigrateFrom = ['5.2.0', '6.1.0'];
+export const allowedVersionsToMigrateFrom = ['5.2.0', '6.1.0', '10.5.1'];

--- a/scripts/split-e2e-test-filters.ts
+++ b/scripts/split-e2e-test-filters.ts
@@ -1,0 +1,12 @@
+export const migrationFromV5Tests = [
+    "src/__tests__/migration_tests/transformer_migration/api.key.migration-2.test.ts",
+    "src/__tests__/migration_tests/transformer_migration/api.key.migration.test.ts",
+  ]
+export const migrationFromV6Tests = [
+    "src/__tests__/migration_tests/transformer_migration/api.key.migration-2.test.ts",
+    "src/__tests__/migration_tests/transformer_migration/api.key.migration.test.ts",
+  ]
+
+export const migrationFromV10Tests = [
+    "src/__tests__/migration_tests_v10/scaffold.test.ts",
+]

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -436,7 +436,7 @@ function main(): void {
   const splitV10MigrationTests = splitTests(
     splitV6MigrationTests,
     'amplify_migration_tests_v10',
-    'build_test_deploy_v3',
+    'build_test_deploy',
     join(repoRoot, 'packages', 'amplify-migration-tests'),
     CONCURRENCY,
     (tests: string[]) => {

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -3,6 +3,7 @@ import * as glob from 'glob';
 import { join } from 'path';
 import * as fs from 'fs-extra';
 import * as execa from 'execa';
+import { migrationFromV10Tests, migrationFromV5Tests, migrationFromV6Tests } from './split-e2e-test-filters';
 
 const CONCURRENCY = 25;
 // Some our e2e tests are known to fail when run on windows hosts
@@ -202,12 +203,15 @@ function splitTests(
   workflowName: string,
   jobRootDir: string,
   concurrency: number = CONCURRENCY,
-  isMigration: boolean = false,
+  pickTests: ((testSuites: string[]) => string[]) | undefined,
 ): CircleCIConfig {
   const output: CircleCIConfig = { ...config };
   const jobs = { ...config.jobs };
   const job = jobs[jobName];
-  const testSuites = getTestFiles(jobRootDir);
+  let testSuites = getTestFiles(jobRootDir);
+  if(pickTests && typeof pickTests === 'function'){
+    testSuites = pickTests(testSuites);
+  }
 
   const newJobs = testSuites.reduce((acc, suite, index) => {
     const newJobName = generateJobName(jobName, suite);
@@ -223,20 +227,6 @@ function splitTests(
         ...(USE_PARENT_ACCOUNT.some(job => newJobName.startsWith(job)) ? { USE_PARENT_ACCOUNT: 1 } : {}),
       },
     };
-    const isPkg = newJobName.endsWith('_pkg');
-    if (!isPkg) {
-      (newJob.environment as any) = {
-        ...newJob.environment,
-        ...(isMigration
-          ? {
-              AMPLIFY_PATH: '/home/circleci/.npm-global/lib/node_modules/@aws-amplify/cli/bin/amplify',
-            }
-          : {
-              AMPLIFY_DIR: '/home/circleci/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin',
-              AMPLIFY_PATH: '/home/circleci/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify',
-            }),
-      };
-    }
     return { ...acc, [newJobName]: newJob };
   }, {});
 
@@ -413,6 +403,7 @@ function main(): void {
     'build_test_deploy',
     join(repoRoot, 'packages', 'amplify-e2e-tests'),
     CONCURRENCY,
+    undefined
   );
   const splitGqlTests = splitTests(
     splitPkgTests,
@@ -420,6 +411,7 @@ function main(): void {
     'build_test_deploy',
     join(repoRoot, 'packages', 'graphql-transformers-e2e-tests'),
     CONCURRENCY,
+    undefined
   );
   const splitV5MigrationTests = splitTests(
     splitGqlTests,
@@ -427,7 +419,9 @@ function main(): void {
     'build_test_deploy',
     join(repoRoot, 'packages', 'amplify-migration-tests'),
     CONCURRENCY,
-    true,
+    (tests: string[]) => {
+      return tests.filter(testName => migrationFromV5Tests.find((t) => t === testName));
+    }
   );
   const splitV6MigrationTests = splitTests(
     splitV5MigrationTests,
@@ -435,9 +429,21 @@ function main(): void {
     'build_test_deploy',
     join(repoRoot, 'packages', 'amplify-migration-tests'),
     CONCURRENCY,
-    true,
+    (tests: string[]) => {
+      return tests.filter(testName => migrationFromV6Tests.find((t) => t === testName));
+    }
   );
-  saveConfig(splitV6MigrationTests);
+  const splitV10MigrationTests = splitTests(
+    splitV6MigrationTests,
+    'amplify_migration_tests_v10',
+    'build_test_deploy_v3',
+    join(repoRoot, 'packages', 'amplify-migration-tests'),
+    CONCURRENCY,
+    (tests: string[]) => {
+      return tests.filter(testName => migrationFromV10Tests.find((t) => t === testName));
+    }
+  );
+  saveConfig(splitV10MigrationTests);
   verifyConfig();
 }
 main();

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,6 +219,46 @@
     prettier "^1.19.1"
     yargs "^15.1.0"
 
+"@aws-amplify/graphql-transformer-core@^0.17.12":
+  version "0.17.15"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/graphql-transformer-core/-/graphql-transformer-core-0.17.15.tgz#f5f6bffc3520dd2f05419a040fbe29a8384a1c6f"
+  integrity sha512-B+zyht8Z7N/emjyeXJ5nh/YYSy2PBDPVz3i6RQqoxa24AYqc/fo0+Tz6bw5RzqbKE3K50pJnfb9MfV08lYqUNg==
+  dependencies:
+    "@aws-amplify/graphql-transformer-interfaces" "1.14.9"
+    "@aws-cdk/aws-applicationautoscaling" "~1.172.0"
+    "@aws-cdk/aws-appsync" "~1.172.0"
+    "@aws-cdk/aws-certificatemanager" "~1.172.0"
+    "@aws-cdk/aws-cloudwatch" "~1.172.0"
+    "@aws-cdk/aws-codeguruprofiler" "~1.172.0"
+    "@aws-cdk/aws-cognito" "~1.172.0"
+    "@aws-cdk/aws-dynamodb" "~1.172.0"
+    "@aws-cdk/aws-ec2" "~1.172.0"
+    "@aws-cdk/aws-efs" "~1.172.0"
+    "@aws-cdk/aws-elasticsearch" "~1.172.0"
+    "@aws-cdk/aws-events" "~1.172.0"
+    "@aws-cdk/aws-iam" "~1.172.0"
+    "@aws-cdk/aws-kms" "~1.172.0"
+    "@aws-cdk/aws-lambda" "~1.172.0"
+    "@aws-cdk/aws-logs" "~1.172.0"
+    "@aws-cdk/aws-route53" "~1.172.0"
+    "@aws-cdk/aws-s3" "~1.172.0"
+    "@aws-cdk/aws-s3-assets" "~1.172.0"
+    "@aws-cdk/aws-sqs" "~1.172.0"
+    "@aws-cdk/cloud-assembly-schema" "~1.172.0"
+    "@aws-cdk/core" "~1.172.0"
+    "@aws-cdk/custom-resources" "~1.172.0"
+    "@aws-cdk/cx-api" "~1.172.0"
+    "@aws-cdk/region-info" "~1.172.0"
+    constructs "^3.3.125"
+    fs-extra "^8.1.0"
+    graphql "^14.5.8"
+    graphql-transformer-common "4.24.0"
+    lodash "^4.17.21"
+    md5 "^2.3.0"
+    object-hash "^3.0.0"
+    ts-dedent "^2.0.0"
+    vm2 "^3.9.8"
+
 "@aws-amplify/graphql-types-generator@3.0.0":
   version "3.0.0"
   resolved "https://registry.npmjs.org/@aws-amplify/graphql-types-generator/-/graphql-types-generator-3.0.0.tgz#6e9dba889ed303fc7c46248154f36d8ba4a30aee"
@@ -11328,6 +11368,16 @@ graphql-tag@^2.10.1, graphql-tag@^2.11.0:
   integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
   dependencies:
     tslib "^2.1.0"
+
+graphql-transformer-common@4.24.0:
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/graphql-transformer-common/-/graphql-transformer-common-4.24.0.tgz#f3be95c4b5ca2ada23fc3d0b01810810ad87810d"
+  integrity sha512-wleRNCFJLrqhYUT4j3KOfh2zTkvVjA6MX/s0HBIFWbNfnzd/W0VDAvpE9q8sMipOvXJ4zcVIZggI7TttrA/fOw==
+  dependencies:
+    graphql "^14.5.8"
+    graphql-mapping-template "4.20.5"
+    md5 "^2.2.1"
+    pluralize "8.0.0"
 
 graphql@0.13.0:
   version "0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,46 +219,6 @@
     prettier "^1.19.1"
     yargs "^15.1.0"
 
-"@aws-amplify/graphql-transformer-core@^0.17.12":
-  version "0.17.15"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/graphql-transformer-core/-/graphql-transformer-core-0.17.15.tgz#f5f6bffc3520dd2f05419a040fbe29a8384a1c6f"
-  integrity sha512-B+zyht8Z7N/emjyeXJ5nh/YYSy2PBDPVz3i6RQqoxa24AYqc/fo0+Tz6bw5RzqbKE3K50pJnfb9MfV08lYqUNg==
-  dependencies:
-    "@aws-amplify/graphql-transformer-interfaces" "1.14.9"
-    "@aws-cdk/aws-applicationautoscaling" "~1.172.0"
-    "@aws-cdk/aws-appsync" "~1.172.0"
-    "@aws-cdk/aws-certificatemanager" "~1.172.0"
-    "@aws-cdk/aws-cloudwatch" "~1.172.0"
-    "@aws-cdk/aws-codeguruprofiler" "~1.172.0"
-    "@aws-cdk/aws-cognito" "~1.172.0"
-    "@aws-cdk/aws-dynamodb" "~1.172.0"
-    "@aws-cdk/aws-ec2" "~1.172.0"
-    "@aws-cdk/aws-efs" "~1.172.0"
-    "@aws-cdk/aws-elasticsearch" "~1.172.0"
-    "@aws-cdk/aws-events" "~1.172.0"
-    "@aws-cdk/aws-iam" "~1.172.0"
-    "@aws-cdk/aws-kms" "~1.172.0"
-    "@aws-cdk/aws-lambda" "~1.172.0"
-    "@aws-cdk/aws-logs" "~1.172.0"
-    "@aws-cdk/aws-route53" "~1.172.0"
-    "@aws-cdk/aws-s3" "~1.172.0"
-    "@aws-cdk/aws-s3-assets" "~1.172.0"
-    "@aws-cdk/aws-sqs" "~1.172.0"
-    "@aws-cdk/cloud-assembly-schema" "~1.172.0"
-    "@aws-cdk/core" "~1.172.0"
-    "@aws-cdk/custom-resources" "~1.172.0"
-    "@aws-cdk/cx-api" "~1.172.0"
-    "@aws-cdk/region-info" "~1.172.0"
-    constructs "^3.3.125"
-    fs-extra "^8.1.0"
-    graphql "^14.5.8"
-    graphql-transformer-common "4.24.0"
-    lodash "^4.17.21"
-    md5 "^2.3.0"
-    object-hash "^3.0.0"
-    ts-dedent "^2.0.0"
-    vm2 "^3.9.8"
-
 "@aws-amplify/graphql-types-generator@3.0.0":
   version "3.0.0"
   resolved "https://registry.npmjs.org/@aws-amplify/graphql-types-generator/-/graphql-types-generator-3.0.0.tgz#6e9dba889ed303fc7c46248154f36d8ba4a30aee"
@@ -11368,16 +11328,6 @@ graphql-tag@^2.10.1, graphql-tag@^2.11.0:
   integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
   dependencies:
     tslib "^2.1.0"
-
-graphql-transformer-common@4.24.0:
-  version "4.24.0"
-  resolved "https://registry.yarnpkg.com/graphql-transformer-common/-/graphql-transformer-common-4.24.0.tgz#f3be95c4b5ca2ada23fc3d0b01810810ad87810d"
-  integrity sha512-wleRNCFJLrqhYUT4j3KOfh2zTkvVjA6MX/s0HBIFWbNfnzd/W0VDAvpE9q8sMipOvXJ4zcVIZggI7TttrA/fOw==
-  dependencies:
-    graphql "^14.5.8"
-    graphql-mapping-template "4.20.5"
-    md5 "^2.2.1"
-    pluralize "8.0.0"
 
 graphql@0.13.0:
   version "0.13.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This adds support for migration testing from v10 to vNext (v11+).
This is done by adding the v10 migration test setup/scaffold & verified with an initial 'scaffold.test.ts' that just installs v10 globally (to .amplify/bin/amplify), and verifies that it works.
This allows us to use the local source code for the latter part of a typical migration test, where we run the amplify commands against the locally installed codebase (located at ~/repo/packages/amplify-cli/bin/amplify).

E2E is running here: https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api?branch=run-e2e/aluja/add-support-for-migration-tests-v10

This PR is a sibling to this other PR in the CLI repo: https://github.com/aws-amplify/amplify-cli/pull/11535
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
