### PR TITLE
add support for eu-south-1 MXP

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/supported-datasources.ts
+++ b/packages/amplify-category-api/src/provider-utils/supported-datasources.ts
@@ -43,6 +43,7 @@ export const supportedDataSources = {
       'ca-central-1',
       'eu-central-1',
       'eu-north-1',
+      'eu-south-1',
       'eu-west-1',
       'eu-west-2',
       'eu-west-3',

--- a/packages/amplify-e2e-core/src/configure/index.ts
+++ b/packages/amplify-e2e-core/src/configure/index.ts
@@ -20,6 +20,7 @@ export const amplifyRegions = [
   'us-west-1',
   'us-west-2',
   'eu-north-1',
+  'eu-south-1',
   'eu-west-1',
   'eu-west-2',
   'eu-west-3',

--- a/packages/amplify-e2e-core/src/utils/pinpoint.ts
+++ b/packages/amplify-e2e-core/src/utils/pinpoint.ts
@@ -38,6 +38,7 @@ const serviceRegionMap = {
   'ap-northeast-1': 'ap-northeast-1',
   'eu-central-1': 'eu-central-1',
   'eu-north-1': 'eu-central-1',
+  'eu-south-1': 'eu-central-1',
   'eu-west-1': 'eu-west-1',
   'eu-west-2': 'eu-west-2',
   'eu-west-3': 'eu-west-1',

--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -264,6 +264,9 @@ export class ResourceFactory {
         'eu-north-1': {
           layerRegion: 'arn:aws:lambda:eu-north-1:642425348156:layer:AWSLambda-Python-AWS-SDK:1',
         },
+        'eu-south-1': {
+          layerRegion: 'arn:aws:lambda:eu-south-1:426215560912:layer:AWSLambda-Python-AWS-SDK:1',
+        },
         'eu-west-2': {
           layerRegion: 'arn:aws:lambda:eu-west-2:142628438157:layer:AWSLambda-Python-AWS-SDK:1',
         },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR enables support in eu-south-1 region (MXP). Associated with https://github.com/aws-amplify/amplify-cli/pull/12042

##### CDK / CloudFormation Parameters Changed

N/A

#### Issue #, if available

N/A

#### Description of how you validated changes

I've created a tagged release of both `amplify-category-api` with https://github.com/aws-amplify/amplify-category-api/pull/1273 and `amplify-cli` including https://github.com/aws-amplify/amplify-cli/pull/12042.

The eu-south-1 CLI can be installed via 

```
npm i -g @aws-amplify/cli@10.8.0-mxp.0
```

I then set eu-south-1 in my `~/.aws/config` for my amplify profile.

First, to test amplify-cli, I ran:

```
amplify init
amplify add auth
amplify add storage
amplify push
```

accepting all default values.

Then, to test `amplify-category-api`, I ran `amplify add api && amplify push`.

It all works and the expected resources / CFN stacks appear in my AWS account in eu-south-1.

* e2e suite: https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api?branch=run-e2e/xss/main

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
