### PR TITLE
chore: force e2e tests from source

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -669,6 +669,8 @@ commands:
                 shell: bash.exe
                 command: |
                   source .circleci/local_publish_helpers.sh
+                  yarn setup-dev
+                  export AMPLIFY_PATH=amplify-dev
                   cd packages/amplify-e2e-tests
                   retry yarn run e2e --detectOpenHandles --maxWorkers=3 $TEST_SUITE
                 no_output_timeout: 60m
@@ -683,6 +685,8 @@ commands:
                   source $BASH_ENV
                   source .circleci/local_publish_helpers.sh
                   amplify version
+                  yarn setup-dev
+                  export AMPLIFY_PATH=amplify-dev
                   retry runE2eTest
                 no_output_timeout: 90m
   scan_e2e_test_artifacts:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -669,8 +669,9 @@ commands:
                 shell: bash.exe
                 command: |
                   source .circleci/local_publish_helpers.sh
-                  yarn setup-dev
-                  export AMPLIFY_PATH=C:/home/circleci/repo/node_modules/@aws-amplify/cli-internal/bin/amplify
+                  yarn add-cli-no-save
+                  yarn hoist-cli-win
+                  export AMPLIFY_PATH=C:/home/circleci/repo/node_modules/amplify-cli-internal/bin/amplify
                   cd packages/amplify-e2e-tests
                   retry yarn run e2e --detectOpenHandles --maxWorkers=3 $TEST_SUITE
                 no_output_timeout: 60m
@@ -685,8 +686,9 @@ commands:
                   source $BASH_ENV
                   source .circleci/local_publish_helpers.sh
                   amplify version
-                  yarn setup-dev
-                  export AMPLIFY_PATH=/home/circleci/repo/node_modules/@aws-amplify/cli-internal/bin/amplify
+                  yarn add-cli-no-save
+                  yarn hoist-cli
+                  export AMPLIFY_PATH=/home/circleci/repo/node_modules/amplify-cli-internal/bin/amplify
                   retry runE2eTest
                 no_output_timeout: 90m
   scan_e2e_test_artifacts:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -670,7 +670,7 @@ commands:
                 command: |
                   source .circleci/local_publish_helpers.sh
                   yarn setup-dev
-                  export AMPLIFY_PATH=amplify-dev
+                  export AMPLIFY_PATH=C:/home/circleci/repo/node_modules/@aws-amplify/cli-internal/bin/amplify
                   cd packages/amplify-e2e-tests
                   retry yarn run e2e --detectOpenHandles --maxWorkers=3 $TEST_SUITE
                 no_output_timeout: 60m
@@ -686,7 +686,7 @@ commands:
                   source .circleci/local_publish_helpers.sh
                   amplify version
                   yarn setup-dev
-                  export AMPLIFY_PATH=amplify-dev
+                  export AMPLIFY_PATH=/home/circleci/repo/node_modules/@aws-amplify/cli-internal/bin/amplify
                   retry runE2eTest
                 no_output_timeout: 90m
   scan_e2e_test_artifacts:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -669,9 +669,7 @@ commands:
                 shell: bash.exe
                 command: |
                   source .circleci/local_publish_helpers.sh
-                  yarn add-cli-no-save
-                  yarn hoist-cli-win
-                  export AMPLIFY_PATH=C:/home/circleci/repo/node_modules/amplify-cli-internal/bin/amplify
+                  forceFromSourceRun
                   cd packages/amplify-e2e-tests
                   retry yarn run e2e --detectOpenHandles --maxWorkers=3 $TEST_SUITE
                 no_output_timeout: 60m
@@ -686,9 +684,7 @@ commands:
                   source $BASH_ENV
                   source .circleci/local_publish_helpers.sh
                   amplify version
-                  yarn add-cli-no-save
-                  yarn hoist-cli
-                  export AMPLIFY_PATH=/home/circleci/repo/node_modules/amplify-cli-internal/bin/amplify
+                  forceFromSourceRun
                   retry runE2eTest
                 no_output_timeout: 90m
   scan_e2e_test_artifacts:

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -172,7 +172,7 @@ function runE2eTest {
 function emitCanarySuccessMetric {
     if [[ "$CIRCLE_BRANCH" = main ]]; then
         USE_PARENT_ACCOUNT=1
-        setAwsAccountCredentials 
+        setAwsAccountCredentials
         aws cloudwatch \
             put-metric-data \
             --metric-name CanarySuccessRate \
@@ -187,7 +187,7 @@ function emitCanarySuccessMetric {
 function emitCanaryFailureMetric {
     if [[ "$CIRCLE_BRANCH" = main ]]; then
         USE_PARENT_ACCOUNT=1
-        setAwsAccountCredentials 
+        setAwsAccountCredentials
         aws cloudwatch \
             put-metric-data \
             --metric-name CanarySuccessRate \
@@ -196,5 +196,27 @@ function emitCanaryFailureMetric {
             --value 0 \
             --dimensions branch=main \
             --region us-west-2
+    fi
+}
+
+function forceFromSourceRun {
+    if [[ "$TEST_SUITE" == "src/__tests__/amplify-app.test.ts"]]
+        echo "Not forcing run from source for $TEST_SUITE"
+        return
+    fi
+
+    if [[ "$TEST_SUITE" == "src/__tests__/datastore-modelgen.test.ts"]]
+        echo "Not forcing run from source for $TEST_SUITE"
+        return
+    fi
+
+    yarn add-cli-no-save
+    if [[ "$OSTYPE" == "msys" ]]; then
+        # windows provided by circleci has this OSTYPE
+        yarn hoist-cli-win
+        export AMPLIFY_PATH=C:/home/circleci/repo/node_modules/amplify-cli-internal/bin/amplify
+    else
+        yarn hoist-cli
+        export AMPLIFY_PATH=/home/circleci/repo/node_modules/amplify-cli-internal/bin/amplify
     fi
 }

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -200,12 +200,12 @@ function emitCanaryFailureMetric {
 }
 
 function forceFromSourceRun {
-    if [[ "$TEST_SUITE" == "src/__tests__/amplify-app.test.ts"]]; then
+    if [[ "$TEST_SUITE" == "src/__tests__/amplify-app.test.ts" ]]; then
         echo "Not forcing run from source for $TEST_SUITE"
         return
     fi
 
-    if [[ "$TEST_SUITE" == "src/__tests__/datastore-modelgen.test.ts"]]; then
+    if [[ "$TEST_SUITE" == "src/__tests__/datastore-modelgen.test.ts" ]]; then
         echo "Not forcing run from source for $TEST_SUITE"
         return
     fi

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -200,12 +200,12 @@ function emitCanaryFailureMetric {
 }
 
 function forceFromSourceRun {
-    if [[ "$TEST_SUITE" == "src/__tests__/amplify-app.test.ts"]]
+    if [[ "$TEST_SUITE" == "src/__tests__/amplify-app.test.ts"]]; then
         echo "Not forcing run from source for $TEST_SUITE"
         return
     fi
 
-    if [[ "$TEST_SUITE" == "src/__tests__/datastore-modelgen.test.ts"]]
+    if [[ "$TEST_SUITE" == "src/__tests__/datastore-modelgen.test.ts"]]; then
         echo "Not forcing run from source for $TEST_SUITE"
         return
     fi


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR forces e2e tests to run from source.
The cdk v2 beta line has pinned down category api and transformer packages versions on the cli side, so mechanism that pulls cli and fresh data packages doesn't work as expected.

This should be undone after GA. https://app.asana.com/0/1202389680978480/1203592330499167/f

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
