### PR TITLE
feat(graphql): add index directive support for rds datasource

### DIFF
--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
@@ -514,7 +514,7 @@ $util.toJson({})
   \\"index\\": \\"CategoryGSI\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                  && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -1161,7 +1161,7 @@ $util.toJson({})
   \\"index\\": \\"GSI\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                  && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -1787,7 +1787,7 @@ $util.toJson({})
   \\"index\\": \\"GSI_Email\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                  && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -2704,7 +2704,7 @@ $util.toJson({})
   \\"index\\": \\"CategoryGSI\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                  && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -3298,7 +3298,7 @@ $util.toJson({})
   \\"index\\": \\"ByCreatedAt\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                  && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -3402,7 +3402,7 @@ $util.toJson({})
   \\"index\\": \\"ByStatus\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                  && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -4461,7 +4461,7 @@ $util.toJson({})
   \\"index\\": \\"byGenre\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                  && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -5210,7 +5210,7 @@ $util.toJson({})
   \\"index\\": \\"byGenre\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                  && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -5986,7 +5986,7 @@ $util.toJson({})
   \\"index\\": \\"ByCreatedAt\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                  && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )
@@ -6090,7 +6090,7 @@ $util.toJson({})
   \\"index\\": \\"ByStatus\\"
 } )
 #if( !$util.isNull($ctx.args.sortDirection)
-                      && $ctx.args.sortDirection == \\"DESC\\" )
+                  && $ctx.args.sortDirection == \\"DESC\\" )
   #set( $QueryRequest.scanIndexForward = false )
 #else
   #set( $QueryRequest.scanIndexForward = true )

--- a/packages/amplify-graphql-index-transformer/src/graphql-primary-key-transformer.ts
+++ b/packages/amplify-graphql-index-transformer/src/graphql-primary-key-transformer.ts
@@ -30,8 +30,7 @@ import {
   constructSyncVTL,
   getResourceOverrides,
   getDeltaSyncTableTtl,
-  RDSIndexVTLGenerator, 
-  DynamoDBIndexVTLGenerator
+  getVTLGenerator,
 } from './resolvers';
 import {
   addKeyConditionInputs,
@@ -117,17 +116,9 @@ export class PrimaryKeyTransformer extends TransformerPluginBase {
   generateResolvers = (ctx: TransformerContextProvider): void => {
     for (const config of this.directiveList) {
       const dbInfo = ctx.modelToDatasourceMap.get(config.object.name.value);
-      const vtlGenerator = this.getVTLGenerator(dbInfo);
+      const vtlGenerator = getVTLGenerator(dbInfo);
       vtlGenerator.generatePrimaryKeyVTL(config, ctx, this.resolverMap);
     }
-  };
-
-  private getVTLGenerator = (dbInfo: DatasourceType | undefined) => {
-    const dbType = dbInfo ? dbInfo.dbType : 'DDB';
-    if (dbType === 'MySQL') {
-      return new RDSIndexVTLGenerator();
-    }
-    return new DynamoDBIndexVTLGenerator();
   };
 }
 

--- a/packages/amplify-graphql-index-transformer/src/resolvers/generators/dynamodb-vtl-generator.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers/generators/dynamodb-vtl-generator.ts
@@ -1,17 +1,102 @@
 import {
   replaceDdbPrimaryKey,
-  updateResolvers
+  updateResolvers,
+  setQuerySnippet,
 } from '../resolvers';
 import {
   TransformerContextProvider,
   TransformerResolverProvider
 } from '@aws-amplify/graphql-transformer-interfaces';
-import { PrimaryKeyDirectiveConfiguration } from '../../types';
+import { IndexDirectiveConfiguration, PrimaryKeyDirectiveConfiguration } from '../../types';
 import {
   IndexVTLGenerator,
 } from "./vtl-generator";
+import {
+  bool,
+  compoundExpression,
+  equals,
+  ifElse,
+  iff,
+  int,
+  isNullOrEmpty,
+  list,
+  methodCall,
+  not,
+  obj,
+  print,
+  qref,
+  raw,
+  ref,
+  RESOLVER_VERSION_ID,
+  set,
+  str
+} from 'graphql-mapping-template';
+import { ResourceConstants } from 'graphql-transformer-common';
 
 export class DynamoDBIndexVTLGenerator implements IndexVTLGenerator {
+  generateIndexQueryRequestTemplate(config: IndexDirectiveConfiguration, ctx: TransformerContextProvider, tableName: string, operationName: string): string {
+    const { name, object, queryField } = config;
+    if (!(name && queryField)) {
+      throw new Error('Expected name and queryField to be defined while generating resolver.');
+    }
+    const authFilter = ref('ctx.stash.authFilter');
+    const requestVariable = 'QueryRequest';
+    return print(
+      compoundExpression([
+        setQuerySnippet(config, ctx, false),
+        set(ref('limit'), ref(`util.defaultIfNull($context.args.limit, ${ResourceConstants.DEFAULT_PAGE_LIMIT})`)),
+        set(
+          ref(requestVariable),
+          obj({
+            version: str(RESOLVER_VERSION_ID),
+            operation: str('Query'),
+            limit: ref('limit'),
+            query: ref(ResourceConstants.SNIPPETS.ModelQueryExpression),
+            index: str(name),
+          }),
+        ),
+        ifElse(
+          raw(`!$util.isNull($ctx.args.sortDirection)
+                  && $ctx.args.sortDirection == "DESC"`),
+          set(ref(`${requestVariable}.scanIndexForward`), bool(false)),
+          set(ref(`${requestVariable}.scanIndexForward`), bool(true)),
+        ),
+        iff(ref('context.args.nextToken'), set(ref(`${requestVariable}.nextToken`), ref('context.args.nextToken')), true),
+        ifElse(
+          not(isNullOrEmpty(authFilter)),
+          compoundExpression([
+            set(ref('filter'), authFilter),
+            iff(
+              not(isNullOrEmpty(ref('ctx.args.filter'))),
+              set(ref('filter'), obj({ and: list([ref('filter'), ref('ctx.args.filter')]) })),
+            ),
+          ]),
+          iff(not(isNullOrEmpty(ref('ctx.args.filter'))), set(ref('filter'), ref('ctx.args.filter'))),
+        ),
+        iff(
+          not(isNullOrEmpty(ref('filter'))),
+          compoundExpression([
+            set(
+              ref('filterExpression'),
+              methodCall(ref('util.parseJson'), methodCall(ref('util.transform.toDynamoDBFilterExpression'), ref('filter'))),
+            ),
+            iff(
+              not(methodCall(ref('util.isNullOrBlank'), ref('filterExpression.expression'))),
+              compoundExpression([
+                iff(
+                  equals(methodCall(ref('filterExpression.expressionValues.size')), int(0)),
+                  qref(methodCall(ref('filterExpression.remove'), str('expressionValues'))),
+                ),
+                set(ref(`${requestVariable}.filter`), ref('filterExpression')),
+              ]),
+            ),
+          ]),
+        ),
+        raw(`$util.toJson($${requestVariable})`),
+      ]),
+    );
+  }
+  
   generatePrimaryKeyVTL = (config: PrimaryKeyDirectiveConfiguration, ctx: TransformerContextProvider, resolverMap: Map<TransformerResolverProvider, string>): void => {
     replaceDdbPrimaryKey(config, ctx);
     updateResolvers(config, ctx, resolverMap);

--- a/packages/amplify-graphql-index-transformer/src/resolvers/generators/vtl-generator.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers/generators/vtl-generator.ts
@@ -3,8 +3,18 @@ import {
   TransformerResolverProvider
 } from '@aws-amplify/graphql-transformer-interfaces';
 
-import { PrimaryKeyDirectiveConfiguration } from '../../types';
+import { IndexDirectiveConfiguration, PrimaryKeyDirectiveConfiguration } from '../../types';
 
 export interface IndexVTLGenerator {
-  generatePrimaryKeyVTL(config: PrimaryKeyDirectiveConfiguration, ctx: TransformerContextProvider, resolverMap: Map<TransformerResolverProvider, string>): void;
+  generatePrimaryKeyVTL(
+    config: PrimaryKeyDirectiveConfiguration,
+    ctx: TransformerContextProvider,
+    resolverMap: Map<TransformerResolverProvider, string>,
+  ): void;
+  generateIndexQueryRequestTemplate(
+    config: IndexDirectiveConfiguration,
+    ctx: TransformerContextProvider,
+    tableName: string,
+    operationName: string,
+  ): string;
 };


### PR DESCRIPTION
Adds @index directive support for RDS datasource. Import workflow detects the indexes and adds @index on the field. 
- Customer can edit a generated index and add a queryField attribute which will create a GraphQL query with the given name.

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
