### PR TITLE
chore: add explicit section for CDK and CFN param changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,17 @@ Thank you for your Pull Request! Please provide a description above and review
 the requirements below.
 -->
 
+##### CDK / CloudFormation Parameters Changed
+
+<!--
+Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html
+
+e.g.
+
+* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
+* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
+-->
+
 #### Issue #, if available
 
 <!-- Also, please reference any associated PRs for documentation updates. -->
@@ -25,5 +36,6 @@ the requirements below.
 - [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
 - [ ] Relevant documentation is changed or added (and PR referenced)
 - [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
+- [ ] Any CDK or CloudFormation parameter changes are called out explicitly
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


### PR DESCRIPTION
Updating the PR template, example of using this updated template below:

#### Description of changes
This change adds support for Code-based AppSync resolvers and functions in Amplify.

Relevant docs update: TK

##### CDK / CloudFormation Parameters Changed

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit and e2e tests all pass.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
