### PR TITLE
chore: enforcing traffic on ES domains via HTTPS

### DIFF
--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
@@ -17,6 +17,7 @@ export const createSearchableDomain = (stack: Construct, parameterMap: Map<strin
 
   const domain = new Domain(stack, OpenSearchDomainLogicalID, {
     version: { version: '7.10' } as ElasticsearchVersion,
+    enforceHttps:true,
     ebs: {
       enabled: true,
       volumeType: EbsDeviceVolumeType.GP2,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
enforcing all network traffic for elasticsearch domains to be over HTTPS instead of HTTP. Added a oneliner in the cloudformation scripts from the documentation: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_elasticsearch-readme.html#audit-logs
#### Issue #, if available
n/a

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
ran yarn test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [n/a] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [n/a] Relevant documentation is changed or added (and PR referenced)
- [n/a] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
