### PR TITLE
Enable top-level appsync resolvers with JS runtime, and flip over primary

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "parse-url": "^8.1.0",
     "moment-timezone": "^0.5.35",
     "@aws-cdk/aws-apigateway": "~1.172.0",
-    "@aws-cdk/aws-appsync": "~1.172.0",
+    "@aws-cdk/aws-appsync": "~1.183.0",
     "@aws-cdk/aws-cognito": "~1.172.0",
     "@aws-cdk/aws-dynamodb": "~1.172.0",
     "@aws-cdk/aws-elasticsearch": "~1.172.0",

--- a/packages/amplify-e2e-tests/src/__tests__/graphql-v2/custom-slot-js-resolver.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/graphql-v2/custom-slot-js-resolver.test.ts
@@ -1,0 +1,127 @@
+import {
+  initJSProjectWithProfile,
+  deleteProject,
+  amplifyPush,
+  addApiWithBlankSchema,
+  updateApiSchema,
+  createNewProjectDir,
+  deleteProjectDir,
+  getProjectMeta,
+} from 'amplify-category-api-e2e-core';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
+import gql from 'graphql-tag';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+// to deal with subscriptions in node env
+(global as any).WebSocket = require('ws');
+
+const projectName = 'jsslotoverride';
+const providerName = 'awscloudformation';
+
+const writeOverrideResolver = (projRoot: string, resolverName: string, contents: string) => fs.writeFileSync(
+  path.join(projRoot, 'amplify', 'backend', 'api', projectName, 'resolvers', resolverName),
+  contents,
+);
+
+const createAndRetrieveEmptyTodoContent = async (projRoot: string): Promise<void> => {
+  const meta = getProjectMeta(projRoot);
+  const region = meta.providers[providerName].Region as string;
+  const { output } = meta.api[projectName];
+  const url = output.GraphQLAPIEndpointOutput as string;
+  const apiKey = output.GraphQLAPIKeyOutput as string;
+
+  const api = new AWSAppSyncClient({
+    url,
+    region,
+    disableOffline: true,
+    auth: { type: AUTH_TYPE.API_KEY, apiKey },
+  });
+
+  const fetchPolicy = 'no-cache';
+
+  const createdTodoResponse = await api.mutate({
+    mutation: gql(/* GraphQL */ `
+      mutation CreateTodo($input: CreateTodoInput!) {
+        createTodo(input: $input) { id }
+      }
+    `),
+    fetchPolicy,
+    variables: { input: {} },
+  });
+
+  const createdTodoId = (createdTodoResponse as any).data.createTodo.id;
+
+  const retrievedTodoContentResponse = await api.query({
+    query: gql(/* GraphQL */ `
+      query GetTodo($id: ID!) {
+        getTodo(id: $id) {
+          content
+        }
+      }
+    `),
+    fetchPolicy,
+    variables: { id: createdTodoId },
+  });
+
+  return (retrievedTodoContentResponse as any).data.getTodo.content;
+};
+
+describe('JS Resolver Overrides for Slots', () => {
+  let projRoot: string;
+
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir(projectName);
+    await initJSProjectWithProfile(projRoot, {
+      name: projectName,
+    });
+
+    await addApiWithBlankSchema(projRoot, { transformerVersion: 2 });
+    updateApiSchema(projRoot, projectName, 'model_with_sandbox_mode.graphql');
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('Allows adding custom resolvers into an unused slot', async () => {
+    const overrideContentMessage = 'I was set by an overridden resolver';
+    writeOverrideResolver(projRoot, 'Query.getTodo.postDataLoad.0.js', `
+      export function request() {
+        return {};
+      }
+
+      export function response(ctx) {
+        const data = ctx.prev.result;
+        data.content = '${overrideContentMessage}';
+        return data;
+      }
+    `);
+
+    await amplifyPush(projRoot);
+    const retrievedTodoContent = await createAndRetrieveEmptyTodoContent(projRoot);
+
+    expect(retrievedTodoContent).toEqual(overrideContentMessage)
+  });
+
+  it('Allows overriding generated VTL resolvers with a JS resolver', async () => {
+    writeOverrideResolver(projRoot, 'Query.getTodo.postAuth.1.js', `
+      import { util } from '@aws-appsync/utils'
+
+      export function request() {
+        util.unauthorized();
+        return {};
+      }
+
+      export function response(ctx) {
+        {}
+      }
+    `);
+
+    await amplifyPush(projRoot);
+    await expect(async () => await createAndRetrieveEmptyTodoContent(projRoot)).rejects.toThrow('Not Authorized to access getTodo on type Todo');
+  });
+});

--- a/packages/amplify-graphql-function-transformer/package.json
+++ b/packages/amplify-graphql-function-transformer/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@aws-amplify/graphql-transformer-core": "0.18.0",
     "@aws-amplify/graphql-transformer-interfaces": "1.14.9",
-    "@aws-cdk/aws-appsync": "~1.172.0",
+    "@aws-cdk/aws-appsync": "~1.183.0",
     "@aws-cdk/aws-lambda": "~1.172.0",
     "@aws-cdk/core": "~1.172.0",
     "graphql": "^14.5.8",

--- a/packages/amplify-graphql-http-transformer/package.json
+++ b/packages/amplify-graphql-http-transformer/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@aws-amplify/graphql-transformer-core": "0.18.0",
     "@aws-amplify/graphql-transformer-interfaces": "1.14.9",
-    "@aws-cdk/aws-appsync": "~1.172.0",
+    "@aws-cdk/aws-appsync": "~1.183.0",
     "@aws-cdk/core": "~1.172.0",
     "graphql": "^14.5.8",
     "graphql-mapping-template": "4.20.5",

--- a/packages/amplify-graphql-index-transformer/package.json
+++ b/packages/amplify-graphql-index-transformer/package.json
@@ -31,7 +31,7 @@
     "@aws-amplify/graphql-model-transformer": "0.16.4",
     "@aws-amplify/graphql-transformer-core": "0.18.0",
     "@aws-amplify/graphql-transformer-interfaces": "1.14.9",
-    "@aws-cdk/aws-appsync": "~1.172.0",
+    "@aws-cdk/aws-appsync": "~1.183.0",
     "@aws-cdk/aws-dynamodb": "~1.172.0",
     "@aws-cdk/core": "~1.172.0",
     "graphql": "^14.5.8",

--- a/packages/amplify-graphql-maps-to-transformer/package.json
+++ b/packages/amplify-graphql-maps-to-transformer/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@aws-amplify/graphql-transformer-core": "0.18.0",
     "@aws-amplify/graphql-transformer-interfaces": "1.14.9",
-    "@aws-cdk/aws-appsync": "~1.172.0",
+    "@aws-cdk/aws-appsync": "~1.183.0",
     "@aws-cdk/aws-iam": "~1.172.0",
     "@aws-cdk/aws-lambda": "~1.172.0",
     "@aws-cdk/core": "~1.172.0",

--- a/packages/amplify-graphql-model-transformer/package.json
+++ b/packages/amplify-graphql-model-transformer/package.json
@@ -32,7 +32,7 @@
     "@aws-amplify/graphql-transformer-core": "0.18.0",
     "@aws-amplify/graphql-transformer-interfaces": "1.14.9",
     "@aws-cdk/aws-applicationautoscaling": "~1.172.0",
-    "@aws-cdk/aws-appsync": "~1.172.0",
+    "@aws-cdk/aws-appsync": "~1.183.0",
     "@aws-cdk/aws-cloudwatch": "~1.172.0",
     "@aws-cdk/aws-dynamodb": "~1.172.0",
     "@aws-cdk/aws-ec2": "~1.172.0",

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer-override.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer-override.test.ts.snap
@@ -197,6 +197,45 @@ Object {
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
         },
+        "Code": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/**
+ * Configure stash variables which will be used downstream in the linked functions.
+ */
+export function request(context) {
+  Object.entries({
+    typeName: 'Mutation',
+    fieldName: 'createPost',
+    conditions: [],
+    metadata: {
+      dataSourceType: 'AMAZON_DYNAMODB',
+      apiId: '",
+              Object {
+                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+              },
+              "',
+    },
+    tableName: '",
+              Object {
+                "Ref": "PostTable",
+              },
+              "',
+  }).forEach(([name, value]) => (context.stash[name] = value));
+  return {};
+}
+
+/**
+ * No-op response function.
+ */
+export function response(context) {
+  return context.prev.result;
+}
+",
+            ],
+          ],
+        },
         "FieldName": "createPost",
         "Kind": "PIPELINE",
         "PipelineConfig": Object {
@@ -221,30 +260,10 @@ Object {
             },
           ],
         },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "$util.qr($ctx.stash.put(\\"typeName\\", \\"Mutation\\"))
-$util.qr($ctx.stash.put(\\"fieldName\\", \\"createPost\\"))
-$util.qr($ctx.stash.put(\\"conditions\\", []))
-$util.qr($ctx.stash.put(\\"metadata\\", {}))
-$util.qr($ctx.stash.metadata.put(\\"dataSourceType\\", \\"AMAZON_DYNAMODB\\"))
-$util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
-              Object {
-                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-              },
-              "\\"))
-$util.qr($ctx.stash.put(\\"tableName\\", \\"",
-              Object {
-                "Ref": "PostTable",
-              },
-              "\\"))
-$util.toJson({})",
-            ],
-          ],
+        "Runtime": Object {
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0",
         },
-        "ResponseMappingTemplate": "$util.toJson($ctx.prev.result)",
         "TypeName": "Mutation",
       },
       "Type": "AWS::AppSync::Resolver",
@@ -253,6 +272,45 @@ $util.toJson({})",
       "Properties": Object {
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "Code": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/**
+ * Configure stash variables which will be used downstream in the linked functions.
+ */
+export function request(context) {
+  Object.entries({
+    typeName: 'Mutation',
+    fieldName: 'deletePost',
+    conditions: [],
+    metadata: {
+      dataSourceType: 'AMAZON_DYNAMODB',
+      apiId: '",
+              Object {
+                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+              },
+              "',
+    },
+    tableName: '",
+              Object {
+                "Ref": "PostTable",
+              },
+              "',
+  }).forEach(([name, value]) => (context.stash[name] = value));
+  return {};
+}
+
+/**
+ * No-op response function.
+ */
+export function response(context) {
+  return context.prev.result;
+}
+",
+            ],
+          ],
         },
         "FieldName": "deletePost",
         "Kind": "PIPELINE",
@@ -272,30 +330,10 @@ $util.toJson({})",
             },
           ],
         },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "$util.qr($ctx.stash.put(\\"typeName\\", \\"Mutation\\"))
-$util.qr($ctx.stash.put(\\"fieldName\\", \\"deletePost\\"))
-$util.qr($ctx.stash.put(\\"conditions\\", []))
-$util.qr($ctx.stash.put(\\"metadata\\", {}))
-$util.qr($ctx.stash.metadata.put(\\"dataSourceType\\", \\"AMAZON_DYNAMODB\\"))
-$util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
-              Object {
-                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-              },
-              "\\"))
-$util.qr($ctx.stash.put(\\"tableName\\", \\"",
-              Object {
-                "Ref": "PostTable",
-              },
-              "\\"))
-$util.toJson({})",
-            ],
-          ],
+        "Runtime": Object {
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0",
         },
-        "ResponseMappingTemplate": "$util.toJson($ctx.prev.result)",
         "TypeName": "Mutation",
       },
       "Type": "AWS::AppSync::Resolver",
@@ -380,6 +418,45 @@ $util.toJson({})",
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
         },
+        "Code": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/**
+ * Configure stash variables which will be used downstream in the linked functions.
+ */
+export function request(context) {
+  Object.entries({
+    typeName: 'Query',
+    fieldName: 'getPost',
+    conditions: [],
+    metadata: {
+      dataSourceType: 'AMAZON_DYNAMODB',
+      apiId: '",
+              Object {
+                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+              },
+              "',
+    },
+    tableName: '",
+              Object {
+                "Ref": "PostTable",
+              },
+              "',
+  }).forEach(([name, value]) => (context.stash[name] = value));
+  return {};
+}
+
+/**
+ * No-op response function.
+ */
+export function response(context) {
+  return context.prev.result;
+}
+",
+            ],
+          ],
+        },
         "FieldName": "getPost",
         "Kind": "PIPELINE",
         "PipelineConfig": Object {
@@ -398,30 +475,10 @@ $util.toJson({})",
             },
           ],
         },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "$util.qr($ctx.stash.put(\\"typeName\\", \\"Query\\"))
-$util.qr($ctx.stash.put(\\"fieldName\\", \\"getPost\\"))
-$util.qr($ctx.stash.put(\\"conditions\\", []))
-$util.qr($ctx.stash.put(\\"metadata\\", {}))
-$util.qr($ctx.stash.metadata.put(\\"dataSourceType\\", \\"AMAZON_DYNAMODB\\"))
-$util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
-              Object {
-                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-              },
-              "\\"))
-$util.qr($ctx.stash.put(\\"tableName\\", \\"",
-              Object {
-                "Ref": "PostTable",
-              },
-              "\\"))
-$util.toJson({})",
-            ],
-          ],
+        "Runtime": Object {
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0",
         },
-        "ResponseMappingTemplate": "$util.toJson($ctx.prev.result)",
         "TypeName": "Query",
       },
       "Type": "AWS::AppSync::Resolver",
@@ -430,6 +487,45 @@ $util.toJson({})",
       "Properties": Object {
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "Code": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/**
+ * Configure stash variables which will be used downstream in the linked functions.
+ */
+export function request(context) {
+  Object.entries({
+    typeName: 'Query',
+    fieldName: 'listPosts',
+    conditions: [],
+    metadata: {
+      dataSourceType: 'AMAZON_DYNAMODB',
+      apiId: '",
+              Object {
+                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+              },
+              "',
+    },
+    tableName: '",
+              Object {
+                "Ref": "PostTable",
+              },
+              "',
+  }).forEach(([name, value]) => (context.stash[name] = value));
+  return {};
+}
+
+/**
+ * No-op response function.
+ */
+export function response(context) {
+  return context.prev.result;
+}
+",
+            ],
+          ],
         },
         "FieldName": "listPosts",
         "Kind": "PIPELINE",
@@ -449,30 +545,10 @@ $util.toJson({})",
             },
           ],
         },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "$util.qr($ctx.stash.put(\\"typeName\\", \\"Query\\"))
-$util.qr($ctx.stash.put(\\"fieldName\\", \\"listPosts\\"))
-$util.qr($ctx.stash.put(\\"conditions\\", []))
-$util.qr($ctx.stash.put(\\"metadata\\", {}))
-$util.qr($ctx.stash.metadata.put(\\"dataSourceType\\", \\"AMAZON_DYNAMODB\\"))
-$util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
-              Object {
-                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-              },
-              "\\"))
-$util.qr($ctx.stash.put(\\"tableName\\", \\"",
-              Object {
-                "Ref": "PostTable",
-              },
-              "\\"))
-$util.toJson({})",
-            ],
-          ],
+        "Runtime": Object {
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0",
         },
-        "ResponseMappingTemplate": "$util.toJson($ctx.prev.result)",
         "TypeName": "Query",
       },
       "Type": "AWS::AppSync::Resolver",
@@ -1049,6 +1125,37 @@ $util.toJson({})",
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
         },
+        "Code": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/**
+ * Configure stash variables which will be used downstream in the linked functions.
+ */
+export function request(context) {
+  Object.entries({
+    typeName: 'Subscription',
+    fieldName: 'onCreatePost',
+    conditions: [],
+    metadata: { dataSourceType: 'NONE', apiId: '",
+              Object {
+                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+              },
+              "' },
+  }).forEach(([name, value]) => (context.stash[name] = value));
+  return {};
+}
+
+/**
+ * No-op response function.
+ */
+export function response(context) {
+  return context.prev.result;
+}
+",
+            ],
+          ],
+        },
         "FieldName": "onCreatePost",
         "Kind": "PIPELINE",
         "PipelineConfig": Object {
@@ -1067,26 +1174,10 @@ $util.toJson({})",
             },
           ],
         },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "$util.qr($ctx.stash.put(\\"typeName\\", \\"Subscription\\"))
-$util.qr($ctx.stash.put(\\"fieldName\\", \\"onCreatePost\\"))
-$util.qr($ctx.stash.put(\\"conditions\\", []))
-$util.qr($ctx.stash.put(\\"metadata\\", {}))
-$util.qr($ctx.stash.metadata.put(\\"dataSourceType\\", \\"NONE\\"))
-$util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
-              Object {
-                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-              },
-              "\\"))
-
-$util.toJson({})",
-            ],
-          ],
+        "Runtime": Object {
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0",
         },
-        "ResponseMappingTemplate": "$util.toJson($ctx.prev.result)",
         "TypeName": "Subscription",
       },
       "Type": "AWS::AppSync::Resolver",
@@ -1095,6 +1186,37 @@ $util.toJson({})",
       "Properties": Object {
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "Code": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/**
+ * Configure stash variables which will be used downstream in the linked functions.
+ */
+export function request(context) {
+  Object.entries({
+    typeName: 'Subscription',
+    fieldName: 'onDeletePost',
+    conditions: [],
+    metadata: { dataSourceType: 'NONE', apiId: '",
+              Object {
+                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+              },
+              "' },
+  }).forEach(([name, value]) => (context.stash[name] = value));
+  return {};
+}
+
+/**
+ * No-op response function.
+ */
+export function response(context) {
+  return context.prev.result;
+}
+",
+            ],
+          ],
         },
         "FieldName": "onDeletePost",
         "Kind": "PIPELINE",
@@ -1114,26 +1236,10 @@ $util.toJson({})",
             },
           ],
         },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "$util.qr($ctx.stash.put(\\"typeName\\", \\"Subscription\\"))
-$util.qr($ctx.stash.put(\\"fieldName\\", \\"onDeletePost\\"))
-$util.qr($ctx.stash.put(\\"conditions\\", []))
-$util.qr($ctx.stash.put(\\"metadata\\", {}))
-$util.qr($ctx.stash.metadata.put(\\"dataSourceType\\", \\"NONE\\"))
-$util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
-              Object {
-                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-              },
-              "\\"))
-
-$util.toJson({})",
-            ],
-          ],
+        "Runtime": Object {
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0",
         },
-        "ResponseMappingTemplate": "$util.toJson($ctx.prev.result)",
         "TypeName": "Subscription",
       },
       "Type": "AWS::AppSync::Resolver",
@@ -1142,6 +1248,37 @@ $util.toJson({})",
       "Properties": Object {
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "Code": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/**
+ * Configure stash variables which will be used downstream in the linked functions.
+ */
+export function request(context) {
+  Object.entries({
+    typeName: 'Subscription',
+    fieldName: 'onUpdatePost',
+    conditions: [],
+    metadata: { dataSourceType: 'NONE', apiId: '",
+              Object {
+                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+              },
+              "' },
+  }).forEach(([name, value]) => (context.stash[name] = value));
+  return {};
+}
+
+/**
+ * No-op response function.
+ */
+export function response(context) {
+  return context.prev.result;
+}
+",
+            ],
+          ],
         },
         "FieldName": "onUpdatePost",
         "Kind": "PIPELINE",
@@ -1162,7 +1299,10 @@ $util.toJson({})",
           ],
         },
         "RequestMappingTemplate": "mockTemplate",
-        "ResponseMappingTemplate": "$util.toJson($ctx.prev.result)",
+        "Runtime": Object {
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0",
+        },
         "TypeName": "Subscription",
       },
       "Type": "AWS::AppSync::Resolver",
@@ -1171,6 +1311,45 @@ $util.toJson({})",
       "Properties": Object {
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "Code": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/**
+ * Configure stash variables which will be used downstream in the linked functions.
+ */
+export function request(context) {
+  Object.entries({
+    typeName: 'Mutation',
+    fieldName: 'updatePost',
+    conditions: [],
+    metadata: {
+      dataSourceType: 'AMAZON_DYNAMODB',
+      apiId: '",
+              Object {
+                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+              },
+              "',
+    },
+    tableName: '",
+              Object {
+                "Ref": "PostTable",
+              },
+              "',
+  }).forEach(([name, value]) => (context.stash[name] = value));
+  return {};
+}
+
+/**
+ * No-op response function.
+ */
+export function response(context) {
+  return context.prev.result;
+}
+",
+            ],
+          ],
         },
         "FieldName": "updatePost",
         "Kind": "PIPELINE",
@@ -1196,30 +1375,10 @@ $util.toJson({})",
             },
           ],
         },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "$util.qr($ctx.stash.put(\\"typeName\\", \\"Mutation\\"))
-$util.qr($ctx.stash.put(\\"fieldName\\", \\"updatePost\\"))
-$util.qr($ctx.stash.put(\\"conditions\\", []))
-$util.qr($ctx.stash.put(\\"metadata\\", {}))
-$util.qr($ctx.stash.metadata.put(\\"dataSourceType\\", \\"AMAZON_DYNAMODB\\"))
-$util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
-              Object {
-                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-              },
-              "\\"))
-$util.qr($ctx.stash.put(\\"tableName\\", \\"",
-              Object {
-                "Ref": "PostTable",
-              },
-              "\\"))
-$util.toJson({})",
-            ],
-          ],
+        "Runtime": Object {
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0",
         },
-        "ResponseMappingTemplate": "$util.toJson($ctx.prev.result)",
         "TypeName": "Mutation",
       },
       "Type": "AWS::AppSync::Resolver",
@@ -1579,6 +1738,45 @@ Object {
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
         },
+        "Code": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/**
+ * Configure stash variables which will be used downstream in the linked functions.
+ */
+export function request(context) {
+  Object.entries({
+    typeName: 'Mutation',
+    fieldName: 'createComment',
+    conditions: [],
+    metadata: {
+      dataSourceType: 'AMAZON_DYNAMODB',
+      apiId: '",
+              Object {
+                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+              },
+              "',
+    },
+    tableName: '",
+              Object {
+                "Ref": "CommentTable",
+              },
+              "',
+  }).forEach(([name, value]) => (context.stash[name] = value));
+  return {};
+}
+
+/**
+ * No-op response function.
+ */
+export function response(context) {
+  return context.prev.result;
+}
+",
+            ],
+          ],
+        },
         "FieldName": "createComment",
         "Kind": "PIPELINE",
         "PipelineConfig": Object {
@@ -1597,30 +1795,10 @@ Object {
             },
           ],
         },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "$util.qr($ctx.stash.put(\\"typeName\\", \\"Mutation\\"))
-$util.qr($ctx.stash.put(\\"fieldName\\", \\"createComment\\"))
-$util.qr($ctx.stash.put(\\"conditions\\", []))
-$util.qr($ctx.stash.put(\\"metadata\\", {}))
-$util.qr($ctx.stash.metadata.put(\\"dataSourceType\\", \\"AMAZON_DYNAMODB\\"))
-$util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
-              Object {
-                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-              },
-              "\\"))
-$util.qr($ctx.stash.put(\\"tableName\\", \\"",
-              Object {
-                "Ref": "CommentTable",
-              },
-              "\\"))
-$util.toJson({})",
-            ],
-          ],
+        "Runtime": Object {
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0",
         },
-        "ResponseMappingTemplate": "$util.toJson($ctx.prev.result)",
         "TypeName": "Mutation",
       },
       "Type": "AWS::AppSync::Resolver",
@@ -1629,6 +1807,45 @@ $util.toJson({})",
       "Properties": Object {
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "Code": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/**
+ * Configure stash variables which will be used downstream in the linked functions.
+ */
+export function request(context) {
+  Object.entries({
+    typeName: 'Mutation',
+    fieldName: 'deleteComment',
+    conditions: [],
+    metadata: {
+      dataSourceType: 'AMAZON_DYNAMODB',
+      apiId: '",
+              Object {
+                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+              },
+              "',
+    },
+    tableName: '",
+              Object {
+                "Ref": "CommentTable",
+              },
+              "',
+  }).forEach(([name, value]) => (context.stash[name] = value));
+  return {};
+}
+
+/**
+ * No-op response function.
+ */
+export function response(context) {
+  return context.prev.result;
+}
+",
+            ],
+          ],
         },
         "FieldName": "deleteComment",
         "Kind": "PIPELINE",
@@ -1645,30 +1862,10 @@ $util.toJson({})",
             },
           ],
         },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "$util.qr($ctx.stash.put(\\"typeName\\", \\"Mutation\\"))
-$util.qr($ctx.stash.put(\\"fieldName\\", \\"deleteComment\\"))
-$util.qr($ctx.stash.put(\\"conditions\\", []))
-$util.qr($ctx.stash.put(\\"metadata\\", {}))
-$util.qr($ctx.stash.metadata.put(\\"dataSourceType\\", \\"AMAZON_DYNAMODB\\"))
-$util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
-              Object {
-                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-              },
-              "\\"))
-$util.qr($ctx.stash.put(\\"tableName\\", \\"",
-              Object {
-                "Ref": "CommentTable",
-              },
-              "\\"))
-$util.toJson({})",
-            ],
-          ],
+        "Runtime": Object {
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0",
         },
-        "ResponseMappingTemplate": "$util.toJson($ctx.prev.result)",
         "TypeName": "Mutation",
       },
       "Type": "AWS::AppSync::Resolver",
@@ -1753,6 +1950,45 @@ $util.toJson({})",
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
         },
+        "Code": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/**
+ * Configure stash variables which will be used downstream in the linked functions.
+ */
+export function request(context) {
+  Object.entries({
+    typeName: 'Query',
+    fieldName: 'getComment',
+    conditions: [],
+    metadata: {
+      dataSourceType: 'AMAZON_DYNAMODB',
+      apiId: '",
+              Object {
+                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+              },
+              "',
+    },
+    tableName: '",
+              Object {
+                "Ref": "CommentTable",
+              },
+              "',
+  }).forEach(([name, value]) => (context.stash[name] = value));
+  return {};
+}
+
+/**
+ * No-op response function.
+ */
+export function response(context) {
+  return context.prev.result;
+}
+",
+            ],
+          ],
+        },
         "FieldName": "getComment",
         "Kind": "PIPELINE",
         "PipelineConfig": Object {
@@ -1768,30 +2004,10 @@ $util.toJson({})",
             },
           ],
         },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "$util.qr($ctx.stash.put(\\"typeName\\", \\"Query\\"))
-$util.qr($ctx.stash.put(\\"fieldName\\", \\"getComment\\"))
-$util.qr($ctx.stash.put(\\"conditions\\", []))
-$util.qr($ctx.stash.put(\\"metadata\\", {}))
-$util.qr($ctx.stash.metadata.put(\\"dataSourceType\\", \\"AMAZON_DYNAMODB\\"))
-$util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
-              Object {
-                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-              },
-              "\\"))
-$util.qr($ctx.stash.put(\\"tableName\\", \\"",
-              Object {
-                "Ref": "CommentTable",
-              },
-              "\\"))
-$util.toJson({})",
-            ],
-          ],
+        "Runtime": Object {
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0",
         },
-        "ResponseMappingTemplate": "$util.toJson($ctx.prev.result)",
         "TypeName": "Query",
       },
       "Type": "AWS::AppSync::Resolver",
@@ -1800,6 +2016,45 @@ $util.toJson({})",
       "Properties": Object {
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "Code": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/**
+ * Configure stash variables which will be used downstream in the linked functions.
+ */
+export function request(context) {
+  Object.entries({
+    typeName: 'Query',
+    fieldName: 'listComments',
+    conditions: [],
+    metadata: {
+      dataSourceType: 'AMAZON_DYNAMODB',
+      apiId: '",
+              Object {
+                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+              },
+              "',
+    },
+    tableName: '",
+              Object {
+                "Ref": "CommentTable",
+              },
+              "',
+  }).forEach(([name, value]) => (context.stash[name] = value));
+  return {};
+}
+
+/**
+ * No-op response function.
+ */
+export function response(context) {
+  return context.prev.result;
+}
+",
+            ],
+          ],
         },
         "FieldName": "listComments",
         "Kind": "PIPELINE",
@@ -1816,30 +2071,10 @@ $util.toJson({})",
             },
           ],
         },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "$util.qr($ctx.stash.put(\\"typeName\\", \\"Query\\"))
-$util.qr($ctx.stash.put(\\"fieldName\\", \\"listComments\\"))
-$util.qr($ctx.stash.put(\\"conditions\\", []))
-$util.qr($ctx.stash.put(\\"metadata\\", {}))
-$util.qr($ctx.stash.metadata.put(\\"dataSourceType\\", \\"AMAZON_DYNAMODB\\"))
-$util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
-              Object {
-                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-              },
-              "\\"))
-$util.qr($ctx.stash.put(\\"tableName\\", \\"",
-              Object {
-                "Ref": "CommentTable",
-              },
-              "\\"))
-$util.toJson({})",
-            ],
-          ],
+        "Runtime": Object {
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0",
         },
-        "ResponseMappingTemplate": "$util.toJson($ctx.prev.result)",
         "TypeName": "Query",
       },
       "Type": "AWS::AppSync::Resolver",
@@ -2104,6 +2339,37 @@ $util.toJson({})",
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
         },
+        "Code": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/**
+ * Configure stash variables which will be used downstream in the linked functions.
+ */
+export function request(context) {
+  Object.entries({
+    typeName: 'Subscription',
+    fieldName: 'onCreateComment',
+    conditions: [],
+    metadata: { dataSourceType: 'NONE', apiId: '",
+              Object {
+                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+              },
+              "' },
+  }).forEach(([name, value]) => (context.stash[name] = value));
+  return {};
+}
+
+/**
+ * No-op response function.
+ */
+export function response(context) {
+  return context.prev.result;
+}
+",
+            ],
+          ],
+        },
         "FieldName": "onCreateComment",
         "Kind": "PIPELINE",
         "PipelineConfig": Object {
@@ -2116,26 +2382,10 @@ $util.toJson({})",
             },
           ],
         },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "$util.qr($ctx.stash.put(\\"typeName\\", \\"Subscription\\"))
-$util.qr($ctx.stash.put(\\"fieldName\\", \\"onCreateComment\\"))
-$util.qr($ctx.stash.put(\\"conditions\\", []))
-$util.qr($ctx.stash.put(\\"metadata\\", {}))
-$util.qr($ctx.stash.metadata.put(\\"dataSourceType\\", \\"NONE\\"))
-$util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
-              Object {
-                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-              },
-              "\\"))
-
-$util.toJson({})",
-            ],
-          ],
+        "Runtime": Object {
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0",
         },
-        "ResponseMappingTemplate": "$util.toJson($ctx.prev.result)",
         "TypeName": "Subscription",
       },
       "Type": "AWS::AppSync::Resolver",
@@ -2144,6 +2394,37 @@ $util.toJson({})",
       "Properties": Object {
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "Code": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/**
+ * Configure stash variables which will be used downstream in the linked functions.
+ */
+export function request(context) {
+  Object.entries({
+    typeName: 'Subscription',
+    fieldName: 'onDeleteComment',
+    conditions: [],
+    metadata: { dataSourceType: 'NONE', apiId: '",
+              Object {
+                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+              },
+              "' },
+  }).forEach(([name, value]) => (context.stash[name] = value));
+  return {};
+}
+
+/**
+ * No-op response function.
+ */
+export function response(context) {
+  return context.prev.result;
+}
+",
+            ],
+          ],
         },
         "FieldName": "onDeleteComment",
         "Kind": "PIPELINE",
@@ -2157,26 +2438,10 @@ $util.toJson({})",
             },
           ],
         },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "$util.qr($ctx.stash.put(\\"typeName\\", \\"Subscription\\"))
-$util.qr($ctx.stash.put(\\"fieldName\\", \\"onDeleteComment\\"))
-$util.qr($ctx.stash.put(\\"conditions\\", []))
-$util.qr($ctx.stash.put(\\"metadata\\", {}))
-$util.qr($ctx.stash.metadata.put(\\"dataSourceType\\", \\"NONE\\"))
-$util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
-              Object {
-                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-              },
-              "\\"))
-
-$util.toJson({})",
-            ],
-          ],
+        "Runtime": Object {
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0",
         },
-        "ResponseMappingTemplate": "$util.toJson($ctx.prev.result)",
         "TypeName": "Subscription",
       },
       "Type": "AWS::AppSync::Resolver",
@@ -2185,6 +2450,37 @@ $util.toJson({})",
       "Properties": Object {
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "Code": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/**
+ * Configure stash variables which will be used downstream in the linked functions.
+ */
+export function request(context) {
+  Object.entries({
+    typeName: 'Subscription',
+    fieldName: 'onUpdateComment',
+    conditions: [],
+    metadata: { dataSourceType: 'NONE', apiId: '",
+              Object {
+                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+              },
+              "' },
+  }).forEach(([name, value]) => (context.stash[name] = value));
+  return {};
+}
+
+/**
+ * No-op response function.
+ */
+export function response(context) {
+  return context.prev.result;
+}
+",
+            ],
+          ],
         },
         "FieldName": "onUpdateComment",
         "Kind": "PIPELINE",
@@ -2198,26 +2494,10 @@ $util.toJson({})",
             },
           ],
         },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "$util.qr($ctx.stash.put(\\"typeName\\", \\"Subscription\\"))
-$util.qr($ctx.stash.put(\\"fieldName\\", \\"onUpdateComment\\"))
-$util.qr($ctx.stash.put(\\"conditions\\", []))
-$util.qr($ctx.stash.put(\\"metadata\\", {}))
-$util.qr($ctx.stash.metadata.put(\\"dataSourceType\\", \\"NONE\\"))
-$util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
-              Object {
-                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-              },
-              "\\"))
-
-$util.toJson({})",
-            ],
-          ],
+        "Runtime": Object {
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0",
         },
-        "ResponseMappingTemplate": "$util.toJson($ctx.prev.result)",
         "TypeName": "Subscription",
       },
       "Type": "AWS::AppSync::Resolver",
@@ -2226,6 +2506,45 @@ $util.toJson({})",
       "Properties": Object {
         "ApiId": Object {
           "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+        },
+        "Code": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/**
+ * Configure stash variables which will be used downstream in the linked functions.
+ */
+export function request(context) {
+  Object.entries({
+    typeName: 'Mutation',
+    fieldName: 'updateComment',
+    conditions: [],
+    metadata: {
+      dataSourceType: 'AMAZON_DYNAMODB',
+      apiId: '",
+              Object {
+                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
+              },
+              "',
+    },
+    tableName: '",
+              Object {
+                "Ref": "CommentTable",
+              },
+              "',
+  }).forEach(([name, value]) => (context.stash[name] = value));
+  return {};
+}
+
+/**
+ * No-op response function.
+ */
+export function response(context) {
+  return context.prev.result;
+}
+",
+            ],
+          ],
         },
         "FieldName": "updateComment",
         "Kind": "PIPELINE",
@@ -2245,30 +2564,10 @@ $util.toJson({})",
             },
           ],
         },
-        "RequestMappingTemplate": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "$util.qr($ctx.stash.put(\\"typeName\\", \\"Mutation\\"))
-$util.qr($ctx.stash.put(\\"fieldName\\", \\"updateComment\\"))
-$util.qr($ctx.stash.put(\\"conditions\\", []))
-$util.qr($ctx.stash.put(\\"metadata\\", {}))
-$util.qr($ctx.stash.metadata.put(\\"dataSourceType\\", \\"AMAZON_DYNAMODB\\"))
-$util.qr($ctx.stash.metadata.put(\\"apiId\\", \\"",
-              Object {
-                "Ref": "referencetotransformerrootstackGraphQLAPI20497F53ApiId",
-              },
-              "\\"))
-$util.qr($ctx.stash.put(\\"tableName\\", \\"",
-              Object {
-                "Ref": "CommentTable",
-              },
-              "\\"))
-$util.toJson({})",
-            ],
-          ],
+        "Runtime": Object {
+          "Name": "APPSYNC_JS",
+          "RuntimeVersion": "1.0.0",
         },
-        "ResponseMappingTemplate": "$util.toJson($ctx.prev.result)",
         "TypeName": "Mutation",
       },
       "Type": "AWS::AppSync::Resolver",

--- a/packages/amplify-graphql-predictions-transformer/package.json
+++ b/packages/amplify-graphql-predictions-transformer/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@aws-amplify/graphql-transformer-core": "0.18.0",
     "@aws-amplify/graphql-transformer-interfaces": "1.14.9",
-    "@aws-cdk/aws-appsync": "~1.172.0",
+    "@aws-cdk/aws-appsync": "~1.183.0",
     "@aws-cdk/aws-iam": "~1.172.0",
     "@aws-cdk/aws-lambda": "~1.172.0",
     "@aws-cdk/core": "~1.172.0",

--- a/packages/amplify-graphql-searchable-transformer/package.json
+++ b/packages/amplify-graphql-searchable-transformer/package.json
@@ -31,7 +31,7 @@
     "@aws-amplify/graphql-model-transformer": "0.16.4",
     "@aws-amplify/graphql-transformer-core": "0.18.0",
     "@aws-amplify/graphql-transformer-interfaces": "1.14.9",
-    "@aws-cdk/aws-appsync": "~1.172.0",
+    "@aws-cdk/aws-appsync": "~1.183.0",
     "@aws-cdk/aws-dynamodb": "~1.172.0",
     "@aws-cdk/aws-ec2": "~1.172.0",
     "@aws-cdk/aws-elasticsearch": "~1.172.0",

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer-override.test.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer-override.test.ts
@@ -106,8 +106,7 @@ test('it overrides expected resources', () => {
           },
         ],
       },
-      RequestMappingTemplate: 'mockTemplate',
-      ResponseMappingTemplate: '$util.toJson($ctx.prev.result)',
+      Code: anything(),
     }),
   );
 });

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
@@ -279,43 +279,6 @@ test('it generates expected resources', () => {
   );
   cdkExpect(searchableStack).to(countResources('AWS::AppSync::Resolver', 2));
   cdkExpect(searchableStack).to(
-    haveResource('AWS::AppSync::Resolver', {
-      ApiId: {
-        Ref: anything(),
-      },
-      FieldName: anything(),
-      TypeName: 'Query',
-      Kind: 'PIPELINE',
-      PipelineConfig: {
-        Functions: [
-          {
-            Ref: anything(),
-          },
-          {
-            'Fn::GetAtt': [anything(), 'FunctionId'],
-          },
-        ],
-      },
-      RequestMappingTemplate: {
-        'Fn::Join': [
-          '',
-          [
-            anything(),
-            {
-              Ref: anything(),
-            },
-            '"))\n$util.qr($ctx.stash.put("endpoint", "https://',
-            {
-              'Fn::GetAtt': ['OpenSearchDomain', 'DomainEndpoint'],
-            },
-            '"))\n$util.toJson({})',
-          ],
-        ],
-      },
-      ResponseMappingTemplate: '$util.toJson($ctx.prev.result)',
-    }),
-  );
-  cdkExpect(searchableStack).to(
     haveResource('AWS::AppSync::FunctionConfiguration', {
       ApiId: {
         Ref: anything(),

--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -9,6 +9,7 @@ import { ApiKeyConfig } from '@aws-cdk/aws-appsync';
 import { App } from '@aws-cdk/core';
 import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-interfaces';
 import { AppSyncDataSourceType } from '@aws-amplify/graphql-transformer-interfaces';
+import { AppSyncExecutionStrategy } from '@aws-amplify/graphql-transformer-interfaces';
 import { AppSyncFunctionConfigurationProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { AuthorizationConfig } from '@aws-cdk/aws-appsync';
 import { AuthorizationType } from '@aws-cdk/aws-appsync';
@@ -643,13 +644,30 @@ export interface TransformerProjectConfig {
 
 // @public (undocumented)
 export class TransformerResolver implements TransformerResolverProvider {
-    constructor(typeName: string, fieldName: string, resolverLogicalId: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider, requestSlots: string[], responseSlots: string[], datasource?: DataSourceProvider | undefined);
+    constructor(typeName: string, fieldName: string, resolverLogicalId: string, requestMappingTemplate: MappingTemplateProvider | undefined, responseMappingTemplate: MappingTemplateProvider | undefined, requestSlots: string[], responseSlots: string[], datasource?: DataSourceProvider | undefined, strategy?: AppSyncExecutionStrategy);
     // (undocumented)
     addToSlot: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider, dataSource?: DataSourceProvider) => void;
+    // (undocumented)
+    addToSlotWithStrategy: (slotName: string, strategy: AppSyncExecutionStrategy, dataSource?: DataSourceProvider) => void;
     // Warning: (ae-forgotten-export) The symbol "Slot" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
     findSlot: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider) => Slot | undefined;
+    // (undocumented)
+    findSlotForStrategy: ({ slotName, strategy, }: {
+        slotName: string;
+        strategy: AppSyncExecutionStrategy;
+    }) => Slot | undefined;
+    // (undocumented)
+    static fromStrategy: ({ typeName, fieldName, resolverLogicalId, requestSlots, responseSlots, datasource, strategy, }: {
+        typeName: string;
+        fieldName: string;
+        resolverLogicalId: string;
+        requestSlots: string[];
+        responseSlots: string[];
+        datasource?: DataSourceProvider | undefined;
+        strategy: AppSyncExecutionStrategy;
+    }) => TransformerResolver;
     // (undocumented)
     getStackName: () => string;
     // (undocumented)
@@ -657,11 +675,15 @@ export class TransformerResolver implements TransformerResolverProvider {
     // (undocumented)
     slotExists: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider) => boolean;
     // (undocumented)
+    slotExistsForStrategy: (slotName: string, strategy: AppSyncExecutionStrategy) => boolean;
+    // (undocumented)
     synthesize: (context: TransformerContextProvider, api: GraphQLAPIProvider) => void;
     // (undocumented)
     synthesizeResolvers: (stack: Stack, api: GraphQLAPIProvider, slotsNames: string[]) => AppSyncFunctionConfigurationProvider[];
     // (undocumented)
     updateSlot: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider) => void;
+    // (undocumented)
+    updateSlotForStrategy: (slotName: string, strategy: AppSyncExecutionStrategy) => void;
 }
 
 // @public (undocumented)

--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@aws-amplify/graphql-transformer-interfaces": "1.14.9",
     "@aws-cdk/aws-applicationautoscaling": "~1.172.0",
-    "@aws-cdk/aws-appsync": "~1.172.0",
+    "@aws-cdk/aws-appsync": "~1.183.0",
     "@aws-cdk/aws-certificatemanager": "~1.172.0",
     "@aws-cdk/aws-cloudwatch": "~1.172.0",
     "@aws-cdk/aws-codeguruprofiler": "~1.172.0",
@@ -61,7 +61,8 @@
     "md5": "^2.3.0",
     "object-hash": "^3.0.0",
     "ts-dedent": "^2.0.0",
-    "vm2": "^3.9.8"
+    "vm2": "^3.9.8",
+    "prettier": "^2.8.1"
   },
   "peerDependencies": {
     "amplify-prompts": "^2.0.1"

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transform-host.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transform-host.test.ts
@@ -1,39 +1,164 @@
 import { DefaultTransformHost } from '../transform-host';
-import { GraphQLApi, TransformerAPIProps } from '../graphql-api';
-import { App } from '@aws-cdk/core';
+import { GraphQLApi } from '../graphql-api';
+import { App, Stack } from '@aws-cdk/core';
 import { InlineTemplate } from '../cdk-compat/template-asset';
 import { TransformerRootStack } from '../cdk-compat/root-stack';
+import { AppSyncExecutionStrategy } from '@aws-amplify/graphql-transformer-interfaces';
 
-describe('addResolver', () => {
-  const app = new App();
-  const stack = new TransformerRootStack(app, 'test-root-stack');
-  const transformHost = new DefaultTransformHost({ api: new GraphQLApi(stack, 'testId', { name: 'testApiName' }) });
+const NONE_DS = 'NONE_DS';
 
-  it('generates resolver name with hash for non-alphanumeric type names', () => {
-    const cfnResolver = transformHost.addResolver(
-      'test_type',
-      'testField',
-      new InlineTemplate('testTemplate'),
-      new InlineTemplate('testTemplate'),
-      undefined,
-      undefined,
-      ['testPipelineConfig'],
-      stack,
-    );
-    expect(cfnResolver.logicalId).toMatch('testtype4c79TestFieldResolver.LogicalID'); // have to use match instead of equals because the logicalId is a CDK token that has some non-deterministic stuff in it
+describe('DefaultTransformHost', () => {
+  describe('addResolver', () => {
+    const app = new App();
+    const stack = new TransformerRootStack(app, 'test-root-stack');
+    const transformHost = new DefaultTransformHost({ api: new GraphQLApi(stack, 'testId', { name: 'testApiName' }) });
+
+    it('generates resolver name with hash for non-alphanumeric type names', () => {
+      const cfnResolver = transformHost.addResolver(
+        'test_type',
+        'testField',
+        new InlineTemplate('testTemplate'),
+        new InlineTemplate('testTemplate'),
+        undefined,
+        undefined,
+        ['testPipelineConfig'],
+        stack,
+      );
+      expect(cfnResolver.logicalId).toMatch('testtype4c79TestFieldResolver.LogicalID'); // have to use match instead of equals because the logicalId is a CDK token that has some non-deterministic stuff in it
+    });
+
+    it('generates resolver name with hash for non-alphanumeric field names', () => {
+      const cfnResolver = transformHost.addResolver(
+        'testType',
+        'test_field',
+        new InlineTemplate('testTemplate'),
+        new InlineTemplate('testTemplate'),
+        undefined,
+        undefined,
+        ['testPipelineConfig'],
+        stack,
+      );
+      expect(cfnResolver.logicalId).toMatch('testTypeTestfield6a0fResolver.LogicalID'); // have to use match instead of equals because the logicalId is a CDK token that has some non-deterministic stuff in it
+    });
   });
 
-  it('generates resolver name with hash for non-alphanumeric field names', () => {
-    const cfnResolver = transformHost.addResolver(
-      'testType',
-      'test_field',
-      new InlineTemplate('testTemplate'),
-      new InlineTemplate('testTemplate'),
-      undefined,
-      undefined,
-      ['testPipelineConfig'],
-      stack,
-    );
-    expect(cfnResolver.logicalId).toMatch('testTypeTestfield6a0fResolver.LogicalID'); // have to use match instead of equals because the logicalId is a CDK token that has some non-deterministic stuff in it
+  describe('addResolverWithStrategy', () => {
+    const app = new App();
+    const stack = new TransformerRootStack(app, 'test-root-stack');
+    const transformHost = new DefaultTransformHost({ api: new GraphQLApi(stack, 'testId', { name: 'testApiName' }) });
+
+    it('generates resolver name with hash for non-alphanumeric type names', () => {
+      const cfnResolver = transformHost.addResolverWithStrategy(
+        'test_type',
+        'testField',
+        {
+          type: 'TEMPLATE',
+          requestMappingTemplate: new InlineTemplate('testTemplate'),
+          responseMappingTemplate: new InlineTemplate('testTemplate'),
+        },
+        undefined,
+        undefined,
+        ['testPipelineConfig'],
+        stack,
+      );
+      expect(cfnResolver.logicalId).toMatch('testtype4c79TestFieldResolver.LogicalID'); // have to use match instead of equals because the logicalId is a CDK token that has some non-deterministic stuff in it
+    });
+
+    it('generates resolver name with hash for non-alphanumeric field names', () => {
+      const cfnResolver = transformHost.addResolverWithStrategy(
+        'testType',
+        'test_field',
+        {
+          type: 'TEMPLATE',
+          requestMappingTemplate: new InlineTemplate('testTemplate'),
+          responseMappingTemplate: new InlineTemplate('testTemplate'),
+        },
+        undefined,
+        undefined,
+        ['testPipelineConfig'],
+        stack,
+      );
+      expect(cfnResolver.logicalId).toMatch('testTypeTestfield6a0fResolver.LogicalID'); // have to use match instead of equals because the logicalId is a CDK token that has some non-deterministic stuff in it
+    });
+
+    it('throws on CODE strategy type', () => {
+      expect(() => {
+        transformHost.addResolverWithStrategy(
+          'testType',
+          'test_field',
+          {
+            type: 'CODE',
+            code: new InlineTemplate('testTemplate'),
+            runtime: { name: '', runtimeVersion: '' },
+          },
+          undefined,
+          undefined,
+          ['testPipelineConfig'],
+          stack,
+        );
+      }).toThrowErrorMatchingInlineSnapshot('"Code Execution strategies are not yet supported for top-level resolvers."');
+    });
+  });
+
+  describe('addAppSyncFunctionWithStrategy', () => {
+    const noopTemplateStrategy: AppSyncExecutionStrategy = {
+      type: 'TEMPLATE',
+      requestMappingTemplate: new InlineTemplate('testTemplate'),
+      responseMappingTemplate: new InlineTemplate('testTemplate'),
+    };
+    const setupHostWithNoneDSAndFns = (
+      ...strategies: AppSyncExecutionStrategy[]
+    ): { stack: Stack, transformHost: DefaultTransformHost } => {
+      const app = new App();
+      const stack = new TransformerRootStack(app, 'test-root-stack');
+      const transformHost = new DefaultTransformHost({ api: new GraphQLApi(stack, 'testId', { name: 'testApiName' }) });
+      transformHost.addNoneDataSource(NONE_DS);
+      strategies.forEach((strategy, i) => transformHost.addAppSyncFunctionWithStrategy(
+        `Function${i}`,
+        strategy,
+        NONE_DS,
+        stack,
+      ));
+      return { stack, transformHost };
+    };
+
+    it('throws for unknown dataSourceName', () => {
+      const { stack, transformHost } = setupHostWithNoneDSAndFns();
+
+      expect(() => {
+        transformHost.addAppSyncFunctionWithStrategy(
+          'TestFunction',
+          noopTemplateStrategy,
+          'UndefinedDataSource',
+          stack,
+        );
+      }).toThrowErrorMatchingInlineSnapshot('"DataSource UndefinedDataSource is missing in the API"');
+    });
+
+    it('adds a template-based function without error', () => {
+      const { stack, transformHost } = setupHostWithNoneDSAndFns();
+
+      transformHost.addAppSyncFunctionWithStrategy(
+        'TestFunction',
+        noopTemplateStrategy,
+        NONE_DS,
+        stack,
+      );
+    });
+
+    it('adds a code-based function without error', () => {
+      const { stack, transformHost } = setupHostWithNoneDSAndFns();
+
+      transformHost.addAppSyncFunctionWithStrategy(
+        'TestFunction',
+        {
+          type: 'CODE',
+          code: new InlineTemplate('I am code'),
+          runtime: { name: '', runtimeVersion: '' },
+        },
+        NONE_DS,
+        stack,
+      );
+    });
   });
 });

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transform-host.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transform-host.test.ts
@@ -81,22 +81,21 @@ describe('DefaultTransformHost', () => {
       expect(cfnResolver.logicalId).toMatch('testTypeTestfield6a0fResolver.LogicalID'); // have to use match instead of equals because the logicalId is a CDK token that has some non-deterministic stuff in it
     });
 
-    it('throws on CODE strategy type', () => {
-      expect(() => {
-        transformHost.addResolverWithStrategy(
-          'testType',
-          'test_field',
-          {
-            type: 'CODE',
-            code: new InlineTemplate('testTemplate'),
-            runtime: { name: '', runtimeVersion: '' },
-          },
-          undefined,
-          undefined,
-          ['testPipelineConfig'],
-          stack,
-        );
-      }).toThrowErrorMatchingInlineSnapshot('"Code Execution strategies are not yet supported for top-level resolvers."');
+    it('generates resolver name with has for non-alphanumeric field names', () => {
+      const cfnResolver = transformHost.addResolverWithStrategy(
+        'testType2',
+        'test_field2',
+        {
+          type: 'CODE',
+          code: new InlineTemplate('testTemplate2'),
+          runtime: { name: '', runtimeVersion: '' },
+        },
+        undefined,
+        undefined,
+        ['testPipelineConfig'],
+        stack,
+      );
+      expect(cfnResolver.logicalId).toMatch('testType2Testfield20c0fResolver.LogicalID')
     });
   });
 

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transformer-context/resolver.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transformer-context/resolver.test.ts
@@ -1,0 +1,256 @@
+import { AppSyncExecutionStrategy, DataSourceProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { App, Stack } from '@aws-cdk/core';
+import { InlineTemplate, S3MappingTemplate, TransformerRootStack } from '../../cdk-compat';
+import { GraphQLApi } from '../../graphql-api';
+import { DefaultTransformHost } from '../../transform-host';
+import { ResolverManager, TransformerResolver } from '../../transformer-context/resolver';
+
+const NONE_DS = 'NONE_DS';
+const noopDataSourceProvider = {} as DataSourceProvider;
+const noopTemplate = new InlineTemplate('mylogic');
+const noopTemplateStrategy: AppSyncExecutionStrategy = {
+  type: 'TEMPLATE',
+  requestMappingTemplate: noopTemplate,
+  responseMappingTemplate: noopTemplate,
+};
+const noopCodeStrategy: AppSyncExecutionStrategy = {
+  type: 'CODE',
+  code: noopTemplate,
+  runtime: { name: '', runtimeVersion: '' },
+};
+
+describe('ResolverManager', () => {
+  describe('generateQueryResolver', () => {
+    it('can be invoked, and generates a TransformerResolver', () => {
+      const manager = new ResolverManager();
+
+      const resolver = manager.generateQueryResolver(
+        'Query',
+        'getTodo',
+        'QuerygetTodoResolver',
+        noopDataSourceProvider,
+        noopTemplate,
+        noopTemplate,
+      );
+
+      expect(resolver).toBeDefined();
+    });
+  });
+
+  describe('generateQueryResolverWithStrategy', () => {
+    it('can be invoked with a Code execution strategy, and generates a TransformerResolver', () => {
+      const manager = new ResolverManager();
+
+      const resolver = manager.generateQueryResolverWithStrategy(
+        'Query',
+        'getTodo',
+        'QuerygetTodoResolver',
+        noopDataSourceProvider,
+        noopCodeStrategy,
+      );
+
+      expect(resolver).toBeDefined();
+    });
+  });
+
+  describe('generateMutationResolver', () => {
+    it('can be invoked, and generates a TransformerResolver', () => {
+      const manager = new ResolverManager();
+
+      const resolver = manager.generateMutationResolver(
+        'Mutation',
+        'createTodo',
+        'MutationcreateTodoResolver',
+        noopDataSourceProvider,
+        new InlineTemplate('mylogic'),
+        new InlineTemplate('mylogic'),
+      );
+
+      expect(resolver).toBeDefined();
+    });
+  });
+
+  describe('generateMutationResolverWithStrategy', () => {
+    it('can be invoked with a Code execution strategy, and generates a TransformerResolver', () => {
+      const manager = new ResolverManager();
+
+      const resolver = manager.generateMutationResolverWithStrategy(
+        'Mutation',
+        'createTodo',
+        'MutationcreateTodoResolver',
+        noopDataSourceProvider,
+        noopCodeStrategy,
+      );
+
+      expect(resolver).toBeDefined();
+    });
+  });
+
+  describe('generateSubscriptionResolver', () => {
+    it('can be invoked, and generates a TransformerResolver', () => {
+      const manager = new ResolverManager();
+
+      const resolver = manager.generateSubscriptionResolver(
+        'Subscription',
+        'onTodoUpdate',
+        'SubscriptionOnTodoUpdateResolver',
+        new InlineTemplate('mylogic'),
+        new InlineTemplate('mylogic'),
+      );
+
+      expect(resolver).toBeDefined();
+    });
+  });
+
+  describe('generateSubscriptionResolverWithStrategy', () => {
+    it('can be invoked with a Code execution strategy, and generates a TransformerResolver', () => {
+      const manager = new ResolverManager();
+
+      const resolver = manager.generateSubscriptionResolverWithStrategy(
+        'Subscription',
+        'onTodoUpdate',
+        'SubscriptionOnTodoUpdateResolver',
+        noopCodeStrategy,
+      );
+
+      expect(resolver).toBeDefined();
+    });
+  });
+});
+
+describe('TransformerResolver', () => {
+  const slotName = 'init';
+  let resolver: TransformerResolver;
+
+  const setupSynthState = (): { stack: Stack, api: GraphQLApi } => {
+    const app = new App();
+    const stack = new TransformerRootStack(app, 'test-root-stack');
+
+    // This is weird, but the transformHost must take in an api in it's constructor
+    // that API also needs the transformHost, which can't be set after initialization
+    // So we do this two-round create w/ a dummy, then update the referances
+    const dummyApi = new GraphQLApi(stack, 'dummyApi', { name: 'dummyApiName' });
+    const transformHost = new DefaultTransformHost({ api: dummyApi });
+    const api = new GraphQLApi(stack, 'testId2', { name: 'testApiName', host: transformHost });
+    transformHost.setAPI(api);
+
+    transformHost.addNoneDataSource(NONE_DS);
+
+    return { stack, api };
+  };
+
+  beforeEach(() => {
+    resolver = TransformerResolver.fromStrategy({
+      typeName: 'Query',
+      fieldName: 'getTodo',
+      resolverLogicalId: 'QuerygetTodoResolver',
+      requestSlots: [slotName],
+      responseSlots: [],
+      strategy: noopCodeStrategy,
+    });
+  });
+
+  describe('addToSlot', () => {
+    it('can be invoked as a proxy to addToSlotWithStrategy', () => {
+      resolver.addToSlot(slotName, noopTemplate, noopTemplate, noopDataSourceProvider);
+      
+      const { stack, api } = setupSynthState();
+
+      const synthesizedResolvers = resolver.synthesizeResolvers(stack, api, [slotName]);
+      expect(synthesizedResolvers.length).toEqual(1);
+    });
+  });
+
+  describe('addToSlotWithStrategy', () => {
+    it('can add a new template function to an empty slot', () => {
+      resolver.addToSlotWithStrategy(
+        slotName,
+        noopTemplateStrategy,
+        noopDataSourceProvider,
+      );
+      
+      const { stack, api } = setupSynthState();
+
+      const synthesizedResolvers = resolver.synthesizeResolvers(stack, api, [slotName]);
+      expect(synthesizedResolvers.length).toEqual(1);
+    });
+
+    it('can add a new code function to an empty slot', () => {
+      resolver.addToSlotWithStrategy(
+        slotName,
+        noopCodeStrategy,
+        noopDataSourceProvider,
+      );
+      
+      const { stack, api } = setupSynthState();
+
+      const synthesizedResolvers = resolver.synthesizeResolvers(stack, api, [slotName]);
+      expect(synthesizedResolvers.length).toEqual(1);
+    });
+
+    it('will append a function for inline functions regardless of type', () => {
+      resolver.addToSlotWithStrategy(slotName, noopTemplateStrategy);
+      resolver.addToSlotWithStrategy(slotName, noopTemplateStrategy);
+      resolver.addToSlotWithStrategy(slotName, noopCodeStrategy);
+      resolver.addToSlotWithStrategy(slotName, noopCodeStrategy);
+      
+      const { stack, api } = setupSynthState();
+
+      const synthesizedResolvers = resolver.synthesizeResolvers(stack, api, [slotName]);
+      expect(synthesizedResolvers.length).toEqual(4);
+    });
+
+    it('will update request and response override templates', () => {
+      const requestMappingTemplate1 = new InlineTemplate('myrequestmappinglogic');
+      (requestMappingTemplate1 as any).name = 'Query.getTodo.init.1.req.vtl';
+      const responseMappingTemplate1 = new InlineTemplate('myresponsemappinglogic');
+      (responseMappingTemplate1 as any).name = 'Query.getTodo.init.1.res.vtl';
+      const requestMappingTemplate2 = new InlineTemplate('myupdatedrequestmappinglogic');
+      (requestMappingTemplate2 as any).name = 'Query.getTodo.init.1.req.vtl';
+      const responseMappingTemplate2 = new InlineTemplate('myupdatedresponsemappinglogic');
+      (responseMappingTemplate2 as any).name = 'Query.getTodo.init.1.res.vtl';
+      resolver.addToSlotWithStrategy(slotName, {
+        type: 'TEMPLATE',
+        requestMappingTemplate: requestMappingTemplate1,
+        responseMappingTemplate: responseMappingTemplate1,
+      });
+      resolver.addToSlotWithStrategy(slotName, {
+        type: 'TEMPLATE',
+        requestMappingTemplate: requestMappingTemplate2,
+        responseMappingTemplate: responseMappingTemplate2,
+      });
+
+      const { stack, api } = setupSynthState();
+
+      const synthesizedResolvers = resolver.synthesizeResolvers(stack, api, [slotName]);
+      expect(synthesizedResolvers.length).toEqual(1);
+      expect((synthesizedResolvers[0] as any).function.requestMappingTemplate).toEqual('myupdatedrequestmappinglogic');
+      expect((synthesizedResolvers[0] as any).function.responseMappingTemplate).toEqual('myupdatedresponsemappinglogic');
+    });
+
+    it('will update request and response override templates with code', () => {
+      const requestMappingTemplate = new InlineTemplate('myrequestmappinglogic');
+      (requestMappingTemplate as any).name = 'Query.getTodo.init.1.req.vtl';
+      const responseMappingTemplate = new InlineTemplate('myresponsemappinglogic');
+      (responseMappingTemplate as any).name = 'Query.getTodo.init.1.res.vtl';
+      const code = new InlineTemplate('myupdatedcode');
+      (code as any).name = 'Query.getTodo.init.1.js';
+      resolver.addToSlotWithStrategy(slotName, {
+        type: 'TEMPLATE',
+        requestMappingTemplate,
+        responseMappingTemplate,
+      });
+      resolver.addToSlotWithStrategy(slotName, {
+        type: 'CODE',
+        code,
+        runtime: { name: 'APP_SYNC_JS', runtimeVersion: '1.0.0' },
+      });
+
+      const { stack, api } = setupSynthState();
+
+      const synthesizedResolvers = resolver.synthesizeResolvers(stack, api, [slotName]);
+      expect(synthesizedResolvers.length).toEqual(1);
+      expect((synthesizedResolvers[0] as any).function._cfnProperties.Code).toEqual('myupdatedcode');
+    });
+  });
+});

--- a/packages/amplify-graphql-transformer-core/src/appsync-function.ts
+++ b/packages/amplify-graphql-transformer-core/src/appsync-function.ts
@@ -1,40 +1,32 @@
-import { MappingTemplateProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { AppSyncExecutionStrategy } from '@aws-amplify/graphql-transformer-interfaces';
 import { BackedDataSource, BaseDataSource, CfnFunctionConfiguration } from '@aws-cdk/aws-appsync';
-import { Construct } from '@aws-cdk/core';
+import { Construct, CfnResource } from '@aws-cdk/core';
 import { InlineTemplate } from './cdk-compat/template-asset';
 import { GraphQLApi } from './graphql-api';
-export interface BaseFunctionConfigurationProps {
-  /**
-   * The request mapping template for this resolver
-   *
-   * @default - No mapping template
-   */
-  readonly requestMappingTemplate: MappingTemplateProvider;
-  /**
-   * The response mapping template for this resolver
-   *
-   * @default - No mapping template
-   */
-  readonly responseMappingTemplate: MappingTemplateProvider;
-
-  readonly description?: string;
-}
 
 /**
  * Additional properties for an AppSync resolver like GraphQL API reference and datasource
  */
-export interface FunctionConfigurationProps extends BaseFunctionConfigurationProps {
+type FunctionConfigurationProps = {
+  /**
+   * Resolvers and code for the given function.
+   */
+  readonly strategy: AppSyncExecutionStrategy;
+
   /**
    * The API this resolver is attached to
    */
   readonly api: GraphQLApi;
+
   /**
-   * The data source this resolver is using
-   *
-   * @default - No datasource
-   */
+  * The data source this resolver is using
+  *
+  * @default - No datasource
+  */
   readonly dataSource: BaseDataSource | string;
-}
+
+  readonly description?: string;
+};
 
 export class AppSyncFunctionConfiguration extends Construct {
   /**
@@ -43,32 +35,90 @@ export class AppSyncFunctionConfiguration extends Construct {
   public readonly arn: string;
   public readonly functionId: string;
 
-  private function: CfnFunctionConfiguration;
+  private function: CfnFunctionConfiguration | CfnResource;
 
   constructor(scope: Construct, id: string, props: FunctionConfigurationProps) {
     super(scope, id);
 
-    const requestTemplate = props.requestMappingTemplate.bind(this);
-    const responseTemplate = props.responseMappingTemplate.bind(this);
-    this.function = new CfnFunctionConfiguration(this, `${id}.AppSyncFunction`, {
-      name: id,
-      apiId: props.api.apiId,
-      functionVersion: '2018-05-29',
-      description: props.description,
-      dataSourceName: props.dataSource instanceof BaseDataSource ? props.dataSource.ds.attrName : props.dataSource,
-      ...(props.requestMappingTemplate instanceof InlineTemplate
-        ? { requestMappingTemplate: requestTemplate }
-        : { requestMappingTemplateS3Location: requestTemplate }),
-      ...(props.responseMappingTemplate instanceof InlineTemplate
-        ? { responseMappingTemplate: responseTemplate }
-        : { responseMappingTemplateS3Location: responseTemplate }),
-    });
+    this.function = this.generateFunction(id, props);
 
     props.api.addSchemaDependency(this.function);
     if (props.dataSource instanceof BackedDataSource) {
       this.function.addDependsOn(props.dataSource?.ds);
     }
-    this.arn = this.function.attrFunctionArn;
-    this.functionId = this.function.attrFunctionId;
+
+    this.arn = this.getFunctionArn();
+    this.functionId = this.getFunctionId();
+  }
+
+  private getFunctionArn = (): string => {
+    if (this.function instanceof CfnFunctionConfiguration) {
+      return this.function.attrFunctionArn;
+    }
+
+    return this.function.getAtt('FunctionArn').toString();
+  };
+
+  private getFunctionId = (): string => {
+    if (this.function instanceof CfnFunctionConfiguration) {
+      return this.function.attrFunctionId;
+    }
+
+    return this.function.getAtt('FunctionId').toString();
+  };
+
+  generateFunction(id: string, props: FunctionConfigurationProps): CfnFunctionConfiguration | CfnResource {
+    switch (props.strategy.type) {
+      case 'TEMPLATE':
+        return this.generateTemplateFunction(id, props);
+      case 'CODE':
+        return this.generateCodeFunction(id, props);
+    }
+  }
+
+  generateTemplateFunction(id: string, props: FunctionConfigurationProps): CfnFunctionConfiguration {
+    if (props.strategy.type !== 'TEMPLATE') {
+      throw new Error(`Expected strategy with type TEMPLATE, got ${props.strategy.type}`);
+    }
+    const requestTemplate = props.strategy.requestMappingTemplate?.bind(this);
+    const responseTemplate = props.strategy.responseMappingTemplate?.bind(this);
+
+    return new CfnFunctionConfiguration(this, `${id}.AppSyncFunction`, {
+      name: id,
+      apiId: props.api.apiId,
+      functionVersion: '2018-05-29',
+      description: props.description,
+      dataSourceName: props.dataSource instanceof BaseDataSource ? props.dataSource.ds.attrName : props.dataSource,
+      ...(props.strategy.requestMappingTemplate instanceof InlineTemplate
+        ? { requestMappingTemplate: requestTemplate }
+        : { requestMappingTemplateS3Location: requestTemplate }),
+      ...(props.strategy.responseMappingTemplate instanceof InlineTemplate
+        ? { responseMappingTemplate: responseTemplate }
+        : { responseMappingTemplateS3Location: responseTemplate }),
+    });
+  }
+
+  generateCodeFunction(id: string, props: FunctionConfigurationProps): CfnResource {
+    if (props.strategy.type !== 'CODE') {
+      throw new Error(`Expected strategy with type CODE, got ${props.strategy.type}`);
+    }
+
+    const code = props.strategy.code.bind(this);
+
+    return new CfnResource(this, `${id}.AppSyncFunctinon`, {
+      type: 'AWS::AppSync::FunctionConfiguration',
+      properties: {
+        ApiId: props.api.apiId,
+        ...(props.strategy.code instanceof InlineTemplate
+          ? { Code: code }
+          : { CodeS3Location: code }),
+        DataSourceName: props.dataSource instanceof BaseDataSource ? props.dataSource.ds.attrName : props.dataSource,
+        Name: id,
+        Runtime: {
+          Name: props.strategy.runtime.name,
+          RuntimeVersion: props.strategy.runtime.runtimeVersion,
+        },
+      },
+    });
   }
 }

--- a/packages/amplify-graphql-transformer-core/src/appsync-function.ts
+++ b/packages/amplify-graphql-transformer-core/src/appsync-function.ts
@@ -1,8 +1,12 @@
 import { AppSyncExecutionStrategy } from '@aws-amplify/graphql-transformer-interfaces';
-import { BackedDataSource, BaseDataSource, CfnFunctionConfiguration } from '@aws-cdk/aws-appsync';
-import { Construct, CfnResource } from '@aws-cdk/core';
-import { InlineTemplate } from './cdk-compat/template-asset';
+import {
+  BackedDataSource,
+  BaseDataSource,
+  CfnFunctionConfiguration,
+} from '@aws-cdk/aws-appsync';
+import { Construct } from '@aws-cdk/core';
 import { GraphQLApi } from './graphql-api';
+import { getStrategyProps } from './utils/execution-strategy-utils';
 
 /**
  * Additional properties for an AppSync resolver like GraphQL API reference and datasource
@@ -35,90 +39,26 @@ export class AppSyncFunctionConfiguration extends Construct {
   public readonly arn: string;
   public readonly functionId: string;
 
-  private function: CfnFunctionConfiguration | CfnResource;
+  private function: CfnFunctionConfiguration;
 
   constructor(scope: Construct, id: string, props: FunctionConfigurationProps) {
     super(scope, id);
 
-    this.function = this.generateFunction(id, props);
-
-    props.api.addSchemaDependency(this.function);
-    if (props.dataSource instanceof BackedDataSource) {
-      this.function.addDependsOn(props.dataSource?.ds);
-    }
-
-    this.arn = this.getFunctionArn();
-    this.functionId = this.getFunctionId();
-  }
-
-  private getFunctionArn = (): string => {
-    if (this.function instanceof CfnFunctionConfiguration) {
-      return this.function.attrFunctionArn;
-    }
-
-    return this.function.getAtt('FunctionArn').toString();
-  };
-
-  private getFunctionId = (): string => {
-    if (this.function instanceof CfnFunctionConfiguration) {
-      return this.function.attrFunctionId;
-    }
-
-    return this.function.getAtt('FunctionId').toString();
-  };
-
-  generateFunction(id: string, props: FunctionConfigurationProps): CfnFunctionConfiguration | CfnResource {
-    switch (props.strategy.type) {
-      case 'TEMPLATE':
-        return this.generateTemplateFunction(id, props);
-      case 'CODE':
-        return this.generateCodeFunction(id, props);
-    }
-  }
-
-  generateTemplateFunction(id: string, props: FunctionConfigurationProps): CfnFunctionConfiguration {
-    if (props.strategy.type !== 'TEMPLATE') {
-      throw new Error(`Expected strategy with type TEMPLATE, got ${props.strategy.type}`);
-    }
-    const requestTemplate = props.strategy.requestMappingTemplate?.bind(this);
-    const responseTemplate = props.strategy.responseMappingTemplate?.bind(this);
-
-    return new CfnFunctionConfiguration(this, `${id}.AppSyncFunction`, {
+    this.function = new CfnFunctionConfiguration(this, `${id}.AppSyncFunction`, {
       name: id,
       apiId: props.api.apiId,
       functionVersion: '2018-05-29',
       description: props.description,
       dataSourceName: props.dataSource instanceof BaseDataSource ? props.dataSource.ds.attrName : props.dataSource,
-      ...(props.strategy.requestMappingTemplate instanceof InlineTemplate
-        ? { requestMappingTemplate: requestTemplate }
-        : { requestMappingTemplateS3Location: requestTemplate }),
-      ...(props.strategy.responseMappingTemplate instanceof InlineTemplate
-        ? { responseMappingTemplate: responseTemplate }
-        : { responseMappingTemplateS3Location: responseTemplate }),
+      ...getStrategyProps(this, props.strategy),
     });
-  }
 
-  generateCodeFunction(id: string, props: FunctionConfigurationProps): CfnResource {
-    if (props.strategy.type !== 'CODE') {
-      throw new Error(`Expected strategy with type CODE, got ${props.strategy.type}`);
+    this.arn = this.function.attrFunctionArn;
+    this.functionId = this.function.attrFunctionId;
+
+    props.api.addSchemaDependency(this.function);
+    if (props.dataSource instanceof BackedDataSource) {
+      this.function.addDependsOn(props.dataSource?.ds);
     }
-
-    const code = props.strategy.code.bind(this);
-
-    return new CfnResource(this, `${id}.AppSyncFunctinon`, {
-      type: 'AWS::AppSync::FunctionConfiguration',
-      properties: {
-        ApiId: props.api.apiId,
-        ...(props.strategy.code instanceof InlineTemplate
-          ? { Code: code }
-          : { CodeS3Location: code }),
-        DataSourceName: props.dataSource instanceof BaseDataSource ? props.dataSource.ds.attrName : props.dataSource,
-        Name: id,
-        Runtime: {
-          Name: props.strategy.runtime.name,
-          RuntimeVersion: props.strategy.runtime.runtimeVersion,
-        },
-      },
-    });
   }
 }

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -5,6 +5,7 @@ import {
   GraphQLAPIProvider,
   TransformerPluginProvider,
   TransformHostProvider,
+  AppSyncRuntime,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import { AuthorizationMode, AuthorizationType } from '@aws-cdk/aws-appsync';
 import {
@@ -42,7 +43,6 @@ import { convertToAppsyncResourceObj, getStackMeta } from '../types/utils';
 import { adoptAuthModes, IAM_AUTH_ROLE_PARAMETER, IAM_UNAUTH_ROLE_PARAMETER } from '../utils/authType';
 import * as SyncUtils from './sync-utils';
 import { MappingTemplate } from '../cdk-compat';
-
 import Template, { DeploymentResources, UserDefinedSlot, OverrideConfig } from './types';
 import {
   makeSeenTransformationKey,
@@ -57,6 +57,11 @@ import { validateAuthModes, validateModelSchema } from './validation';
 import { DocumentNode } from 'graphql/language';
 import { TransformerPreProcessContext } from '../transformer-context/pre-process-context';
 import { AmplifyApiGraphQlResourceStackTemplate } from '../types/amplify-api-resource-stack-types';
+
+const JS_RUNTIME: AppSyncRuntime = {
+  name: 'APPSYNC_JS',
+  runtimeVersion: '1.0.0',
+}
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 function isFunction(obj: any): obj is Function {
@@ -494,7 +499,7 @@ export class GraphQLTransform {
 
   private collectResolvers(context: TransformerContext, api: GraphQLAPIProvider): void {
     const resolverEntries = context.resolvers.collectResolvers() as Map<string, TransformerResolver>;
-    //Sort resolvers by stack name to group each resolver before synthesis to avoid circular dependency
+    // Sort resolvers by stack name to group each resolver before synthesis to avoid circular dependency
     const sortedResolverEntries = new Map([...resolverEntries].sort((a,b) => {
       const left = a[1].getStackName();
       const right = b[1].getStackName();
@@ -510,17 +515,37 @@ export class GraphQLTransform {
       const userSlots = this.userDefinedSlots[resolverName] || [];
 
       userSlots.forEach(slot => {
-        const requestTemplate = slot.requestResolver
-          ? MappingTemplate.s3MappingTemplateFromString(slot.requestResolver.template, slot.requestResolver.fileName)
-          : undefined;
-        const responseTemplate = slot.responseResolver
-          ? MappingTemplate.s3MappingTemplateFromString(slot.responseResolver.template, slot.responseResolver.fileName)
-          : undefined;
-        resolver.addToSlot(slot.slotName, requestTemplate, responseTemplate);
+        if (this.isSlotAJSResolver(slot)) {
+          const code = MappingTemplate.s3MappingTemplateFromString(
+            // eslint-disable-next-line @typescript-eslint/no-extra-non-null-assertion
+            slot.requestResolver!!.template,
+            // eslint-disable-next-line @typescript-eslint/no-extra-non-null-assertion
+            slot.requestResolver!!.fileName,
+          );
+          resolver.addToSlotWithStrategy(slot.slotName, { type: 'CODE', code, runtime: JS_RUNTIME});
+        } else {
+          const requestMappingTemplate = slot.requestResolver
+            ? MappingTemplate.s3MappingTemplateFromString(slot.requestResolver.template, slot.requestResolver.fileName)
+            : undefined;
+          const responseMappingTemplate = slot.responseResolver
+            ? MappingTemplate.s3MappingTemplateFromString(slot.responseResolver.template, slot.responseResolver.fileName)
+            : undefined;
+          resolver.addToSlotWithStrategy(slot.slotName, { type: 'TEMPLATE', requestMappingTemplate, responseMappingTemplate },
+          );
+        }
       });
 
       resolver.synthesize(context, api);
     }
+  }
+
+  /**
+   * We impute that a slot is a code-based resolver if there is only a request resolver, and the filename ends in either js or ts.
+   */
+  private isSlotAJSResolver = (slot: UserDefinedSlot): boolean => {
+    const hasJSRuntimeFileMatch = slot.requestResolver?.fileName.match(/\.(ts|js)$/);
+    const hasJSRuntimeFileEnding: boolean = hasJSRuntimeFileMatch !== undefined && hasJSRuntimeFileMatch !== null;
+    return slot.responseResolver === undefined && slot.requestResolver !== undefined && hasJSRuntimeFileEnding;
   }
 
   private transformObject(

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -6,6 +6,9 @@ import {
   TransformerContextProvider,
   TransformerResolverProvider,
   TransformerResolversManagerProvider,
+  AppSyncExecutionStrategy,
+  AppSyncTemplateExecutionStrategy,
+  AppSyncCodeExecutionStrategy,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import { AuthorizationType, CfnFunctionConfiguration } from '@aws-cdk/aws-appsync';
 import { isResolvableObject, Stack, CfnParameter } from '@aws-cdk/core';
@@ -18,13 +21,15 @@ import { IAM_AUTH_ROLE_PARAMETER, IAM_UNAUTH_ROLE_PARAMETER } from '../utils';
 import { StackManager } from './stack-manager';
 
 type Slot = {
-  requestMappingTemplate?: MappingTemplateProvider;
-  responseMappingTemplate?: MappingTemplateProvider;
   dataSource?: DataSourceProvider;
+  strategy: AppSyncExecutionStrategy;
 };
 
 // Name of the None Data source used for pipeline resolver
 const NONE_DATA_SOURCE_NAME = 'NONE_DS';
+
+const FILE_FORMAT_PATTERN = /\.[a-zA-Z]*$/;
+const TEMPLATE_SLOT_FILENAME_PATTERN = /\.(req|res).vtl$/;
 
 /**
  * ResolverManager
@@ -32,57 +37,103 @@ const NONE_DATA_SOURCE_NAME = 'NONE_DS';
 export class ResolverManager implements TransformerResolversManagerProvider {
   private resolvers: Map<string, TransformerResolverProvider> = new Map();
 
+  /**
+   * @deprecated use generateQueryResolverWithStrategy, which supports all appsync runtimes
+   */
   generateQueryResolver = (
     typeName: string,
     fieldName: string,
     resolverLogicalId: string,
-    dataSource: DataSourceProvider,
+    datasource: DataSourceProvider,
     requestMappingTemplate: MappingTemplateProvider,
     responseMappingTemplate: MappingTemplateProvider,
-  ): TransformerResolver => new TransformerResolver(
+  ): TransformerResolver => this.generateQueryResolverWithStrategy(
     typeName,
     fieldName,
     resolverLogicalId,
-    requestMappingTemplate,
-    responseMappingTemplate,
-    ['init', 'preAuth', 'auth', 'postAuth', 'preDataLoad'],
-    ['postDataLoad', 'finish'],
-    dataSource,
+    datasource,
+    { type: 'TEMPLATE', requestMappingTemplate, responseMappingTemplate },
   );
 
+  generateQueryResolverWithStrategy = (
+    typeName: string,
+    fieldName: string,
+    resolverLogicalId: string,
+    datasource: DataSourceProvider,
+    strategy: AppSyncExecutionStrategy,
+  ): TransformerResolver => TransformerResolver.fromStrategy({
+    typeName,
+    fieldName,
+    resolverLogicalId,
+    strategy,
+    requestSlots: ['init', 'preAuth', 'auth', 'postAuth', 'preDataLoad'],
+    responseSlots: ['postDataLoad', 'finish'],
+    datasource,
+  });
+
+  /**
+   * @deprecated use generateMutationResolverWithStrategy, which supports all appsync runtimes
+   */
   generateMutationResolver = (
     typeName: string,
     fieldName: string,
     resolverLogicalId: string,
-    dataSource: DataSourceProvider,
+    datasource: DataSourceProvider,
     requestMappingTemplate: MappingTemplateProvider,
     responseMappingTemplate: MappingTemplateProvider,
-  ): TransformerResolver => new TransformerResolver(
+  ): TransformerResolver => this.generateMutationResolverWithStrategy(
     typeName,
     fieldName,
     resolverLogicalId,
-    requestMappingTemplate,
-    responseMappingTemplate,
-    ['init', 'preAuth', 'auth', 'postAuth', 'preUpdate'],
-    ['postUpdate', 'finish'],
-    dataSource,
+    datasource,
+    { type: 'TEMPLATE', requestMappingTemplate, responseMappingTemplate },
   );
 
+  generateMutationResolverWithStrategy = (
+    typeName: string,
+    fieldName: string,
+    resolverLogicalId: string,
+    datasource: DataSourceProvider,
+    strategy: AppSyncExecutionStrategy,
+  ): TransformerResolver => TransformerResolver.fromStrategy({
+    typeName,
+    fieldName,
+    resolverLogicalId,
+    strategy,
+    requestSlots: ['init', 'preAuth', 'auth', 'postAuth', 'preUpdate'],
+    responseSlots: ['postUpdate', 'finish'],
+    datasource,
+  });
+
+  /**
+   * @deprecated use generateSubscriptionResolverWithStrategy, which supports all appsync runtimes
+   */
   generateSubscriptionResolver = (
     typeName: string,
     fieldName: string,
     resolverLogicalId: string,
     requestMappingTemplate: MappingTemplateProvider,
     responseMappingTemplate: MappingTemplateProvider,
-  ): TransformerResolver => new TransformerResolver(
+  ): TransformerResolver => this.generateSubscriptionResolverWithStrategy(
     typeName,
     fieldName,
     resolverLogicalId,
-    requestMappingTemplate,
-    responseMappingTemplate,
-    ['init', 'preAuth', 'auth', 'postAuth', 'preSubscribe'],
-    [],
+    { type: 'TEMPLATE', requestMappingTemplate, responseMappingTemplate },
   );
+
+  generateSubscriptionResolverWithStrategy = (
+    typeName: string,
+    fieldName: string,
+    resolverLogicalId: string,
+    strategy: AppSyncExecutionStrategy,
+  ): TransformerResolver => TransformerResolver.fromStrategy({
+    typeName,
+    fieldName,
+    resolverLogicalId,
+    strategy,
+    requestSlots: ['init', 'preAuth', 'auth', 'postAuth', 'preSubscribe'],
+    responseSlots: [],
+  });
 
   addResolver = (typeName: string, fieldName: string, resolver: TransformerResolverProvider): TransformerResolverProvider => {
     const key = `${typeName}.${fieldName}`;
@@ -117,6 +168,7 @@ export class ResolverManager implements TransformerResolversManagerProvider {
 
   collectResolvers = (): Map<string, TransformerResolverProvider> => new Map(this.resolvers.entries());
 }
+
 /**
  * TransformerResolver
  */
@@ -125,15 +177,18 @@ export class TransformerResolver implements TransformerResolverProvider {
   private readonly slotNames: Set<string>;
   private stack?: Stack;
   private stackName?: string;
+  private strategy: AppSyncExecutionStrategy
+
   constructor(
     private typeName: string,
     private fieldName: string,
     private resolverLogicalId: string,
-    private requestMappingTemplate: MappingTemplateProvider,
-    private responseMappingTemplate: MappingTemplateProvider,
+    requestMappingTemplate: MappingTemplateProvider | undefined,
+    responseMappingTemplate: MappingTemplateProvider | undefined,
     private requestSlots: string[],
     private responseSlots: string[],
     private datasource?: DataSourceProvider,
+    strategy? : AppSyncExecutionStrategy,
   ) {
     if (!typeName) {
       throw new InvalidDirectiveError('typeName is required');
@@ -144,14 +199,45 @@ export class TransformerResolver implements TransformerResolverProvider {
     if (!resolverLogicalId) {
       throw new InvalidDirectiveError('resolverLogicalId is required');
     }
-    if (!requestMappingTemplate) {
-      throw new InvalidDirectiveError('requestMappingTemplate is required');
+
+    if (strategy) {
+      this.strategy = strategy;
+    } else if (requestMappingTemplate && responseMappingTemplate) {
+    this.strategy = { type: 'TEMPLATE', requestMappingTemplate, responseMappingTemplate };
+    } else {
+      throw new InvalidDirectiveError('Either strategy, or both requestMappingTemplate and responseMappingTemplate must be provided.');
     }
-    if (!responseMappingTemplate) {
-      throw new InvalidDirectiveError('responseMappingTemplate is required');
-    }
+
     this.slotNames = new Set([...requestSlots, ...responseSlots]);
   }
+
+  static fromStrategy = ({
+    typeName,
+    fieldName,
+    resolverLogicalId,
+    requestSlots,
+    responseSlots,
+    datasource,
+    strategy,
+  }: {
+    typeName: string,
+    fieldName: string,
+    resolverLogicalId: string,
+    requestSlots: string[],
+    responseSlots: string[],
+    datasource?: DataSourceProvider,
+    strategy : AppSyncExecutionStrategy,
+  }): TransformerResolver => new TransformerResolver(
+    typeName,
+    fieldName,
+    resolverLogicalId,
+    undefined,
+    undefined,
+    requestSlots,
+    responseSlots,
+    datasource,
+    strategy,
+  );
 
   mapToStack = (stack: Stack) => {
     this.stack = stack;
@@ -162,10 +248,23 @@ export class TransformerResolver implements TransformerResolverProvider {
     return this.stackName ?? '';
   };
 
+  /**
+   * @deprecated use addToSlotWithStrategy, which supports all appsync runtimes
+   */
   addToSlot = (
     slotName: string,
     requestMappingTemplate?: MappingTemplateProvider,
     responseMappingTemplate?: MappingTemplateProvider,
+    dataSource?: DataSourceProvider,
+  ): void => this.addToSlotWithStrategy(
+    slotName,
+    { type: 'TEMPLATE', requestMappingTemplate, responseMappingTemplate },
+    dataSource,
+  );
+
+  addToSlotWithStrategy = (
+    slotName: string,
+    strategy: AppSyncExecutionStrategy,
     dataSource?: DataSourceProvider,
   ): void => {
     if (!this.slotNames.has(slotName)) {
@@ -178,75 +277,161 @@ export class TransformerResolver implements TransformerResolverProvider {
       slotEntry = [];
     }
 
-    if (this.slotExists(slotName, requestMappingTemplate, responseMappingTemplate)) {
-      this.updateSlot(slotName, requestMappingTemplate, responseMappingTemplate);
+    if (this.slotExistsForStrategy(slotName, strategy)) {
+      this.updateSlotForStrategy(slotName, strategy);
     } else {
-      slotEntry.push({
-        requestMappingTemplate,
-        responseMappingTemplate,
-        dataSource,
-      });
+      slotEntry.push({ strategy, dataSource });
     }
     this.slotMap.set(slotName, slotEntry);
   };
 
+  /**
+   * @deprecated - use slotExistsForStrategy instead.
+   */
   slotExists = (
     slotName: string,
     requestMappingTemplate?: MappingTemplateProvider,
     responseMappingTemplate?: MappingTemplateProvider,
-  ): boolean => this.findSlot(slotName, requestMappingTemplate, responseMappingTemplate) !== undefined
+  ) => this.slotExistsForStrategy(
+    slotName,
+    { type: 'TEMPLATE', requestMappingTemplate, responseMappingTemplate },
+  );
 
+  /**
+   * Determine if we can find an existing function in a given slot that matches up by name.
+   */
+  slotExistsForStrategy = (
+    slotName: string,
+    strategy: AppSyncExecutionStrategy,
+  ): boolean => this.findSlotForStrategy({ slotName, strategy }) !== undefined
+
+  /**
+   * Determine if the templates are already defined in a given slot, for use in the decision to create/update functions.
+   * @deprecated - use findSlotForStrategy instead
+   */
   findSlot = (
     slotName: string,
     requestMappingTemplate?: MappingTemplateProvider,
     responseMappingTemplate?: MappingTemplateProvider,
-  ): Slot | undefined => {
+  ) => this.findSlotForStrategy({
+    slotName,
+    strategy: { type: 'TEMPLATE', requestMappingTemplate, responseMappingTemplate} },
+  );
+
+  /**
+   * Find a slot for a given slot name and strategy, this is done by matching up the names, using trimmed names to
+   * compare between different strategy types.
+   * e.g. Query.getBlog.postDataLoad.1.req.vtl will collide with Query.getBlog.postDataLoad.1.js
+   */
+  findSlotForStrategy = ({
+    slotName,
+    strategy,
+  }: {
+    slotName: string,
+    strategy: AppSyncExecutionStrategy,
+  }): Slot | undefined => {
     const slotEntries = this.slotMap.get(slotName);
-    const requestMappingTemplateName = (requestMappingTemplate as any)?.name ?? '';
-    const responseMappingTemplateName = (responseMappingTemplate as any)?.name ?? '';
-    if (!slotEntries
-      || requestMappingTemplateName.includes('{slotIndex}')
-      || responseMappingTemplateName.includes('{slotIndex}')) {
+
+    const requestMappingTemplateName: string = strategy.type === 'TEMPLATE' ? (strategy.requestMappingTemplate as any)?.name?.replace(TEMPLATE_SLOT_FILENAME_PATTERN, '') ?? '' : '';
+    const responseMappingTemplateName: string = strategy.type === 'TEMPLATE' ? (strategy.responseMappingTemplate as any)?.name?.replace(TEMPLATE_SLOT_FILENAME_PATTERN, '') ?? '' : '';
+    const codeTemplateName: string = strategy.type === 'CODE' ? (strategy.code as any)?.name?.replace(FILE_FORMAT_PATTERN, '') ?? '' : '';
+
+    if (!slotEntries || [requestMappingTemplateName, responseMappingTemplateName, codeTemplateName].some(name => name.includes('{slotIndex}'))) {
       return;
     }
 
     let slotIndex = 1;
     for (const slotEntry of slotEntries) {
-      const [slotEntryRequestMappingTemplate, slotEntryResponseMappingTemplate] = [
-        (slotEntry.requestMappingTemplate as any)?.name ?? 'NOT-FOUND',
-        (slotEntry.responseMappingTemplate as any)?.name ?? 'NOT-FOUND',
-      ]
-        .map(name => name.replace('{slotName}', slotName).replace('{slotIndex}', slotIndex));
 
-      // If both request and response mapping templates are inline, skip check
-      if (slotEntryRequestMappingTemplate === '' && slotEntryResponseMappingTemplate === '') {
-        continue;
+      const isSameStrategyType = strategy.type === slotEntry.strategy.type;
+
+      switch(slotEntry.strategy.type) {
+        case 'TEMPLATE':
+          const [slotEntryRequestMappingTemplate, slotEntryResponseMappingTemplate]: string[] = [
+            (slotEntry.strategy.requestMappingTemplate as any)?.name ?? 'NOT-FOUND',
+            (slotEntry.strategy.responseMappingTemplate as any)?.name ?? 'NOT-FOUND',
+          ]
+            .map(name => name.replace('{slotName}', slotName).replace('{slotIndex}', slotIndex).replace(TEMPLATE_SLOT_FILENAME_PATTERN, ''));
+    
+          // If both request and response mapping templates are inline, skip check
+          if (slotEntryRequestMappingTemplate === '' && slotEntryResponseMappingTemplate === '') {
+            continue;
+          }
+    
+          // If type and name matches, then it is an overridden resolver
+          // If type mismatches and trimmed names match, then it is an overridden resolver
+          // This is really verbose, keeping it this way for now
+          if (
+            (isSameStrategyType && (
+              slotEntryRequestMappingTemplate === requestMappingTemplateName ||
+              slotEntryResponseMappingTemplate === responseMappingTemplateName
+            )) ||
+            (!isSameStrategyType && [slotEntryRequestMappingTemplate, slotEntryResponseMappingTemplate].some(name => name === codeTemplateName))
+          ) {
+            return slotEntry;
+          }
+          break;
+        case 'CODE':
+          const slotEntryCodeTemplate = ((slotEntry.strategy.code as any)?.name ?? 'NOT-FOUND')
+            .replace('{slotName}', slotName)
+            .replace('{slotIndex}', slotIndex)
+            .replace(FILE_FORMAT_PATTERN, '')
+
+          // If inline, skip check
+          if (slotEntryCodeTemplate === '') {
+            continue;
+          }
+    
+          // If type and name matches, then it is an overridden resolver
+          // If type mismatches and trimmed names match, then it is an overridden resolver
+          // This is really verbose, keeping it this way for now
+          if (
+            (isSameStrategyType && codeTemplateName === slotEntryCodeTemplate) ||
+            (!isSameStrategyType && [requestMappingTemplateName, responseMappingTemplateName].some(name => name === slotEntryCodeTemplate))
+          ) {
+            return slotEntry;
+          }
+          break;
       }
 
-      // If name matches, then it is an overridden resolver
-      if (
-        slotEntryRequestMappingTemplate === requestMappingTemplateName
-        || slotEntryResponseMappingTemplate === responseMappingTemplateName
-      ) {
-        return slotEntry;
-      }
       slotIndex++;
     }
   }
 
+  /**
+   * @deprecated - use updateSlotForStrategy instead
+   */
   updateSlot = (
     slotName: string,
     requestMappingTemplate?: MappingTemplateProvider,
     responseMappingTemplate?: MappingTemplateProvider,
+  ) => this.updateSlotForStrategy(
+    slotName,
+    { type: 'TEMPLATE', requestMappingTemplate, responseMappingTemplate },
+  );
+
+  /**
+   * Update an existing function with a new strategy, and merge templates if possible.
+   */
+ updateSlotForStrategy = (
+    slotName: string,
+    strategy: AppSyncExecutionStrategy,
   ): void => {
-    const slot = this.findSlot(slotName, requestMappingTemplate, responseMappingTemplate);
+    const slot = this.findSlotForStrategy({ slotName, strategy });
     if (slot) {
-      slot.requestMappingTemplate = (requestMappingTemplate as any)?.name
-        ? requestMappingTemplate
-        : slot.requestMappingTemplate;
-      slot.responseMappingTemplate = (responseMappingTemplate as any)?.name
-        ? responseMappingTemplate
-        : slot.responseMappingTemplate;
+      // If we're updating an atomic 'strategy', as in the case of code strategies, or when replacing a code strategy, replace whole hog.
+      if (strategy.type === 'CODE' || slot.strategy.type === 'CODE') {
+        slot.strategy = strategy;
+        return;
+      }
+
+      // If we're updating template-based mappings with another template mapping, merge in the templates (to allow independent req/res templates)
+      slot.strategy.requestMappingTemplate = (strategy.requestMappingTemplate as any)?.name
+        ? strategy.requestMappingTemplate
+        : slot.strategy.requestMappingTemplate;
+      slot.strategy.responseMappingTemplate = (strategy.responseMappingTemplate as any)?.name
+        ? strategy.responseMappingTemplate
+        : slot.strategy.responseMappingTemplate;
     }
   }
 
@@ -255,13 +440,12 @@ export class TransformerResolver implements TransformerResolverProvider {
     this.ensureNoneDataSource(api);
     const requestFns = this.synthesizeResolvers(stack, api, this.requestSlots);
     const responseFns = this.synthesizeResolvers(stack, api, this.responseSlots);
-    // substitue template name values
-    [this.requestMappingTemplate, this.requestMappingTemplate].map(template => this.substitueSlotInfo(template, 'main', 0));
+      
+    this.substituteSlotInfoForStrategy(this.strategy, 'main', 0);
 
-    const dataSourceProviderFn = api.host.addAppSyncFunction(
+    const dataSourceProviderFn = api.host.addAppSyncFunctionWithStrategy(
       toPascalCase([this.typeName, this.fieldName, 'DataResolverFn']),
-      this.requestMappingTemplate,
-      this.responseMappingTemplate,
+      this.strategy,
       this.datasource?.name || NONE_DATA_SOURCE_NAME,
       stack,
     );
@@ -356,11 +540,14 @@ export class TransformerResolver implements TransformerResolverProvider {
       `;
     }
     initResolver += '\n$util.toJson({})';
-    api.host.addResolver(
+    api.host.addResolverWithStrategy(
       this.typeName,
       this.fieldName,
-      MappingTemplate.inlineTemplateFromString(initResolver),
-      MappingTemplate.inlineTemplateFromString('$util.toJson($ctx.prev.result)'),
+      {
+        type: 'TEMPLATE',
+        requestMappingTemplate: MappingTemplate.inlineTemplateFromString(initResolver),
+        responseMappingTemplate: MappingTemplate.inlineTemplateFromString('$util.toJson($ctx.prev.result)'),
+      },
       this.resolverLogicalId,
       undefined,
       [...requestFns, dataSourceProviderFn, ...responseFns].map(fn => fn.functionId),
@@ -368,6 +555,10 @@ export class TransformerResolver implements TransformerResolverProvider {
     );
   };
 
+  /**
+   * For all functions in all defined slots, render out to AppSyncFunctionConfigurationProviders,
+   * attached to the relevant stacks and api.
+   */
   synthesizeResolvers = (stack: Stack, api: GraphQLAPIProvider, slotsNames: string[]): AppSyncFunctionConfigurationProvider[] => {
     const appSyncFunctions: AppSyncFunctionConfigurationProvider[] = [];
 
@@ -378,19 +569,16 @@ export class TransformerResolver implements TransformerResolverProvider {
         let index = 0;
         for (const slotItem of slotEntries!) {
           const name = `${this.typeName}${this.fieldName}${slotName}${index++}Function`;
-          const { requestMappingTemplate, responseMappingTemplate, dataSource } = slotItem;
-          // eslint-disable-next-line no-unused-expressions
-          requestMappingTemplate && this.substitueSlotInfo(requestMappingTemplate, slotName, index);
-          // eslint-disable-next-line no-unused-expressions
-          responseMappingTemplate && this.substitueSlotInfo(responseMappingTemplate, slotName, index);
-          const fn = api.host.addAppSyncFunction(
+          const { strategy, dataSource } = slotItem;
+
+          this.substituteSlotInfoForStrategy(strategy, slotName, index);
+
+          appSyncFunctions.push(api.host.addAppSyncFunctionWithStrategy(
             name,
-            requestMappingTemplate || MappingTemplate.inlineTemplateFromString('$util.toJson({})'),
-            responseMappingTemplate || MappingTemplate.inlineTemplateFromString('$util.toJson({})'),
+            this.imputeMappingTemplates(strategy),
             dataSource?.name || NONE_DATA_SOURCE_NAME,
             stack,
-          );
-          appSyncFunctions.push(fn);
+          ));
         }
       }
     }
@@ -398,15 +586,38 @@ export class TransformerResolver implements TransformerResolverProvider {
   };
 
   /**
-   * substitueSlotInfo
+   * For TEMPLATE based strategies, fill in either a missing req or res mapping template.
    */
-  private substitueSlotInfo(template: MappingTemplateProvider, slotName: string, index: number) {
-    // Check the constructor name instead of using 'instanceof' because the latter does not work
-    // with copies of the class, which happens with custom transformers.
-    // See: https://github.com/aws-amplify/amplify-cli/issues/9362
-    if (template.constructor.name === S3MappingTemplate.name) {
-      (template as S3MappingTemplate).substitueValues({ slotName, slotIndex: index, typeName: this.typeName, fieldName: this.fieldName });
+  private imputeMappingTemplates = (strategy: AppSyncExecutionStrategy): AppSyncExecutionStrategy => {
+    if (strategy.type === 'CODE') {
+      return strategy;
     }
+
+    return {
+      type: strategy.type,
+      requestMappingTemplate: strategy.requestMappingTemplate || MappingTemplate.inlineTemplateFromString('$util.toJson({})'),
+      responseMappingTemplate: strategy.responseMappingTemplate || MappingTemplate.inlineTemplateFromString('$util.toJson({})'),
+    }
+  };
+
+  /**
+   * Perform substitutions in the Mapping names for all mappings in a strategy.
+   */
+  private substituteSlotInfoForStrategy(strategy: AppSyncExecutionStrategy, slotName: string, index: number) {
+    [
+      (strategy as AppSyncTemplateExecutionStrategy).requestMappingTemplate,
+      (strategy as AppSyncTemplateExecutionStrategy).responseMappingTemplate,
+      (strategy as AppSyncCodeExecutionStrategy).code,
+    ]
+      .filter(template => template !== undefined)
+      .forEach(template => {
+        // Check the constructor name instead of using 'instanceof' because the latter does not work
+        // with copies of the class, which happens with custom transformers.
+        // See: https://github.com/aws-amplify/amplify-cli/issues/9362
+        if (template?.constructor.name === S3MappingTemplate.name) {
+          (template as S3MappingTemplate).substitueValues({ slotName, slotIndex: index, typeName: this.typeName, fieldName: this.fieldName });
+        }
+      });
   }
 
   /**

--- a/packages/amplify-graphql-transformer-core/src/utils/execution-strategy-utils.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/execution-strategy-utils.ts
@@ -1,0 +1,49 @@
+import {
+  AppSyncCodeExecutionStrategy,
+  AppSyncExecutionStrategy,
+  AppSyncTemplateExecutionStrategy,
+} from "@aws-amplify/graphql-transformer-interfaces";
+import { CfnResolverProps } from "@aws-cdk/aws-appsync";
+import { Construct } from "@aws-cdk/core";
+import { InlineTemplate } from "../cdk-compat";
+
+type CfnResolverStrategyProps =
+  | Pick<
+    CfnResolverProps,
+    | 'requestMappingTemplate'
+    | 'requestMappingTemplateS3Location'
+    | 'responseMappingTemplate'
+    | 'responseMappingTemplateS3Location'
+  >
+  | Pick<
+    CfnResolverProps,
+    | 'code'
+    | 'codeS3Location'
+    | 'runtime'
+  >;
+
+export const getStrategyProps = (scope: Construct, strategy: AppSyncExecutionStrategy): CfnResolverStrategyProps => {
+  const requestTemplateLocation = (strategy as AppSyncTemplateExecutionStrategy).requestMappingTemplate?.bind(scope);
+  const responseTemplateLocation = (strategy as AppSyncTemplateExecutionStrategy).responseMappingTemplate?.bind(scope);
+  const codeLocation = (strategy as AppSyncCodeExecutionStrategy).code?.bind(scope);
+
+  switch (strategy.type) {
+    case 'TEMPLATE':
+      return {
+        ...(strategy.requestMappingTemplate instanceof InlineTemplate
+          ? { requestMappingTemplate: requestTemplateLocation }
+          : { requestMappingTemplateS3Location: requestTemplateLocation }),
+        ...(strategy.responseMappingTemplate instanceof InlineTemplate
+          ? { responseMappingTemplate: responseTemplateLocation }
+          : { responseMappingTemplateS3Location: responseTemplateLocation }),
+      };
+    case 'CODE': {
+      return {
+        ...(strategy.code instanceof InlineTemplate
+          ? { code: codeLocation }
+          : { codeS3Location: codeLocation }),
+        runtime: strategy.runtime,
+      };
+    }
+  }
+};

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -104,6 +104,13 @@ export type AppSyncAuthConfigurationUserPoolEntry = {
 export type AppSyncAuthMode = 'API_KEY' | 'AMAZON_COGNITO_USER_POOLS' | 'AWS_IAM' | 'OPENID_CONNECT' | 'AWS_LAMBDA';
 
 // @public (undocumented)
+export type AppSyncCodeExecutionStrategy = {
+    type: 'CODE';
+    code: MappingTemplateProvider;
+    runtime: AppSyncRuntime;
+};
+
+// @public (undocumented)
 export enum AppSyncDataSourceType {
     // (undocumented)
     AMAZON_DYNAMODB = "AMAZON_DYNAMODB",
@@ -120,12 +127,28 @@ export enum AppSyncDataSourceType {
 }
 
 // @public (undocumented)
+export type AppSyncExecutionStrategy = AppSyncTemplateExecutionStrategy | AppSyncCodeExecutionStrategy;
+
+// @public (undocumented)
 export interface AppSyncFunctionConfigurationProvider extends IConstruct {
     // (undocumented)
     readonly arn: string;
     // (undocumented)
     readonly functionId: string;
 }
+
+// @public (undocumented)
+export type AppSyncRuntime = {
+    name: string;
+    runtimeVersion: string;
+};
+
+// @public (undocumented)
+export type AppSyncTemplateExecutionStrategy = {
+    type: 'TEMPLATE';
+    requestMappingTemplate?: MappingTemplateProvider;
+    responseMappingTemplate?: MappingTemplateProvider;
+};
 
 // Warning: (ae-forgotten-export) The symbol "NoneDataSourceProvider" needs to be exported by the entry point index.d.ts
 //
@@ -557,6 +580,8 @@ export interface TransformerResolverProvider {
     // (undocumented)
     addToSlot: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider, dataSource?: DataSourceProvider) => void;
     // (undocumented)
+    addToSlotWithStrategy: (slotName: string, strategy: AppSyncExecutionStrategy, dataSource?: DataSourceProvider) => void;
+    // (undocumented)
     mapToStack: (stack: Stack) => void;
     // (undocumented)
     synthesize: (context: TransformerContextProvider, api: GraphQLAPIProvider) => void;
@@ -571,9 +596,15 @@ export interface TransformerResolversManagerProvider {
     // (undocumented)
     generateMutationResolver: (typeName: string, fieldName: string, resolverLogicalId: string, dataSource: DataSourceProvider, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider) => TransformerResolverProvider;
     // (undocumented)
+    generateMutationResolverWithStrategy: (typeName: string, fieldName: string, resolverLogicalId: string, dataSource: DataSourceProvider, strategy: AppSyncExecutionStrategy) => TransformerResolverProvider;
+    // (undocumented)
     generateQueryResolver: (typeName: string, fieldName: string, resolverLogicalId: string, dataSource: DataSourceProvider, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider) => TransformerResolverProvider;
     // (undocumented)
+    generateQueryResolverWithStrategy: (typeName: string, fieldName: string, resolverLogicalId: string, dataSource: DataSourceProvider, strategy: AppSyncExecutionStrategy) => TransformerResolverProvider;
+    // (undocumented)
     generateSubscriptionResolver: (typeName: string, fieldName: string, resolverLogicalId: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider) => TransformerResolverProvider;
+    // (undocumented)
+    generateSubscriptionResolverWithStrategy: (typeName: string, fieldName: string, resolverLogicalId: string, strategy: AppSyncExecutionStrategy) => TransformerResolverProvider;
     // (undocumented)
     getResolver: (typeName: string, fieldName: string) => TransformerResolverProvider | void;
     // (undocumented)
@@ -628,6 +659,8 @@ export interface TransformHostProvider {
     // (undocumented)
     addAppSyncFunction: (name: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider, dataSourceName: string, stack?: Stack) => AppSyncFunctionConfigurationProvider;
     // (undocumented)
+    addAppSyncFunctionWithStrategy: (name: string, strategy: AppSyncExecutionStrategy, dataSourceName: string, stack?: Stack) => AppSyncFunctionConfigurationProvider;
+    // (undocumented)
     addDynamoDbDataSource(name: string, table: ITable, options?: DynamoDbDataSourceOptions, stack?: Stack): DynamoDbDataSource;
     // (undocumented)
     addHttpDataSource(name: string, endpoint: string, options?: DataSourceOptions, stack?: Stack): HttpDataSource;
@@ -641,6 +674,8 @@ export interface TransformHostProvider {
     addNoneDataSource(name: string, options?: DataSourceOptions, stack?: Stack): NoneDataSource;
     // (undocumented)
     addResolver: (typeName: string, fieldName: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider, resolverLogicalId?: string, dataSourceName?: string, pipelineConfig?: string[], stack?: Stack) => CfnResolver;
+    // (undocumented)
+    addResolverWithStrategy: (typeName: string, fieldName: string, strategy: AppSyncExecutionStrategy, resolverLogicalId?: string, dataSourceName?: string, pipelineConfig?: string[], stack?: Stack) => CfnResolver;
     // (undocumented)
     addSearchableDataSource(name: string, endpoint: string, region: string, options?: SearchableDataSourceOptions, stack?: Stack): BaseDataSource;
     // (undocumented)

--- a/packages/amplify-graphql-transformer-interfaces/package.json
+++ b/packages/amplify-graphql-transformer-interfaces/package.json
@@ -27,7 +27,7 @@
     "extract-api": "ts-node ../../scripts/extract-api.ts"
   },
   "dependencies": {
-    "@aws-cdk/aws-appsync": "~1.172.0",
+    "@aws-cdk/aws-appsync": "~1.183.0",
     "@aws-cdk/aws-cloudwatch": "~1.172.0",
     "@aws-cdk/aws-dynamodb": "~1.172.0",
     "@aws-cdk/aws-ec2": "~1.172.0",

--- a/packages/amplify-graphql-transformer-interfaces/src/appsync-execution-strategy.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/appsync-execution-strategy.ts
@@ -1,0 +1,20 @@
+import { MappingTemplateProvider } from "./graphql-api-provider";
+
+export type AppSyncRuntime = {
+  name: string;
+  runtimeVersion: string;
+};
+
+export type AppSyncTemplateExecutionStrategy = {
+  type: 'TEMPLATE',
+  requestMappingTemplate?: MappingTemplateProvider,
+  responseMappingTemplate?: MappingTemplateProvider,
+};
+
+export type AppSyncCodeExecutionStrategy = {
+  type: 'CODE',
+  code: MappingTemplateProvider,
+  runtime: AppSyncRuntime,
+};
+
+export type AppSyncExecutionStrategy = AppSyncTemplateExecutionStrategy | AppSyncCodeExecutionStrategy;

--- a/packages/amplify-graphql-transformer-interfaces/src/index.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/index.ts
@@ -9,7 +9,7 @@ export {
   TransformerAuthProvider,
 } from './transformer-model-provider';
 export { FeatureFlagProvider } from './feature-flag-provider';
-
+export * from './appsync-execution-strategy';
 export {
   GraphQLAPIProvider,
   AppSyncFunctionConfigurationProvider,

--- a/packages/amplify-graphql-transformer-interfaces/src/transform-host-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transform-host-provider.ts
@@ -17,6 +17,7 @@ import {
   MappingTemplateProvider,
 } from './graphql-api-provider';
 import { IRole } from '@aws-cdk/aws-iam';
+import { AppSyncExecutionStrategy } from './appsync-execution-strategy';
 
 export interface DynamoDbDataSourceOptions extends DataSourceOptions {
   /**
@@ -40,6 +41,9 @@ export interface TransformHostProvider {
     stack?: Stack,
   ): BaseDataSource;
 
+  /**
+   * @deprecated Use addAppSyncFunctionWithStrategy, which adds support for all AppSync runtimes.
+   */
   addAppSyncFunction: (
     name: string,
     requestMappingTemplate: MappingTemplateProvider,
@@ -48,11 +52,31 @@ export interface TransformHostProvider {
     stack?: Stack,
   ) => AppSyncFunctionConfigurationProvider;
 
+  addAppSyncFunctionWithStrategy: (
+    name: string,
+    strategy: AppSyncExecutionStrategy,
+    dataSourceName: string,
+    stack?: Stack,
+  ) => AppSyncFunctionConfigurationProvider;
+
+  /**
+   * @deprecated Use addResolverWithStrategy, which supports all AppSync runtimes.
+   */
   addResolver: (
     typeName: string,
     fieldName: string,
     requestMappingTemplate: MappingTemplateProvider,
     responseMappingTemplate: MappingTemplateProvider,
+    resolverLogicalId?: string,
+    dataSourceName?: string,
+    pipelineConfig?: string[],
+    stack?: Stack,
+  ) => CfnResolver;
+
+  addResolverWithStrategy: (
+    typeName: string,
+    fieldName: string,
+    strategy: AppSyncExecutionStrategy,
     resolverLogicalId?: string,
     dataSourceName?: string,
     pipelineConfig?: string[],

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-resolver-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-resolver-provider.ts
@@ -2,12 +2,21 @@ import { Stack } from '@aws-cdk/core';
 import { GraphQLAPIProvider, MappingTemplateProvider } from '../graphql-api-provider';
 import { DataSourceProvider } from './transformer-datasource-provider';
 import { TransformerContextProvider } from './transformer-context-provider';
+import { AppSyncExecutionStrategy } from '../appsync-execution-strategy';
 
 export interface TransformerResolverProvider {
+  /**
+   * @deprecated use addToSlotWithStrategy, which supports all appsync runtimes
+   */
   addToSlot: (
     slotName: string,
     requestMappingTemplate?: MappingTemplateProvider,
     responseMappingTemplate?: MappingTemplateProvider,
+    dataSource?: DataSourceProvider,
+  ) => void;
+  addToSlotWithStrategy: (
+    slotName: string,
+    strategy: AppSyncExecutionStrategy,
     dataSource?: DataSourceProvider,
   ) => void;
   synthesize: (context: TransformerContextProvider, api: GraphQLAPIProvider) => void;
@@ -21,6 +30,9 @@ export interface TransformerResolversManagerProvider {
   removeResolver: (typeName: string, fieldName: string) => TransformerResolverProvider;
   collectResolvers: () => Map<string, TransformerResolverProvider>;
 
+  /**
+   * @deprecated use generateQueryResolverWithStrategy, which supports all appsync runtimes
+   */
   generateQueryResolver: (
     typeName: string,
     fieldName: string,
@@ -30,6 +42,17 @@ export interface TransformerResolversManagerProvider {
     responseMappingTemplate: MappingTemplateProvider,
   ) => TransformerResolverProvider;
 
+  generateQueryResolverWithStrategy: (
+    typeName: string,
+    fieldName: string,
+    resolverLogicalId: string,
+    dataSource: DataSourceProvider,
+    strategy: AppSyncExecutionStrategy,
+  ) => TransformerResolverProvider;
+
+  /**
+   * @deprecated use generateMutationResolverWithStrategy, which supports all appsync runtimes
+   */
   generateMutationResolver: (
     typeName: string,
     fieldName: string,
@@ -39,11 +62,29 @@ export interface TransformerResolversManagerProvider {
     responseMappingTemplate: MappingTemplateProvider,
   ) => TransformerResolverProvider;
 
+  generateMutationResolverWithStrategy: (
+    typeName: string,
+    fieldName: string,
+    resolverLogicalId: string,
+    dataSource: DataSourceProvider,
+    strategy: AppSyncExecutionStrategy,
+  ) => TransformerResolverProvider;
+
+  /**
+   * @deprecated use generateSubscriptionResolverWithStrategy, which supports all appsync runtimes
+   */
   generateSubscriptionResolver: (
     typeName: string,
     fieldName: string,
     resolverLogicalId: string,
     requestMappingTemplate: MappingTemplateProvider,
     responseMappingTemplate: MappingTemplateProvider,
+  ) => TransformerResolverProvider;
+
+  generateSubscriptionResolverWithStrategy: (
+    typeName: string,
+    fieldName: string,
+    resolverLogicalId: string,
+    strategy: AppSyncExecutionStrategy,
   ) => TransformerResolverProvider;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,6 +219,46 @@
     prettier "^1.19.1"
     yargs "^15.1.0"
 
+"@aws-amplify/graphql-transformer-core@^0.17.12":
+  version "0.17.15"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/graphql-transformer-core/-/graphql-transformer-core-0.17.15.tgz#f5f6bffc3520dd2f05419a040fbe29a8384a1c6f"
+  integrity sha512-B+zyht8Z7N/emjyeXJ5nh/YYSy2PBDPVz3i6RQqoxa24AYqc/fo0+Tz6bw5RzqbKE3K50pJnfb9MfV08lYqUNg==
+  dependencies:
+    "@aws-amplify/graphql-transformer-interfaces" "1.14.9"
+    "@aws-cdk/aws-applicationautoscaling" "~1.172.0"
+    "@aws-cdk/aws-appsync" "~1.172.0"
+    "@aws-cdk/aws-certificatemanager" "~1.172.0"
+    "@aws-cdk/aws-cloudwatch" "~1.172.0"
+    "@aws-cdk/aws-codeguruprofiler" "~1.172.0"
+    "@aws-cdk/aws-cognito" "~1.172.0"
+    "@aws-cdk/aws-dynamodb" "~1.172.0"
+    "@aws-cdk/aws-ec2" "~1.172.0"
+    "@aws-cdk/aws-efs" "~1.172.0"
+    "@aws-cdk/aws-elasticsearch" "~1.172.0"
+    "@aws-cdk/aws-events" "~1.172.0"
+    "@aws-cdk/aws-iam" "~1.172.0"
+    "@aws-cdk/aws-kms" "~1.172.0"
+    "@aws-cdk/aws-lambda" "~1.172.0"
+    "@aws-cdk/aws-logs" "~1.172.0"
+    "@aws-cdk/aws-route53" "~1.172.0"
+    "@aws-cdk/aws-s3" "~1.172.0"
+    "@aws-cdk/aws-s3-assets" "~1.172.0"
+    "@aws-cdk/aws-sqs" "~1.172.0"
+    "@aws-cdk/cloud-assembly-schema" "~1.172.0"
+    "@aws-cdk/core" "~1.172.0"
+    "@aws-cdk/custom-resources" "~1.172.0"
+    "@aws-cdk/cx-api" "~1.172.0"
+    "@aws-cdk/region-info" "~1.172.0"
+    constructs "^3.3.125"
+    fs-extra "^8.1.0"
+    graphql "^14.5.8"
+    graphql-transformer-common "4.24.0"
+    lodash "^4.17.21"
+    md5 "^2.3.0"
+    object-hash "^3.0.0"
+    ts-dedent "^2.0.0"
+    vm2 "^3.9.8"
+
 "@aws-amplify/graphql-types-generator@3.0.0":
   version "3.0.0"
   resolved "https://registry.npmjs.org/@aws-amplify/graphql-types-generator/-/graphql-types-generator-3.0.0.tgz#6e9dba889ed303fc7c46248154f36d8ba4a30aee"
@@ -348,6 +388,14 @@
     "@aws-cdk/core" "1.172.0"
     constructs "^3.3.69"
 
+"@aws-cdk/aws-acmpca@1.183.0":
+  version "1.183.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-acmpca/-/aws-acmpca-1.183.0.tgz#a4450bbc509b7c8d39461f522a538a64c937e2d7"
+  integrity sha512-lJHElE2H8hsA6I69igWMUM9Bswp5zQ882yySyAWPJWemBDPXlKyqc9lwgbhtBnE6ThLYQCBZUojrkFf9kCCYtA==
+  dependencies:
+    "@aws-cdk/core" "1.183.0"
+    constructs "^3.3.69"
+
 "@aws-cdk/aws-apigateway@1.172.0", "@aws-cdk/aws-apigateway@^1.159.0", "@aws-cdk/aws-apigateway@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-1.172.0.tgz#86563deb3b6d6a303ab0736995149451e22d4eb7"
@@ -392,23 +440,23 @@
     "@aws-cdk/core" "1.172.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-appsync@^1.159.0", "@aws-cdk/aws-appsync@~1.172.0":
-  version "1.172.0"
-  resolved "https://registry.npmjs.org/@aws-cdk/aws-appsync/-/aws-appsync-1.172.0.tgz#f54365c1e8814b7b221dbf6cc00b5841e1e3614e"
-  integrity sha512-eWzMQyZMk6mCko3ToHTnsl2yGR/Tvx6UxsVidEP6HxdLE/DBTyYUENqK0h29q6OTxThtyq3oMTGXKCu/Egg7+g==
+"@aws-cdk/aws-appsync@^1.159.0", "@aws-cdk/aws-appsync@~1.172.0", "@aws-cdk/aws-appsync@~1.183.0":
+  version "1.183.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-appsync/-/aws-appsync-1.183.0.tgz#6d978dd9c3ad3072bbb00af41487a75af6b646c7"
+  integrity sha512-CcU9/wYNpqxlFc1CGAAeQaEChA9wVyic3Y0yu8d7y3SPhPP/a6mm36gKWNXlJT0aFTEb3+WSdzBzgEEaNzYywg==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.172.0"
-    "@aws-cdk/aws-cognito" "1.172.0"
-    "@aws-cdk/aws-dynamodb" "1.172.0"
-    "@aws-cdk/aws-ec2" "1.172.0"
-    "@aws-cdk/aws-elasticsearch" "1.172.0"
-    "@aws-cdk/aws-iam" "1.172.0"
-    "@aws-cdk/aws-lambda" "1.172.0"
-    "@aws-cdk/aws-opensearchservice" "1.172.0"
-    "@aws-cdk/aws-rds" "1.172.0"
-    "@aws-cdk/aws-s3-assets" "1.172.0"
-    "@aws-cdk/aws-secretsmanager" "1.172.0"
-    "@aws-cdk/core" "1.172.0"
+    "@aws-cdk/aws-certificatemanager" "1.183.0"
+    "@aws-cdk/aws-cognito" "1.183.0"
+    "@aws-cdk/aws-dynamodb" "1.183.0"
+    "@aws-cdk/aws-ec2" "1.183.0"
+    "@aws-cdk/aws-elasticsearch" "1.183.0"
+    "@aws-cdk/aws-iam" "1.183.0"
+    "@aws-cdk/aws-lambda" "1.183.0"
+    "@aws-cdk/aws-opensearchservice" "1.183.0"
+    "@aws-cdk/aws-rds" "1.183.0"
+    "@aws-cdk/aws-s3-assets" "1.183.0"
+    "@aws-cdk/aws-secretsmanager" "1.183.0"
+    "@aws-cdk/core" "1.183.0"
     constructs "^3.3.69"
 
 "@aws-cdk/aws-autoscaling-common@1.172.0":
@@ -463,6 +511,19 @@
     "@aws-cdk/core" "1.172.0"
     constructs "^3.3.69"
 
+"@aws-cdk/aws-certificatemanager@1.183.0":
+  version "1.183.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.183.0.tgz#2c350cda273afca69b47106d545fd433800a564a"
+  integrity sha512-zzWLyoNF6iImHG76+3N49wjHJFe93vbqO9GcOnoQvE4JdUnLLBeDXeWM65gmkj16lN5UnjpJeE10wITqnfSAVA==
+  dependencies:
+    "@aws-cdk/aws-acmpca" "1.183.0"
+    "@aws-cdk/aws-cloudwatch" "1.183.0"
+    "@aws-cdk/aws-iam" "1.183.0"
+    "@aws-cdk/aws-lambda" "1.183.0"
+    "@aws-cdk/aws-route53" "1.183.0"
+    "@aws-cdk/core" "1.183.0"
+    constructs "^3.3.69"
+
 "@aws-cdk/aws-cloudformation@1.172.0", "@aws-cdk/aws-cloudformation@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.172.0.tgz#1ac855fa3a629d27084fdcf854a4bc356a434abf"
@@ -474,6 +535,19 @@
     "@aws-cdk/aws-sns" "1.172.0"
     "@aws-cdk/core" "1.172.0"
     "@aws-cdk/cx-api" "1.172.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-cloudformation@1.183.0":
+  version "1.183.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.183.0.tgz#94355a69ab2fcc50706c7f4ee369d1b42d71e26d"
+  integrity sha512-xEGjLPLdJLcTlW7+dNZ1UV7Mb1FCxJ50ozPpJSmdd1/bEXOJ2f6e0rFm8MiOBxQJsbIQksfLoS/xEjxWu+XffQ==
+  dependencies:
+    "@aws-cdk/aws-iam" "1.183.0"
+    "@aws-cdk/aws-lambda" "1.183.0"
+    "@aws-cdk/aws-s3" "1.183.0"
+    "@aws-cdk/aws-sns" "1.183.0"
+    "@aws-cdk/core" "1.183.0"
+    "@aws-cdk/cx-api" "1.183.0"
     constructs "^3.3.69"
 
 "@aws-cdk/aws-cloudfront@1.172.0", "@aws-cdk/aws-cloudfront@~1.172.0":
@@ -493,7 +567,7 @@
     "@aws-cdk/cx-api" "1.172.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudwatch@1.172.0", "@aws-cdk/aws-cloudwatch@^1.159.0", "@aws-cdk/aws-cloudwatch@~1.172.0":
+"@aws-cdk/aws-cloudwatch@1.172.0", "@aws-cdk/aws-cloudwatch@1.183.0", "@aws-cdk/aws-cloudwatch@^1.159.0", "@aws-cdk/aws-cloudwatch@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.172.0.tgz#125b197a2b5497e5519e8963f710a2f4371feffc"
   integrity sha512-Sk/LUDfZyK9tAjvqLimTFZ7Bt9V9lt0ax66WxofdkFWzta+6T8Gsw+Y02NYcsTKl5OVKJocZErXiYkZichwRwA==
@@ -611,7 +685,7 @@
     "@aws-cdk/core" "1.172.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cognito@1.172.0", "@aws-cdk/aws-cognito@^1.159.0", "@aws-cdk/aws-cognito@~1.172.0":
+"@aws-cdk/aws-cognito@1.172.0", "@aws-cdk/aws-cognito@1.183.0", "@aws-cdk/aws-cognito@^1.159.0", "@aws-cdk/aws-cognito@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.172.0.tgz#8cadd83d52bbcd8cc588ad281c9cc6efdafc132c"
   integrity sha512-Owq17lrFsTk5SHt9szc1y406cXlBPshBwkpGgGCpzm9nnCVlOR72Swfp1BRSemYt8IlObS8lxlz1vgCus+qqhw==
@@ -625,7 +699,7 @@
     constructs "^3.3.69"
     punycode "^2.1.1"
 
-"@aws-cdk/aws-dynamodb@1.172.0", "@aws-cdk/aws-dynamodb@^1.159.0", "@aws-cdk/aws-dynamodb@~1.172.0":
+"@aws-cdk/aws-dynamodb@1.183.0", "@aws-cdk/aws-dynamodb@^1.159.0", "@aws-cdk/aws-dynamodb@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.172.0.tgz#78aefd44fc3bad996092b5a43b2ae05aedefdcc3"
   integrity sha512-xuEPPJYMDZDonzQfSGUqsPeUpfQeBrp1OipqSTjDMXPagHDvn2ewiM7tniLPVYTdMN/9Fci5UnIUtZHxrXEXrQ==
@@ -640,7 +714,7 @@
     "@aws-cdk/custom-resources" "1.172.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-ec2@1.172.0", "@aws-cdk/aws-ec2@^1.159.0", "@aws-cdk/aws-ec2@~1.172.0":
+"@aws-cdk/aws-ec2@1.172.0", "@aws-cdk/aws-ec2@1.183.0", "@aws-cdk/aws-ec2@^1.159.0", "@aws-cdk/aws-ec2@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.172.0.tgz#e10ed2cc050d2ab03ad23ba705349cf89693b7f2"
   integrity sha512-rBDxpCDm9m9Fuq6+o7Bblkhj2hVEzlh1NDt8tAV/cVncy+ywZGOx7kjELjAFoj2h4e+XS8QS4QLfQT/mFUYccA==
@@ -754,7 +828,7 @@
     "@aws-cdk/region-info" "1.172.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-elasticsearch@1.172.0", "@aws-cdk/aws-elasticsearch@^1.159.0", "@aws-cdk/aws-elasticsearch@~1.172.0":
+"@aws-cdk/aws-elasticsearch@1.183.0", "@aws-cdk/aws-elasticsearch@^1.159.0", "@aws-cdk/aws-elasticsearch@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/aws-elasticsearch/-/aws-elasticsearch-1.172.0.tgz#eb7dcfc0405a3fe40f9de333b95cdb3855a2db63"
   integrity sha512-gQJ1Bi6A9wqSUOvE84idBky5CGQ44Z5CIUR1jzwg69mkppggqYsYKbcAVN6Vikd9ei2TW4IaVYQGYky6gQhyig==
@@ -797,7 +871,7 @@
     "@aws-cdk/custom-resources" "1.172.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-events@1.172.0", "@aws-cdk/aws-events@^1.159.0", "@aws-cdk/aws-events@~1.172.0":
+"@aws-cdk/aws-events@1.172.0", "@aws-cdk/aws-events@1.183.0", "@aws-cdk/aws-events@^1.159.0", "@aws-cdk/aws-events@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.172.0.tgz#a870f5654554cfa5807b00899ab30bbcd7288f97"
   integrity sha512-Ovcd/MCQ35wqdirdzCLc125+XTd4Fm/MOhUwB5YOpytVxijFSb7NNnrobI1bJBHNrUZutUPGjQseB/mqh/1nhQ==
@@ -816,7 +890,7 @@
     "@aws-cdk/custom-resources" "1.172.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-iam@1.172.0", "@aws-cdk/aws-iam@^1.159.0", "@aws-cdk/aws-iam@~1.172.0":
+"@aws-cdk/aws-iam@1.172.0", "@aws-cdk/aws-iam@1.183.0", "@aws-cdk/aws-iam@^1.159.0", "@aws-cdk/aws-iam@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.172.0.tgz#32c09c11860fa8a70049b80d07065f2799bb755e"
   integrity sha512-9E2iU9kHTCPMIa5K95/Ypeeiov6GCDdJFoyJuE24KaQ2Un+UJNDl0BG9T02CmB7xGXwQKcn5BP+dkThR0n3DMQ==
@@ -855,7 +929,7 @@
     "@aws-cdk/region-info" "1.172.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-kms@1.172.0", "@aws-cdk/aws-kms@^1.159.0", "@aws-cdk/aws-kms@~1.172.0":
+"@aws-cdk/aws-kms@1.172.0", "@aws-cdk/aws-kms@1.183.0", "@aws-cdk/aws-kms@^1.159.0", "@aws-cdk/aws-kms@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.172.0.tgz#8d651b07ac72ba281656647d8e79dad6e16309af"
   integrity sha512-0qDstcobbjDNFTRlflMXo4MTubJibjLJ4qFr8Ot14teqUGhfelNaTm19RYb+pOcxA6ypFEuUMl50PjMXj3iuHw==
@@ -866,7 +940,7 @@
     "@aws-cdk/cx-api" "1.172.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-lambda@1.172.0", "@aws-cdk/aws-lambda@^1.159.0", "@aws-cdk/aws-lambda@~1.172.0":
+"@aws-cdk/aws-lambda@1.172.0", "@aws-cdk/aws-lambda@1.183.0", "@aws-cdk/aws-lambda@^1.159.0", "@aws-cdk/aws-lambda@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.172.0.tgz#ddf02cf8128a47b952895eb08426bd678027aa94"
   integrity sha512-7jx0wmJWbD+FRL/8VeTr3PMYkYW1b66DYwX8DyAPvuNeMXcmHWu3GvOo/AV/F8K/SHBm6dEilWQeJGAVDxltmg==
@@ -892,7 +966,7 @@
     "@aws-cdk/region-info" "1.172.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-logs@1.172.0", "@aws-cdk/aws-logs@^1.159.0", "@aws-cdk/aws-logs@~1.172.0":
+"@aws-cdk/aws-logs@1.172.0", "@aws-cdk/aws-logs@1.183.0", "@aws-cdk/aws-logs@^1.159.0", "@aws-cdk/aws-logs@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.172.0.tgz#826214e406448fd0fc3399ece7809e8c4f76b7ed"
   integrity sha512-tCPWS5Xyd7jw5BDetyzsJN+uudaMDgxUPK5G+9O+WoqRVsP8iUlPuIW+akGZhvqEcHux+P1t9ANLO+NvV3ZrbA==
@@ -905,26 +979,43 @@
     "@aws-cdk/cx-api" "1.172.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-opensearchservice@1.172.0":
-  version "1.172.0"
-  resolved "https://registry.npmjs.org/@aws-cdk/aws-opensearchservice/-/aws-opensearchservice-1.172.0.tgz#9cd68d98710137f54bb82579c4ce1d92730ff4a1"
-  integrity sha512-VJoF8w1HPG8Dwh0UWuWNx/mu389v2Nuq+qQcxA2S89/vBayUo3AoxPgFusCd88vIeYnHc8xEzj2SGvbFBWR2Jw==
+"@aws-cdk/aws-opensearchservice@1.183.0":
+  version "1.183.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-opensearchservice/-/aws-opensearchservice-1.183.0.tgz#eede2324764dee87c737c60666a4dfedf63da1dc"
+  integrity sha512-MqBRhxKHGD608+k2kqP+XNPEJJ6AfSlqZYkto5Pao+JY0U5nT0FgwzRjXu46zfsq3L8AVnh6hiSkAcdcFH0cuQ==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.172.0"
-    "@aws-cdk/aws-cloudwatch" "1.172.0"
-    "@aws-cdk/aws-ec2" "1.172.0"
-    "@aws-cdk/aws-iam" "1.172.0"
-    "@aws-cdk/aws-kms" "1.172.0"
-    "@aws-cdk/aws-logs" "1.172.0"
-    "@aws-cdk/aws-route53" "1.172.0"
-    "@aws-cdk/aws-secretsmanager" "1.172.0"
-    "@aws-cdk/core" "1.172.0"
-    "@aws-cdk/custom-resources" "1.172.0"
+    "@aws-cdk/aws-certificatemanager" "1.183.0"
+    "@aws-cdk/aws-cloudwatch" "1.183.0"
+    "@aws-cdk/aws-ec2" "1.183.0"
+    "@aws-cdk/aws-iam" "1.183.0"
+    "@aws-cdk/aws-kms" "1.183.0"
+    "@aws-cdk/aws-logs" "1.183.0"
+    "@aws-cdk/aws-route53" "1.183.0"
+    "@aws-cdk/aws-secretsmanager" "1.183.0"
+    "@aws-cdk/core" "1.183.0"
+    "@aws-cdk/custom-resources" "1.183.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-rds@1.172.0", "@aws-cdk/aws-rds@~1.172.0":
+"@aws-cdk/aws-rds@1.183.0":
+  version "1.183.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-rds/-/aws-rds-1.183.0.tgz#cc635261d772f3b1a69abb0fd86e6eeaba332111"
+  integrity sha512-QZ02OlZbSIpHxlGq30hAdxF+oapZtfitxMoFPb8Sd1HZr3QtOgCi7fTPd+nuRb+3NLRXp2SjIrZBfrZD+8+bvQ==
+  dependencies:
+    "@aws-cdk/aws-cloudwatch" "1.183.0"
+    "@aws-cdk/aws-ec2" "1.183.0"
+    "@aws-cdk/aws-events" "1.183.0"
+    "@aws-cdk/aws-iam" "1.183.0"
+    "@aws-cdk/aws-kms" "1.183.0"
+    "@aws-cdk/aws-logs" "1.183.0"
+    "@aws-cdk/aws-s3" "1.183.0"
+    "@aws-cdk/aws-secretsmanager" "1.183.0"
+    "@aws-cdk/core" "1.183.0"
+    "@aws-cdk/cx-api" "1.183.0"
+    constructs "^3.3.69"
+
+"@aws-cdk/aws-rds@~1.172.0":
   version "1.172.0"
-  resolved "https://registry.npmjs.org/@aws-cdk/aws-rds/-/aws-rds-1.172.0.tgz#ccc540c8c324da979bd8177c8c321d493e1ad618"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-rds/-/aws-rds-1.172.0.tgz#ccc540c8c324da979bd8177c8c321d493e1ad618"
   integrity sha512-x15dItL/vvcqiM+Y6WdXUA85Q0r4gQPR6HMy8HtLFFXgu/17hMpLrNF9pR8O25udPmT1Lb9DgkzUd2BBzoS7Hw==
   dependencies:
     "@aws-cdk/aws-cloudwatch" "1.172.0"
@@ -958,7 +1049,7 @@
     "@aws-cdk/region-info" "1.172.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-route53@1.172.0", "@aws-cdk/aws-route53@^1.159.0", "@aws-cdk/aws-route53@~1.172.0":
+"@aws-cdk/aws-route53@1.172.0", "@aws-cdk/aws-route53@1.183.0", "@aws-cdk/aws-route53@^1.159.0", "@aws-cdk/aws-route53@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.172.0.tgz#222452e458c81bc020cdedcfd3a72ce788c5b6e9"
   integrity sha512-CXftpIYyXYP1WZA+a0xUfpJo/j1mgB49wD80WTKhBP/xwO0iJ/gHXIuKzX10VXiomJIMGzdTMn6sww7xWGwOMw==
@@ -971,7 +1062,7 @@
     "@aws-cdk/custom-resources" "1.172.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-s3-assets@1.172.0", "@aws-cdk/aws-s3-assets@^1.159.0", "@aws-cdk/aws-s3-assets@~1.172.0":
+"@aws-cdk/aws-s3-assets@1.172.0", "@aws-cdk/aws-s3-assets@1.183.0", "@aws-cdk/aws-s3-assets@^1.159.0", "@aws-cdk/aws-s3-assets@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.172.0.tgz#5dd5515f41d5b576581f413d0881715e2666c11b"
   integrity sha512-UTZyMnvW9VsjSmcueD7rKHc6Pnkte6LUBiWWdlehrIVIz/TUMkytz41xc3Id/KjMlHaMJ7xev1nvaZNmAOpIwQ==
@@ -984,7 +1075,7 @@
     "@aws-cdk/cx-api" "1.172.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-s3@1.172.0", "@aws-cdk/aws-s3@^1.159.0", "@aws-cdk/aws-s3@~1.172.0":
+"@aws-cdk/aws-s3@1.172.0", "@aws-cdk/aws-s3@1.183.0", "@aws-cdk/aws-s3@^1.159.0", "@aws-cdk/aws-s3@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.172.0.tgz#2953f5f87636bd45d97f78ddc023ac8de454a56f"
   integrity sha512-ctzjSPLQMPE+HxndzaqlOaB1LhZfVQjniE8yGb0HXvbaONqcVxulnLoP4YW536Rh47vzIyqNsVybYTwxVVYDag==
@@ -1004,7 +1095,7 @@
     "@aws-cdk/core" "1.172.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-secretsmanager@1.172.0", "@aws-cdk/aws-secretsmanager@^1.159.0", "@aws-cdk/aws-secretsmanager@~1.172.0":
+"@aws-cdk/aws-secretsmanager@1.172.0", "@aws-cdk/aws-secretsmanager@1.183.0", "@aws-cdk/aws-secretsmanager@^1.159.0", "@aws-cdk/aws-secretsmanager@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.172.0.tgz#75f0cba42c0b8fd4185985a44812891e5a77c997"
   integrity sha512-bgOXU0zDxFaCG0sUfpPV3Nxptd2bOuEKfWNYwcbmkzxSO05a735NcAr/oHM8JzegC1f88lOQJo8GlZ8Z4JomVg==
@@ -1050,7 +1141,7 @@
     "@aws-cdk/core" "1.172.0"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-sns@1.172.0", "@aws-cdk/aws-sns@^1.159.0", "@aws-cdk/aws-sns@~1.172.0":
+"@aws-cdk/aws-sns@1.172.0", "@aws-cdk/aws-sns@1.183.0", "@aws-cdk/aws-sns@^1.159.0", "@aws-cdk/aws-sns@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.172.0.tgz#0d9b2b59614bf9cecb7ceb61a6332b30b7980ec1"
   integrity sha512-y9V+jqRU4Y3/iCaL5I8S675l3ZsV9jpACTXwBIToEx3As/wAKHzKxvp0jvinh0QT5HGu3DvXG7d+fZMYcFdB9A==
@@ -1115,6 +1206,14 @@
     jsonschema "^1.4.1"
     semver "^7.3.7"
 
+"@aws-cdk/cloud-assembly-schema@1.183.0":
+  version "1.183.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.183.0.tgz#bd7bb21f8e1d31a7f9e5143d1069853c31e601bc"
+  integrity sha512-Mv5aoc79RVlUcoNCvrfu5PfKOWkFIH/5D8lnNvjO01HPPq3L3kuj4HW1DXUNjUD/4cYUISCFAIiwTPRukY0yzg==
+  dependencies:
+    jsonschema "^1.4.1"
+    semver "^7.3.8"
+
 "@aws-cdk/cloudformation-diff@1.172.0", "@aws-cdk/cloudformation-diff@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.172.0.tgz#9eb9e2c1b2fe15abee492852977f145006a996bc"
@@ -1128,7 +1227,7 @@
     string-width "^4.2.3"
     table "^6.8.0"
 
-"@aws-cdk/core@1.172.0", "@aws-cdk/core@^1.159.0", "@aws-cdk/core@~1.172.0":
+"@aws-cdk/core@1.172.0", "@aws-cdk/core@1.183.0", "@aws-cdk/core@^1.159.0", "@aws-cdk/core@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/core/-/core-1.172.0.tgz#f47bdbd71648d45900780257ee62276ddbc9b0d5"
   integrity sha512-Hy7jNNzkNSf+oCmhhXnTcybunejTtCuGmfEFNZXsizcWBUjm0zD0K1X3kjD7Fqs0p+4xbaorCTgIB3Cu9qrF1Q==
@@ -1156,6 +1255,20 @@
     "@aws-cdk/core" "1.172.0"
     constructs "^3.3.69"
 
+"@aws-cdk/custom-resources@1.183.0":
+  version "1.183.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/custom-resources/-/custom-resources-1.183.0.tgz#dfa7eeeb69eef659f25e88f2557bb79b1d16c593"
+  integrity sha512-NpjfPwpW2nCemZfz694Twl0Iim7JfBGXt61begjyro46lnCsSWNwcdehA2KDFaExsHnHHO2oND60wIoYyk0pfA==
+  dependencies:
+    "@aws-cdk/aws-cloudformation" "1.183.0"
+    "@aws-cdk/aws-ec2" "1.183.0"
+    "@aws-cdk/aws-iam" "1.183.0"
+    "@aws-cdk/aws-lambda" "1.183.0"
+    "@aws-cdk/aws-logs" "1.183.0"
+    "@aws-cdk/aws-sns" "1.183.0"
+    "@aws-cdk/core" "1.183.0"
+    constructs "^3.3.69"
+
 "@aws-cdk/cx-api@1.172.0", "@aws-cdk/cx-api@~1.172.0":
   version "1.172.0"
   resolved "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.172.0.tgz#678504f0c2a16843aa8c1c746f16feb3129f92d5"
@@ -1163,6 +1276,14 @@
   dependencies:
     "@aws-cdk/cloud-assembly-schema" "1.172.0"
     semver "^7.3.7"
+
+"@aws-cdk/cx-api@1.183.0":
+  version "1.183.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.183.0.tgz#7d990138dd3d0be53ba3010c0ac0b0f2378fa9a5"
+  integrity sha512-r77PMtK7czNAdHYi6AbUQ7kpCBcaJP/3sS1nykofjPIK0Zayqy9u+vzKnMu4PPm4smB29n8VWc8OrQdnxQbVYg==
+  dependencies:
+    "@aws-cdk/cloud-assembly-schema" "1.183.0"
+    semver "^7.3.8"
 
 "@aws-cdk/region-info@1.172.0", "@aws-cdk/region-info@^1.159.0", "@aws-cdk/region-info@~1.172.0":
   version "1.172.0"
@@ -11432,6 +11553,16 @@ graphql-tag@^2.10.1, graphql-tag@^2.11.0:
   dependencies:
     tslib "^2.1.0"
 
+graphql-transformer-common@4.24.0:
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/graphql-transformer-common/-/graphql-transformer-common-4.24.0.tgz#f3be95c4b5ca2ada23fc3d0b01810810ad87810d"
+  integrity sha512-wleRNCFJLrqhYUT4j3KOfh2zTkvVjA6MX/s0HBIFWbNfnzd/W0VDAvpE9q8sMipOvXJ4zcVIZggI7TttrA/fOw==
+  dependencies:
+    graphql "^14.5.8"
+    graphql-mapping-template "4.20.5"
+    md5 "^2.2.1"
+    pluralize "8.0.0"
+
 graphql@0.13.0:
   version "0.13.0"
   resolved "https://registry.npmjs.org/graphql/-/graphql-0.13.0.tgz#d1b44a282279a9ce0a6ec1037329332f4c1079b6"
@@ -15316,6 +15447,11 @@ prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.1.tgz#4e1fd11c34e2421bc1da9aea9bd8127cd0a35efc"
+  integrity sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==
 
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
#### Description of changes

* Bump to AppSync CDK v 1.183.0, which is required to get the L1 Code support, and simplifying a bit of code around it.
* Add shared utility to produce partial of the CfnFunctionProps for the MappingTemplates and Code/Resolvers
* Add support for top-level pipeline resolvers to use CODE strategy.
* Flip pipeline definition to CODE

TODO:
* Flip to using EJS or some other template system for the JS.

#### Issue #, if available
N/A

#### Description of how you validated changes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
