### PR TITLE
chore: use node.id instead of node._actualNode.id when references table stack

### DIFF
--- a/packages/amplify-graphql-index-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers.ts
@@ -539,7 +539,7 @@ function makeQueryResolver(config: IndexDirectiveConfiguration, ctx: Transformer
     ),
   );
 
-  resolver.mapToStack(ctx.stackManager.getStackFor(resolverResourceId, table.stack.node._actualNode.id));
+  resolver.mapToStack(ctx.stackManager.getStackFor(resolverResourceId, table.stack.node.id));
   ctx.resolvers.addResolver(object.name.value, queryField, resolver);
 }
 


### PR DESCRIPTION
#### Description of changes
Use node.id instead of `node._actualNode.id` when references table stack. This is important because CDKv2 does not expose `_actualNode`.

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit tests pass, and I have an e2e test that will act as a regression test, verifying that the mapped resolver sits in the correct stack.

[E2E Test Run](https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api/3001/workflows/7a869669-6745-4947-acb4-f39520f33392)

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
