### PR TITLE
feat(graphql): infer enums from database schema

### DIFF
--- a/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/mysql-datasource-adapter.test.ts.snap
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/mysql-datasource-adapter.test.ts.snap
@@ -38,3 +38,17 @@ type Tasks @model {
 }
 "
 `;
+
+exports[`testDataSourceAdapter test generate graphql schema on model with enum field 1`] = `
+"enum Profile_type {
+  Manager
+  Employee
+}
+
+type Profile @model {
+  id: Int! @primaryKey
+  name: String
+  type: Profile_type
+}
+"
+`;

--- a/packages/amplify-graphql-schema-generator/src/datasource-adapter/datasource-adapter.ts
+++ b/packages/amplify-graphql-schema-generator/src/datasource-adapter/datasource-adapter.ts
@@ -5,7 +5,7 @@ export abstract class DataSourceAdapter {
   public abstract getFields(tableName: string): Promise<Field[]>;
   public abstract getPrimaryKey(tableName: string): Promise<Index | null>;
   public abstract getIndexes(tableName: string): Promise<Index[]>;
-  public abstract mapDataType(type: string, nullable: boolean): FieldType;
+  public abstract mapDataType(datatype: string, nullable: boolean, tableName: string, fieldName:string, columnType: string): FieldType;
   public abstract initialize(): Promise<void>;
   public abstract cleanup(): void;
 

--- a/packages/amplify-graphql-schema-generator/src/datasource-adapter/mysql-datasource-adapter.ts
+++ b/packages/amplify-graphql-schema-generator/src/datasource-adapter/mysql-datasource-adapter.ts
@@ -286,7 +286,7 @@ export class MySQLDataSourceAdapter extends DataSourceAdapter {
   }
 
   private generateEnumName(tableName: string, fieldName: string) {
-    let enumNamePrefix = [tableName, fieldName].join("_");
+    const enumNamePrefix = [tableName, fieldName].join("_");
     let enumName = enumNamePrefix;
     let counter = 0;
     while (this.enums.has(enumName)) {

--- a/packages/amplify-graphql-schema-generator/src/schema-representation/types.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-representation/types.ts
@@ -1,7 +1,7 @@
-export type FieldType = DefaultType | CustomType | ListType | NonNullType;
+export type FieldType = DefaultType | CustomType | ListType | NonNullType | EnumType;
 
 export type FieldDataType = 'String' | 'ID' | 'Int' | 'Float' | 'AWSJSON' 
-| 'AWSDate' | 'AWSTime' | 'AWSDateTime' | 'AWSTimestamp'
+| 'AWSDate' | 'AWSTime' | 'AWSDateTime' | 'AWSTimestamp' | 'ENUM'
 | 'Boolean' | 'AWSEmail' | 'AWSPhone' | 'AWSURL' | 'AWSIPAddress';
 
 export interface DefaultType {
@@ -21,7 +21,13 @@ export interface ListType {
 
 export interface NonNullType {
   readonly kind: 'NonNull';
-  readonly type: DefaultType | CustomType | ListType;
+  readonly type: DefaultType | CustomType | ListType | EnumType;
+}
+
+export interface EnumType {
+  readonly kind: 'Enum';
+  name: string;
+  readonly values: string[];
 }
 
 export interface DefaultValue {


### PR DESCRIPTION
#### Description of changes

Infer Enum field types from MySQL table and creates a GraphQL schema.

For example: The below SQL table should generate the GraphQL schema as shown.

```sql
/* Create Table Script */ 
CREATE TABLE `Person` (
  `id` varchar(40) default (uuid()) not null primary key,
  `firstName` varchar(50),
  `profile_type` ENUM('EMPLOYEE', 'MANAGER')
)
```

```graphql
# GraphQL Schema
enum Person_profile_type {
  EMPLOYEE
  MANAGER
}

type Person @model {
  id: String! @default(value: "uuid()") @primaryKey
  firstName: String
  profile_type: Person_profile_type
}
```

#### Description of how you validated changes
- yarn test
- manual test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
