### PR TITLE
fix(api): default value for model name start with lowercase

### DIFF
--- a/packages/amplify-graphql-default-value-transformer/src/__tests__/__snapshots__/amplify-grapphql-default-value-transformer.test.ts.snap
+++ b/packages/amplify-graphql-default-value-transformer/src/__tests__/__snapshots__/amplify-grapphql-default-value-transformer.test.ts.snap
@@ -220,6 +220,13 @@ type Subscription {
 "
 `;
 
+exports[`DefaultValueModelTransformer: should successfully set the default values when model name starts with lowercase 1`] = `
+"## [Start] Setting \\"stringValue\\" to default value of \\"hello world\\". **
+$util.qr($context.args.input.put(\\"stringValue\\", $util.defaultIfNull($ctx.args.input.stringValue, \\"hello world\\")))
+## [End] Setting \\"stringValue\\" to default value of \\"hello world\\". **
+{}"
+`;
+
 exports[`DefaultValueModelTransformer: should successfully transform simple valid schema 1`] = `
 "
 type Post {

--- a/packages/amplify-graphql-default-value-transformer/src/__tests__/amplify-grapphql-default-value-transformer.test.ts
+++ b/packages/amplify-graphql-default-value-transformer/src/__tests__/amplify-grapphql-default-value-transformer.test.ts
@@ -307,7 +307,7 @@ describe('DefaultValueModelTransformer:', () => {
     validateModelSchema(schema);
   });
 
-  it.only('should successfully set the default values when model name starts with lowercase', async () => {
+  it('should successfully set the default values when model name starts with lowercase', async () => {
     const inputSchema = `
       type post @model {
         id: ID!

--- a/packages/amplify-graphql-default-value-transformer/src/__tests__/amplify-grapphql-default-value-transformer.test.ts
+++ b/packages/amplify-graphql-default-value-transformer/src/__tests__/amplify-grapphql-default-value-transformer.test.ts
@@ -306,4 +306,23 @@ describe('DefaultValueModelTransformer:', () => {
     const schema = parse(out.schema);
     validateModelSchema(schema);
   });
+
+  it.only('should successfully set the default values when model name starts with lowercase', async () => {
+    const inputSchema = `
+      type post @model {
+        id: ID!
+        stringValue: String @default(value: "hello world")
+      }
+    `;
+    const transformer = new GraphQLTransform({
+      transformers: [new ModelTransformer(), new DefaultValueTransformer()],
+    });
+    const out = transformer.transform(inputSchema);
+    expect(out).toBeDefined();
+    expect(out.resolvers).toBeDefined();
+    expect(out.resolvers["Mutation.createPost.init.2.req.vtl"]).toBeDefined();
+    expect(out.resolvers["Mutation.createPost.init.2.req.vtl"]).toMatchSnapshot();
+    const schema = parse(out.schema);
+    validateModelSchema(schema);
+  });
 });

--- a/packages/amplify-graphql-default-value-transformer/src/graphql-default-value-transformer.ts
+++ b/packages/amplify-graphql-default-value-transformer/src/graphql-default-value-transformer.ts
@@ -31,6 +31,7 @@ import {
   isListType,
   isScalarOrEnum,
   ModelResourceIDs,
+  toCamelCase,
 } from 'graphql-transformer-common';
 import { DefaultValueDirectiveConfiguration } from './types';
 import { TypeValidators } from './validators';
@@ -141,7 +142,7 @@ export class DefaultValueTransformer extends TransformerPluginBase {
         snippets.push(this.makeDefaultValueSnippet(fieldName, defaultValue, !nonStringTypes.includes(getBaseType(config.field.type))));
       }
 
-      this.updateResolverWithDefaultValues(context, `create${typeName}`, snippets);
+      this.updateResolverWithDefaultValues(context, toCamelCase(['create', typeName]), snippets);
     }
   };
 


### PR DESCRIPTION
#### Description of changes

When using the @default directive there is a minor bug where the function to assign the custom default values is not created if your Model name is in lowercase.

```
##doesn't work
type priceApprovalsTemp @model @auth(rules: [
 {allow: private, provider: userPools},
  {allow: private, provider: iam, operations: [read, create, delete, update]}]) {
  id: ID!
  oldPrice: Float
  newPrice: Float
  approvalStatus: String @default(value:"PENDING")
  approvedBy: String
  name: String @default(value: "Some name")
}     

## works
type PriceApprovalsNew @model @auth(rules: [
 {allow: private, provider: userPools},
  {allow: private, provider: iam, operations: [read, create, delete, update]}]) {
  id: ID!
  oldPrice: Float
  newPrice: Float
  approvalStatus: String @default(value:"PENDING")
  approvedBy: String
}   
```

#### Issue #, if available

NA

#### Description of how you validated changes
- Manual test
- Existing unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
