### PR TITLE
throw a cpk warning on the CLI when a schema has CPK, the project has datastore enabled and the corresponding feature flag is disabled

### DIFF
--- a/packages/amplify-graphql-transformer-core/src/__tests__/transformation/transform.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transformation/transform.test.ts
@@ -1,9 +1,12 @@
+import { $TSAny } from 'amplify-cli-core';
 import { AppSyncAuthConfiguration, TransformerPluginProvider, TransformerPluginType } from '@aws-amplify/graphql-transformer-interfaces';
 import { App } from '@aws-cdk/core';
 import { GraphQLApi } from '../../graphql-api';
 import { GraphQLTransform } from '../../transformation/transform';
 import { TransformerOutput } from '../../transformer-context/output';
 import { StackManager } from '../../transformer-context/stack-manager';
+import { TransformerContext } from '../../transformer-context';
+import { printer } from 'amplify-prompts';
 
 class TestGraphQLTransform extends GraphQLTransform {
   testGenerateGraphQlApi(stackManager: StackManager, output: TransformerOutput): GraphQLApi {
@@ -26,7 +29,39 @@ const mockTransformer: TransformerPluginProvider = {
   typeDefinitions: [],
 };
 
+const printerMock = printer as jest.Mocked<typeof printer>;
+printerMock.info = jest.fn();
+
+const mockContext = {
+  isProjectUsingDataStore: jest.fn(),
+  featureFlags: {
+    getBoolean: jest.fn(),
+    getNumber: jest.fn(),
+    getObject: jest.fn(),
+  },
+  isProjectUsingCPK: jest.fn(),
+} as $TSAny as TransformerContext;
+
 describe('GraphQLTransform', () => {
+  const CPK_ERROR_MESSAGE = expect.stringContaining(
+    `
+⚠️  WARNING: Your schema has a custom primary key but the Feature Flag \"respectPrimaryKeyAttributesOnConnectionField\" is disabled. Check the value in your "amplify/cli.json" file, change it to "true" and re-run
+`,
+  );
+
+  it('has isProjectUsingCPK which returns true if a model has a primary key', () => {
+    const transform = new GraphQLTransform({
+      transformers: [mockTransformer],
+    });
+    const schema = `  
+    type Post @model {  
+      id: ID! @primaryKey
+      title: String!
+    `;
+    const ctx: TransformerContext = mockContext;
+        
+  });
+
   it('throws on construction with no transformers', () => {
     expect(() => {
       // eslint-disable-next-line no-new
@@ -41,6 +76,55 @@ describe('GraphQLTransform', () => {
       transformers: [mockTransformer],
     });
     expect(transform).toBeDefined();
+  });
+
+  it(`throws a cpk warning when datastore exists and FF is false but primary key exists`, () => {
+    const transform = new GraphQLTransform({
+      transformers: [mockTransformer],
+    });
+    mockContext.isProjectUsingDataStore = jest.fn().mockReturnValueOnce(true);
+    mockContext.featureFlags.getBoolean = jest.fn().mockReturnValueOnce(false);
+    mockContext.isProjectUsingCPK = jest.fn().mockReturnValueOnce(true);
+    transform.validateCPKFeatureFlag(mockContext)
+    expect(printerMock.info).toBeCalledWith(
+      `
+⚠️  WARNING: Your schema has a custom primary key but the Feature Flag \"respectPrimaryKeyAttributesOnConnectionField\" is disabled. Check the value in your "amplify/cli.json" file, change it to "true" and re-run
+  `,
+      'yellow',
+    );
+  });
+
+  it(`doesn't throw a cpk warning when datastore exists and FF is true and also primary key exists`, () => {
+    const transform = new GraphQLTransform({
+      transformers: [mockTransformer],
+    });
+    mockContext.isProjectUsingDataStore = jest.fn().mockReturnValueOnce(true);
+    mockContext.featureFlags.getBoolean = jest.fn().mockReturnValueOnce(true);
+    mockContext.isProjectUsingCPK = jest.fn().mockReturnValueOnce(true);
+    transform.validateCPKFeatureFlag(mockContext);
+    expect(printerMock.info).not.toBeCalledWith(CPK_ERROR_MESSAGE);
+  });
+
+  it(`doesn't throw a cpk warning when datastore doesn't exist and FF is false and also primary key exists`, () => {
+    const transform = new GraphQLTransform({
+      transformers: [mockTransformer],
+    });
+    mockContext.isProjectUsingDataStore = jest.fn().mockReturnValueOnce(false);
+    mockContext.featureFlags.getBoolean = jest.fn().mockReturnValueOnce(false);
+    mockContext.isProjectUsingCPK = jest.fn().mockReturnValueOnce(true);
+    transform.validateCPKFeatureFlag(mockContext);
+    expect(printerMock.info).not.toBeCalledWith(CPK_ERROR_MESSAGE);
+  });
+
+  it(`doesn't throw a cpk warning when primary key doesn't exists`, () => {
+    const transform = new GraphQLTransform({
+      transformers: [mockTransformer],
+    });
+    mockContext.isProjectUsingDataStore = jest.fn().mockReturnValueOnce(true);
+    mockContext.featureFlags.getBoolean = jest.fn().mockReturnValueOnce(false);
+    mockContext.isProjectUsingCPK = jest.fn().mockReturnValueOnce(false);
+    transform.validateCPKFeatureFlag(mockContext);
+    expect(printerMock.info).not.toBeCalledWith(CPK_ERROR_MESSAGE);
   });
 
   describe('generateGraphQlApi', () => {

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -832,7 +832,7 @@ public validateCPKFeatureFlag = (context: TransformerContext ) => {
   if (isDataStoreEnabled && !isCPKFeatureEnabled(context) && context.isProjectUsingCPK()) {
     printer.info(
       `
-⚠️  WARNING: Your schema has a custom primary key but the Feature Flag "${cpkFeatureFlagName}" is disabled. Check the value in your "amplify/cli.json" file, change it to "true" and re-run
+⚠️  WARNING: Your schema has a custom primary key but the Feature Flag "${cpkFeatureFlagName}" is disabled. Check the value in your "amplify/cli.json" file, change it to `true`, and execute `amplify codegen models` with the CLI
   `,
       'yellow',
     );

--- a/packages/amplify-graphql-transformer-core/src/transformation/utils.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/utils.ts
@@ -8,7 +8,7 @@ import {
   TypeSystemDefinitionNode,
   Kind,
 } from 'graphql';
-import { TransformerPluginProvider, TransformerPluginType } from '@aws-amplify/graphql-transformer-interfaces';
+import { TransformerContextProvider, TransformerPluginProvider, TransformerPluginType } from '@aws-amplify/graphql-transformer-interfaces';
 
 export function makeSeenTransformationKey(
   directive: DirectiveNode,
@@ -179,3 +179,8 @@ export function sortTransformerPlugins(plugins: TransformerPluginProvider[]): Tr
     return aIdx - bIdx;
   });
 }
+
+export const cpkFeatureFlagName = 'respectPrimaryKeyAttributesOnConnectionField';
+
+// Read the CPK Feature flag
+export const isCPKFeatureEnabled = (ctx: TransformerContextProvider): boolean => ctx.featureFlags.getBoolean(cpkFeatureFlagName);


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR helps the CX by throwing a CPK warning ⚠️ on the CLI when:
1. schema has a CPK - @primarykey and
2. conflict detection is enabled (datastore is used in the project) and
3. the feature flag for CPK - `respectPrimaryKeyAttributesOnConnectionField` is false in "amplify/cli.json" file

When CPK modelgen is being disabled in a schema with CPK's, this PR would aid the CX to enable the feature flag and solve issues with the CPK models.

sample schema used:

```
type Todo @model {
  todoId: ID! @primaryKey
  content: String
}

type TodoCopy @model {
  todoCopyId: ID! @primaryKey
  contentCopy: String
}
```

screenshot of the warning when the schema is compiled by running the command -
`amplify-dev api gql-compile`

<img width="1270" alt="Screen Shot 2022-12-28 at 12 23 57 PM" src="https://user-images.githubusercontent.com/107574718/209869130-4572eafc-dbb3-4cb4-a8ef-72c6a182f796.png">


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
