### PR TITLE
chore: adding multiple lambda functions with authorizer will have access to Graphql API

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/function_10.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_10.test.ts
@@ -33,4 +33,28 @@ describe('test function deploy when other resources are present', () => {
     'nodejs');
     await amplifyPushFunction(projectRoot);
   });
+// amplify push function -- test with two functions
+  it('testing amplify push function command with AppSync VTL ', async () => {
+    const apiName = 'myApi';
+    await initJSProjectWithProfile(projectRoot, {
+      name: 'functions',
+    });
+    await addApiWithBlankSchema(projectRoot, { apiName });
+    await updateApiSchema(projectRoot, apiName, 'simple_model.graphql');
+    await amplifyPush(projectRoot);
+    const random = Math.floor(Math.random() * 10000);
+    const fnName = `integtestFn${random}`;
+    const fnTwoName = `integtestFnTwo${random}`;
+    await addFunction(projectRoot, {
+      name: fnName,
+      functionTemplate: 'AppSync - GraphQL API request (with IAM)',
+    },
+    'nodejs');
+    await addFunction(projectRoot, {
+      name: fnTwoName,
+      functionTemplate: 'AppSync - GraphQL API request (with IAM)',
+    },
+    'nodejs');
+    await amplifyPushFunction(projectRoot);
+  });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This PR adds additional checks by adding unit & integration tests to the custom authorization rule of the Auth Transformer for a scenario where adding multiple Lambda functions to grant access to the GraphQL API should succeed with an `amplify add/update function` along with an `amplify push --force`.

The following amplify workflow helps understand the use case:

1. `amplify init` in a project root directory
2. `amplify add api` and choose Lambda as **default** authorizer

For a given schema:
```
type Todo @model @auth(rules: [{ allow: custom, provider: function }]) {
  id: ID!
  content: String!
}
```
3. `amplify add function` named `envFunction1` and allow this function to access the GraphQL API
4. `amplify add function` named `envFunction2` and allow this function also to access the GraphQL API
4. `amplify push --force`

Now, checking the working of the two Lambda functions (`envFunction1`, `envFunction2`)on the console and successfully returning the appropriate queries/mutations/subscriptions results.


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
