### PR TITLE
fix(transformer): conflict detection respects to per model rule

### DIFF
--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -409,6 +409,42 @@ export function updateApiConflictHandlerType(
   });
 }
 
+export function updateApiConflictHandlerTypePerModel(
+  cwd: string,
+  opts?: Partial<AddApiOptions>
+) {
+  const options = _.assign(defaultOptions, opts);
+  return new Promise<void>((resolve, reject) => {
+    const chain = spawn(getCLIPath(options.testingWithLatestCodebase), ['update', 'api'], { cwd, stripColors: true })
+      .wait('Select from one of the below mentioned services:')
+      .sendCarriageReturn()
+      .wait(/.*Select a setting to edit*/)
+      .sendKeyDown()
+      .sendCarriageReturn()
+      .wait(/.*Select the default resolution strategy.*/)
+      .sendCarriageReturn() // Select Automerge Handler for project
+      .wait(/.*Do you want to override default per model settings*/)
+      .sendConfirmYes()
+      .wait('Select the models from below:')
+      .send('a')
+      .sendCarriageReturn()
+      .wait('Select the resolution strategy for') //First model
+      .sendKeyDown(2).sendCarriageReturn() // Select Lambda Handler
+      .wait(/.*Select from the options below.*/)
+      .sendCarriageReturn() // Create a new Lambda
+      .wait('Select the resolution strategy for') //Second model
+      .sendCarriageReturn() // Select Automerge Handler
+      .wait(/.*Successfully updated resource*/)
+      .run((err: Error) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
+  });
+}
+
 export function apiEnableDataStore(cwd: string, settings: any) {
   return new Promise<void>((resolve, reject) => {
     spawn(getCLIPath(settings.testingWithLatestCodebase), ['update', 'api'], { cwd, stripColors: true })

--- a/packages/amplify-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-core/src/utils/sdk-calls.ts
@@ -225,6 +225,11 @@ export const getAppSyncApi = async (appSyncApiId: string, region: string) => {
   return await service.getGraphqlApi({ apiId: appSyncApiId }).promise();
 };
 
+export const listAppSyncFunctions = async (appSyncApiId: string, region: string) => {
+  const service = new AppSync({ region });
+  return await service.listFunctions({ apiId: appSyncApiId }).promise();
+}
+
 export const getCloudWatchLogs = async (region: string, logGroupName: string, logStreamName: string | undefined = undefined) => {
   const cloudwatchlogs = new CloudWatchLogs({ region, retryDelayOptions: { base: 500 } });
 

--- a/packages/amplify-e2e-tests/schemas/simple_two_models.graphql
+++ b/packages/amplify-e2e-tests/schemas/simple_two_models.graphql
@@ -1,0 +1,8 @@
+type Todo @model {
+  id: ID!
+  content: String
+}
+type Author @model {
+  id: ID!
+  name: String
+}

--- a/packages/amplify-e2e-tests/src/__tests__/graphql-v2/lambda-conflict-handler.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/graphql-v2/lambda-conflict-handler.test.ts
@@ -123,7 +123,6 @@ describe('amplify api (GraphQL) - Customer Lambda Conflict Handler', () => {
   it('amplify update api (GraphQL) - Per model rule of Conflict Resolution', async () => {
     const envName = 'test';
     const projName = 'permodelconflict';
-    console.log(projRoot)
     await initJSProjectWithProfile(projRoot, { name: projName, envName });
     await addApiWithBlankSchemaAndConflictDetection(projRoot);
     await updateApiSchema(projRoot, projName, 'simple_two_models.graphql');
@@ -142,14 +141,12 @@ describe('amplify api (GraphQL) - Customer Lambda Conflict Handler', () => {
     const lambdaArn = Object.values(meta.function)[0]['output']['Arn']
     const todoFunctions = functions.filter(f => f.dataSourceName === 'TodoTable');
     todoFunctions.forEach(func => {
-      console.log(func.name)
       expect(func.syncConfig.conflictHandler).toBe('LAMBDA');
       expect(func.syncConfig.conflictDetection).toBe('VERSION');
       expect(func.syncConfig.lambdaConflictHandlerConfig.lambdaConflictHandlerArn).toBe(lambdaArn);
     })
     const authorFunctions = functions.filter(f => f.dataSourceName === 'AuthorTable');
     authorFunctions.forEach(func => {
-      console.log(func.name)
       expect(func.syncConfig.conflictHandler).toBe('AUTOMERGE');
       expect(func.syncConfig.conflictDetection).toBe('VERSION');
       expect(func.syncConfig.lambdaConflictHandlerConfig).not.toBeDefined();

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -278,7 +278,10 @@ export class TransformerResolver implements TransformerResolverProvider {
           }
 
           if (context.isProjectUsingDataStore()) {
-            const syncConfig = SyncUtils.getSyncConfig(context, this.typeName)!;
+            //Remove the suffix "Table" from the datasource name
+            //The stack name cannot be retrieved as during the runtime it is tokenized and value not being revealed
+            const modelName = this.datasource.name.slice(0, -5);
+            const syncConfig = SyncUtils.getSyncConfig(context, modelName)!;
             const funcConf = dataSourceProviderFn.node.children.find(
               (it: any) => it.cfnResourceType === 'AWS::AppSync::FunctionConfiguration',
             ) as CfnFunctionConfiguration;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fix the bug that per model conflict resolution is not respected
##### CDK / CloudFormation Parameters Changed
The `SyncConfig` is now correctly generated based on per model rule.
<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available
Fix https://github.com/aws-amplify/amplify-category-api/issues/1192
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
