### PR TITLE
test(api): use 10.7.1 for e2e tests

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -51,7 +51,7 @@ install_cli_from_local_registry: &install_cli_from_local_registry
     startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
     setNpmRegistryUrlToLocal
     changeNpmGlobalPath
-    npm install -g @aws-amplify/cli-internal
+    npm install -g @aws-amplify/cli-internal@10.7.1
     echo "using Amplify CLI version: "$(amplify --version)
     unsetNpmRegistryUrl
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ install_cli_from_local_registry: &install_cli_from_local_registry
     startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
     setNpmRegistryUrlToLocal
     changeNpmGlobalPath
-    npm install -g @aws-amplify/cli-internal
+    npm install -g @aws-amplify/cli-internal@10.7.1
     echo "using Amplify CLI version: "$(amplify --version)
     unsetNpmRegistryUrl
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "update-versions": "lerna version --yes --no-commit-hooks --no-push --exact --conventional-commits --no-git-tag-version",
     "commit": "git-cz",
     "coverage": "codecov || exit 0",
-    "add-cli-no-save": "yarn add @aws-amplify/cli-internal -W  && git checkout -- package.json",
+    "add-cli-no-save": "yarn add @aws-amplify/cli-internal@10.7.1 -W  && git checkout -- package.json",
     "hoist-cli": "rm -rf node_modules/amplify-cli-internal && mkdir node_modules/amplify-cli-internal && cp -r node_modules/@aws-amplify/cli-internal/* node_modules/amplify-cli-internal",
     "hoist-cli-win": "rimraf node_modules/amplify-cli-internal && mkdir node_modules\\amplify-cli-internal && xcopy /e /q node_modules\\@aws-amplify\\cli-internal node_modules\\amplify-cli-internal\\",
     "publish:main": "lerna publish --canary --force-publish --preid=alpha --exact --include-merged-tags --conventional-prerelease --no-verify-access --yes",


### PR DESCRIPTION
CLI 10.7.2 and 10.7.3 are based off API tagged release and using them for E2E testing causing version conflict on the tests. With this change, we lock the CLI version to 10.7.1.

```
? Select the plugin module to execute …  (Use arrow keys or type to filter)
❯ @aws-amplify/amplify-category-api@4.1.9-alhotpatchfeb.0
  @aws-amplify/amplify-category-api@4.1.8
```