### PR TITLE
chore(api): add datasource info to transformer context instance

### DIFF
--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/utils.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/utils.test.ts
@@ -1,5 +1,5 @@
 import { mergeUserConfigWithTransformOutput, writeDeploymentToDisk } from '../../graphql-transformer/utils';
-import { TransformerProjectConfig, DeploymentResources } from '@aws-amplify/graphql-transformer-core';
+import { TransformerProjectConfig, DeploymentResources, DatasourceType } from '@aws-amplify/graphql-transformer-core';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { $TSContext, CloudformationProviderFacade } from 'amplify-cli-core';
@@ -72,7 +72,7 @@ describe('graphql transformer utils', () => {
           pipelineFunctions: {},
           resolvers: {},
           stacks: {},
-          modelToDatasourceMap: undefined,
+          modelToDatasourceMap: new Map<string, DatasourceType>(),
           config: { Version: 5, ElasticsearchWarning: true },
         } as TransformerProjectConfig;
       });
@@ -94,7 +94,7 @@ describe('graphql transformer utils', () => {
             'Query.listTodos.req.vtl': '$util.unauthorized\n',
           },
           stacks: {},
-          modelToDatasourceMap: undefined,
+          modelToDatasourceMap: new Map<string, DatasourceType>(),
           config: { Version: 5, ElasticsearchWarning: true },
         } as TransformerProjectConfig;
       });
@@ -116,7 +116,7 @@ describe('graphql transformer utils', () => {
           },
           resolvers: {},
           stacks: {},
-          modelToDatasourceMap: undefined,
+          modelToDatasourceMap: new Map<string, DatasourceType>(),
           config: { Version: 5, ElasticsearchWarning: true },
         } as TransformerProjectConfig;
       });
@@ -202,7 +202,7 @@ describe('graphql transformer utils', () => {
               },
             },
           },
-          modelToDatasourceMap: undefined,
+          modelToDatasourceMap: new Map<string, DatasourceType>(),
           config: { Version: 5, ElasticsearchWarning: true },
         } as unknown as TransformerProjectConfig;
       });

--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/utils.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/utils.test.ts
@@ -72,6 +72,7 @@ describe('graphql transformer utils', () => {
           pipelineFunctions: {},
           resolvers: {},
           stacks: {},
+          modelToDatasourceMap: undefined,
           config: { Version: 5, ElasticsearchWarning: true },
         } as TransformerProjectConfig;
       });
@@ -93,6 +94,7 @@ describe('graphql transformer utils', () => {
             'Query.listTodos.req.vtl': '$util.unauthorized\n',
           },
           stacks: {},
+          modelToDatasourceMap: undefined,
           config: { Version: 5, ElasticsearchWarning: true },
         } as TransformerProjectConfig;
       });
@@ -114,6 +116,7 @@ describe('graphql transformer utils', () => {
           },
           resolvers: {},
           stacks: {},
+          modelToDatasourceMap: undefined,
           config: { Version: 5, ElasticsearchWarning: true },
         } as TransformerProjectConfig;
       });
@@ -199,6 +202,7 @@ describe('graphql transformer utils', () => {
               },
             },
           },
+          modelToDatasourceMap: undefined,
           config: { Version: 5, ElasticsearchWarning: true },
         } as unknown as TransformerProjectConfig;
       });

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -237,8 +237,8 @@ const _buildProject = async (opts: TransformerProjectOptions<TransformerFactoryA
     overrideConfig: opts.overrideConfig,
   });
 
-  const schema = userProjectConfig.schema.toString();
-  const transformOutput = transform.transform(schema);
+  const { schema, modelToDatasourceMap } = userProjectConfig;
+  const transformOutput = transform.transform(schema.toString(), modelToDatasourceMap);
 
   return mergeUserConfigWithTransformOutput(userProjectConfig, transformOutput, opts);
 };

--- a/packages/amplify-category-api/src/graphql-transformer/transformer-factory.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transformer-factory.ts
@@ -78,7 +78,6 @@ const getTransformerFactoryV2 = (
   resourceDir: string,
 ): (options: TransformerFactoryArgs) => Promise<TransformerPluginProviderV2[]> => async (options?: TransformerFactoryArgs) => {
   const modelTransformer = new ModelTransformerV2();
-  const rdsModelTransformer = new RdsModelTransformer();
   const indexTransformer = new IndexTransformerV2();
   const hasOneTransformer = new HasOneTransformerV2();
   const authTransformer = new AuthTransformerV2({
@@ -87,7 +86,6 @@ const getTransformerFactoryV2 = (
   });
   const transformerList: TransformerPluginProviderV2[] = [
     modelTransformer,
-    rdsModelTransformer,
     new FunctionTransformerV2(),
     new HttpTransformerV2(),
     new PredictionsTransformerV2(options?.storageConfig),

--- a/packages/amplify-graphql-transformer-core/src/config/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/config/index.ts
@@ -1,2 +1,2 @@
-export { TransformerProjectConfig } from './project-config';
+export { TransformerProjectConfig, DatasourceType } from './project-config';
 export * from './transformer-config';

--- a/packages/amplify-graphql-transformer-core/src/config/project-config.ts
+++ b/packages/amplify-graphql-transformer-core/src/config/project-config.ts
@@ -16,7 +16,9 @@ export interface TransformerProjectConfig {
   modelToDatasourceMap: Map<string, DatasourceType>;
 }
 
+export type DBType = 'MySQL' | 'DDB';
+
 export interface DatasourceType {
-  dbType: 'MySQL' | 'DDB';
+  dbType: DBType;
   provisionDB: boolean;
 }

--- a/packages/amplify-graphql-transformer-core/src/config/project-config.ts
+++ b/packages/amplify-graphql-transformer-core/src/config/project-config.ts
@@ -13,4 +13,10 @@ export interface TransformerProjectConfig {
   resolvers: Record<string, string>;
   stacks: Record<string, Template>;
   config: TransformConfig;
+  modelToDatasourceMap: Map<string, DatasourceType>;
+}
+
+export interface DatasourceType {
+  dbType: 'MySQL' | 'DDB';
+  provisionDB: boolean;
 }

--- a/packages/amplify-graphql-transformer-core/src/config/project-config.ts
+++ b/packages/amplify-graphql-transformer-core/src/config/project-config.ts
@@ -13,7 +13,7 @@ export interface TransformerProjectConfig {
   resolvers: Record<string, string>;
   stacks: Record<string, Template>;
   config: TransformConfig;
-  modelToDatasourceMap: Map<string, DatasourceType>;
+  modelToDatasourceMap: Map<string, DatasourceType> | undefined;
 }
 
 export type DBType = 'MySQL' | 'DDB';

--- a/packages/amplify-graphql-transformer-core/src/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/index.ts
@@ -24,6 +24,7 @@ export {
   SyncConfigLambda,
   TransformConfig,
   TransformerProjectConfig,
+  DatasourceType,
 } from './config/index';
 export {
   GetArgumentsOptions,

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -173,14 +173,14 @@ export class GraphQLTransform {
    * @param schema The model schema.
    * @param references Any cloudformation references.
    */
-  public transform(schema: string, modelToDatasourceMap: Map<string, DatasourceType>): DeploymentResources {
+  public transform(schema: string, modelToDatasourceMap?: Map<string, DatasourceType>): DeploymentResources {
     this.seenTransformations = {};
     const parsedDocument = parse(schema);
     this.app = new App();
     const context = new TransformerContext(
       this.app,
       parsedDocument,
-      modelToDatasourceMap,
+      modelToDatasourceMap ?? new Map<string, DatasourceType>(),
       this.stackMappingOverrides,
       this.authConfig,
       this.options.sandboxModeEnabled,

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -57,6 +57,7 @@ import { validateAuthModes, validateModelSchema } from './validation';
 import { DocumentNode } from 'graphql/language';
 import { TransformerPreProcessContext } from '../transformer-context/pre-process-context';
 import { AmplifyApiGraphQlResourceStackTemplate } from '../types/amplify-api-resource-stack-types';
+import { DatasourceType } from '../config/project-config';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 function isFunction(obj: any): obj is Function {
@@ -172,13 +173,14 @@ export class GraphQLTransform {
    * @param schema The model schema.
    * @param references Any cloudformation references.
    */
-  public transform(schema: string): DeploymentResources {
+  public transform(schema: string, modelToDatasourceMap: Map<string, DatasourceType>): DeploymentResources {
     this.seenTransformations = {};
     const parsedDocument = parse(schema);
     this.app = new App();
     const context = new TransformerContext(
       this.app,
       parsedDocument,
+      modelToDatasourceMap,
       this.stackMappingOverrides,
       this.authConfig,
       this.options.sandboxModeEnabled,

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
@@ -10,6 +10,7 @@ import {
 import { TransformerContextMetadataProvider } from '@aws-amplify/graphql-transformer-interfaces/src/transformer-context/transformer-context-provider';
 import { App } from '@aws-cdk/core';
 import { DocumentNode } from 'graphql';
+import { DatasourceType } from '../config/project-config';
 import { ResolverConfig } from '../config/transformer-config';
 import { TransformerDataSourceManager } from './datasource';
 import { NoopFeatureFlagProvider } from './noop-feature-flag';
@@ -52,11 +53,13 @@ export class TransformerContext implements TransformerContextProvider {
   public readonly authConfig: AppSyncAuthConfiguration;
   public readonly sandboxModeEnabled: boolean;
   private resolverConfig: ResolverConfig | undefined;
+  public readonly modelToDatasourceMap: Map<string, DatasourceType>;
 
   public metadata: TransformerContextMetadata;
   constructor(
     app: App,
     public readonly inputDocument: DocumentNode,
+    modelToDatasourceMap: Map<string, DatasourceType>,
     stackMapping: Record<string, string>,
     authConfig: AppSyncAuthConfiguration,
     sandboxModeEnabled?: boolean,
@@ -75,6 +78,7 @@ export class TransformerContext implements TransformerContextProvider {
     this.featureFlags = featureFlags ?? new NoopFeatureFlagProvider();
     this.resolverConfig = resolverConfig;
     this.metadata = new TransformerContextMetadata();
+    this.modelToDatasourceMap = modelToDatasourceMap;
   }
 
   /**

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
@@ -53,13 +53,13 @@ export class TransformerContext implements TransformerContextProvider {
   public readonly authConfig: AppSyncAuthConfiguration;
   public readonly sandboxModeEnabled: boolean;
   private resolverConfig: ResolverConfig | undefined;
-  public readonly modelToDatasourceMap: Map<string, DatasourceType> | undefined;
+  public readonly modelToDatasourceMap: Map<string, DatasourceType>;
 
   public metadata: TransformerContextMetadata;
   constructor(
     app: App,
     public readonly inputDocument: DocumentNode,
-    modelToDatasourceMap: Map<string, DatasourceType> | undefined,
+    modelToDatasourceMap: Map<string, DatasourceType>,
     stackMapping: Record<string, string>,
     authConfig: AppSyncAuthConfiguration,
     sandboxModeEnabled?: boolean,

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
@@ -53,13 +53,13 @@ export class TransformerContext implements TransformerContextProvider {
   public readonly authConfig: AppSyncAuthConfiguration;
   public readonly sandboxModeEnabled: boolean;
   private resolverConfig: ResolverConfig | undefined;
-  public readonly modelToDatasourceMap: Map<string, DatasourceType>;
+  public readonly modelToDatasourceMap: Map<string, DatasourceType> | undefined;
 
   public metadata: TransformerContextMetadata;
   constructor(
     app: App,
     public readonly inputDocument: DocumentNode,
-    modelToDatasourceMap: Map<string, DatasourceType>,
+    modelToDatasourceMap: Map<string, DatasourceType> | undefined,
     stackMapping: Record<string, string>,
     authConfig: AppSyncAuthConfiguration,
     sandboxModeEnabled?: boolean,

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
@@ -1,5 +1,5 @@
 import { TransformerResolversManagerProvider } from './transformer-resolver-provider';
-import { TransformerDataSourceManagerProvider } from './transformer-datasource-provider';
+import { TransformerDataSourceManagerProvider, DatasourceType } from './transformer-datasource-provider';
 import { TransformerProviderRegistry } from './transformer-provider-registry';
 import { DocumentNode } from 'graphql';
 import { TransformerContextOutputProvider } from './transformer-context-output-provider';
@@ -21,6 +21,7 @@ export interface TransformerContextProvider {
   providerRegistry: TransformerProviderRegistry;
 
   inputDocument: DocumentNode;
+  modelToDatasourceMap: Map<string, DatasourceType>;
   output: TransformerContextOutputProvider;
   stackManager: StackManagerProvider;
   api: GraphQLAPIProvider;
@@ -35,11 +36,20 @@ export interface TransformerContextProvider {
 
 export type TransformerBeforeStepContextProvider = Pick<
   TransformerContextProvider,
-  'inputDocument' | 'featureFlags' | 'isProjectUsingDataStore' | 'getResolverConfig' | 'authConfig' | 'stackManager' | 'sandboxModeEnabled'
+  | 'inputDocument'
+  | 'modelToDatasourceMap'
+  | 'featureFlags'
+  | 'isProjectUsingDataStore'
+  | 'getResolverConfig'
+  | 'authConfig'
+  | 'stackManager'
+  | 'sandboxModeEnabled'
 >;
+
 export type TransformerSchemaVisitStepContextProvider = Pick<
   TransformerContextProvider,
   | 'inputDocument'
+  | 'modelToDatasourceMap'
   | 'output'
   | 'providerRegistry'
   | 'featureFlags'
@@ -50,9 +60,11 @@ export type TransformerSchemaVisitStepContextProvider = Pick<
   | 'resourceHelper'
   | 'sandboxModeEnabled'
 >;
+
 export type TransformerValidationStepContextProvider = Pick<
   TransformerContextProvider,
   | 'inputDocument'
+  | 'modelToDatasourceMap'
   | 'output'
   | 'providerRegistry'
   | 'dataSources'
@@ -66,5 +78,7 @@ export type TransformerValidationStepContextProvider = Pick<
   | 'resolvers'
   | 'stackManager'
 >;
+
 export type TransformerPrepareStepContextProvider = TransformerValidationStepContextProvider;
+
 export type TransformerTransformSchemaStepContextProvider = TransformerValidationStepContextProvider;

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
@@ -21,7 +21,7 @@ export interface TransformerContextProvider {
   providerRegistry: TransformerProviderRegistry;
 
   inputDocument: DocumentNode;
-  modelToDatasourceMap: Map<string, DatasourceType>;
+  modelToDatasourceMap: Map<string, DatasourceType> | undefined;
   output: TransformerContextOutputProvider;
   stackManager: StackManagerProvider;
   api: GraphQLAPIProvider;

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-datasource-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-datasource-provider.ts
@@ -26,3 +26,8 @@ export interface TransformerDataSourceManagerProvider {
 }
 
 export interface DataSourceProvider extends BackedDataSource {}
+
+export interface DatasourceType {
+  dbType: 'MySQL' | 'DDB';
+  provisionDB: boolean;
+}

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-datasource-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-datasource-provider.ts
@@ -27,7 +27,9 @@ export interface TransformerDataSourceManagerProvider {
 
 export interface DataSourceProvider extends BackedDataSource {}
 
+export type DBType = 'MySQL' | 'DDB';
+
 export interface DatasourceType {
-  dbType: 'MySQL' | 'DDB';
+  dbType: DBType;
   provisionDB: boolean;
 }

--- a/packages/graphql-transformer-core/src/util/amplifyUtils.ts
+++ b/packages/graphql-transformer-core/src/util/amplifyUtils.ts
@@ -510,7 +510,7 @@ interface AmplifyApiV1Project {
  */
 export async function readV1ProjectConfiguration(projectDirectory: string): Promise<AmplifyApiV1Project> {
   // Schema
-  const schema = await readSchema(projectDirectory);
+  const { schema } = await readSchema(projectDirectory);
 
   // Get the template
   const cloudFormationTemplatePath = path.join(projectDirectory, CLOUDFORMATION_FILE_NAME);

--- a/packages/graphql-transformer-core/src/util/transformConfig.ts
+++ b/packages/graphql-transformer-core/src/util/transformConfig.ts
@@ -4,10 +4,12 @@ import { throwIfNotJSONExt } from './fileUtils';
 import { ProjectOptions } from './amplifyUtils';
 const fs = require('fs-extra');
 import _ from 'lodash';
+import { parse, Kind, ObjectTypeDefinitionNode } from 'graphql';
 
 export const TRANSFORM_CONFIG_FILE_NAME = `transform.conf.json`;
 export const TRANSFORM_BASE_VERSION = 4;
 export const TRANSFORM_CURRENT_VERSION = 5;
+const MODEL_DIRECTIVE_NAME = 'model';
 
 export interface TransformMigrationConfig {
   V1?: {
@@ -160,10 +162,11 @@ interface ProjectConfiguration {
     [k: string]: Template;
   };
   config: TransformConfig;
+  modelToDatasourceMap: Map<string, DatasourceType>;
 }
 export async function loadProject(projectDirectory: string, opts?: ProjectOptions): Promise<ProjectConfiguration> {
   // Schema
-  const schema = await readSchema(projectDirectory);
+  const { schema, modelToDatasourceMap } = await readSchema(projectDirectory);
 
   // Load functions
   const functions = {};
@@ -246,6 +249,7 @@ export async function loadProject(projectDirectory: string, opts?: ProjectOption
     resolvers,
     schema,
     config,
+    modelToDatasourceMap,
   };
 }
 
@@ -255,7 +259,8 @@ export async function loadProject(projectDirectory: string, opts?: ProjectOption
  * Preference is given to the `schema.graphql` if provided.
  * @param projectDirectory The project directory.
  */
-export async function readSchema(projectDirectory: string): Promise<string> {
+export async function readSchema(projectDirectory: string): Promise<{schema: string, modelToDatasourceMap: Map<string, DatasourceType>}> {
+  let modelToDatasourceMap = new Map<string, DatasourceType>();
   const schemaFilePaths = [
     path.join(projectDirectory, 'schema.graphql'),
     path.join(projectDirectory, 'schema.rds.graphql')
@@ -264,16 +269,36 @@ export async function readSchema(projectDirectory: string): Promise<string> {
   const schemaFilePath = schemaFilePaths.filter( path => fs.existsSync(path));
   const schemaDirectoryPath = path.join(projectDirectory, 'schema');
 
-  let schema;
-  if (!(_.isEmpty(schemaFilePath))) {
-    // Todo: merge all the schemas to a single schema file
-    schema = (await fs.readFile(schemaFilePath[0])).toString();
+  let schema = "";
+  if (!(_.isEmpty(schemaFilePaths))) {
+    // Schema.graphql contains the models for DynamoDB datasource
+    // Schema.rds.graphql contains the models for imported 'MySQL' datasource 
+    // Intentionally using 'for ... of ...' instead of 'object.foreach' to process this in sequence 
+    for (const file of schemaFilePaths) {
+      const datasourceType = file.endsWith('.rds.graphql') ? constructDataSourceType("MySQL", false) : constructDataSourceType("DDB");
+      const fileSchema = (await fs.readFile(file)).toString();
+      modelToDatasourceMap = {
+        ...modelToDatasourceMap,
+        ...constructDataSourceMap(fileSchema, datasourceType),
+      };
+      schema += fileSchema;
+    }
   } else if (fs.existsSync(schemaDirectoryPath)) {
-    schema = (await readSchemaDocuments(schemaDirectoryPath)).join('\n');
+    // Schema folder is used only for DynamoDB datasource
+    const datasourceType = constructDataSourceType("DDB");
+    const schemaInDirectory = (await readSchemaDocuments(schemaDirectoryPath)).join('\n');
+    modelToDatasourceMap = {
+      ...modelToDatasourceMap,
+      ...constructDataSourceMap(schemaInDirectory, datasourceType),
+    };
+    schema += schemaInDirectory;
   } else {
     throw new Error(`Could not find a schema at ${schemaFilePath}`);
   }
-  return schema;
+  return {
+    schema,
+    modelToDatasourceMap,
+  };
 }
 
 async function readSchemaDocuments(schemaDirectoryPath: string): Promise<string[]> {
@@ -295,4 +320,30 @@ async function readSchemaDocuments(schemaDirectoryPath: string): Promise<string[
     }
   }
   return schemaDocuments;
+}
+
+export interface DatasourceType {
+  dbType: 'MySQL' | 'DDB';
+  provisionDB: boolean;
+}
+
+function constructDataSourceType(dbType: 'MySQL' | 'DDB', provisionDB: boolean = true): DatasourceType {
+  return {
+    dbType,
+    provisionDB,
+  }
+}
+
+function constructDataSourceMap(schema: string, datasourceType: DatasourceType): Map<string, DatasourceType> {
+  const parsedSchema = parse(schema);
+  const result = new Map<string, DatasourceType>();
+  parsedSchema.definitions
+    .filter(obj => obj.kind === Kind.OBJECT_TYPE_DEFINITION && obj.directives.some(dir => dir.name.value === MODEL_DIRECTIVE_NAME))
+    .map(type => {
+      result.set(
+        (type as ObjectTypeDefinitionNode).name.value,
+        datasourceType,
+      );
+    });
+  return result;
 }

--- a/packages/graphql-transformer-core/src/util/transformConfig.ts
+++ b/packages/graphql-transformer-core/src/util/transformConfig.ts
@@ -316,12 +316,14 @@ async function readSchemaDocuments(schemaDirectoryPath: string): Promise<string[
   return schemaDocuments;
 }
 
+export type DBType = 'MySQL' | 'DDB';
+
 export interface DatasourceType {
-  dbType: 'MySQL' | 'DDB';
+  dbType: DBType;
   provisionDB: boolean;
 }
 
-function constructDataSourceType(dbType: 'MySQL' | 'DDB', provisionDB: boolean = true): DatasourceType {
+function constructDataSourceType(dbType: DBType, provisionDB: boolean = true): DatasourceType {
   return {
     dbType,
     provisionDB,


### PR DESCRIPTION
#### Description of changes

Introduces model to datasource mapping to transformer context instance. This will help future work to differentiate between DDB vs MySQL for amplify GraphQL transformers.

Once this is merged, we can use the below logic to get database type.

```ts
const dbInfo = context.modelToDatasourceMap.get(modelName);
// If dbInfo doesn't have an entry for the model, then treat it as DDB.
const dbType = dbInfo ? dbInfo.dbType : 'DDB';
// dbType will be DDB or MySQL
```

#### Description of how you validated changes
- Manual test
- No E2E added (should be added as part of transformer changes)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
