### PR TITLE
fix(graphql): add filter null check to index query resolver

### DIFF
--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
@@ -534,6 +534,9 @@ $util.toJson({})
 #end
 #if( !$util.isNullOrEmpty($filter) )
   #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( $util.isNullOrEmpty($filterExpression) )
+    $util.error(\\"Unable to process the filter expression\\", \\"Unrecognized Filter\\")
+  #end
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterExpression.expressionValues.size() == 0 )
       $util.qr($filterExpression.remove(\\"expressionValues\\"))
@@ -1181,6 +1184,9 @@ $util.toJson({})
 #end
 #if( !$util.isNullOrEmpty($filter) )
   #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( $util.isNullOrEmpty($filterExpression) )
+    $util.error(\\"Unable to process the filter expression\\", \\"Unrecognized Filter\\")
+  #end
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterExpression.expressionValues.size() == 0 )
       $util.qr($filterExpression.remove(\\"expressionValues\\"))
@@ -1807,6 +1813,9 @@ $util.toJson({})
 #end
 #if( !$util.isNullOrEmpty($filter) )
   #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( $util.isNullOrEmpty($filterExpression) )
+    $util.error(\\"Unable to process the filter expression\\", \\"Unrecognized Filter\\")
+  #end
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterExpression.expressionValues.size() == 0 )
       $util.qr($filterExpression.remove(\\"expressionValues\\"))
@@ -2724,6 +2733,9 @@ $util.toJson({})
 #end
 #if( !$util.isNullOrEmpty($filter) )
   #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( $util.isNullOrEmpty($filterExpression) )
+    $util.error(\\"Unable to process the filter expression\\", \\"Unrecognized Filter\\")
+  #end
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterExpression.expressionValues.size() == 0 )
       $util.qr($filterExpression.remove(\\"expressionValues\\"))
@@ -3318,6 +3330,9 @@ $util.toJson({})
 #end
 #if( !$util.isNullOrEmpty($filter) )
   #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( $util.isNullOrEmpty($filterExpression) )
+    $util.error(\\"Unable to process the filter expression\\", \\"Unrecognized Filter\\")
+  #end
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterExpression.expressionValues.size() == 0 )
       $util.qr($filterExpression.remove(\\"expressionValues\\"))
@@ -3422,6 +3437,9 @@ $util.toJson({})
 #end
 #if( !$util.isNullOrEmpty($filter) )
   #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( $util.isNullOrEmpty($filterExpression) )
+    $util.error(\\"Unable to process the filter expression\\", \\"Unrecognized Filter\\")
+  #end
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterExpression.expressionValues.size() == 0 )
       $util.qr($filterExpression.remove(\\"expressionValues\\"))
@@ -4481,6 +4499,9 @@ $util.toJson({})
 #end
 #if( !$util.isNullOrEmpty($filter) )
   #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( $util.isNullOrEmpty($filterExpression) )
+    $util.error(\\"Unable to process the filter expression\\", \\"Unrecognized Filter\\")
+  #end
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterExpression.expressionValues.size() == 0 )
       $util.qr($filterExpression.remove(\\"expressionValues\\"))
@@ -5230,6 +5251,9 @@ $util.toJson({})
 #end
 #if( !$util.isNullOrEmpty($filter) )
   #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( $util.isNullOrEmpty($filterExpression) )
+    $util.error(\\"Unable to process the filter expression\\", \\"Unrecognized Filter\\")
+  #end
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterExpression.expressionValues.size() == 0 )
       $util.qr($filterExpression.remove(\\"expressionValues\\"))
@@ -6006,6 +6030,9 @@ $util.toJson({})
 #end
 #if( !$util.isNullOrEmpty($filter) )
   #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( $util.isNullOrEmpty($filterExpression) )
+    $util.error(\\"Unable to process the filter expression\\", \\"Unrecognized Filter\\")
+  #end
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterExpression.expressionValues.size() == 0 )
       $util.qr($filterExpression.remove(\\"expressionValues\\"))
@@ -6110,6 +6137,9 @@ $util.toJson({})
 #end
 #if( !$util.isNullOrEmpty($filter) )
   #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( $util.isNullOrEmpty($filterExpression) )
+    $util.error(\\"Unable to process the filter expression\\", \\"Unrecognized Filter\\")
+  #end
   #if( !$util.isNullOrBlank($filterExpression.expression) )
     #if( $filterExpression.expressionValues.size() == 0 )
       $util.qr($filterExpression.remove(\\"expressionValues\\"))

--- a/packages/amplify-graphql-index-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers.ts
@@ -505,6 +505,10 @@ function makeQueryResolver(config: IndexDirectiveConfiguration, ctx: Transformer
                 methodCall(ref('util.parseJson'), methodCall(ref('util.transform.toDynamoDBFilterExpression'), ref('filter'))),
               ),
               iff(
+                isNullOrEmpty(ref('filterExpression')),
+                methodCall(ref('util.error'), str('Unable to process the filter expression'), str('Unrecognized Filter')),
+              ),
+              iff(
                 not(methodCall(ref('util.isNullOrBlank'), ref('filterExpression.expression'))),
                 compoundExpression([
                   iff(


### PR DESCRIPTION
#### Description of changes

Add null check to filter argument for index query resolvers. This will make sure that the index query resolver satisfy the resolver security check.

#### Issue #, if available
https://github.com/aws-amplify/amplify-category-api/issues/729

#### Description of how you validated changes
- Manual test
- yarn test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
