### PR TITLE
fix: resolvers generated from index respect StackMappings

### DIFF
--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -8,7 +8,9 @@ import {
   ExecutionContext,
   getCLIPath,
   getProjectMeta,
+  getTransformConfig,
   nspawn as spawn,
+  setTransformConfig,
   setTransformerVersionFlag,
   updateSchema,
 } from '..';
@@ -978,4 +980,10 @@ export async function validateRestApiMeta(projRoot: string, meta?: any) {
     seenAtLeastOneFunc = true;
   }
   expect(seenAtLeastOneFunc).toBe(true);
+}
+
+export function setStackMapping(projRoot: string, projectName: string, stackMapping: Record<string, string>) {
+  const transformConfig = getTransformConfig(projRoot, projectName);
+  transformConfig.StackMapping = stackMapping;
+  setTransformConfig(projRoot, projectName, transformConfig);
 }

--- a/packages/amplify-e2e-tests/src/__tests__/graphql-v2/index-with-stack-mappings.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/graphql-v2/index-with-stack-mappings.test.ts
@@ -1,0 +1,145 @@
+import {
+  initJSProjectWithProfile,
+  deleteProject,
+  amplifyPush,
+  addApiWithBlankSchema,
+  updateApiSchema,
+  createNewProjectDir,
+  deleteProjectDir,
+  apiGqlCompile,
+  setStackMapping,
+  getProjectMeta,
+} from 'amplify-category-api-e2e-core';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { assertNotNull } from '@aws-amplify/graphql-transformer-core/lib/cdk-compat/stack-synthesizer';
+import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
+import gql from 'graphql-tag';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+// to deal with subscriptions in node env
+(global as any).WebSocket = require('ws');
+
+const projectName = 'indexmap';
+const mappedResolverStack = 'MappedResolvers';
+const providerName = 'awscloudformation';
+
+const getMappedStackPath = (projRoot: string): string => path.join(projRoot, 'amplify', 'backend', 'api', projectName, 'build', 'stacks', `${mappedResolverStack}.json`);
+
+const validateThatSongsCanBeCreatedAndQueriedByIndex = async (projRoot: string): Promise<void> => {
+  const meta = getProjectMeta(projRoot);
+  const region = meta.providers[providerName].Region as string;
+  const { output } = meta.api[projectName];
+  const url = output.GraphQLAPIEndpointOutput as string;
+  const apiKey = output.GraphQLAPIKeyOutput as string;
+
+  const api = new AWSAppSyncClient({
+    url,
+    region,
+    disableOffline: true,
+    auth: { type: AUTH_TYPE.API_KEY, apiKey },
+  });
+
+  const fetchPolicy = 'no-cache';
+  const name = 'songName';
+  const genre = 'songGenre';
+
+  await api.mutate({
+    mutation: gql(/* GraphQL */ `
+      mutation CreateSong($input: CreateSongInput!) {
+        createSong(input: $input) { id }
+      }
+    `),
+    fetchPolicy,
+    variables: { input: { name, genre } },
+  });
+
+  const songInfoByGenreResponse = await api.query({
+    query: gql(/* GraphQL */ `
+      query SongInfoByGenre($genre: String!) {
+        songInfoByGenre(genre: $genre) {
+          items { id }
+        }
+      }
+    `),
+    fetchPolicy,
+    variables: { genre },
+  });
+  expect((songInfoByGenreResponse as any).data.songInfoByGenre.items.length).toEqual(1);
+
+  await api.mutate({
+    mutation: gql(/* GraphQL */ `
+      mutation CreateSongWithSortKey($input: CreateSongWithSortKeyInput!) {
+        createSongWithSortKey(input: $input) { id }
+      }
+    `),
+    fetchPolicy,
+    variables: { input: { name, genre } },
+  });
+
+  const songWithSortKeysByNameAndGenreResponse = await api.query({
+    query: gql(/* GraphQL */ `
+      query SongWithSortKeysByNameAndGenre($name: String! $genre: ModelStringKeyConditionInput) {
+        songWithSortKeysByNameAndGenre(name: $name, genre: $genre) {
+          items { id }
+        }
+      }
+    `),
+    fetchPolicy,
+    variables: { name, genre: { eq: genre } },
+  });
+  expect((songWithSortKeysByNameAndGenreResponse as any).data.songWithSortKeysByNameAndGenre.items.length).toEqual(1);
+};
+
+describe('Index Directive with Stack Mapping Tests', () => {
+  let projRoot: string;
+
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir(projectName);
+    await initJSProjectWithProfile(projRoot, {
+      name: projectName,
+    });
+
+    await addApiWithBlankSchema(projRoot, { transformerVersion: 2 });
+    updateApiSchema(projRoot, projectName, 'schema_with_index.graphql');
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('Generates mapped index resolvers in the mapped stack, and can be queried', async () => {
+    // Set stack mappings for our index resolvers and compile the backend cloudformation
+    setStackMapping(projRoot, projectName, {
+      QuerysongInfoByGenreResolver: mappedResolverStack,
+      QuerysongWithSortKeysByNameAndGenreResolver: mappedResolverStack,
+    });
+    await apiGqlCompile(projRoot);
+
+    // Validate resolvers exist in mapped stack definition
+    expect(fs.existsSync(getMappedStackPath(projRoot))).toEqual(true);
+    const mappedStackDefinition = JSON.parse(fs.readFileSync(getMappedStackPath(projRoot), 'utf8'));
+
+    assertNotNull(mappedStackDefinition.Resources.QuerysongInfoByGenreResolver);
+    assertNotNull(mappedStackDefinition.Resources.QuerysongWithSortKeysByNameAndGenreResolver);
+
+    // Push and ensure that we can query against the indexes
+    await amplifyPush(projRoot);
+    await validateThatSongsCanBeCreatedAndQueriedByIndex(projRoot);
+  });
+
+  it('Generates unmapped index resolvers in the mapped stack, and can be queried', async () => {
+    // Set empty stack mappings and compile the backend cloudformation
+    setStackMapping(projRoot, projectName, {});
+    await apiGqlCompile(projRoot);
+
+    // Validate mapped stack definition does not exist
+    expect(fs.existsSync(getMappedStackPath(projRoot))).toEqual(false);
+
+    // Push and ensure that we can query against the indexes
+    await amplifyPush(projRoot);
+    await validateThatSongsCanBeCreatedAndQueriedByIndex(projRoot);
+  });
+});

--- a/packages/amplify-graphql-index-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers.ts
@@ -458,10 +458,11 @@ function makeQueryResolver(config: IndexDirectiveConfiguration, ctx: Transformer
     throw new Error(`Could not find datasource with name ${dataSourceName} in context.`);
   }
 
+  const resolverResourceId = ResolverResourceIDs.ResolverResourceID(queryTypeName, queryField);
   const resolver = ctx.resolvers.generateQueryResolver(
     queryTypeName,
     queryField,
-    ResolverResourceIDs.ResolverResourceID(queryTypeName, queryField),
+    resolverResourceId,
     dataSource as DataSourceProvider,
     MappingTemplate.s3MappingTemplateFromString(
       print(
@@ -537,7 +538,8 @@ function makeQueryResolver(config: IndexDirectiveConfiguration, ctx: Transformer
       `${queryTypeName}.${queryField}.{slotName}.{slotIndex}.res.vtl`,
     ),
   );
-  resolver.mapToStack(table.stack);
+
+  resolver.mapToStack(ctx.stackManager.getStackFor(resolverResourceId, table.stack.node._actualNode.id));
   ctx.resolvers.addResolver(object.name.value, queryField, resolver);
 }
 


### PR DESCRIPTION
#### Description of changes
Use stack resource manage to get stack to attach index-based resolvers to. Without this change, the StackMapping isn't being respected for these items. Add an e2e test to verify the behavior.

#### Issue #, if available
Internal ticket.

#### Description of how you validated changes
Tested manually, and via e2e test which verifies that resolvers are in the correct stack, and that they can still be queried against.

[E2E Test Flow](https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api/2830/workflows/edad96fd-a3e1-439a-a445-e80c4331817e)

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
