### PR TITLE
feat: add api import, generate-schema workflows

### DIFF
--- a/packages/amplify-category-api/amplify-plugin.json
+++ b/packages/amplify-category-api/amplify-plugin.json
@@ -13,7 +13,8 @@
     "remove",
     "update",
     "help",
-    "import"
+    "import",
+    "generate-schema"
   ],
   "commandAliases": {
     "configure": "update"

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/amplify-meta-utils.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/amplify-meta-utils.test.ts
@@ -1,4 +1,8 @@
-import { authConfigHasApiKey } from '../../../../provider-utils/awscloudformation/utils/amplify-meta-utils';
+import { authConfigHasApiKey, getAppSyncAPINames, getAppSyncAPIName, ensureNoAppSyncAPIExists } from '../../../../provider-utils/awscloudformation/utils/amplify-meta-utils';
+import { stateManager } from 'amplify-cli-core';
+
+jest.mock('amplify-cli-core');
+const stateManager_mock = stateManager as jest.Mocked<typeof stateManager>;
 
 describe('auth config has api key', () => {
   it('returns true when default auth is api key', () => {
@@ -41,5 +45,49 @@ describe('auth config has api key', () => {
     };
 
     expect(authConfigHasApiKey(authConfig)).toBe(false);
+  });
+});
+
+describe('API resource information utils', () => {
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
+  const metaWithMultipleAPIs = {
+    api: {
+      api1: {
+        service: 'AppSync'
+      },
+      api2: {
+        service: 'AppSync'
+      }
+    }
+  };
+
+  const metaWithNoAPI = {};
+
+  it('Returns all existing AppSync API names', () => {
+    stateManager_mock.getMeta = jest.fn().mockReturnValueOnce(metaWithMultipleAPIs);
+    expect(getAppSyncAPINames()).toEqual(['api1', 'api2']);
+  });
+
+  it('getAppSyncAPIName returns first API when there are multiple added', () => {
+    stateManager_mock.getMeta = jest.fn().mockReturnValueOnce(metaWithMultipleAPIs);
+    expect(getAppSyncAPIName()).toEqual('api1');
+  });
+
+  it('getAppSyncAPIName throws when there is no API added', () => {
+    stateManager_mock.getMeta = jest.fn().mockReturnValueOnce(metaWithNoAPI);
+    expect( () => getAppSyncAPIName()).toThrowError('You do not have AppSync API added. Use "amplify add api" or "amplify import api" to add one to your project.');
+  });
+
+  it('ensureNoAppSyncAPIExists throws when there is an API added', () => {
+    stateManager_mock.getMeta = jest.fn().mockReturnValueOnce(metaWithMultipleAPIs);
+    expect( () => ensureNoAppSyncAPIExists()).toThrowError('You already have an AppSync API named api1 in your project. Use the "amplify update api" command to update your existing AppSync API.');
+  });
+
+  it('ensureNoAppSyncAPIExists does not throw when there is no API added', () => {
+    stateManager_mock.getMeta = jest.fn().mockReturnValueOnce(metaWithNoAPI);
+    expect(() => ensureNoAppSyncAPIExists()).not.toThrowError();
   });
 });

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/import-rds-utils/globalAmplifyInputs.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/import-rds-utils/globalAmplifyInputs.test.ts
@@ -1,0 +1,94 @@
+import { $TSAny, $TSContext } from 'amplify-cli-core';
+import { constructGlobalAmplifyInput, readGlobalAmplifyInput, validateInputConfig } from '../../../../../provider-utils/awscloudformation/utils/import-rds-utils/globalAmplifyInputs';
+import { ImportedRDSType } from '../../../../../provider-utils/awscloudformation/service-walkthrough-types/import-appsync-api-types';
+import * as fs from 'fs-extra';
+
+jest.mock('fs-extra', () => ({
+  readFileSync: jest.fn(),
+}));
+const readFileSync_mock = fs.readFileSync as jest.MockedFunction<typeof fs.readFileSync>;
+
+jest.mock('amplify-cli-core', () => {
+  const original = jest.requireActual('amplify-cli-core');
+  return {
+    ...original,
+    ApiCategoryFacade: {
+      getTransformerVersion: jest.fn().mockResolvedValue(2),
+    },
+  };
+});
+
+describe('Amplify Input read/write from schema', () => {
+  const mockContext = {} as $TSAny as $TSContext;
+
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  it('constructs valid input parameters for MySQL datasource with global auth rule', async () => {
+    const expectedGraphQLInputString = `input Amplify {
+      engine: String = \"mysql\"  
+      host: String = \"ENTER YOUR DATABASE HOSTNAME HERE\"  
+      port: Int = 3306 # ENTER PORT NUMBER HERE
+      database: String = \"ENTER YOUR DATABASE NAME HERE\" 
+      globalAuthRule: AuthRule = { allow: public } # This "input" configures a global authorization rule to enable public access to all models in this schema. Learn more about authorization rules here:https://docs.amplify.aws/cli/graphql/authorization-rules 
+    }`;
+    const constructedInputString = await constructGlobalAmplifyInput(mockContext, ImportedRDSType.MYSQL);
+    expect(constructedInputString?.replace(/\s/g, '')).toEqual(expectedGraphQLInputString.replace(/\s/g, ''));
+  });
+
+  it('reads the input arguments for database connection details', async () => {
+    const mockValidInputs = {
+      engine: 'mysql',
+      host: 'mockdatabase.rds.amazonaws.com',
+      port: '1010',
+      database: 'mockdatabase'
+    };
+
+    const mockInputSchema = `input Amplify {
+      engine: String = \"${mockValidInputs.engine}\"  
+      host: String = \"${mockValidInputs.host}\"  
+      port: Int = ${mockValidInputs.port} # ENTER PORT NUMBER HERE
+      database: String = \"${mockValidInputs.database}\" 
+      globalAuthRule: AuthRule = { allow: public } # This "input" configures a global authorization rule to enable public access to all models in this schema. Learn more about authorization rules here:https://docs.amplify.aws/cli/graphql/authorization-rules 
+    }`;
+    readFileSync_mock.mockReturnValue(mockInputSchema);
+
+    const readInputs = await readGlobalAmplifyInput(mockContext, '');
+    
+    expect(readInputs).toEqual(mockValidInputs);
+  });
+
+  it('reports missing input arguments for database connection details', async () => {
+    const mockInvalidInputs = {
+      engine: 'mysql',
+      port: '1010',
+      database: 'mockdatabase'
+    };
+
+    try {
+      await validateInputConfig(mockContext, mockInvalidInputs);
+      fail('invalid input configuration is not reported');
+    }
+    catch(error) {
+      expect(error?.message).toEqual('The database connection parameters: host, are missing. Specify them in the schema and re-run.');
+    }
+  });
+
+  it('reports invalid input arguments for database connection details', async () => {
+    const mockInvalidInputs = {
+      engine: 'mysql',
+      host: 'ENTER YOUR DATABASE HOSTNAME HERE', //invalid entry
+      port: '1010',
+      database: 'mockdatabase'
+    };
+
+    try {
+      await validateInputConfig(mockContext, mockInvalidInputs);
+      fail('invalid input configuration is not reported');
+    }
+    catch(error) {
+      expect(error?.message).toEqual('The database connection parameters: host, might be invalid. Correct them in the schema and re-run.');
+    }
+  });
+});

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/rds-secrets/database-secrets.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/rds-secrets/database-secrets.test.ts
@@ -1,0 +1,49 @@
+import { $TSAny, $TSContext, stateManager } from 'amplify-cli-core';
+import { getExistingConnectionSecrets, storeConnectionSecrets, getParameterStoreSecretPath } from '../../../../../provider-utils/awscloudformation/utils/rds-secrets/database-secrets';
+
+const mockDatabase = 'mockdatabase';
+
+jest.mock('../../../../../provider-utils/awscloudformation/utils/rds-secrets/ssmClient', () => ({
+  SSMClient: {
+    getInstance: jest.fn().mockResolvedValue({
+      getSecrets: jest.fn(),
+      setSecret: jest.fn()
+    })
+  }
+}));
+
+jest.mock('amplify-cli-core', () => {
+  const original = jest.requireActual('amplify-cli-core');
+  return {
+    ...original,
+    stateManager: {
+      getAppID: jest.fn().mockReturnValue('fake-app-id'),
+      getCurrentEnvName: jest.fn().mockReturnValue('test')
+    },
+  };
+});
+
+describe('Test database secrets management', () => {
+  const mockContext = {} as $TSAny as $TSContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  it('Returns correct path for secrets in parameter store for a database', () => {
+    const usernamePath = getParameterStoreSecretPath('username', mockDatabase);
+    expect(usernamePath).toEqual('/amplify/fake-app-id/test/mockdatabase/AMPLIFY_username');
+
+    const passwordPath = getParameterStoreSecretPath('password', mockDatabase);
+    expect(passwordPath).toEqual('/amplify/fake-app-id/test/mockdatabase/AMPLIFY_password');
+  });
+
+  it('Returns undefined if secrets do not exist in parameter store for a database', async () => {
+    const fetchedSecrets = await getExistingConnectionSecrets(mockContext, mockDatabase);
+    expect(fetchedSecrets).not.toBeDefined();
+  });
+});

--- a/packages/amplify-category-api/src/commands/api.ts
+++ b/packages/amplify-category-api/src/commands/api.ts
@@ -56,10 +56,14 @@ export const run = async (context: $TSContext) => {
       name: 'override',
       description: 'Generates overrides file to apply custom modifications to CloudFormation',
     },
-    // TODO: Add it once we enable RDS support
+    // TODO: Add these once we enable RDS support
     // {
     //   name: 'import',
     //   description: 'Imports existing datasource to GraphQL API',
+    // },
+    // {
+    //   name: 'generate-schema',
+    //   description: 'Generates the GraphQL schema from the Data Source',
     // },
   ];
 

--- a/packages/amplify-category-api/src/commands/api/generate-schema.ts
+++ b/packages/amplify-category-api/src/commands/api/generate-schema.ts
@@ -1,0 +1,67 @@
+import { $TSAny, $TSContext } from 'amplify-cli-core';
+import { printer } from 'amplify-prompts';
+import * as path from 'path';
+import fs from 'fs-extra';
+import { MySQLDataSourceAdapter, generateGraphQLSchema, Schema, Engine } from '@aws-amplify/graphql-schema-generator';
+import { getDBUserSecretsWalkthrough } from '../../provider-utils/awscloudformation/service-walkthroughs/generate-graphql-schema-walkthrough';
+import { RDS_SCHEMA_FILE_NAME } from '../../provider-utils/awscloudformation/service-walkthrough-types/import-appsync-api-types';
+import { readGlobalAmplifyInput, validateInputConfig } from '../../provider-utils/awscloudformation/utils/import-rds-utils/globalAmplifyInputs';
+import { getAppSyncAPIName, getAPIResourceDir } from '../../provider-utils/awscloudformation/utils/amplify-meta-utils';
+import { getExistingConnectionSecrets, storeConnectionSecrets } from '../../provider-utils/awscloudformation/utils/rds-secrets/database-secrets';
+import { writeSchemaFile } from '../../provider-utils/awscloudformation/utils/graphql-schema-utils';
+
+const subcommand = 'generate-schema';
+
+export const name = subcommand;
+
+export const run = async (context: $TSContext) => {
+  const apiName = getAppSyncAPIName();
+  const apiResourceDir = getAPIResourceDir(apiName);
+
+  // proceed if there are any existing imported Relational Data Sources
+  const pathToSchemaFile = path.join(apiResourceDir, RDS_SCHEMA_FILE_NAME);
+  if(fs.existsSync(pathToSchemaFile)) {
+    // read and validate the RDS connection parameters
+    const config: $TSAny = await readGlobalAmplifyInput(pathToSchemaFile);
+    validateInputConfig(config);
+
+    // read and validate the RDS connection secrets
+    let secretsExistInParameterStore = true;
+    let secrets = await getExistingConnectionSecrets(context, config.database);
+    if(!secrets) {
+      secrets = await getDBUserSecretsWalkthrough(context, config.database);
+      secretsExistInParameterStore = false;
+    }
+    config['username'] = secrets?.username;
+    config['password'] = secrets?.password;
+    
+    // Test the connection
+    const adapter = new MySQLDataSourceAdapter(config);
+    try {
+      await adapter.initialize();
+    } catch(error) {
+      printer.error('Failed to connect to the specified RDS Data Source. Check the connection details in the schema and re-try. Use "amplify api update-environment-variables" to update the user credentials.');
+      console.log(error?.message);
+      throw(error);      
+    };
+
+    // If connection is successful, store the secrets in parameter store
+    if(!secretsExistInParameterStore) {
+      await storeConnectionSecrets(context, config.database, secrets);
+    }
+
+    const models = await adapter.getModels();
+    adapter.cleanup();
+
+    const schema = new Schema(new Engine('MySQL'));
+    models.forEach(m => schema.addModel(m));
+
+    const schemaString = generateGraphQLSchema(schema);
+    writeSchemaFile(pathToSchemaFile, schemaString);
+
+    printer.info(`Successfully imported the schema definition for ${config.database} database`);
+  }
+  else {
+    printer.info('No imported Data Sources to Generate GraphQL Schema.');
+  }
+};

--- a/packages/amplify-category-api/src/commands/api/import.ts
+++ b/packages/amplify-category-api/src/commands/api/import.ts
@@ -2,11 +2,9 @@ import { $TSContext } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import * as path from 'path';
 import fs from 'fs-extra';
-import { importAppSyncAPIWalkthrough } from '../../provider-utils/awscloudformation/service-walkthroughs/import-appsync-api-walkthrough';
-import { RDS_SCHEMA_FILE_NAME, ImportedRDSType } from '../../provider-utils/awscloudformation/service-walkthrough-types/import-appsync-api-types';
-import { constructGlobalAmplifyInput } from '../../provider-utils/awscloudformation/utils/import-rds-utils/globalAmplifyInputs';
+import { importAppSyncAPIWalkthrough, writeDefaultGraphQLSchema } from '../../provider-utils/awscloudformation/service-walkthroughs/import-appsync-api-walkthrough';
+import { RDS_SCHEMA_FILE_NAME } from '../../provider-utils/awscloudformation/service-walkthrough-types/import-appsync-api-types';
 import { getAPIResourceDir } from '../../provider-utils/awscloudformation/utils/amplify-meta-utils';
-import { writeSchemaFile } from '../../provider-utils/awscloudformation/utils/graphql-schema-utils';
 
 const subcommand = 'import';
 
@@ -19,11 +17,10 @@ export const run = async (context: $TSContext) => {
   const apiResourceDir = getAPIResourceDir(importAppSyncAPIWalkInputs.apiName);
   fs.ensureDirSync(apiResourceDir);
 
-  if(Object.values(ImportedRDSType).includes(importAppSyncAPIWalkInputs.dataSourceType)) {
-    const pathToSchemaFile = path.join(apiResourceDir, RDS_SCHEMA_FILE_NAME);
-    const globalAmplifyInputTemplate = constructGlobalAmplifyInput(importAppSyncAPIWalkInputs.dataSourceType);
-    writeSchemaFile(pathToSchemaFile, globalAmplifyInputTemplate);
-    printer.info(`Update the database connection details in the file at ${pathToSchemaFile}.`);
-    printer.info('Run "amplify api generate-schema" to fetch the schema.');
-  }
+  const pathToSchemaFile = path.join(apiResourceDir, RDS_SCHEMA_FILE_NAME);
+  await writeDefaultGraphQLSchema(context, pathToSchemaFile, importAppSyncAPIWalkInputs.dataSourceType);
+  
+  // print next steps
+  printer.info(`Update the database connection details in the file at ${pathToSchemaFile}.`);
+  printer.info('Run "amplify api generate-schema" to fetch the schema.');
 };

--- a/packages/amplify-category-api/src/commands/api/import.ts
+++ b/packages/amplify-category-api/src/commands/api/import.ts
@@ -1,66 +1,30 @@
-import { $TSAny, $TSContext, AmplifyCategories, pathManager, stateManager } from 'amplify-cli-core';
+import { $TSContext } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import * as path from 'path';
 import fs from 'fs-extra';
-import { MySQLDataSourceAdapter, generateGraphQLSchema, Schema, Engine } from '@aws-amplify/graphql-schema-generator';
+import { importAppSyncAPIWalkthrough } from '../../provider-utils/awscloudformation/service-walkthroughs/import-appsync-api-walkthrough';
+import { RDS_SCHEMA_FILE_NAME, ImportedRDSType } from '../../provider-utils/awscloudformation/service-walkthrough-types/import-appsync-api-types';
+import { constructGlobalAmplifyInput } from '../../provider-utils/awscloudformation/utils/import-rds-utils/globalAmplifyInputs';
+import { getAPIResourceDir } from '../../provider-utils/awscloudformation/utils/amplify-meta-utils';
+import { writeSchemaFile } from '../../provider-utils/awscloudformation/utils/graphql-schema-utils';
+
 const subcommand = 'import';
 
 export const name = subcommand;
 
 export const run = async (context: $TSContext) => {
-  const apiResourceDir = getResourceDir();
+  const importAppSyncAPIWalkInputs = await importAppSyncAPIWalkthrough(context);
+  
+  // ensure imported API resource artifacts are created
+  const apiResourceDir = getAPIResourceDir(importAppSyncAPIWalkInputs.apiName);
+  fs.ensureDirSync(apiResourceDir);
 
-  if (!apiResourceDir) {
-    throw new Error("No API Resource found.");
+  if(Object.values(ImportedRDSType).includes(importAppSyncAPIWalkInputs.dataSourceType)) {
+    const pathToSchemaFile = path.join(apiResourceDir, RDS_SCHEMA_FILE_NAME);
+    const globalAmplifyInputTemplate = constructGlobalAmplifyInput(importAppSyncAPIWalkInputs.dataSourceType);
+    writeSchemaFile(pathToSchemaFile, globalAmplifyInputTemplate);
+    printer.info(`Update the database connection details in the file at ${pathToSchemaFile}. Run "amplify api generate-schema" to fetch the schema.`);
   }
-
-  const config = await readConfigFile(apiResourceDir);
-
-  // TODO: Change this to a factory method once we support multiple RDS engines
-  const adapter = new MySQLDataSourceAdapter(config);
-  await adapter.initialize();
-  const models = await adapter.getModels();
-  adapter.cleanup();
-
-  const schema = new Schema(new Engine('MySQL'));
-  models.forEach(m => schema.addModel(m));
-
-  const schemaString = generateGraphQLSchema(schema);
-  writeSchemaFile(apiResourceDir, schemaString);
-
-  printer.info('Successfully imported the database schema.');
-};
-
-const getResourceDir = () => {
-  const apiNames = Object.entries(stateManager.getMeta()?.api || {})
-    .filter(([_, apiResource]) => (apiResource as $TSAny).service === 'AppSync')
-    .map(([name]) => name);
-  if (apiNames.length === 0) {
-    printer.info(
-      'No GraphQL API configured in the project.',
-    );
-    return;
-  }
-  if (apiNames.length > 1) {
-    // this condition should never hit as we have upstream defensive logic to prevent multiple GraphQL APIs. But just to cover all the bases
-    printer.error(
-      'You have multiple GraphQL APIs in the project. Only one GraphQL API is allowed per project. Run `amplify remove api` to remove an API.',
-    );
-    return;
-  }
-  const apiName = apiNames[0];
-  const apiResourceDir = path.join(pathManager.getBackendDirPath(), AmplifyCategories.API, apiName);
-  return apiResourceDir;
-};
-
-// TODO: Move the file handling to amplify-cli-core
-
-const readConfigFile = async (apiResourceDir: string) => {
-  const configFilePath = path.join(apiResourceDir, 'rds.env');
-  return fs.readJSON(configFilePath);
-};
-
-const writeSchemaFile = async (apiResourceDir: string, schema: string) => {
-  const schemaFilePath = path.join(apiResourceDir, 'schema.rds.graphql');
-  fs.writeFileSync(schemaFilePath, schema);
+  // TODO: add/update artifacts post add api
+  printer.info('Successfully initialized the API. Run "amplify api generate-schema" to import the GraphQL schema.');
 };

--- a/packages/amplify-category-api/src/commands/api/import.ts
+++ b/packages/amplify-category-api/src/commands/api/import.ts
@@ -23,8 +23,7 @@ export const run = async (context: $TSContext) => {
     const pathToSchemaFile = path.join(apiResourceDir, RDS_SCHEMA_FILE_NAME);
     const globalAmplifyInputTemplate = constructGlobalAmplifyInput(importAppSyncAPIWalkInputs.dataSourceType);
     writeSchemaFile(pathToSchemaFile, globalAmplifyInputTemplate);
-    printer.info(`Update the database connection details in the file at ${pathToSchemaFile}. Run "amplify api generate-schema" to fetch the schema.`);
+    printer.info(`Update the database connection details in the file at ${pathToSchemaFile}.`);
+    printer.info('Run "amplify api generate-schema" to fetch the schema.');
   }
-  // TODO: add/update artifacts post add api
-  printer.info('Successfully initialized the API. Run "amplify api generate-schema" to import the GraphQL schema.');
 };

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cfn-api-artifact-handler.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cfn-api-artifact-handler.ts
@@ -94,18 +94,19 @@ class CfnApiArtifactHandler implements ApiArtifactHandler {
       path.join(resourceDir, stacksDirName, defaultStackName),
     );
 
-    // write the template buffer to the project folder
-    this.writeSchema(path.join(resourceDir, gqlSchemaFilename), serviceConfig.transformSchema);
-
     const authConfig = this.extractAuthConfig(appsyncCLIInputs.serviceConfiguration);
-
-    await this.context.amplify.executeProviderUtils(this.context, 'awscloudformation', 'compileSchema', {
-      resourceDir,
-      parameters: this.getCfnParameters(serviceConfig.apiName, authConfig, resourceDir),
-      authConfig,
-    });
-
     const dependsOn = amendDependsOnForAuthConfig([], authConfig);
+
+    if(serviceConfig?.transformSchema) {
+      // write the template buffer to the project folder
+      this.writeSchema(path.join(resourceDir, gqlSchemaFilename), serviceConfig.transformSchema);
+
+      await this.context.amplify.executeProviderUtils(this.context, 'awscloudformation', 'compileSchema', {
+        resourceDir,
+        parameters: this.getCfnParameters(serviceConfig.apiName, authConfig, resourceDir),
+        authConfig,
+      });
+    }
 
     this.context.amplify.updateamplifyMetaAfterResourceAdd(category, serviceConfig.apiName, this.createAmplifyMeta(authConfig, dependsOn));
     return serviceConfig.apiName;

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthrough-types/import-appsync-api-types.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthrough-types/import-appsync-api-types.ts
@@ -1,0 +1,13 @@
+export enum ImportedRDSType {
+  MYSQL = 'mysql',
+  POSTGRESQL= 'postgresql'
+};
+
+export type ImportedDataSourceType = ImportedRDSType;
+
+export type ImportAppSyncAPIInputs =  {
+  apiName: string,
+  dataSourceType: ImportedDataSourceType
+};
+
+export const RDS_SCHEMA_FILE_NAME = 'schema.rds.graphql';

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.ts
@@ -207,7 +207,7 @@ export const openConsole = async (context: $TSContext) => {
   }
 };
 
-const serviceApiInputWalkthrough = async (context: $TSContext, serviceMetadata) => {
+export const serviceApiInputWalkthrough = async (context: $TSContext, serviceMetadata) => {
   let continuePrompt = false;
   let authConfig;
   let defaultAuthType;

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/generate-graphql-schema-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/generate-graphql-schema-walkthrough.ts
@@ -1,0 +1,14 @@
+import { $TSContext } from 'amplify-cli-core';
+import { prompter } from 'amplify-prompts';
+import { RDSConnectionSecrets } from '../utils/rds-secrets/database-secrets';
+
+export const getDBUserSecretsWalkthrough = async (context: $TSContext, database: string): Promise<RDSConnectionSecrets> => {
+  // Get the database user credentials
+  const username = await prompter.input(`Enter the username for ${database} database user:`);
+  const password = await prompter.input(`Enter the password for ${database} database user:`);
+
+  return {
+    username: username,
+    password: password
+  };
+};

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/import-appsync-api-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/import-appsync-api-walkthrough.ts
@@ -1,0 +1,28 @@
+import { v4 as uuid } from 'uuid';
+import { $TSContext } from 'amplify-cli-core';
+import { prompter, alphanumeric } from 'amplify-prompts';
+import { getAppSyncAPINames } from '../utils/amplify-meta-utils';
+import { ImportAppSyncAPIInputs, ImportedDataSourceType, ImportedRDSType } from '../service-walkthrough-types/import-appsync-api-types';
+
+export const importAppSyncAPIWalkthrough = async (context: $TSContext): Promise<ImportAppSyncAPIInputs> => {
+  const existingAPIs = getAppSyncAPINames();
+
+  // Get the name for the imported API
+  const defaultAPIName = context.amplify.getProjectConfig()?.projectName || `api${uuid().split('-')}`;
+  const apiName = await prompter.input('Provide API name:', { validate: alphanumeric(), initial: defaultAPIName });
+
+  // Get the Imported Data Source Type
+  const supportedDataSourceTypes = [
+    { name: 'GraphQL (Existing MySQL data source)', value: ImportedRDSType.MYSQL },
+    { name: 'GraphQL (Existing PostgreSQL data source)', value: ImportedRDSType.POSTGRESQL }
+  ];
+  const importedDataSourceType = await prompter.pick<'one', string>(
+    `Select from one of the below mentioned services:`,
+    supportedDataSourceTypes
+  ) as ImportedDataSourceType;
+
+  return {
+    apiName: apiName,
+    dataSourceType: importedDataSourceType
+  };
+};

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/import-appsync-api-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/import-appsync-api-walkthrough.ts
@@ -6,6 +6,8 @@ import { serviceApiInputWalkthrough } from './appSync-walkthrough';
 import { serviceMetadataFor } from '../utils/dynamic-imports';
 import { getCfnApiArtifactHandler } from '../cfn-api-artifact-handler';
 import { serviceWalkthroughResultToAddApiRequest } from '../utils/service-walkthrough-result-to-add-api-request';
+import { writeSchemaFile } from '../utils/graphql-schema-utils';
+import { constructGlobalAmplifyInput } from '../utils/import-rds-utils/globalAmplifyInputs';
 
 const service = 'AppSync';
 
@@ -36,4 +38,14 @@ export const importAppSyncAPIWalkthrough = async (context: $TSContext): Promise<
     apiName: apiName,
     dataSourceType: importedDataSourceType
   };
+};
+
+export const writeDefaultGraphQLSchema = async (context: $TSContext, pathToSchemaFile: string, dataSourceType: ImportedDataSourceType) => {
+  if(Object.values(ImportedRDSType).includes(dataSourceType)) {
+    const globalAmplifyInputTemplate = await constructGlobalAmplifyInput(context, dataSourceType);
+    writeSchemaFile(pathToSchemaFile, globalAmplifyInputTemplate);
+  }
+  else {
+    throw new Error(`Data source type ${dataSourceType} is not supported.`);
+  }
 };

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/amplify-meta-utils.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/amplify-meta-utils.ts
@@ -1,5 +1,6 @@
-import { $TSAny, $TSMeta, $TSObject, AmplifyCategories, AmplifySupportedService, stateManager } from 'amplify-cli-core';
+import { $TSAny, $TSMeta, $TSObject, AmplifyCategories, AmplifySupportedService, stateManager, pathManager } from 'amplify-cli-core';
 import _ from 'lodash';
+import * as path from 'path';
 
 export const authConfigHasApiKey = (authConfig?: $TSAny) => {
   if (!authConfig) {
@@ -30,6 +31,33 @@ export const checkIfAuthExists = () => {
   }
 
   return authResourceName;
+};
+
+export const getAppSyncAPINames = () => {
+  return Object.entries(stateManager.getMeta()?.api || {})
+    .filter(([_, apiResource]) => (apiResource as $TSAny).service === 'AppSync')
+    .map(([name]) => name);
+};
+
+export const ensureNoAppSyncAPIExists = () => {
+  const apiNames = getAppSyncAPINames();
+  // This restriction of having a single AppSync API might change in future.
+  if (apiNames?.length > 0) {
+    throw new Error(`You already have an AppSync API named ${apiNames[0]} in your project. Use the "amplify update api" command to update your existing AppSync API.`);
+  }
+}
+
+export const getAppSyncAPIName = () => {
+  const apiNames = getAppSyncAPINames();
+  // This restriction of having a single AppSync API might change in future.
+  if (apiNames?.length === 0) {
+    throw new Error(`You do not have AppSync API added. Use "amplify add api" or "amplify import api" to add one to your project.`);
+  }
+  return apiNames[0];
+};
+
+export const getAPIResourceDir = (apiName: string) => {
+  return path.join(pathManager.getBackendDirPath(), AmplifyCategories.API, apiName);
 };
 
 // some utility functions to extract the AppSync API name and config from amplify-meta

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/graphql-schema-utils.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/graphql-schema-utils.ts
@@ -1,0 +1,6 @@
+import * as fs from 'fs-extra';
+
+export const writeSchemaFile = (pathToSchemaFile: string, schemaString: string) => {
+  fs.ensureFileSync(pathToSchemaFile);
+  fs.writeFileSync(pathToSchemaFile, schemaString);
+};

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/import-rds-utils/globalAmplifyInputs.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/import-rds-utils/globalAmplifyInputs.ts
@@ -1,11 +1,22 @@
 import { ImportedRDSType } from '../../service-walkthrough-types/import-appsync-api-types';
 import { parse } from 'graphql';
 import * as fs from 'fs-extra';
-import { $TSAny } from 'amplify-cli-core';
+import { $TSAny, $TSContext, ApiCategoryFacade, getGraphQLTransformerAuthDocLink } from 'amplify-cli-core';
 import _ from 'lodash';
 
-const getGlobalAmplifyInputEntries = (dataSourceType: ImportedRDSType = ImportedRDSType.MYSQL) => {
-  return [
+type AmplifyInputEntry = {
+  name: string,
+  type: string,
+  default: string|number,
+  comment?: string|undefined
+};
+
+const getGlobalAmplifyInputEntries = async (
+  context: $TSContext, 
+  dataSourceType = ImportedRDSType.MYSQL, 
+  includeAuthRule = true
+  ): Promise<AmplifyInputEntry[]> => {
+  const inputs: AmplifyInputEntry[] = [
     { 
       name: 'engine',
       type: 'String',
@@ -19,7 +30,7 @@ const getGlobalAmplifyInputEntries = (dataSourceType: ImportedRDSType = Imported
     {
       name: 'port',
       type: 'Int',
-      default: 1010,
+      default: 3306,
       comment: 'ENTER PORT NUMBER HERE'
     },
     {
@@ -28,18 +39,33 @@ const getGlobalAmplifyInputEntries = (dataSourceType: ImportedRDSType = Imported
       default: 'ENTER YOUR DATABASE NAME HERE'
     }
   ];
+
+  if (includeAuthRule && (await ApiCategoryFacade.getTransformerVersion(context) === 2)) {
+    const authDocLink = getGraphQLTransformerAuthDocLink(2);
+    inputs.push({
+      name: 'globalAuthRule',
+      type: 'AuthRule',
+      default: '{ allow: public }',
+      comment: `This "input" configures a global authorization rule to enable public access to all models in this schema. Learn more about authorization rules here:${authDocLink}`
+    });
+  };
+  return inputs;
 };
 
-export const constructGlobalAmplifyInput = (dataSourceType: ImportedRDSType) => {
-  const inputs = getGlobalAmplifyInputEntries(dataSourceType);
+export const constructGlobalAmplifyInput = async (context: $TSContext, dataSourceType: ImportedRDSType) => {
+  const inputs = await getGlobalAmplifyInputEntries(context, dataSourceType);
   const inputsString = inputs.reduce((acc: string, input): string =>
     acc + ` ${input.name}: ${input.type} = ${input.type === 'String' ? '"'+ input.default + '"' : input.default} ${input.comment ? '# ' + input.comment: ''} \n`
   , '');
   return `input Amplify {\n${inputsString}}\n`;
 };
 
-export const readGlobalAmplifyInput = async (pathToSchemaFile: string) => {
+export const readGlobalAmplifyInput = async (context: $TSContext, pathToSchemaFile: string) => {
   const schemaContent = fs.readFileSync(pathToSchemaFile, 'utf-8');
+  if(_.isEmpty(schemaContent?.replace(/[\r\n]/gm, ''))) {
+    throw new Error('The schema file is empty');
+  }
+
   const parsedSchema = parse(schemaContent);
 
   const inputDirective: $TSAny = parsedSchema.definitions.find(
@@ -49,7 +75,7 @@ export const readGlobalAmplifyInput = async (pathToSchemaFile: string) => {
      definition.name.value === 'Amplify'
   );
 
-  const expectedInputs = getGlobalAmplifyInputEntries().map(item => item.name);
+  const expectedInputs = (await getGlobalAmplifyInputEntries(context, ImportedRDSType.MYSQL, false)).map(item => item.name);
   const inputs = {};
   expectedInputs.map(input => {
     const value = inputDirective?.fields?.find( 
@@ -64,10 +90,16 @@ export const readGlobalAmplifyInput = async (pathToSchemaFile: string) => {
   return inputs;
 };
 
-export const validateInputConfig = (config: { [x: string]: any; }) => {
-  const expectedInputs = getGlobalAmplifyInputEntries().map(item => item.name);
+export const validateInputConfig = async (context: $TSContext, config: { [x: string]: any; }) => {
+  const expectedInputs = (await getGlobalAmplifyInputEntries(context, ImportedRDSType.MYSQL, false)).map(item => item.name);
   const missingInputs = expectedInputs.filter(input => _.isEmpty(config[input]));
   if(!_.isEmpty(missingInputs)) {
     throw new Error(`The input parameters ${missingInputs.join(',')} are missing. Specify them in the schema and re-run.`);
+  }
+
+  // The database connection details shouldn't have space
+  const invalidInputs = expectedInputs.filter(input => config[input]?.indexOf(' ') >= 0);
+  if(!_.isEmpty(invalidInputs)) {
+    throw new Error(`The database connection parameters ${invalidInputs.join(',')} might be invalid. Correct them in the schema and re-run.`);
   }
 };

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/import-rds-utils/globalAmplifyInputs.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/import-rds-utils/globalAmplifyInputs.ts
@@ -80,7 +80,7 @@ export const readGlobalAmplifyInput = async (context: $TSContext, pathToSchemaFi
   expectedInputs.map(input => {
     const value = inputDirective?.fields?.find( 
       field => field?.name?.value === input
-    ).defaultValue?.value;
+    )?.defaultValue?.value;
     if (_.isEmpty(value)) {
       throw new Error(`Invalid value for ${input} input in the GraphQL schema. Correct and re-try.`);
     }
@@ -94,12 +94,12 @@ export const validateInputConfig = async (context: $TSContext, config: { [x: str
   const expectedInputs = (await getGlobalAmplifyInputEntries(context, ImportedRDSType.MYSQL, false)).map(item => item.name);
   const missingInputs = expectedInputs.filter(input => _.isEmpty(config[input]));
   if(!_.isEmpty(missingInputs)) {
-    throw new Error(`The input parameters ${missingInputs.join(',')} are missing. Specify them in the schema and re-run.`);
+    throw new Error(`The database connection parameters: ${missingInputs.join(',')}, are missing. Specify them in the schema and re-run.`);
   }
 
   // The database connection details shouldn't have space
   const invalidInputs = expectedInputs.filter(input => config[input]?.indexOf(' ') >= 0);
   if(!_.isEmpty(invalidInputs)) {
-    throw new Error(`The database connection parameters ${invalidInputs.join(',')} might be invalid. Correct them in the schema and re-run.`);
+    throw new Error(`The database connection parameters: ${invalidInputs.join(',')}, might be invalid. Correct them in the schema and re-run.`);
   }
 };

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/import-rds-utils/globalAmplifyInputs.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/import-rds-utils/globalAmplifyInputs.ts
@@ -1,0 +1,73 @@
+import { ImportedRDSType } from '../../service-walkthrough-types/import-appsync-api-types';
+import { parse } from 'graphql';
+import * as fs from 'fs-extra';
+import { $TSAny } from 'amplify-cli-core';
+import _ from 'lodash';
+
+const getGlobalAmplifyInputEntries = (dataSourceType: ImportedRDSType = ImportedRDSType.MYSQL) => {
+  return [
+    { 
+      name: 'engine',
+      type: 'String',
+      default: dataSourceType,
+    },
+    {
+      name: 'host',
+      type: 'String',
+      default: 'ENTER YOUR DATABASE HOSTNAME HERE',
+    },
+    {
+      name: 'port',
+      type: 'Int',
+      default: 1010,
+      comment: 'ENTER PORT NUMBER HERE'
+    },
+    {
+      name: 'database',
+      type: 'String',
+      default: 'ENTER YOUR DATABASE NAME HERE'
+    }
+  ];
+};
+
+export const constructGlobalAmplifyInput = (dataSourceType: ImportedRDSType) => {
+  const inputs = getGlobalAmplifyInputEntries(dataSourceType);
+  const inputsString = inputs.reduce((acc: string, input): string =>
+    acc + ` ${input.name}: ${input.type} = ${input.type === 'String' ? '"'+ input.default + '"' : input.default} ${input.comment ? '# ' + input.comment: ''} \n`
+  , '');
+  return `input Amplify {\n${inputsString}}\n`;
+};
+
+export const readGlobalAmplifyInput = async (pathToSchemaFile: string) => {
+  const schemaContent = fs.readFileSync(pathToSchemaFile, 'utf-8');
+  const parsedSchema = parse(schemaContent);
+
+  const inputDirective: $TSAny = parsedSchema.definitions.find(
+    definition =>
+     definition.kind === 'InputObjectTypeDefinition' &&
+     definition.name &&
+     definition.name.value === 'Amplify'
+  );
+
+  const expectedInputs = getGlobalAmplifyInputEntries().map(item => item.name);
+  const inputs = {};
+  expectedInputs.map(input => {
+    const value = inputDirective?.fields?.find( 
+      field => field?.name?.value === input
+    ).defaultValue?.value;
+    if (_.isEmpty(value)) {
+      throw new Error(`Invalid value for ${input} input in the GraphQL schema. Correct and re-try.`);
+    }
+    inputs[input] = value;
+  });
+
+  return inputs;
+};
+
+export const validateInputConfig = (config: { [x: string]: any; }) => {
+  const expectedInputs = getGlobalAmplifyInputEntries().map(item => item.name);
+  const missingInputs = expectedInputs.filter(input => _.isEmpty(config[input]));
+  if(!_.isEmpty(missingInputs)) {
+    throw new Error(`The input parameters ${missingInputs.join(',')} are missing. Specify them in the schema and re-run.`);
+  }
+};

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-secrets/database-secrets.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-secrets/database-secrets.ts
@@ -1,0 +1,60 @@
+import { stateManager, $TSContext } from 'amplify-cli-core';
+import { __promisify__ } from 'glob';
+import _ from 'lodash';
+import * as path from 'path';
+import { SSMClient } from './ssmClient';
+
+const secretNames = ['username', 'password'];
+
+export type RDSConnectionSecrets = {
+  username: string,
+  password: string
+};
+
+export const getExistingConnectionSecrets = async (context: $TSContext, database: string): Promise<RDSConnectionSecrets|undefined> => {
+  try {
+    const ssmClient = await SSMClient.getInstance(context);
+    const secrets = await ssmClient.getSecrets(
+      secretNames.map( secret => getParameterStoreSecretPath(secret, database))
+    );
+
+    if(_.isEmpty(secrets)) {
+      return;
+    }
+  
+    const existingSecrets = secretNames.map( secretName => {
+      const secretPath = getParameterStoreSecretPath(secretName, database);
+      const matchingSecret = secrets?.find( secret => (secret?.secretName === secretPath) && !_.isEmpty(secret?.secretValue) );
+      const result = {};
+      if(matchingSecret) {
+        result[secretName] = matchingSecret.secretValue;
+      }
+      return result;
+    }).reduce((result, current) => {
+      if(!_.isEmpty(current)) {
+        return Object.assign(result, current);
+      }
+    }, {});
+
+    if(existingSecrets && (Object.keys(existingSecrets)?.length === secretNames?.length)) {
+      return existingSecrets;
+    }
+  }
+  catch (error) {
+    return;
+  }
+};
+
+export const storeConnectionSecrets = async (context: $TSContext, database: string, secrets: RDSConnectionSecrets) => {
+  const ssmClient = await SSMClient.getInstance(context);
+  secretNames.map( async (secret) => {
+    const parameterPath = getParameterStoreSecretPath(secret, database);
+    await ssmClient.setSecret(parameterPath, secrets[secret]);
+  });
+};
+
+export const getParameterStoreSecretPath = (secret: string, database:string): string => {
+  const appId = stateManager.getAppID();
+  const envName = stateManager.getCurrentEnvName();
+  return path.posix.join('/amplify', appId, envName, database, `AMPLIFY_${secret}`);
+};

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-secrets/ssmClient.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-secrets/ssmClient.ts
@@ -1,6 +1,11 @@
 import { $TSAny, $TSContext } from 'amplify-cli-core';
 import aws from 'aws-sdk';
 
+export type Secret = {
+  secretName: string,
+  secretValue: string
+};
+
 /**
  *  SSM client provider for AWS SDK calls
  */
@@ -19,7 +24,7 @@ export class SSMClient {
   /**
    * Returns a list of secret name value pairs
    */
-  getSecrets = async (secretNames: string[]): Promise<$TSAny> => {
+  getSecrets = async (secretNames: string[]): Promise<Secret[]> => {
     if (!secretNames || secretNames?.length === 0) {
       return [];
     }

--- a/packages/amplify-graphql-base-default-value-transformer/package.json
+++ b/packages/amplify-graphql-base-default-value-transformer/package.json
@@ -24,7 +24,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "clean": "rimraf ./lib",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "test-watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/amplify-graphql-base-index-transformer/package.json
+++ b/packages/amplify-graphql-base-index-transformer/package.json
@@ -24,7 +24,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "clean": "rimraf ./lib",
-    "test": "jest"
+    "test": "jest --passWithNoTests"
   },
   "dependencies": {
     "@aws-amplify/graphql-model-transformer": "0.16.3",

--- a/packages/amplify-graphql-base-model-transformer/package.json
+++ b/packages/amplify-graphql-base-model-transformer/package.json
@@ -24,7 +24,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "clean": "rimraf ./lib",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "test-watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/amplify-graphql-rds-default-value-transformer/package.json
+++ b/packages/amplify-graphql-rds-default-value-transformer/package.json
@@ -24,7 +24,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "clean": "rimraf ./lib",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "test-watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/amplify-graphql-rds-index-transformer/package.json
+++ b/packages/amplify-graphql-rds-index-transformer/package.json
@@ -24,7 +24,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "clean": "rimraf ./lib",
-    "test": "jest"
+    "test": "jest --passWithNoTests"
   },
   "dependencies": {
     "@aws-amplify/graphql-model-transformer": "0.16.3",

--- a/packages/amplify-graphql-rds-model-transformer/package.json
+++ b/packages/amplify-graphql-rds-model-transformer/package.json
@@ -24,7 +24,7 @@
     "build": "tsc && cd rds-lambda && tsc && bestzip --force node ../lib/streaming-lambda.zip ./lib*",
     "watch": "tsc -w",
     "clean": "rimraf ./lib",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "test-watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/amplify-graphql-schema-generator/src/datasource-adapter/mysql-datasource-adapter.ts
+++ b/packages/amplify-graphql-schema-generator/src/datasource-adapter/mysql-datasource-adapter.ts
@@ -17,7 +17,7 @@ interface MySQLIndex {
   indexName: string;
   sequence: number;
   columnName: string;
-  nullable: boolean;  
+  nullable: boolean;
 }
 
 interface MySQLColumn {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Initial Draft of the `amplify import api` and `amplify api generate-schema` commands.
The behavior matches the Options A.2 and B.1 discussed in the RFC https://github.com/aws-amplify/amplify-category-api/issues/815.
This covers the most common use-case where the customers want to import the existing MySQL DataSource with or without an already existing API.
**Note:** This PR does not include:
- The multi-database use-cases where a customer wants to import multiple different RDS engine DBs.
- `update-environment-variables` flow that will be added later.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
