### PR TITLE
feat(graphql): add index directive rds support

### DIFF
--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
@@ -514,7 +514,7 @@ $util.toJson({})
   \\"index\\": \\"CategoryGSI\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -1161,7 +1161,7 @@ $util.toJson({})
   \\"index\\": \\"GSI\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -1787,7 +1787,7 @@ $util.toJson({})
   \\"index\\": \\"GSI_Email\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -2704,7 +2704,7 @@ $util.toJson({})
   \\"index\\": \\"CategoryGSI\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -3298,7 +3298,7 @@ $util.toJson({})
   \\"index\\": \\"ByCreatedAt\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -3402,7 +3402,7 @@ $util.toJson({})
   \\"index\\": \\"ByStatus\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -4461,7 +4461,7 @@ $util.toJson({})
   \\"index\\": \\"byGenre\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -5210,7 +5210,7 @@ $util.toJson({})
   \\"index\\": \\"byGenre\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -5986,7 +5986,7 @@ $util.toJson({})
   \\"index\\": \\"ByCreatedAt\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -6090,7 +6090,7 @@ $util.toJson({})
   \\"index\\": \\"ByStatus\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )

--- a/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
@@ -10,7 +10,7 @@ import { FeatureFlagProvider } from '@aws-amplify/graphql-transformer-interfaces
 import { expect as cdkExpect, haveResourceLike } from '@aws-cdk/assert';
 import { DocumentNode, parse } from 'graphql';
 import { IndexTransformer, PrimaryKeyTransformer } from '..';
-import * as resolverUtils from '../resolvers';
+import * as resolverUtils from '../resolvers/resolvers';
 
 const generateFeatureFlagWithBooleanOverrides = (overrides: Record<string, boolean>): FeatureFlagProvider => ({
   getBoolean: (name: string, defaultValue?: boolean): boolean => {

--- a/packages/amplify-graphql-index-transformer/src/index.ts
+++ b/packages/amplify-graphql-index-transformer/src/index.ts
@@ -1,3 +1,3 @@
 export { IndexTransformer } from './graphql-index-transformer';
 export { PrimaryKeyTransformer } from './graphql-primary-key-transformer';
-export { attributeTypeFromType } from './resolvers';
+export { attributeTypeFromType } from './resolvers/common';

--- a/packages/amplify-graphql-index-transformer/src/resolvers/common.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers/common.ts
@@ -1,0 +1,122 @@
+import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { DynamoDbDataSource } from '@aws-cdk/aws-appsync';
+import { Table } from '@aws-cdk/aws-dynamodb';
+import { ObjectTypeDefinitionNode } from 'graphql';
+import {
+  ModelResourceIDs
+} from 'graphql-transformer-common';
+import {
+  compoundExpression, iff, methodCall, not,
+  obj, printBlock, ref, str,
+  notEquals,
+  toJson
+} from 'graphql-mapping-template';
+import { Kind, TypeNode } from 'graphql';
+import {
+  and,
+  block, Expression, raw, set
+} from 'graphql-mapping-template';
+import {
+  applyKeyExpressionForCompositeKey,
+  attributeTypeFromScalar,
+  getBaseType, ResourceConstants
+} from 'graphql-transformer-common';
+import { PrimaryKeyDirectiveConfiguration } from '../types';
+const API_KEY = 'API Key Authorization';
+
+export function getTable(context: TransformerContextProvider, object: ObjectTypeDefinitionNode): Table {
+  const ddbDataSource = context.dataSources.get(object) as DynamoDbDataSource;
+  const tableName = ModelResourceIDs.ModelTableResourceID(object.name.value);
+  const table = ddbDataSource.ds.stack.node.findChild(tableName) as Table;
+
+  if (!table) {
+    throw new Error(`Table not found in stack with table name ${tableName}`);
+  }
+  return table;
+}
+
+/**
+ * Util function to generate sandbox mode expression
+ */
+export function generateAuthExpressionForSandboxMode(enabled: boolean): string {
+  let exp;
+
+  if (enabled) exp = iff(notEquals(methodCall(ref('util.authType')), str(API_KEY)), methodCall(ref('util.unauthorized')));
+  else exp = methodCall(ref('util.unauthorized'));
+
+  return printBlock(`Sandbox Mode ${enabled ? 'Enabled' : 'Disabled'}`)(
+    compoundExpression([iff(not(ref('ctx.stash.get("hasAuth")')), exp), toJson(obj({}))]),
+  );
+};
+
+export function attributeTypeFromType(type: TypeNode, ctx: TransformerContextProvider) {
+  const baseTypeName = getBaseType(type);
+  const ofType = ctx.output.getType(baseTypeName);
+  if (ofType && ofType.kind === Kind.ENUM_TYPE_DEFINITION) {
+    return 'S';
+  }
+  return attributeTypeFromScalar(type);
+}
+
+export function setQuerySnippet(config: PrimaryKeyDirectiveConfiguration, ctx: TransformerContextProvider, isListResolver: boolean) {
+  const { field, sortKey, sortKeyFields } = config;
+  const keyFields = [field, ...sortKey];
+  const keyNames = [field.name.value, ...sortKeyFields];
+  const keyTypes = keyFields.map(k => attributeTypeFromType(k.type, ctx));
+  const expressions: Expression[] = [];
+
+  if (keyNames.length === 1) {
+    const sortDirectionValidation = iff(
+      raw('!$util.isNull($ctx.args.sortDirection)'),
+      raw('$util.error("sortDirection is not supported for List operations without a Sort key defined.", "InvalidArgumentsError")'),
+    );
+
+    expressions.push(sortDirectionValidation);
+  } else if (isListResolver === true && keyNames.length >= 1) {
+    // This check is only needed for List queries.
+    const sortDirectionValidation = iff(
+      and([raw(`$util.isNull($ctx.args.${keyNames[0]})`), raw('!$util.isNull($ctx.args.sortDirection)')]),
+      raw(
+        `$util.error("When providing argument 'sortDirection' you must also provide argument '${keyNames[0]}'.", "InvalidArgumentsError")`,
+      ),
+    );
+
+    expressions.push(sortDirectionValidation);
+  }
+
+  expressions.push(
+    set(ref(ResourceConstants.SNIPPETS.ModelQueryExpression), obj({})),
+    applyKeyExpressionForCompositeKey(keyNames, keyTypes, ResourceConstants.SNIPPETS.ModelQueryExpression)!,
+  );
+
+  return block('Set query expression for key', expressions);
+}
+
+export function attributeDefinitions(config: PrimaryKeyDirectiveConfiguration, ctx: TransformerContextProvider) {
+  const { field, sortKey, sortKeyFields } = config;
+  const definitions = [{ attributeName: field.name.value, attributeType: attributeTypeFromType(field.type, ctx) }];
+
+  if (sortKeyFields.length === 1) {
+    definitions.push({
+      attributeName: sortKeyFields[0],
+      attributeType: attributeTypeFromType(sortKey[0].type, ctx),
+    });
+  } else if (sortKeyFields.length > 1) {
+    definitions.push({
+      attributeName: getSortKeyName(config),
+      attributeType: 'S',
+    });
+  }
+
+  return definitions;
+}
+
+export function getSortKeyName(config: PrimaryKeyDirectiveConfiguration): string {
+  return config.sortKeyFields.join(ModelResourceIDs.ModelCompositeKeySeparator());
+}
+
+export function getDBType(ctx: TransformerContextProvider, modelName: string) {
+  const dbInfo = ctx.modelToDatasourceMap.get(modelName);
+  const dbType = dbInfo ? dbInfo.dbType : 'DDB';
+  return dbType;
+}

--- a/packages/amplify-graphql-index-transformer/src/resolvers/index.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers/index.ts
@@ -1,0 +1,2 @@
+export * from './query';
+export * from './resolvers';

--- a/packages/amplify-graphql-index-transformer/src/resolvers/query.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers/query.ts
@@ -1,0 +1,168 @@
+import { MappingTemplate } from '@aws-amplify/graphql-transformer-core';
+import { DataSourceProvider, TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import {
+  bool,
+  compoundExpression, equals, ifElse,
+  iff,
+  int,
+  isNullOrEmpty,
+  list,
+  methodCall, not,
+  obj,
+  print, printBlock, qref,
+  raw,
+  ref,
+  RESOLVER_VERSION_ID,
+  set,
+  str
+} from 'graphql-mapping-template';
+import {
+  ResolverResourceIDs,
+  ResourceConstants
+} from 'graphql-transformer-common';
+import { IndexDirectiveConfiguration } from '../types';
+import { getTable, generateAuthExpressionForSandboxMode, setQuerySnippet, getDBType } from "./common";
+
+export function makeQueryResolver(config: IndexDirectiveConfiguration, ctx: TransformerContextProvider) {
+  const { name, object, queryField } = config;
+  if (!(name && queryField)) {
+    throw new Error('Expected name and queryField to be defined while generating resolver.');
+  }
+  const dataSourceName = `${object.name.value}Table`;
+  const dataSource = ctx.api.host.getDataSource(dataSourceName);
+  const queryTypeName = ctx.output.getQueryTypeName() as string;
+  const table = getTable(ctx, object);
+  
+  if (!dataSource) {
+    throw new Error(`Could not find datasource with name ${dataSourceName} in context.`);
+  }
+
+  const resolverResourceId = ResolverResourceIDs.ResolverResourceID(queryTypeName, queryField);
+  const resolver = ctx.resolvers.generateQueryResolver(
+    queryTypeName,
+    queryField,
+    resolverResourceId,
+    dataSource as DataSourceProvider,
+    MappingTemplate.s3MappingTemplateFromString(
+      makeQueryRequestMappingTemplate(config, ctx, queryField),
+      `${queryTypeName}.${queryField}.req.vtl`,
+    ),
+    MappingTemplate.s3MappingTemplateFromString(
+      print(
+        compoundExpression([
+          iff(ref('ctx.error'), raw('$util.error($ctx.error.message, $ctx.error.type)')),
+          raw('$util.toJson($ctx.result)'),
+        ]),
+      ),
+      `${queryTypeName}.${queryField}.res.vtl`,
+    ),
+  );
+  resolver.addToSlot(
+    'postAuth',
+    MappingTemplate.s3MappingTemplateFromString(
+      generateAuthExpressionForSandboxMode(ctx.sandboxModeEnabled),
+      `${queryTypeName}.${queryField}.{slotName}.{slotIndex}.res.vtl`,
+    ),
+  );
+
+  resolver.mapToStack(ctx.stackManager.getStackFor(resolverResourceId, table.stack.node.id));
+  ctx.resolvers.addResolver(object.name.value, queryField, resolver);
+}
+
+function makeQueryRequestMappingTemplate(config: IndexDirectiveConfiguration, ctx: TransformerContextProvider, queryName: string): string {
+  const { object } = config;
+  const modelName = object.name.value;
+  const dbType = getDBType(ctx, modelName);
+  switch (dbType) {
+    case 'MySQL':
+      return makeRDSQueryRequestMappingTemplate(config, ctx, modelName, queryName);
+    default:
+      return makeDDBQueryRequestMappingTemplate(config, ctx);
+  }
+}
+
+function makeDDBQueryRequestMappingTemplate(config: IndexDirectiveConfiguration, ctx: TransformerContextProvider): string {
+  const { name, object, queryField } = config;
+  if (!(name && queryField)) {
+    throw new Error('Expected name and queryField to be defined while generating resolver.');
+  }
+  const authFilter = ref('ctx.stash.authFilter');
+  const requestVariable = 'QueryRequest';
+  return print(
+    compoundExpression([
+      setQuerySnippet(config, ctx, false),
+      set(ref('limit'), ref(`util.defaultIfNull($context.args.limit, ${ResourceConstants.DEFAULT_PAGE_LIMIT})`)),
+      set(
+        ref(requestVariable),
+        obj({
+          version: str(RESOLVER_VERSION_ID),
+          operation: str('Query'),
+          limit: ref('limit'),
+          query: ref(ResourceConstants.SNIPPETS.ModelQueryExpression),
+          index: str(name),
+        }),
+      ),
+      ifElse(
+        raw(`!$util.isNull($ctx.args.sortDirection)
+                && $ctx.args.sortDirection == "DESC"`),
+        set(ref(`${requestVariable}.scanIndexForward`), bool(false)),
+        set(ref(`${requestVariable}.scanIndexForward`), bool(true)),
+      ),
+      iff(ref('context.args.nextToken'), set(ref(`${requestVariable}.nextToken`), ref('context.args.nextToken')), true),
+      ifElse(
+        not(isNullOrEmpty(authFilter)),
+        compoundExpression([
+          set(ref('filter'), authFilter),
+          iff(
+            not(isNullOrEmpty(ref('ctx.args.filter'))),
+            set(ref('filter'), obj({ and: list([ref('filter'), ref('ctx.args.filter')]) })),
+          ),
+        ]),
+        iff(not(isNullOrEmpty(ref('ctx.args.filter'))), set(ref('filter'), ref('ctx.args.filter'))),
+      ),
+      iff(
+        not(isNullOrEmpty(ref('filter'))),
+        compoundExpression([
+          set(
+            ref('filterExpression'),
+            methodCall(ref('util.parseJson'), methodCall(ref('util.transform.toDynamoDBFilterExpression'), ref('filter'))),
+          ),
+          iff(
+            not(methodCall(ref('util.isNullOrBlank'), ref('filterExpression.expression'))),
+            compoundExpression([
+              iff(
+                equals(methodCall(ref('filterExpression.expressionValues.size')), int(0)),
+                qref(methodCall(ref('filterExpression.remove'), str('expressionValues'))),
+              ),
+              set(ref(`${requestVariable}.filter`), ref('filterExpression')),
+            ]),
+          ),
+        ]),
+      ),
+      raw(`$util.toJson($${requestVariable})`),
+    ]),
+  );
+}
+
+function makeRDSQueryRequestMappingTemplate(
+  config: IndexDirectiveConfiguration,
+  ctx: TransformerContextProvider,
+  tableName: string,
+  operationName: string,
+): string {
+  //TODO: Verify correctness of template once Lambda code is merged.
+  return printBlock('Invoke RDS Lambda data source')(
+    compoundExpression([
+      set(ref('args'), obj({})),
+      set(ref('args.args'), ref('context.arguments')),
+      set(ref('args.table'), str(tableName)),
+      set(ref('args.operation'), str('QUERY')),
+      set(ref('args.operationName'), str(operationName)),
+      obj({
+        version: str('2018-05-29'),
+        operation: str('Invoke'),
+        payload: methodCall(ref('util.toJson'), ref('args')),
+      }),
+    ]),
+  );
+}


### PR DESCRIPTION
Adds @index directive support for RDS datasource. Import workflow detects the indexes and adds @index on the field. 
- Customer can edit a generated index and add a queryField attribute which will create a GraphQL query with the given name.
- Refactor resolvers.ts on index package (moved out index related code to `query.ts` file).

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
