### PR TITLE
test(api): e2e core library for rds tests

### DIFF
--- a/packages/amplify-e2e-core/package.json
+++ b/packages/amplify-e2e-core/package.json
@@ -35,7 +35,10 @@
     "rimraf": "^3.0.0",
     "strip-ansi": "^6.0.0",
     "throat": "^5.0.0",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "@aws-sdk/client-ec2": "^3.226.0",
+    "@aws-sdk/client-rds": "^3.226.0",
+    "knex": "~2.3.0"
   },
   "peerDependencies": {
     "amplify-cli-core": "^3.0.0"

--- a/packages/amplify-e2e-core/src/utils/index.ts
+++ b/packages/amplify-e2e-core/src/utils/index.ts
@@ -25,6 +25,7 @@ export * from './transformConfig';
 export * from './admin-ui';
 export * from './hooks';
 export * from './transform-current-project-to-git-pulled-project';
+export * from './rds';
 
 // run dotenv config to update env variable
 config();

--- a/packages/amplify-e2e-core/src/utils/rds.ts
+++ b/packages/amplify-e2e-core/src/utils/rds.ts
@@ -1,0 +1,173 @@
+import { 
+  RDSClient,
+  CreateDBInstanceCommand,
+  waitUntilDBInstanceAvailable,
+  DeleteDBInstanceCommand,
+  waitUntilDBInstanceDeleted 
+} from "@aws-sdk/client-rds";
+import { EC2Client, AuthorizeSecurityGroupIngressCommand } from '@aws-sdk/client-ec2';
+import { knex } from 'knex';
+
+const DEFAULT_DB_INSTANCE_TYPE = "db.m5.large";
+const DEFAULT_DB_STORAGE = 8;
+const DEFAULT_SECURITY_GROUP = "default";
+
+export const createRDSInstance = async (config: {
+  identifier: string,
+  engine: 'mysql',
+  dbname: string,
+  username: string,
+  password: string,
+  region: string,
+  instanceClass?: string,
+  storage?: number,
+}) => {
+  const client = new RDSClient({ region: config.region });
+  const params = {
+    /** input parameters */
+    "DBInstanceClass": config.instanceClass ?? DEFAULT_DB_INSTANCE_TYPE,
+    "DBInstanceIdentifier": config.identifier,
+    "AllocatedStorage": config.storage ?? DEFAULT_DB_STORAGE,
+    "Engine": config.engine,
+    "DBName": config.dbname,
+    "MasterUsername": config.username,
+    "MasterUserPassword": config.password,
+  };
+  const command = new CreateDBInstanceCommand(params);
+  
+  try {
+    await client.send(command);
+    const availableResponse = await waitUntilDBInstanceAvailable(
+      {
+        maxWaitTime: 3600,
+        maxDelay: 120,
+        minDelay: 60,
+        client,
+      },
+      {
+        DBInstanceIdentifier: config.identifier,
+      },
+    );
+
+    const dbInstance = (availableResponse as any).DBInstances[0];
+    if (!dbInstance) {
+      throw new Error("RDS Instance details are missing.");
+    }
+
+    return {
+      endpoint: dbInstance.Endpoint.Address,
+      port: dbInstance.Endpoint.Port,
+      dbName: dbInstance.DBName,
+    };
+  } catch (error) {
+    console.log(error);
+    throw new Error("Error in creating RDS instance.");
+  }
+};
+
+export const deleteDBInstance = async (identifier: string, region: string) => {
+  const client = new RDSClient({ region });
+  const params = {
+    "DBInstanceIdentifier": identifier,
+    "SkipFinalSnapshot": true,
+  };
+  const command = new DeleteDBInstanceCommand(params);
+  try {
+    await client.send(command);
+    await waitUntilDBInstanceDeleted(
+      {
+        maxWaitTime: 3600,
+        maxDelay: 120,
+        minDelay: 60,
+        client,
+      },
+      {
+        DBInstanceIdentifier: identifier,
+      },
+    );
+  } catch (error) {
+    console.log(error);
+    throw new Error("Error in deleting RDS instance.");
+  }  
+};
+
+export const addRDSPortInboundRule = async (config: {
+  region: string,
+  port: number,
+  securityGroup?: string,
+}) => {
+  const ec2_client = new EC2Client({
+    region: config.region,
+  });
+  
+  const command = new AuthorizeSecurityGroupIngressCommand({
+    GroupName: config.securityGroup ?? DEFAULT_SECURITY_GROUP,
+    FromPort: config.port,
+    ToPort: config.port,
+    IpProtocol: "TCP",
+    CidrIp: "0.0.0.0/0",
+  });
+  
+  try {
+    await ec2_client.send(command);
+  } catch (error) {
+    // Ignore this error
+    // It usually throws error if the security group rule is a duplicate
+    // If the rule is not added, we will get an error while establishing connection to the database
+  } 
+};
+
+export class RDSTestDataProvider {
+  private dbBuilder: any;
+
+  constructor(private config: {
+    host: string,
+    port: number,
+    username: string,
+    password: string,
+    database: string,
+  }) {
+    this.establishDatabaseConnection();
+  }
+
+  private establishDatabaseConnection() {
+    const databaseConfig = {
+      host: this.config.host,
+      database: this.config.database,
+      port: this.config.port,
+      user: this.config.username,
+      password: this.config.password,
+      ssl: { rejectUnauthorized: false},
+    };
+    try {
+      this.dbBuilder = knex({
+        client: 'mysql2',
+        connection: databaseConfig,
+        pool: {
+          min: 5, 
+          max: 30,
+          createTimeoutMillis: 30000,
+          acquireTimeoutMillis: 30000,
+          idleTimeoutMillis: 30000,
+          reapIntervalMillis: 1000,
+          createRetryIntervalMillis: 100
+        },
+        debug: false,
+      });
+    }
+    catch(err) {
+      console.log(err);
+      throw err;
+    }
+  }
+
+  public cleanup(): void {
+    this.dbBuilder && this.dbBuilder.destroy();
+  }
+
+  public async runQuery(statements: string[]) {
+    for (const statement of statements) {
+      await this.dbBuilder.raw(statement);
+    }
+  }
+}

--- a/packages/amplify-e2e-core/src/utils/rds.ts
+++ b/packages/amplify-e2e-core/src/utils/rds.ts
@@ -12,6 +12,11 @@ const DEFAULT_DB_INSTANCE_TYPE = "db.m5.large";
 const DEFAULT_DB_STORAGE = 8;
 const DEFAULT_SECURITY_GROUP = "default";
 
+/**
+ * Creates a new RDS instance using the given input configuration and returns the details of the created RDS instance.
+ * @param config Configuration of the database instance
+ * @returns EndPoint address, port and database name of the created RDS instance.
+ */
 export const createRDSInstance = async (config: {
   identifier: string,
   engine: 'mysql',
@@ -21,7 +26,7 @@ export const createRDSInstance = async (config: {
   region: string,
   instanceClass?: string,
   storage?: number,
-}) => {
+}): Promise<{endpoint: string, port: number, dbName: string}> => {
   const client = new RDSClient({ region: config.region });
   const params = {
     /** input parameters */
@@ -59,17 +64,22 @@ export const createRDSInstance = async (config: {
     }
 
     return {
-      endpoint: dbInstance.Endpoint.Address,
-      port: dbInstance.Endpoint.Port,
-      dbName: dbInstance.DBName,
+      endpoint: dbInstance.Endpoint.Address as string,
+      port: dbInstance.Endpoint.Port as number,
+      dbName: dbInstance.DBName as string,
     };
   } catch (error) {
-    console.log(error);
+    console.error(error);
     throw new Error("Error in creating RDS instance.");
   }
 };
 
-export const deleteDBInstance = async (identifier: string, region: string) => {
+/**
+ * Deletes the given RDS instance
+ * @param identifier RDS Instance identifier to delete
+ * @param region RDS Instance region
+ */
+export const deleteDBInstance = async (identifier: string, region: string): Promise<void> => {
   const client = new RDSClient({ region });
   const params = {
     "DBInstanceIdentifier": identifier,
@@ -100,12 +110,16 @@ export const deleteDBInstance = async (identifier: string, region: string) => {
   }  
 };
 
+/**
+ * Adds the given inbound rule to the security group.
+ * @param config Inbound rule configuration
+ */
 export const addRDSPortInboundRule = async (config: {
   region: string,
   port: number,
   securityGroup?: string,
   cidrIp: string,
-}) => {
+}): Promise<void> => {
   const ec2_client = new EC2Client({
     region: config.region,
   });
@@ -127,12 +141,16 @@ export const addRDSPortInboundRule = async (config: {
   } 
 };
 
+/**
+ * Removes the given Inbound rule to the security group
+ * @param config Inbound rule configuration
+ */
 export const removeRDSPortInboundRule = async (config: {
   region: string,
   port: number,
   securityGroup?: string,
   cidrIp: string,
-}) => {
+}): Promise<void> => {
   const ec2_client = new EC2Client({
     region: config.region,
   });

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -40,7 +40,9 @@
     "node-fetch": "^2.6.7",
     "uuid": "^8.3.2",
     "ws": "^7.5.7",
-    "yargs": "^15.1.0"
+    "yargs": "^15.1.0",
+    "axios": "^0.26.0",
+    "generate-password": "~1.7.0"
   },
   "peerDependencies": {
     "amplify-cli-core": "^3.0.0"

--- a/packages/amplify-e2e-tests/src/__tests__/rds-v2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-v2.test.ts
@@ -24,7 +24,7 @@ describe("RDS Tests", () => {
     const username = db_user;
     const password = db_password;
     const region = 'us-east-1';
-    const identifier = `integ_test_${db_identifier}`;
+    const identifier = `integtest${db_identifier}`;
     const db = await createRDSInstance({
       identifier,
       engine: 'mysql',

--- a/packages/amplify-e2e-tests/src/__tests__/rds-v2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-v2.test.ts
@@ -1,0 +1,63 @@
+import { createRDSInstance, addRDSPortInboundRule, RDSTestDataProvider, removeRDSPortInboundRule, deleteDBInstance } from 'amplify-category-api-e2e-core';
+import axios from 'axios';
+import generator from 'generate-password';
+
+describe("RDS Tests", () => {
+  let publicIpCidr = "0.0.0.0/0";
+  const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
+
+  beforeAll(async () => {
+    // Get the public IP of the machine running the test
+    const url = "http://api.ipify.org/";
+    const response = await axios(url);
+    publicIpCidr = `${response.data.trim()}/32`;
+  });
+
+  it("create database, setup initial tables and delete database", async () => {
+    // This test performs the below
+    // 1. Create a RDS Instance
+    // 2. Add the external IP address of the current machine to security group inbound rule to allow public access
+    // 3. Connect to the database and execute DDL
+    // 4. Remove the IP address from the security group
+    // 5. Delete the RDS instance
+
+    const username = db_user;
+    const password = db_password;
+    const region = 'us-east-1';
+    const identifier = `integ_test_${db_identifier}`;
+    const db = await createRDSInstance({
+      identifier,
+      engine: 'mysql',
+      dbname: 'default_db',
+      username,
+      password,
+      region,
+    });
+    await addRDSPortInboundRule({
+      region,
+      port: db.port,
+      cidrIp: publicIpCidr,
+    });
+
+    const dbAdapter = new RDSTestDataProvider({
+      host: db.endpoint,
+      port: db.port,
+      username,
+      password,
+      database: db.dbName,
+    });
+    await dbAdapter.runQuery([
+      "CREATE TABLE Contacts (ID INT PRIMARY KEY, FirstName VARCHAR(20), LastName VARCHAR(50))",
+      "CREATE TABLE Person (ID INT PRIMARY KEY, FirstName VARCHAR(20), LastName VARCHAR(50))",
+      "CREATE TABLE Employee (ID INT PRIMARY KEY, FirstName VARCHAR(20), LastName VARCHAR(50))",
+    ]);
+    dbAdapter.cleanup();
+
+    await removeRDSPortInboundRule({
+      region,
+      port: db.port,
+      cidrIp: publicIpCidr,
+    });
+    await deleteDBInstance(identifier, region);
+  });
+}); 


### PR DESCRIPTION
#### Description of changes

E2E Core library for RDS tests. This includes the below helpers.

- Create a RDS Instance
- Add external IP of current machine running the test to security group
- Remove the IP from the security group
- Delete a RDS Instance
- A sample test to show how to use the above methods

#### Description of how you validated changes
- E2E Test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
