### PR TITLE
chore: remove all reference to minification from API category, now that this is centralized in CLI

### DIFF
--- a/packages/amplify-category-api/src/commands/api/gql-compile.ts
+++ b/packages/amplify-category-api/src/commands/api/gql-compile.ts
@@ -8,8 +8,5 @@ export const run = async (context: $TSContext) => {
   const {
     parameters: { options },
   } = context;
-  return context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
-    forceCompile: true,
-    minify: options['minify'],
-  });
+  return context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', { forceCompile: true });
 };

--- a/packages/amplify-category-api/src/graphql-transformer/transform-config.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-config.ts
@@ -14,7 +14,6 @@ export interface ProjectOptions {
   disablePipelineFunctionOverrides?: boolean;
   disableResolverOverrides?: boolean;
   buildParameters?: Object;
-  minify?: boolean;
 }
 
 /**

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v1.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v1.ts
@@ -381,7 +381,6 @@ export async function transformGraphQLSchemaV1(context, options) {
     transformersFactoryArgs: [searchableTransformerFlag, storageConfig],
     rootStackFileName: 'cloudformation-template.json',
     currentCloudBackendDirectory: previouslyDeployedBackendDir,
-    minify: options.minify,
     featureFlags: ff,
     sanityCheckRules: sanityCheckRulesList,
   };

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -196,7 +196,7 @@ const buildAPIProject = async (
   const currentCloudLocation = opts.currentCloudBackendDirectory ? path.join(opts.currentCloudBackendDirectory, 'build') : undefined;
 
   if (opts.projectDirectory && !opts.dryRun) {
-    await writeDeploymentToDisk(context, builtProject, buildLocation, opts.rootStackFileName, opts.buildParameters, opts.minify);
+    await writeDeploymentToDisk(context, builtProject, buildLocation, opts.rootStackFileName, opts.buildParameters);
     await sanityCheckProject(
       currentCloudLocation,
       buildLocation,

--- a/packages/amplify-category-api/src/graphql-transformer/transformer-options-types.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transformer-options-types.ts
@@ -30,7 +30,6 @@ export type TransformerProjectOptions<T> = {
   transformersFactoryArgs: T;
   rootStackFileName: 'cloudformation-template.json';
   currentCloudBackendDirectory?: string;
-  minify: boolean;
   lastDeployedProjectConfig?: TransformerProjectConfig;
   projectConfig: TransformerProjectConfig;
   resolverConfig?: ResolverConfig;

--- a/packages/amplify-category-api/src/graphql-transformer/transformer-options-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transformer-options-v2.ts
@@ -255,7 +255,6 @@ export const generateTransformerOptions = async (
     },
     rootStackFileName: 'cloudformation-template.json',
     currentCloudBackendDirectory: previouslyDeployedBackendDir,
-    minify: options.minify,
     projectConfig: project,
     lastDeployedProjectConfig,
     authConfig,

--- a/packages/amplify-category-api/src/graphql-transformer/utils.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/utils.ts
@@ -204,7 +204,6 @@ export async function writeDeploymentToDisk(
   directory: string,
   rootStackFileName: string = 'rootStack.json',
   buildParameters: Object,
-  minify = false,
 ) {
   fs.ensureDirSync(directory);
   // Delete the last deployments resources except for tsconfig if present
@@ -250,7 +249,7 @@ export async function writeDeploymentToDisk(
       stackContent = JSON.parse(stackContent);
     }
     await CloudformationProviderFacade.prePushCfnTemplateModifier(context, stackContent);
-    fs.writeFileSync(fullStackPath, JSONUtilities.stringify(stackContent, { minify }));
+    fs.writeFileSync(fullStackPath, JSONUtilities.stringify(stackContent));
   }
 
   // Write any functions to disk
@@ -266,7 +265,7 @@ export async function writeDeploymentToDisk(
   }
   const rootStack = deployment.rootStack;
   const rootStackPath = path.normalize(directory + `/${rootStackFileName}`);
-  const rootStackString = minify ? JSON.stringify(rootStack) : JSON.stringify(rootStack, null, 4);
+  const rootStackString = JSON.stringify(rootStack, null, 4);
   fs.writeFileSync(rootStackPath, rootStackString);
 
   // Write params to disk

--- a/packages/graphql-transformer-core/API.md
+++ b/packages/graphql-transformer-core/API.md
@@ -590,8 +590,8 @@ export { writeConfig as writeTransformerConfiguration }
 
 // Warnings were encountered during analysis:
 //
-// src/util/amplifyUtils.ts:51:3 - (ae-forgotten-export) The symbol "StringMap" needs to be exported by the entry point index.d.ts
-// src/util/amplifyUtils.ts:55:3 - (ae-forgotten-export) The symbol "StackMapping_3" needs to be exported by the entry point index.d.ts
+// src/util/amplifyUtils.ts:50:3 - (ae-forgotten-export) The symbol "StringMap" needs to be exported by the entry point index.d.ts
+// src/util/amplifyUtils.ts:54:3 - (ae-forgotten-export) The symbol "StackMapping_3" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/graphql-transformer-core/src/util/amplifyUtils.ts
+++ b/packages/graphql-transformer-core/src/util/amplifyUtils.ts
@@ -37,7 +37,6 @@ export interface ProjectOptions {
   disablePipelineFunctionOverrides?: boolean;
   disableResolverOverrides?: boolean;
   buildParameters?: Object;
-  minify?: boolean;
   featureFlags: FeatureFlagProvider;
   sanityCheckRules: SanityCheckRules;
 }
@@ -57,8 +56,7 @@ export async function buildProject(opts: ProjectOptions) {
       builtProject,
       path.join(opts.projectDirectory, 'build'),
       opts.rootStackFileName,
-      opts.buildParameters,
-      opts.minify,
+      opts.buildParameters
     );
 
     const lastBuildPath =
@@ -386,8 +384,7 @@ async function writeDeploymentToDisk(
   deployment: DeploymentResources,
   directory: string,
   rootStackFileName: string = 'rootStack.json',
-  buildParameters: Object,
-  minify = false,
+  buildParameters: Object
 ) {
   // Delete the last deployments resources.
   await emptyDirectory(directory);
@@ -431,8 +428,6 @@ async function writeDeploymentToDisk(
     stackString =
       typeof stackString === 'string'
         ? deployment.stacks[stackFileName]
-        : minify
-        ? JSON.stringify(deployment.stacks[stackFileName])
         : JSON.stringify(deployment.stacks[stackFileName], null, 4);
     fs.writeFileSync(fullStackPath, stackString);
   }
@@ -450,7 +445,7 @@ async function writeDeploymentToDisk(
   }
   const rootStack = deployment.rootStack;
   const rootStackPath = path.normalize(directory + `/${rootStackFileName}`);
-  const rootStackString = minify ? JSON.stringify(rootStack) : JSON.stringify(rootStack, null, 4);
+  const rootStackString = JSON.stringify(rootStack, null, 4);
   fs.writeFileSync(rootStackPath, rootStackString);
 
   // Write params to disk


### PR DESCRIPTION
#### Description of changes
Now that CFN minification has been centralized in the Amplify CLI https://github.com/aws-amplify/amplify-cli/pull/12072 remove explicit handling from these packages.

##### CDK / CloudFormation Parameters Changed
No params changed, but we will no longer internally write CFN files in a minified (e.g. no whitespace) format.

#### Issue #, if available
N/A - cleanup associated w/ bug fix.

#### Description of how you validated changes
Unit tests, e2e tests in CLI.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
