### PR TITLE
chore(graphql): improve typing on vtl generator methods

### DIFF
--- a/packages/amplify-graphql-model-transformer/API.md
+++ b/packages/amplify-graphql-model-transformer/API.md
@@ -47,29 +47,29 @@ export const createEnumModelFilters: (ctx: TransformerTransformSchemaStepContext
 // @public (undocumented)
 export class DynamoDBModelVTLGenerator implements ModelVTLGenerator {
     // (undocumented)
-    generateCreateInitSlotTemplate: (modelConfig: ModelDirectiveConfiguration) => string;
+    generateCreateInitSlotTemplate(config: ModelCreateInitSlotConfig): string;
     // (undocumented)
-    generateCreateRequestTemplate: (modelName: string, modelIndexFields: string[]) => string;
+    generateCreateRequestTemplate(config: ModelCreateRequestConfig): string;
     // (undocumented)
-    generateDefaultResponseMappingTemplate: (isSyncEnabled: boolean, mutation?: boolean) => string;
+    generateDefaultResponseMappingTemplate(config: ModelDefaultResponseConfig): string;
     // (undocumented)
-    generateDeleteRequestTemplate: (modelName: string, isSyncEnabled: boolean) => string;
+    generateDeleteRequestTemplate(config: ModelUpdateRequestConfig): string;
     // (undocumented)
-    generateGetRequestTemplate: () => string;
+    generateGetRequestTemplate(config: ModelRequestConfig): string;
     // (undocumented)
-    generateGetResponseTemplate: (isSyncEnabled: boolean) => string;
+    generateGetResponseTemplate(config: ModelUpdateRequestConfig): string;
     // (undocumented)
-    generateListRequestTemplate: () => string;
+    generateListRequestTemplate(config: ModelRequestConfig): string;
     // (undocumented)
-    generateSubscriptionRequestTemplate: () => string;
+    generateSubscriptionRequestTemplate(): string;
     // (undocumented)
-    generateSubscriptionResponseTemplate: () => string;
+    generateSubscriptionResponseTemplate(): string;
     // (undocumented)
-    generateSyncRequestTemplate: () => string;
+    generateSyncRequestTemplate(config: ModelRequestConfig): string;
     // (undocumented)
-    generateUpdateInitSlotTemplate: (modelConfig: ModelDirectiveConfiguration) => string;
+    generateUpdateInitSlotTemplate(config: ModelCreateInitSlotConfig): string;
     // (undocumented)
-    generateUpdateRequestTemplate: (modelName: string, isSyncEnabled: boolean) => string;
+    generateUpdateRequestTemplate(config: ModelUpdateRequestConfig): string;
 }
 
 // @public (undocumented)
@@ -136,6 +136,26 @@ export const makeSubscriptionQueryFilterInput: (ctx: TransformerTransformSchemaS
 export const makeUpdateInputField: (obj: ObjectTypeDefinitionNode, modelDirectiveConfig: ModelDirectiveConfiguration, knownModelTypes: Set<string>, document: DocumentNode, isSyncEnabled: boolean) => InputObjectTypeDefinitionNode;
 
 // @public (undocumented)
+export type ModelCreateInitSlotConfig = {
+    modelConfig: ModelDirectiveConfiguration;
+};
+
+// @public (undocumented)
+export type ModelCreateRequestConfig = ModelRequestConfig & {
+    modelName: string;
+    modelIndexFields: string[];
+};
+
+// @public (undocumented)
+export type ModelDefaultResponseConfig = ModelRequestConfig & {
+    isSyncEnabled: boolean;
+    mutation: boolean;
+};
+
+// @public (undocumented)
+export type ModelDeleteRequestConfig = ModelUpdateRequestConfig;
+
+// @public (undocumented)
 export type ModelDirectiveConfiguration = {
     queries?: Partial<{
         get: Partial<string>;
@@ -157,6 +177,15 @@ export type ModelDirectiveConfiguration = {
         createdAt: Partial<string>;
         updatedAt: Partial<string>;
     }>;
+};
+
+// @public (undocumented)
+export type ModelGetResponseConfig = ModelUpdateRequestConfig;
+
+// @public (undocumented)
+export type ModelRequestConfig = {
+    operation: string;
+    operationName: string;
 };
 
 // @public (undocumented)
@@ -242,43 +271,44 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
 }
 
 // @public (undocumented)
+export type ModelUpdateInitSlotConfig = ModelCreateInitSlotConfig;
+
+// @public (undocumented)
+export type ModelUpdateRequestConfig = ModelRequestConfig & {
+    modelName: string;
+    isSyncEnabled: boolean;
+};
+
+// @public (undocumented)
 export interface ModelVTLGenerator {
     // (undocumented)
-    generateCreateInitSlotTemplate(modelConfig: ModelDirectiveConfiguration, config?: OperationConfig): string;
+    generateCreateInitSlotTemplate(config: ModelCreateInitSlotConfig): string;
     // (undocumented)
-    generateCreateRequestTemplate(modelName: string, modelIndexFields: string[], config?: OperationConfig): string;
+    generateCreateRequestTemplate(config: ModelCreateRequestConfig): string;
     // (undocumented)
-    generateDefaultResponseMappingTemplate(isSyncEnabled: boolean, mutation: boolean): string;
+    generateDefaultResponseMappingTemplate(config: ModelDefaultResponseConfig): string;
     // (undocumented)
-    generateDeleteRequestTemplate(modelName: string, isSyncEnabled: boolean, config?: OperationConfig): string;
+    generateDeleteRequestTemplate(config: ModelDeleteRequestConfig): string;
     // (undocumented)
-    generateGetRequestTemplate(config?: OperationConfig): string;
+    generateGetRequestTemplate(config: ModelRequestConfig): string;
     // (undocumented)
-    generateGetResponseTemplate(isSyncEnabled: boolean, config?: OperationConfig): string;
+    generateGetResponseTemplate(config: ModelGetResponseConfig): string;
     // (undocumented)
-    generateListRequestTemplate(config?: OperationConfig): string;
+    generateListRequestTemplate(config: ModelRequestConfig): string;
     // (undocumented)
-    generateSubscriptionRequestTemplate(config?: OperationConfig): string;
+    generateSubscriptionRequestTemplate(): string;
     // (undocumented)
-    generateSubscriptionResponseTemplate(config?: OperationConfig): string;
+    generateSubscriptionResponseTemplate(): string;
     // (undocumented)
-    generateSyncRequestTemplate(config?: OperationConfig): string;
+    generateSyncRequestTemplate(config: ModelRequestConfig): string;
     // (undocumented)
-    generateUpdateInitSlotTemplate(modelConfig: ModelDirectiveConfiguration, config?: OperationConfig): string;
+    generateUpdateInitSlotTemplate(config: ModelUpdateInitSlotConfig): string;
     // (undocumented)
-    generateUpdateRequestTemplate(modelName: string, isSyncEnabled: boolean, config?: OperationConfig): string;
+    generateUpdateRequestTemplate(config: ModelUpdateRequestConfig): string;
 }
 
 // @public (undocumented)
 export const OPERATION_KEY = "__operation";
-
-// @public (undocumented)
-export interface OperationConfig {
-    // (undocumented)
-    operation?: string;
-    // (undocumented)
-    operationName?: string;
-}
 
 // @public (undocumented)
 export const propagateApiKeyToNestedTypes: (ctx: TransformerContextProvider, def: ObjectTypeDefinitionNode, seenNonModelTypes: Set<string>) => void;
@@ -286,29 +316,29 @@ export const propagateApiKeyToNestedTypes: (ctx: TransformerContextProvider, def
 // @public (undocumented)
 export class RDSModelVTLGenerator implements ModelVTLGenerator {
     // (undocumented)
-    generateCreateInitSlotTemplate(modelConfig: ModelDirectiveConfiguration, config?: OperationConfig | undefined): string;
+    generateCreateInitSlotTemplate(config: ModelCreateInitSlotConfig): string;
     // (undocumented)
-    generateCreateRequestTemplate(modelName: string, modelIndexFields: string[], config?: OperationConfig | undefined): string;
+    generateCreateRequestTemplate(config: ModelCreateRequestConfig): string;
     // (undocumented)
-    generateDefaultResponseMappingTemplate(isSyncEnabled: boolean, mutation: boolean): string;
+    generateDefaultResponseMappingTemplate(config: ModelDefaultResponseConfig): string;
     // (undocumented)
-    generateDeleteRequestTemplate(modelName: string, isSyncEnabled: boolean, config?: OperationConfig | undefined): string;
+    generateDeleteRequestTemplate(config: ModelUpdateRequestConfig): string;
     // (undocumented)
-    generateGetRequestTemplate(config?: OperationConfig | undefined): string;
+    generateGetRequestTemplate(config: ModelRequestConfig): string;
     // (undocumented)
-    generateGetResponseTemplate(isSyncEnabled: boolean, config?: OperationConfig | undefined): string;
+    generateGetResponseTemplate(config: ModelUpdateRequestConfig): string;
     // (undocumented)
-    generateListRequestTemplate(config?: OperationConfig | undefined): string;
+    generateListRequestTemplate(config: ModelRequestConfig): string;
     // (undocumented)
-    generateSubscriptionRequestTemplate(config?: OperationConfig | undefined): string;
+    generateSubscriptionRequestTemplate(): string;
     // (undocumented)
-    generateSubscriptionResponseTemplate(config?: OperationConfig | undefined): string;
+    generateSubscriptionResponseTemplate(): string;
     // (undocumented)
-    generateSyncRequestTemplate(config?: OperationConfig | undefined): string;
+    generateSyncRequestTemplate(config: ModelRequestConfig): string;
     // (undocumented)
-    generateUpdateInitSlotTemplate(modelConfig: ModelDirectiveConfiguration, config?: OperationConfig | undefined): string;
+    generateUpdateInitSlotTemplate(config: ModelCreateInitSlotConfig): string;
     // (undocumented)
-    generateUpdateRequestTemplate(modelName: string, isSyncEnabled: boolean, config?: OperationConfig | undefined): string;
+    generateUpdateRequestTemplate(config: ModelUpdateRequestConfig): string;
 }
 
 // @public (undocumented)

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -929,7 +929,7 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
-  "Mutation.updatePost.req.vtl": "## [Start] Post Update resolver. **
+  "Mutation.updatePost.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -1059,7 +1059,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($UpdateItem.put(\\"condition\\", $Conditions))
 #end
 $util.toJson($UpdateItem)
-## [End] Post Update resolver. **",
+## [End] Mutation Update resolver. **",
   "Mutation.updatePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
@@ -1471,7 +1471,7 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
-  "Mutation.updatePost.req.vtl": "## [Start] Post Update resolver. **
+  "Mutation.updatePost.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -1601,7 +1601,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($UpdateItem.put(\\"condition\\", $Conditions))
 #end
 $util.toJson($UpdateItem)
-## [End] Post Update resolver. **",
+## [End] Mutation Update resolver. **",
   "Mutation.updatePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
@@ -2013,7 +2013,7 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
-  "Mutation.updatePost.req.vtl": "## [Start] Post Update resolver. **
+  "Mutation.updatePost.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2143,7 +2143,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($UpdateItem.put(\\"condition\\", $Conditions))
 #end
 $util.toJson($UpdateItem)
-## [End] Post Update resolver. **",
+## [End] Mutation Update resolver. **",
   "Mutation.updatePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
@@ -2674,7 +2674,7 @@ $util.toJson($PutObject)
 `;
 
 exports[`ModelTransformer:  should have timestamps as nullable fields when the type makes it non-nullable 3`] = `
-"## [Start] Post Update resolver. **
+"## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2803,7 +2803,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($UpdateItem.put(\\"condition\\", $Conditions))
 #end
 $util.toJson($UpdateItem)
-## [End] Post Update resolver. **"
+## [End] Mutation Update resolver. **"
 `;
 
 exports[`ModelTransformer:  should not add default primary key when ID is defined 1`] = `
@@ -3341,7 +3341,7 @@ $util.toJson($PutObject)
 `;
 
 exports[`ModelTransformer:  should not to auto generate createdAt and updatedAt when the type in schema is not AWSDateTime 3`] = `
-"## [Start] Post Update resolver. **
+"## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -3470,7 +3470,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($UpdateItem.put(\\"condition\\", $Conditions))
 #end
 $util.toJson($UpdateItem)
-## [End] Post Update resolver. **"
+## [End] Mutation Update resolver. **"
 `;
 
 exports[`ModelTransformer:  should not to include createdAt and updatedAt field when timestamps is set to null 1`] = `
@@ -3761,7 +3761,7 @@ $util.toJson($PutObject)
 `;
 
 exports[`ModelTransformer:  should not to include createdAt and updatedAt field when timestamps is set to null 3`] = `
-"## [Start] Post Update resolver. **
+"## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -3890,7 +3890,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($UpdateItem.put(\\"condition\\", $Conditions))
 #end
 $util.toJson($UpdateItem)
-## [End] Post Update resolver. **"
+## [End] Mutation Update resolver. **"
 `;
 
 exports[`ModelTransformer:  should support timestamp parameters when generating resolvers and output schema 1`] = `
@@ -4183,7 +4183,7 @@ $util.toJson($PutObject)
 `;
 
 exports[`ModelTransformer:  should support timestamp parameters when generating resolvers and output schema 3`] = `
-"## [Start] Post Update resolver. **
+"## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -4312,7 +4312,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($UpdateItem.put(\\"condition\\", $Conditions))
 #end
 $util.toJson($UpdateItem)
-## [End] Post Update resolver. **"
+## [End] Mutation Update resolver. **"
 `;
 
 exports[`ModelTransformer:  the datastore table should be configured 1`] = `

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -929,7 +929,7 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
-  "Mutation.updatePost.req.vtl": "## [Start] Mutation Update resolver. **
+  "Mutation.updatePost.req.vtl": "## [Start] Post Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -1059,7 +1059,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($UpdateItem.put(\\"condition\\", $Conditions))
 #end
 $util.toJson($UpdateItem)
-## [End] Mutation Update resolver. **",
+## [End] Post Update resolver. **",
   "Mutation.updatePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
@@ -1471,7 +1471,7 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
-  "Mutation.updatePost.req.vtl": "## [Start] Mutation Update resolver. **
+  "Mutation.updatePost.req.vtl": "## [Start] Post Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -1601,7 +1601,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($UpdateItem.put(\\"condition\\", $Conditions))
 #end
 $util.toJson($UpdateItem)
-## [End] Mutation Update resolver. **",
+## [End] Post Update resolver. **",
   "Mutation.updatePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
@@ -2013,7 +2013,7 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
-  "Mutation.updatePost.req.vtl": "## [Start] Mutation Update resolver. **
+  "Mutation.updatePost.req.vtl": "## [Start] Post Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2143,7 +2143,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($UpdateItem.put(\\"condition\\", $Conditions))
 #end
 $util.toJson($UpdateItem)
-## [End] Mutation Update resolver. **",
+## [End] Post Update resolver. **",
   "Mutation.updatePost.res.vtl": "## [Start] ResponseTemplate. **
 $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #if( $ctx.error )
@@ -2674,7 +2674,7 @@ $util.toJson($PutObject)
 `;
 
 exports[`ModelTransformer:  should have timestamps as nullable fields when the type makes it non-nullable 3`] = `
-"## [Start] Mutation Update resolver. **
+"## [Start] Post Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -2803,7 +2803,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($UpdateItem.put(\\"condition\\", $Conditions))
 #end
 $util.toJson($UpdateItem)
-## [End] Mutation Update resolver. **"
+## [End] Post Update resolver. **"
 `;
 
 exports[`ModelTransformer:  should not add default primary key when ID is defined 1`] = `
@@ -3341,7 +3341,7 @@ $util.toJson($PutObject)
 `;
 
 exports[`ModelTransformer:  should not to auto generate createdAt and updatedAt when the type in schema is not AWSDateTime 3`] = `
-"## [Start] Mutation Update resolver. **
+"## [Start] Post Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -3470,7 +3470,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($UpdateItem.put(\\"condition\\", $Conditions))
 #end
 $util.toJson($UpdateItem)
-## [End] Mutation Update resolver. **"
+## [End] Post Update resolver. **"
 `;
 
 exports[`ModelTransformer:  should not to include createdAt and updatedAt field when timestamps is set to null 1`] = `
@@ -3761,7 +3761,7 @@ $util.toJson($PutObject)
 `;
 
 exports[`ModelTransformer:  should not to include createdAt and updatedAt field when timestamps is set to null 3`] = `
-"## [Start] Mutation Update resolver. **
+"## [Start] Post Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -3890,7 +3890,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($UpdateItem.put(\\"condition\\", $Conditions))
 #end
 $util.toJson($UpdateItem)
-## [End] Mutation Update resolver. **"
+## [End] Post Update resolver. **"
 `;
 
 exports[`ModelTransformer:  should support timestamp parameters when generating resolvers and output schema 1`] = `
@@ -4183,7 +4183,7 @@ $util.toJson($PutObject)
 `;
 
 exports[`ModelTransformer:  should support timestamp parameters when generating resolvers and output schema 3`] = `
-"## [Start] Mutation Update resolver. **
+"## [Start] Post Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
 #set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
@@ -4312,7 +4312,7 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
   $util.qr($UpdateItem.put(\\"condition\\", $Conditions))
 #end
 $util.toJson($UpdateItem)
-## [End] Mutation Update resolver. **"
+## [End] Post Update resolver. **"
 `;
 
 exports[`ModelTransformer:  the datastore table should be configured 1`] = `

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -445,14 +445,23 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     const resolverKey = `Get${generateResolverKey(typeName, fieldName)}`;
     const dbInfo = ctx.modelToDatasourceMap.get(type.name.value);
     const vtlGenerator = this.getVTLGenerator(dbInfo);
+    const requestConfig = {
+      operation: 'GET',
+      operationName: fieldName,
+    };
+    const responseConfig = {
+      ...requestConfig,
+      isSyncEnabled,
+      modelName: typeName,
+    };
     if (!this.resolverMap[resolverKey]) {
       this.resolverMap[resolverKey] = ctx.resolvers.generateQueryResolver(
         typeName,
         fieldName,
         resolverLogicalId,
         dataSource,
-        MappingTemplate.s3MappingTemplateFromString(vtlGenerator.generateGetRequestTemplate(), `${typeName}.${fieldName}.req.vtl`),
-        MappingTemplate.s3MappingTemplateFromString(vtlGenerator.generateGetResponseTemplate(isSyncEnabled), `${typeName}.${fieldName}.res.vtl`),
+        MappingTemplate.s3MappingTemplateFromString(vtlGenerator.generateGetRequestTemplate(requestConfig), `${typeName}.${fieldName}.req.vtl`),
+        MappingTemplate.s3MappingTemplateFromString(vtlGenerator.generateGetResponseTemplate(responseConfig), `${typeName}.${fieldName}.res.vtl`),
       );
     }
     return this.resolverMap[resolverKey];
@@ -470,15 +479,24 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     const resolverKey = `List${generateResolverKey(typeName, fieldName)}`;
     const dbInfo = ctx.modelToDatasourceMap.get(type.name.value);
     const vtlGenerator = this.getVTLGenerator(dbInfo);
+    const requestConfig = {
+      operation: 'LIST',
+      operationName: fieldName,
+    };
+    const responseConfig = {
+      ...requestConfig,
+      isSyncEnabled,
+      mutation: false,
+    };
     if (!this.resolverMap[resolverKey]) {
       this.resolverMap[resolverKey] = ctx.resolvers.generateQueryResolver(
         typeName,
         fieldName,
         resolverLogicalId,
         dataSource,
-        MappingTemplate.s3MappingTemplateFromString(vtlGenerator.generateListRequestTemplate(), `${typeName}.${fieldName}.req.vtl`),
+        MappingTemplate.s3MappingTemplateFromString(vtlGenerator.generateListRequestTemplate(requestConfig), `${typeName}.${fieldName}.req.vtl`),
         MappingTemplate.s3MappingTemplateFromString(
-          vtlGenerator.generateDefaultResponseMappingTemplate(isSyncEnabled, false),
+          vtlGenerator.generateDefaultResponseMappingTemplate(responseConfig),
           `${typeName}.${fieldName}.res.vtl`,
         ),
       );
@@ -498,6 +516,18 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     const resolverKey = `Update${generateResolverKey(typeName, fieldName)}`;
     const dbInfo = ctx.modelToDatasourceMap.get(type.name.value);
     const vtlGenerator = this.getVTLGenerator(dbInfo);
+    const requestConfig = {
+      operation: 'UPDATE',
+      operationName: fieldName,
+      isSyncEnabled,
+      modelName: typeName,
+    };
+    const responseConfig = {
+      operation: 'UPDATE',
+      operationName: fieldName,
+      isSyncEnabled,
+      mutation: false,
+    };
     if (!this.resolverMap[resolverKey]) {
       const resolver = ctx.resolvers.generateMutationResolver(
         typeName,
@@ -505,19 +535,24 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
         resolverLogicalId,
         dataSource,
         MappingTemplate.s3MappingTemplateFromString(
-          vtlGenerator.generateUpdateRequestTemplate(typeName, isSyncEnabled),
+          vtlGenerator.generateUpdateRequestTemplate(requestConfig),
           `${typeName}.${fieldName}.req.vtl`,
         ),
         MappingTemplate.s3MappingTemplateFromString(
-          vtlGenerator.generateDefaultResponseMappingTemplate(isSyncEnabled, true),
+          vtlGenerator.generateDefaultResponseMappingTemplate(responseConfig),
           `${typeName}.${fieldName}.res.vtl`,
         ),
       );
       // Todo: get the slot index from the resolver to keep the name unique and show the order of functions
+      const updateInitConfig = {
+        modelConfig: this.modelDirectiveConfig.get(type.name.value)!,
+        operation: 'UPDATE',
+        operationName: fieldName,
+      };
       resolver.addToSlot(
         'init',
         MappingTemplate.s3MappingTemplateFromString(
-          vtlGenerator.generateUpdateInitSlotTemplate(this.modelDirectiveConfig.get(type.name.value)!),
+          vtlGenerator.generateUpdateInitSlotTemplate(updateInitConfig),
           `${typeName}.${fieldName}.{slotName}.{slotIndex}.req.vtl`,
         ),
       );
@@ -538,15 +573,27 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     const resolverKey = `delete${generateResolverKey(typeName, fieldName)}`;
     const dbInfo = ctx.modelToDatasourceMap.get(type.name.value);
     const vtlGenerator = this.getVTLGenerator(dbInfo);
+    const requestConfig = {
+      operation: 'DELETE',
+      operationName: fieldName,
+      isSyncEnabled,
+      modelName: typeName,
+    };
+    const responseConfig = {
+      operation: 'DELETE',
+      operationName: fieldName,
+      isSyncEnabled,
+      mutation: false,
+    };
     if (!this.resolverMap[resolverKey]) {
       this.resolverMap[resolverKey] = ctx.resolvers.generateMutationResolver(
         typeName,
         fieldName,
         resolverLogicalId,
         dataSource,
-        MappingTemplate.s3MappingTemplateFromString(vtlGenerator.generateDeleteRequestTemplate(typeName, isSyncEnabled), `${typeName}.${fieldName}.req.vtl`),
+        MappingTemplate.s3MappingTemplateFromString(vtlGenerator.generateDeleteRequestTemplate(requestConfig), `${typeName}.${fieldName}.req.vtl`),
         MappingTemplate.s3MappingTemplateFromString(
-          vtlGenerator.generateDefaultResponseMappingTemplate(isSyncEnabled, true),
+          vtlGenerator.generateDefaultResponseMappingTemplate(responseConfig),
           `${typeName}.${fieldName}.res.vtl`,
         ),
       );
@@ -629,15 +676,24 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     const resolverKey = `Sync${generateResolverKey(typeName, fieldName)}`;
     const dbInfo = ctx.modelToDatasourceMap.get(type.name.value);
     const vtlGenerator = this.getVTLGenerator(dbInfo);
+    const requestConfig = {
+      operation: 'SYNC',
+      operationName: fieldName,
+    };
+    const responseConfig = {
+      ...requestConfig,
+      isSyncEnabled,
+      mutation: false,
+    };
     if (!this.resolverMap[resolverKey]) {
       this.resolverMap[resolverKey] = ctx.resolvers.generateQueryResolver(
         typeName,
         fieldName,
         resolverLogicalId,
         dataSource,
-        MappingTemplate.s3MappingTemplateFromString(vtlGenerator.generateSyncRequestTemplate(), `${typeName}.${fieldName}.req.vtl`),
+        MappingTemplate.s3MappingTemplateFromString(vtlGenerator.generateSyncRequestTemplate(requestConfig), `${typeName}.${fieldName}.req.vtl`),
         MappingTemplate.s3MappingTemplateFromString(
-          vtlGenerator.generateDefaultResponseMappingTemplate(isSyncEnabled, false),
+          vtlGenerator.generateDefaultResponseMappingTemplate(responseConfig),
           `${typeName}.${fieldName}.res.vtl`,
         ),
       );
@@ -885,23 +941,40 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     const dbInfo = ctx.modelToDatasourceMap.get(type.name.value);
     const vtlGenerator = this.getVTLGenerator(dbInfo);
     const modelIndexFields = type.fields!.filter(field => field.directives?.some(it => it.name.value === 'index')).map(it => it.name.value);
+    const requestConfig = {
+      operation: 'CREATE',
+      operationName: fieldName,
+      modelIndexFields,
+      modelName: typeName,
+    };
+    const responseConfig = {
+      operation: 'CREATE',
+      operationName: fieldName,
+      isSyncEnabled,
+      mutation: false,
+    };
     if (!this.resolverMap[resolverKey]) {
       const resolver = ctx.resolvers.generateMutationResolver(
         typeName,
         fieldName,
         resolverLogicalId,
         dataSource,
-        MappingTemplate.s3MappingTemplateFromString(vtlGenerator.generateCreateRequestTemplate(type.name.value, modelIndexFields), `${typeName}.${fieldName}.req.vtl`),
+        MappingTemplate.s3MappingTemplateFromString(vtlGenerator.generateCreateRequestTemplate(requestConfig), `${typeName}.${fieldName}.req.vtl`),
         MappingTemplate.s3MappingTemplateFromString(
-          vtlGenerator.generateDefaultResponseMappingTemplate(isSyncEnabled, true),
+          vtlGenerator.generateDefaultResponseMappingTemplate(responseConfig),
           `${typeName}.${fieldName}.res.vtl`,
         ),
       );
       this.resolverMap[resolverKey] = resolver;
+      const initSlotConfig = {
+        operation: 'CREATE',
+        operationName: fieldName,
+        modelConfig: this.modelDirectiveConfig.get(type.name.value)!,
+      };
       resolver.addToSlot(
         'init',
         MappingTemplate.s3MappingTemplateFromString(
-          vtlGenerator.generateCreateInitSlotTemplate(this.modelDirectiveConfig.get(type.name.value)!),
+          vtlGenerator.generateCreateInitSlotTemplate(initSlotConfig),
           `${typeName}.${fieldName}.{slotName}.{slotIndex}.req.vtl`,
         ),
       );

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -526,7 +526,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
       operation: 'UPDATE',
       operationName: fieldName,
       isSyncEnabled,
-      mutation: false,
+      mutation: true,
     };
     if (!this.resolverMap[resolverKey]) {
       const resolver = ctx.resolvers.generateMutationResolver(
@@ -583,7 +583,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
       operation: 'DELETE',
       operationName: fieldName,
       isSyncEnabled,
-      mutation: false,
+      mutation: true,
     };
     if (!this.resolverMap[resolverKey]) {
       this.resolverMap[resolverKey] = ctx.resolvers.generateMutationResolver(
@@ -951,7 +951,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
       operation: 'CREATE',
       operationName: fieldName,
       isSyncEnabled,
-      mutation: false,
+      mutation: true,
     };
     if (!this.resolverMap[resolverKey]) {
       const resolver = ctx.resolvers.generateMutationResolver(

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -452,7 +452,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     const responseConfig = {
       ...requestConfig,
       isSyncEnabled,
-      modelName: typeName,
+      modelName: type.name.value,
     };
     if (!this.resolverMap[resolverKey]) {
       this.resolverMap[resolverKey] = ctx.resolvers.generateQueryResolver(
@@ -520,7 +520,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
       operation: 'UPDATE',
       operationName: fieldName,
       isSyncEnabled,
-      modelName: typeName,
+      modelName: type.name.value,
     };
     const responseConfig = {
       operation: 'UPDATE',
@@ -577,7 +577,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
       operation: 'DELETE',
       operationName: fieldName,
       isSyncEnabled,
-      modelName: typeName,
+      modelName: type.name.value,
     };
     const responseConfig = {
       operation: 'DELETE',
@@ -945,7 +945,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
       operation: 'CREATE',
       operationName: fieldName,
       modelIndexFields,
-      modelName: typeName,
+      modelName: type.name.value,
     };
     const responseConfig = {
       operation: 'CREATE',

--- a/packages/amplify-graphql-model-transformer/src/resolvers/dynamodb/mutation.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/dynamodb/mutation.ts
@@ -145,7 +145,7 @@ export const generateUpdateRequestTemplate = (modelName: string, isSyncEnabled: 
     ),
     toJson(ref('UpdateItem')),
   ];
-  return printBlock(`${modelName} Update resolver`)(compoundExpression(statements));
+  return printBlock(`Mutation Update resolver`)(compoundExpression(statements));
 };
 
 /**

--- a/packages/amplify-graphql-model-transformer/src/resolvers/generator/dynamodb-vtl-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/generator/dynamodb-vtl-generator.ts
@@ -1,4 +1,11 @@
-import { ModelCreateInitSlotConfig, ModelCreateRequestConfig, ModelDefaultResponseConfig, ModelRequestConfig, ModelUpdateRequestConfig, ModelVTLGenerator } from "./vtl-generator";
+import {
+  ModelCreateInitSlotConfig,
+  ModelCreateRequestConfig,
+  ModelDefaultResponseConfig,
+  ModelRequestConfig,
+  ModelUpdateRequestConfig,
+  ModelVTLGenerator,
+} from "./vtl-generator";
 import {
   generateUpdateRequestTemplate,
   generateCreateRequestTemplate,

--- a/packages/amplify-graphql-model-transformer/src/resolvers/generator/dynamodb-vtl-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/generator/dynamodb-vtl-generator.ts
@@ -1,4 +1,4 @@
-import { ModelVTLGenerator } from "./vtl-generator";
+import { ModelCreateInitSlotConfig, ModelCreateRequestConfig, ModelDefaultResponseConfig, ModelRequestConfig, ModelUpdateRequestConfig, ModelVTLGenerator } from "./vtl-generator";
 import {
   generateUpdateRequestTemplate,
   generateCreateRequestTemplate,
@@ -15,16 +15,40 @@ import {
 } from '../dynamodb';
 
 export class DynamoDBModelVTLGenerator implements ModelVTLGenerator {
-  public generateUpdateRequestTemplate = generateUpdateRequestTemplate;
-  public generateCreateRequestTemplate = generateCreateRequestTemplate;
-  public generateCreateInitSlotTemplate = generateCreateInitSlotTemplate;
-  public generateDeleteRequestTemplate = generateDeleteRequestTemplate;
-  public generateUpdateInitSlotTemplate = generateUpdateInitSlotTemplate;
-  public generateGetRequestTemplate = generateGetRequestTemplate;
-  public generateGetResponseTemplate = generateGetResponseTemplate;
-  public generateListRequestTemplate = generateListRequestTemplate;
-  public generateSyncRequestTemplate = generateSyncRequestTemplate;
-  public generateSubscriptionRequestTemplate = generateSubscriptionRequestTemplate;
-  public generateSubscriptionResponseTemplate = generateSubscriptionResponseTemplate;
-  public generateDefaultResponseMappingTemplate = generateDefaultResponseMappingTemplate;
+  generateUpdateRequestTemplate(config: ModelUpdateRequestConfig): string {
+    return generateUpdateRequestTemplate(config.modelName, config.isSyncEnabled);
+  }
+  generateCreateRequestTemplate(config: ModelCreateRequestConfig): string {
+    return generateCreateRequestTemplate(config.modelName, config.modelIndexFields);
+  }
+  generateCreateInitSlotTemplate(config: ModelCreateInitSlotConfig): string {
+    return generateCreateInitSlotTemplate(config.modelConfig);
+  }
+  generateDeleteRequestTemplate(config: ModelUpdateRequestConfig): string {
+    return generateDeleteRequestTemplate(config.modelName, config.isSyncEnabled);
+  }
+  generateUpdateInitSlotTemplate(config: ModelCreateInitSlotConfig): string {
+    return generateUpdateInitSlotTemplate(config.modelConfig);
+  }
+  generateGetRequestTemplate(config: ModelRequestConfig): string {
+    return generateGetRequestTemplate();
+  }
+  generateGetResponseTemplate(config: ModelUpdateRequestConfig): string {
+    return generateGetResponseTemplate(config.isSyncEnabled);
+  }
+  generateListRequestTemplate(config: ModelRequestConfig): string {
+    return generateListRequestTemplate();
+  }
+  generateSyncRequestTemplate(config: ModelRequestConfig): string {
+    return generateSyncRequestTemplate();
+  }
+  generateSubscriptionRequestTemplate(): string {
+    return generateSubscriptionRequestTemplate();
+  }
+  generateSubscriptionResponseTemplate(): string {
+    return generateSubscriptionResponseTemplate();
+  }
+  generateDefaultResponseMappingTemplate(config: ModelDefaultResponseConfig): string {
+    return generateDefaultResponseMappingTemplate(config.isSyncEnabled, config.mutation);
+  }
 }

--- a/packages/amplify-graphql-model-transformer/src/resolvers/generator/rds-vtl-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/generator/rds-vtl-generator.ts
@@ -1,48 +1,53 @@
-import { ModelDirectiveConfiguration } from "../../directive";
-import { OperationConfig, ModelVTLGenerator } from "./vtl-generator";
 import {
   generateDefaultLambdaResponseMappingTemplate,
   generateGetLambdaResponseTemplate,
-  generateLambdaRequestTemplate,
+  generateLambdaRequestTemplate
 } from '../rds';
+import { 
+  ModelCreateInitSlotConfig, 
+  ModelCreateRequestConfig, 
+  ModelDefaultResponseConfig, 
+  ModelRequestConfig, 
+  ModelUpdateRequestConfig, 
+  ModelVTLGenerator 
+} from "./vtl-generator";
 
 // TODO: This class is created only to show the class structure. This needs a revisit to generate correct resolvers for RDS.
 export class RDSModelVTLGenerator implements ModelVTLGenerator {
-  generateUpdateRequestTemplate(modelName: string, isSyncEnabled: boolean, config?: OperationConfig | undefined): string {
-    return generateLambdaRequestTemplate(modelName, config?.operation!, config?.operationName!);
+  generateUpdateRequestTemplate(config: ModelUpdateRequestConfig): string {
+    return generateLambdaRequestTemplate(config.modelName, config.operation, config.operationName);
   }
-  generateCreateRequestTemplate(modelName: string, modelIndexFields: string[], config?: OperationConfig | undefined): string {
-    return generateLambdaRequestTemplate(modelName, config?.operation!, config?.operationName!);
+  generateCreateRequestTemplate(config: ModelCreateRequestConfig): string {
+    return generateLambdaRequestTemplate(config.modelName, config.operation, config.operationName);
   }
-  generateCreateInitSlotTemplate(modelConfig: ModelDirectiveConfiguration, config?: OperationConfig | undefined): string {
+  generateCreateInitSlotTemplate(config: ModelCreateInitSlotConfig): string {
     return generateDefaultLambdaResponseMappingTemplate(false);
   }
-  generateDeleteRequestTemplate(modelName: string, isSyncEnabled: boolean, config?: OperationConfig | undefined): string {
-    return generateLambdaRequestTemplate(modelName, config?.operation!, config?.operationName!);
+  generateDeleteRequestTemplate(config: ModelUpdateRequestConfig): string {
+    return generateLambdaRequestTemplate(config.modelName, config.operation, config.operationName);
   }
-  generateUpdateInitSlotTemplate(modelConfig: ModelDirectiveConfiguration, config?: OperationConfig | undefined): string {
+  generateUpdateInitSlotTemplate(config: ModelCreateInitSlotConfig): string {
     return generateDefaultLambdaResponseMappingTemplate(false);
   }
-  generateGetRequestTemplate(config?: OperationConfig | undefined): string {
+  generateGetRequestTemplate(config: ModelRequestConfig): string {
     return generateGetLambdaResponseTemplate(false);
   }
-  generateGetResponseTemplate(isSyncEnabled: boolean, config?: OperationConfig | undefined): string {
+  generateGetResponseTemplate(config: ModelUpdateRequestConfig): string {
     return generateDefaultLambdaResponseMappingTemplate(false);
   }
-  generateListRequestTemplate(config?: OperationConfig | undefined): string {
+  generateListRequestTemplate(config: ModelRequestConfig): string {
     return generateDefaultLambdaResponseMappingTemplate(false);
   }
-  generateSyncRequestTemplate(config?: OperationConfig | undefined): string {
+  generateSyncRequestTemplate(config: ModelRequestConfig): string {
     return generateDefaultLambdaResponseMappingTemplate(false);
   }
-  generateSubscriptionRequestTemplate(config?: OperationConfig | undefined): string {
+  generateSubscriptionRequestTemplate(): string {
     return generateDefaultLambdaResponseMappingTemplate(false);
   }
-  generateSubscriptionResponseTemplate(config?: OperationConfig | undefined): string {
+  generateSubscriptionResponseTemplate(): string {
     return generateDefaultLambdaResponseMappingTemplate(false);
   }
-  generateDefaultResponseMappingTemplate(isSyncEnabled: boolean, mutation: boolean): string {
+  generateDefaultResponseMappingTemplate(config: ModelDefaultResponseConfig): string {
     return generateDefaultLambdaResponseMappingTemplate(false);
   }
-
 }

--- a/packages/amplify-graphql-model-transformer/src/resolvers/generator/rds-vtl-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/generator/rds-vtl-generator.ts
@@ -1,7 +1,7 @@
 import {
   generateDefaultLambdaResponseMappingTemplate,
   generateGetLambdaResponseTemplate,
-  generateLambdaRequestTemplate
+  generateLambdaRequestTemplate,
 } from '../rds';
 import { 
   ModelCreateInitSlotConfig, 
@@ -9,7 +9,7 @@ import {
   ModelDefaultResponseConfig, 
   ModelRequestConfig, 
   ModelUpdateRequestConfig, 
-  ModelVTLGenerator 
+  ModelVTLGenerator, 
 } from "./vtl-generator";
 
 // TODO: This class is created only to show the class structure. This needs a revisit to generate correct resolvers for RDS.

--- a/packages/amplify-graphql-model-transformer/src/resolvers/generator/vtl-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/generator/vtl-generator.ts
@@ -1,21 +1,46 @@
 import { ModelDirectiveConfiguration } from "../../directive";
 
-export interface OperationConfig {
-  operation?: string;
-  operationName?: string;
+export type ModelRequestConfig = {
+  operation: string;
+  operationName: string;
+}
+
+export type ModelUpdateRequestConfig = ModelRequestConfig & {
+  modelName: string;
+  isSyncEnabled: boolean;
+}
+
+export type ModelDeleteRequestConfig = ModelUpdateRequestConfig;
+
+export type ModelCreateRequestConfig = ModelRequestConfig & {
+  modelName: string;
+  modelIndexFields: string[];
+}
+
+export type ModelCreateInitSlotConfig = {
+  modelConfig: ModelDirectiveConfiguration;
+}
+
+export type ModelUpdateInitSlotConfig = ModelCreateInitSlotConfig;
+
+export type ModelGetResponseConfig = ModelUpdateRequestConfig;
+
+export type ModelDefaultResponseConfig = ModelRequestConfig & {
+  isSyncEnabled: boolean;
+  mutation: boolean;
 }
 
 export interface ModelVTLGenerator {
-  generateUpdateRequestTemplate(modelName: string, isSyncEnabled: boolean, config?: OperationConfig): string;
-  generateCreateRequestTemplate(modelName: string, modelIndexFields: string[], config?: OperationConfig): string;
-  generateCreateInitSlotTemplate(modelConfig: ModelDirectiveConfiguration, config?: OperationConfig): string;
-  generateDeleteRequestTemplate(modelName: string, isSyncEnabled: boolean, config?: OperationConfig): string;
-  generateUpdateInitSlotTemplate(modelConfig: ModelDirectiveConfiguration, config?: OperationConfig): string;
-  generateGetRequestTemplate(config?: OperationConfig): string;
-  generateGetResponseTemplate(isSyncEnabled: boolean, config?: OperationConfig): string;
-  generateListRequestTemplate(config?: OperationConfig): string;
-  generateSyncRequestTemplate(config?: OperationConfig): string;
-  generateSubscriptionRequestTemplate(config?: OperationConfig): string;
-  generateSubscriptionResponseTemplate(config?: OperationConfig): string;
-  generateDefaultResponseMappingTemplate(isSyncEnabled: boolean, mutation: boolean): string;
+  generateUpdateRequestTemplate(config: ModelUpdateRequestConfig): string;
+  generateCreateRequestTemplate(config: ModelCreateRequestConfig): string;
+  generateCreateInitSlotTemplate(config: ModelCreateInitSlotConfig): string;
+  generateDeleteRequestTemplate(config: ModelDeleteRequestConfig): string;
+  generateUpdateInitSlotTemplate(config: ModelUpdateInitSlotConfig): string;
+  generateGetRequestTemplate(config: ModelRequestConfig): string;
+  generateGetResponseTemplate(config: ModelGetResponseConfig): string;
+  generateListRequestTemplate(config: ModelRequestConfig): string;
+  generateSyncRequestTemplate(config: ModelRequestConfig): string;
+  generateSubscriptionRequestTemplate(): string;
+  generateSubscriptionResponseTemplate(): string;
+  generateDefaultResponseMappingTemplate(config: ModelDefaultResponseConfig): string;
 }


### PR DESCRIPTION
#### Description of changes

This PR improves the typing for the VTL generator methods' arguments as per this [discussion](https://github.com/aws-amplify/amplify-category-api/pull/1188#discussion_r1087322819).

- (Type safety) Adds config types which are strongly typed for the respective operation.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
