### PR TITLE
fix(test): canary joi package version issue

### DIFF
--- a/client-test-apps/js/api-model-relationship-app/package.json
+++ b/client-test-apps/js/api-model-relationship-app/package.json
@@ -19,7 +19,7 @@
     "cypress": "^10.4.0",
     "hjson": "^3.2.2",
     "ini": "^3.0.1",
-    "jest-dev-server": "^6.1.1",
+    "jest-dev-server": "~7.0.1",
     "jest-junit": "^14.0.1",
     "lodash": "^4.17.21",
     "node-pty": "^0.10.1",
@@ -32,6 +32,9 @@
     "retimer": "^3.0.0",
     "typescript": "^4.8.2",
     "web-vitals": "^2.1.4"
+  },
+  "resolutions": {
+    "joi": "17.7.0"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Fix the failing canary tests in main branch.

The failures are caused by the 'joi' dependency. It is addressed here by resolving it to a specific version.