### PR TITLE
feat(api): convert rds schema graphql

### DIFF
--- a/packages/amplify-category-api/amplify-plugin.json
+++ b/packages/amplify-category-api/amplify-plugin.json
@@ -12,7 +12,8 @@
     "rebuild",
     "remove",
     "update",
-    "help"
+    "help",
+    "import"
   ],
   "commandAliases": {
     "configure": "update"

--- a/packages/amplify-category-api/src/commands/api.ts
+++ b/packages/amplify-category-api/src/commands/api.ts
@@ -56,6 +56,11 @@ export const run = async (context: $TSContext) => {
       name: 'override',
       description: 'Generates overrides file to apply custom modifications to CloudFormation',
     },
+    // TODO: Add it once we enable RDS support
+    // {
+    //   name: 'import',
+    //   description: 'Imports existing datasource to GraphQL API',
+    // },
   ];
 
   context.amplify.showHelp(header, commands);

--- a/packages/amplify-category-api/src/commands/api/import.ts
+++ b/packages/amplify-category-api/src/commands/api/import.ts
@@ -2,7 +2,7 @@ import { $TSAny, $TSContext, AmplifyCategories, pathManager, stateManager } from
 import { printer } from 'amplify-prompts';
 import * as path from 'path';
 import fs from 'fs-extra';
-import { MySQLDataSourceAdapter, generteGraphQLSchema, Schema, Engine } from '@aws-amplify/graphql-schema-generator';
+import { MySQLDataSourceAdapter, generateGraphQLSchema, Schema, Engine } from '@aws-amplify/graphql-schema-generator';
 const subcommand = 'import';
 
 export const name = subcommand;
@@ -25,7 +25,7 @@ export const run = async (context: $TSContext) => {
   const schema = new Schema(new Engine('MySQL'));
   models.forEach(m => schema.addModel(m));
 
-  const schemaString = generteGraphQLSchema(schema);
+  const schemaString = generateGraphQLSchema(schema);
   writeSchemaFile(apiResourceDir, schemaString);
 
   printer.info('Successfully imported the database schema.');

--- a/packages/amplify-category-api/src/commands/api/import.ts
+++ b/packages/amplify-category-api/src/commands/api/import.ts
@@ -1,0 +1,66 @@
+import { $TSAny, $TSContext, AmplifyCategories, pathManager, stateManager } from 'amplify-cli-core';
+import { printer } from 'amplify-prompts';
+import * as path from 'path';
+import fs from 'fs-extra';
+import { MySQLDataSourceAdapter, generteGraphQLSchema, Schema, Engine } from '@aws-amplify/graphql-schema-generator';
+const subcommand = 'import';
+
+export const name = subcommand;
+
+export const run = async (context: $TSContext) => {
+  const apiResourceDir = getResourceDir();
+
+  if (!apiResourceDir) {
+    throw new Error("No API Resource found.");
+  }
+
+  const config = await readConfigFile(apiResourceDir);
+
+  // TODO: Change this to a factory method once we support multiple RDS engines
+  const adapter = new MySQLDataSourceAdapter(config);
+  await adapter.initialize();
+  const models = await adapter.getModels();
+  adapter.cleanup();
+
+  const schema = new Schema(new Engine('MySQL'));
+  models.forEach(m => schema.addModel(m));
+
+  const schemaString = generteGraphQLSchema(schema);
+  writeSchemaFile(apiResourceDir, schemaString);
+
+  printer.info('Successfully imported the database schema.');
+};
+
+const getResourceDir = () => {
+  const apiNames = Object.entries(stateManager.getMeta()?.api || {})
+    .filter(([_, apiResource]) => (apiResource as $TSAny).service === 'AppSync')
+    .map(([name]) => name);
+  if (apiNames.length === 0) {
+    printer.info(
+      'No GraphQL API configured in the project.',
+    );
+    return;
+  }
+  if (apiNames.length > 1) {
+    // this condition should never hit as we have upstream defensive logic to prevent multiple GraphQL APIs. But just to cover all the bases
+    printer.error(
+      'You have multiple GraphQL APIs in the project. Only one GraphQL API is allowed per project. Run `amplify remove api` to remove an API.',
+    );
+    return;
+  }
+  const apiName = apiNames[0];
+  const apiResourceDir = path.join(pathManager.getBackendDirPath(), AmplifyCategories.API, apiName);
+  return apiResourceDir;
+};
+
+// TODO: Move the file handling to amplify-cli-core
+
+const readConfigFile = async (apiResourceDir: string) => {
+  const configFilePath = path.join(apiResourceDir, 'rds.env');
+  return fs.readJSON(configFilePath);
+};
+
+const writeSchemaFile = async (apiResourceDir: string, schema: string) => {
+  const schemaFilePath = path.join(apiResourceDir, 'schema.rds.graphql');
+  fs.writeFileSync(schemaFilePath, schema);
+};

--- a/packages/amplify-graphql-schema-generator/package.json
+++ b/packages/amplify-graphql-schema-generator/package.json
@@ -27,7 +27,9 @@
   },
   "dependencies": {
     "knex": "~2.3.0",
-    "mysql2": "~2.3.3"
+    "mysql2": "~2.3.3",
+    "graphql": "^14.5.8",
+    "@aws-amplify/graphql-transformer-core": "0.17.15"
   },
   "peerDependencies": {
     "amplify-prompts": "^2.6.0"

--- a/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/mysql-datasource-adapter.test.ts.snap
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/mysql-datasource-adapter.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`testDataSourceAdapter test generate graphql schema from internal reprensentation 1`] = `
+"type Capital @model {
+  id: Int! @primaryKey
+  name: String
+  countryId: Int @index(name: \\"countryId\\")
+}
+
+type Country @model {
+  id: Int! @default(value: \\"uuid()\\") @primaryKey
+  name: String
+}
+
+type Tasks @model {
+  id: String! @primaryKey(sortKeyFields: [\\"title\\"])
+  title: String @index(name: \\"tasks_title\\") @index(name: \\"tasks_title_description\\", sortKeyFields: [\\"description\\"])
+  description: String
+  priority: String
+}
+"
+`;

--- a/packages/amplify-graphql-schema-generator/src/__tests__/mysql-datasource-adapter.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/mysql-datasource-adapter.test.ts
@@ -1,18 +1,18 @@
-import { DataSourceAdapter, MySQLDataSourceAdapter } from '../datasource-adapter';
-import { Field, FieldType, Index } from '../schema-representation';
-
+import { DataSourceAdapter, MySQLDataSourceAdapter } from "../datasource-adapter";
+import { Engine, Field, FieldType, Index, Model, Schema } from "../schema-representation";
+import { generateGraphQLSchema } from "../schema-generator";
 class TestDataSourceAdapter extends DataSourceAdapter {
   public async initialize(): Promise<void> {
     // Do Nothing
   }
   public mapDataType(type: string, nullable: boolean): FieldType {
     return {
-      kind: 'Scalar',
-      name: 'String',
+      kind: "Scalar",
+      name: "String",
     }
   }
   public async getTablesList(): Promise<string[]> {
-    return ['Test'];
+    return ["Test"];
   }
   public async getFields(tableName: string): Promise<Field[]> {
     return [];
@@ -28,10 +28,10 @@ class TestDataSourceAdapter extends DataSourceAdapter {
   }
 }
 
-describe('testDataSourceAdapter', () => {
-  it('getModels call the default implementation', async () => {
+describe("testDataSourceAdapter", () => {
+  it("getModels call the default implementation", async () => {
     let adapter: DataSourceAdapter = new TestDataSourceAdapter();
-    adapter.getTablesList = jest.fn(async () => ['Test']);
+    adapter.getTablesList = jest.fn(async () => ["Test"]);
     adapter.getFields = jest.fn(async () => []);
     adapter.getPrimaryKey = jest.fn();
     adapter.getIndexes = jest.fn(async () => []);
@@ -43,7 +43,7 @@ describe('testDataSourceAdapter', () => {
     expect(adapter.getPrimaryKey).toBeCalledTimes(1);
   });
 
-  it('test mysql datatype mapping', () => {
+  it("test mysql datatype mapping", () => {
     const config = {
       host: "host",
       database: "database",
@@ -52,32 +52,66 @@ describe('testDataSourceAdapter', () => {
       password: "password",
     };
     const adapter = new MySQLDataSourceAdapter(config);
-    expect(adapter.mapDataType('varchar', true)).toEqual({
+    expect(adapter.mapDataType("varchar", true)).toEqual({
       "kind": "Scalar",
       "name": "String",
     });
-    expect(adapter.mapDataType('char', true)).toEqual({
+    expect(adapter.mapDataType("char", true)).toEqual({
       "kind": "Scalar",
       "name": "String",
     });
-    expect(adapter.mapDataType('enum', true)).toEqual({
+    expect(adapter.mapDataType("enum", true)).toEqual({
       "kind": "Scalar",
       "name": "String",
     });
-    expect(adapter.mapDataType('bool', true)).toEqual({
+    expect(adapter.mapDataType("bool", true)).toEqual({
       "kind": "Scalar",
       "name": "Boolean",
     });
-    expect(adapter.mapDataType('decimal', true)).toEqual({
+    expect(adapter.mapDataType("decimal", true)).toEqual({
       "kind": "Scalar",
       "name": "Float",
     });
-    expect(adapter.mapDataType('year', false)).toEqual({
+    expect(adapter.mapDataType("year", false)).toEqual({
       "kind": "NonNull",
       "type": {
         "kind": "Scalar",
         "name": "Int",
       },
     });
+  });
+
+  it("test generate graphql schema from internal reprensentation", () => {
+
+    const dbschema = new Schema(new Engine("MySQL"));
+
+    let model = new Model("Capital");
+    model.addField(new Field("id", { "kind": "NonNull", "type": { "kind": "Scalar", "name": "Int" } }));
+    model.addField(new Field("name", { "kind": "Scalar", "name": "String" }));
+    model.addField(new Field("countryId", { "kind": "Scalar", "name": "Int" }));
+    model.setPrimaryKey(["id"]);
+    model.addIndex("countryId", ["countryId"])
+    dbschema.addModel(model);
+
+    model = new Model("Country");
+    const countryIdField = new Field("id", { "kind": "NonNull", "type": { "kind": "Scalar", "name": "Int" } });
+    countryIdField.default = { kind: "DB_GENERATED", value: "uuid()" };
+    model.addField(countryIdField);
+    model.addField(new Field("name", { "kind": "Scalar", "name": "String" }));
+    model.setPrimaryKey(["id"]);
+    dbschema.addModel(model);
+
+    model = new Model("Tasks");
+    model.addField(new Field("id", { "kind": "NonNull", "type": { "kind": "Scalar", "name": "String" } }));
+    model.addField(new Field("title", { "kind": "Scalar", "name": "String" }));
+    model.addField(new Field("description", { "kind": "Scalar", "name": "String" }));
+    model.addField(new Field("priority", { "kind": "Scalar", "name": "String" }));
+    model.setPrimaryKey(["id", "title"]);
+    model.addIndex("tasks_title", ["title"])
+    model.addIndex("tasks_title_description", ["title", "description"])
+    dbschema.addModel(model);
+
+    const graphqlSchema = generateGraphQLSchema(dbschema);
+    expect(graphqlSchema).toMatchSnapshot();
   });
 });

--- a/packages/amplify-graphql-schema-generator/src/datasource-adapter/mysql-datasource-adapter.ts
+++ b/packages/amplify-graphql-schema-generator/src/datasource-adapter/mysql-datasource-adapter.ts
@@ -1,4 +1,4 @@
-import { DefaultType, Field, FieldDataType, FieldType, Index } from "../schema-representation";
+import { Field, FieldDataType, FieldType, Index } from "../schema-representation";
 import { DataSourceAdapter } from "./datasource-adapter";
 import { knex } from 'knex';
 import { printer } from 'amplify-prompts';

--- a/packages/amplify-graphql-schema-generator/src/index.ts
+++ b/packages/amplify-graphql-schema-generator/src/index.ts
@@ -1,2 +1,3 @@
 export * from './schema-representation';
 export * from './datasource-adapter';
+export * from './schema-generator';

--- a/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
@@ -2,7 +2,7 @@ import { Field, Index, Model, Schema } from '../schema-representation';
 import { Kind, print } from 'graphql';
 import { FieldWrapper, ObjectDefinitionWrapper, DirectiveWrapper } from '@aws-amplify/graphql-transformer-core';
 
-export const generteGraphQLSchema = (schema: Schema): string => {
+export const generateGraphQLSchema = (schema: Schema): string => {
   const models = schema.getModels();
   const document: any = {
     kind: Kind.DOCUMENT,

--- a/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
@@ -1,0 +1,207 @@
+import { Field, Index, Model, Schema } from '../schema-representation';
+import { Kind, print } from 'graphql';
+import { FieldWrapper, ObjectDefinitionWrapper, DirectiveWrapper } from '@aws-amplify/graphql-transformer-core';
+
+export const generteGraphQLSchema = (schema: Schema): string => {
+  const models = schema.getModels();
+  const document: any = {
+    kind: Kind.DOCUMENT,
+    definitions: [],
+  };
+
+  models.forEach(model => {
+    const type = constructObjectType(model);
+    
+    const fields = model.getFields();
+    fields.forEach(f => {
+      const field: any = convertInternalFieldTypeToGraphQL(f);
+      type.fields.push(field);
+    });
+    
+    addPrimaryKey(type, model.getPrimaryKey());
+    addIndexes(type, model.getIndexes());
+
+    document.definitions.push(type.serialize());
+  });
+
+  const schemaStr = print(document);
+  return schemaStr;
+};
+
+const convertInternalFieldTypeToGraphQL = (field: Field): FieldWrapper => {
+  const typeWrappers = [];
+  let fieldType = field.type;
+  while (fieldType.kind !== "Scalar" && fieldType.kind !== "Custom") {
+    typeWrappers.push(fieldType.kind);
+    fieldType = (fieldType as any).type;
+  }
+
+  // construct the default directive
+  const fieldDirectives = [];
+  if (field.default) {
+    fieldDirectives.push(new DirectiveWrapper({
+      kind: Kind.DIRECTIVE,
+      name: {
+        kind: "Name",
+        value: "default",
+      },
+      arguments: [
+        {
+          kind: "Argument",
+          name: {
+            kind: "Name",
+            value: "value",
+          },
+          value: {
+            kind: "StringValue",
+            value: field.default.value as string,
+          },              
+        },
+      ],
+    }));
+  }
+
+  // Construct the field wrapper object
+  const result = new FieldWrapper({
+    kind: "FieldDefinition",
+    name: {
+      kind: "Name",
+      value: field.name,
+    },
+    type: {
+      kind: "NamedType",
+      name: {
+        kind: "Name",
+        value: fieldType.name,
+      },
+    },
+    directives: fieldDirectives,
+  });
+
+  while (typeWrappers.length > 0) {
+    const wrapperType = typeWrappers.pop();
+    if (wrapperType === "List") {
+      result.wrapListType();
+    } else if (wrapperType === "NonNull") {
+      result.makeNonNullable();
+    }
+  }
+
+  return result;
+};
+
+const constructObjectType = (model: Model) => {
+  return new ObjectDefinitionWrapper({
+    kind: Kind.OBJECT_TYPE_DEFINITION,
+    name: {
+      kind: "Name",
+      value: model.getName(),
+    },
+    fields: [],
+    directives: [
+      {
+        kind: Kind.DIRECTIVE,
+        name: {
+          kind: "Name",
+          value: "model",
+        },
+      },
+    ],
+  });
+};
+
+const addIndexes = (type: ObjectDefinitionWrapper, indexes: Index[]): void => {
+  indexes.forEach(index => {
+    const firstField = index.getFields()[0];
+    const indexField = type.getField(firstField);
+    
+    const indexArguments = [];
+    indexArguments.push(
+      {
+        kind: "Argument",
+        name: {
+          kind: "Name",
+          value: "name",
+        },
+        value: {
+          kind: "StringValue",
+          value: index.name,
+        },
+      },
+    );
+
+    if (index.getFields().length > 1) {
+      indexArguments.push(
+        {
+          kind: "Argument",
+          name: {
+            kind: "Name",
+            value: "sortKeyFields",
+          },
+          value: {
+            kind: "ListValue",
+            values: index.getFields().slice(1).map(k => {
+              return {
+                kind: "StringValue",
+                value: k,
+              };
+            }),
+          },            
+        },
+      )
+    }
+
+    indexField.directives.push(
+      new DirectiveWrapper({
+        kind: Kind.DIRECTIVE,
+        name: {
+          kind: "Name",
+          value: "index",
+        },
+        arguments: indexArguments,
+      }),
+    );
+  });
+};
+
+const addPrimaryKey = (type: ObjectDefinitionWrapper, primaryKey: Index): void => {
+  if (!primaryKey) {
+    return;
+  }
+
+  const firstField = primaryKey.getFields()[0];
+  const primaryKeyField = type.getField(firstField);
+  const keyArguments = [];
+
+  if (primaryKey.getFields().length > 1) {
+    keyArguments.push(
+      {
+        kind: "Argument",
+        name: {
+          kind: "Name",
+          value: "sortKeyFields",
+        },
+        value: {
+          kind: "ListValue",
+          values: primaryKey.getFields().slice(1).map(k => {
+            return {
+              kind: "StringValue",
+              value: k,
+            };
+          }),
+        },           
+      },
+    );
+  }
+
+  primaryKeyField.directives.push(
+    new DirectiveWrapper({
+      kind: Kind.DIRECTIVE,
+      name: {
+        kind: "Name",
+        value: "primaryKey",
+      },
+      arguments: keyArguments,
+    }),
+  );
+};

--- a/packages/amplify-graphql-schema-generator/src/schema-generator/index.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-generator/index.ts
@@ -1,0 +1,1 @@
+export * from './generate-schema';

--- a/packages/amplify-graphql-schema-generator/src/schema-representation/types.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-representation/types.ts
@@ -79,6 +79,14 @@ export class Model {
     this.primaryKey = primaryKey;
   }
 
+  public getPrimaryKey(): Index | undefined {
+    return this.primaryKey;
+  }
+
+  public getIndexes(): Index[] {
+    return this.indexes;
+  }
+
   public addIndex(name: string, fields: string[]): void {
     if (this.hasIndex(name)) {
       throw new Error(`Index "${name}" already exists.`);


### PR DESCRIPTION
#### Description of changes

Generate GraphQL schema from schema internal representation data structure.

Temporarily we are reading the DB details from `rds.env` file from the API resource folder. Eventually, we will modify the workflow to prompt from the customer.

Sample rds.env file below:

```json
{
  "host": "host.server.com",
  "database": "db_name",
  "port": 3306,
  "username": "username",
  "password": "password"
}
```

Running `amplify import api` will import the database schema and convert it to GraphQL schema and store it in `schema.rds.graphql` file.

#### Description of how you validated changes
- manual test
- added unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
