### PR TITLE
chore: refactor amplify-prompts out of all deps except for api category, dependency inject everywhere else

### DIFF
--- a/packages/amplify-category-api/src/commands/api/migrate.ts
+++ b/packages/amplify-category-api/src/commands/api/migrate.ts
@@ -1,5 +1,5 @@
 import { $TSAny, $TSContext, AmplifyCategories, pathManager, stateManager } from 'amplify-cli-core';
-import { printer } from 'amplify-prompts';
+import { printer, prompter } from 'amplify-prompts';
 import { attemptV2TransformerMigration, revertV2Migration } from '@aws-amplify/graphql-transformer-migrator';
 import * as path from 'path';
 import { checkAppsyncApiResourceMigration } from '../../provider-utils/awscloudformation/utils/check-appsync-api-migration';
@@ -33,8 +33,8 @@ export const run = async (context: $TSContext) => {
   }
 
   if (context.parameters?.options?.revert) {
-    await revertV2Migration(apiResourceDir, stateManager.getCurrentEnvName());
+    await revertV2Migration(printer, prompter, apiResourceDir, stateManager.getCurrentEnvName());
     return;
   }
-  await attemptV2TransformerMigration(apiResourceDir, apiName, stateManager.getCurrentEnvName());
+  await attemptV2TransformerMigration(printer, apiResourceDir, apiName, stateManager.getCurrentEnvName());
 };

--- a/packages/amplify-category-api/src/force-updates/auth-notifications.ts
+++ b/packages/amplify-category-api/src/force-updates/auth-notifications.ts
@@ -203,7 +203,7 @@ export const notifyFieldAuthSecurityChange = async (context: $TSContext): Promis
   }
 
   const project = await readProjectConfiguration(apiResourceDir);
-  const directiveMap = collectDirectivesByType(project.schema);
+  const directiveMap = collectDirectivesByType(printer, project.schema);
   const doc: DocumentNode = parse(project.schema);
   const fieldDirectives: Set<string> = hasFieldAuthDirectives(doc);
 
@@ -314,7 +314,7 @@ export const notifySecurityEnhancement = async (context: $TSContext): Promise<vo
 
     const project = await readProjectConfiguration(apiResourceDir);
 
-    const directiveMap = collectDirectivesByTypeNames(project.schema);
+    const directiveMap = collectDirectivesByTypeNames(printer, project.schema);
     const notifyAuthWithKey = Object.keys(directiveMap.types).some(
       (type) => directiveMap.types[type].includes('auth') && directiveMap.types[type].includes('primaryKey'),
     );

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v1.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v1.ts
@@ -33,6 +33,7 @@ import {
 import { exitOnNextTick } from 'amplify-cli-core';
 import { searchablePushChecks } from './api-utils';
 import { getTransformerFactory } from './transformer-factory';
+import { printer } from 'amplify-prompts';
 
 const apiCategory = 'api';
 const parametersFileName = 'parameters.json';
@@ -355,7 +356,7 @@ export async function transformGraphQLSchemaV1(context, options) {
   const project = await readProjectConfiguration(resourceDir);
 
   // Check for common errors
-  const directiveMap = collectDirectivesByTypeNames(project.schema);
+  const directiveMap = collectDirectivesByTypeNames(printer, project.schema);
   await warnOnAuth(context, directiveMap.types);
   await searchablePushChecks(context, directiveMap.types, parameters[ResourceConstants.PARAMETERS.AppSyncApiName]);
 

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -235,6 +235,7 @@ const _buildProject = async (opts: TransformerProjectOptions<TransformerFactoryA
     userDefinedSlots,
     resolverConfig: opts.resolverConfig,
     overrideConfig: opts.overrideConfig,
+    printer,
   });
 
   const schema = userProjectConfig.schema.toString();

--- a/packages/amplify-category-api/src/graphql-transformer/transformer-factory.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transformer-factory.ts
@@ -266,6 +266,7 @@ export const constructGraphQLTransformV2 = async (opts: TransformerProjectOption
     userDefinedSlots,
     resolverConfig: opts.resolverConfig,
     overrideConfig: opts.overrideConfig,
+    printer,
   });
 
   return transform;

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.ts
@@ -472,7 +472,7 @@ export const updateWalkthrough = async (context: $TSContext): Promise<UpdateApiR
   await displayApiInformation(context, resource, project);
 
   // Check for common errors
-  const directiveMap = collectDirectivesByTypeNames(project.schema);
+  const directiveMap = collectDirectivesByTypeNames(printer, project.schema);
   let modelTypes = [];
 
   if (directiveMap.types) {

--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -42,9 +42,6 @@
     "lodash": "^4.17.21",
     "md5": "^2.3.0"
   },
-  "peerDependencies": {
-    "amplify-prompts": "^2.0.0"
-  },
   "devDependencies": {
     "@aws-amplify/graphql-index-transformer": "0.14.9",
     "@aws-amplify/graphql-searchable-transformer": "0.16.9",

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/acm.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/acm.test.ts
@@ -5,8 +5,6 @@ import { AuthTransformer } from '..';
 import { AcmTest, acmTests } from './acm-test-library';
 import { featureFlags } from './test-helpers';
 
-jest.mock('amplify-prompts');
-
 const testSchemaACM = (test: AcmTest): void => {
   const authTransformer = new AuthTransformer();
   const transformer = new GraphQLTransform({

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/conflict-resolution.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/conflict-resolution.test.ts
@@ -3,8 +3,6 @@ import { GraphQLTransform, ConflictHandlerType } from '@aws-amplify/graphql-tran
 import { AuthTransformer } from '../graphql-auth-transformer';
 import { featureFlags } from './test-helpers';
 
-jest.mock('amplify-prompts');
-
 test('single auth model is enabled with conflict resolution', () => {
   const validSchema = `
     type Post @model @auth(rules: [{ allow: owner}]) {

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/field-auth-argument.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/field-auth-argument.test.ts
@@ -5,8 +5,6 @@ import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-inter
 import { AuthTransformer } from '../graphql-auth-transformer';
 import { featureFlags } from './test-helpers';
 
-jest.mock('amplify-prompts');
-
 test('subscriptions are only generated if the respective mutation operation exists', () => {
   const validSchema = `
       type Salary

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/group-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/group-auth.test.ts
@@ -6,8 +6,6 @@ import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-inter
 import { AuthTransformer } from '../graphql-auth-transformer';
 import { featureFlags } from './test-helpers';
 
-jest.mock('amplify-prompts');
-
 test('happy case with static groups', () => {
   const authConfig: AppSyncAuthConfiguration = {
     defaultAuthentication: {

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
@@ -7,8 +7,6 @@ import {
 import { AuthTransformer } from '../graphql-auth-transformer';
 import { featureFlags } from './test-helpers';
 
-jest.mock('amplify-prompts');
-
 const userPoolsDefaultConfig: AppSyncAuthConfiguration = {
   defaultAuthentication: {
     authenticationType: 'AMAZON_COGNITO_USER_POOLS',

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
@@ -8,8 +8,6 @@ import { HasManyTransformer } from '@aws-amplify/graphql-relational-transformer'
 import { AuthTransformer } from '../graphql-auth-transformer';
 import { getField, getObjectType, featureFlags } from './test-helpers';
 
-jest.mock('amplify-prompts');
-
 describe('owner based @auth', () => {
   test('auth transformer validation happy case', () => {
     const authConfig: AppSyncAuthConfiguration = {

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/searchable-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/searchable-auth.test.ts
@@ -8,8 +8,6 @@ import {
 import { AuthTransformer, SEARCHABLE_AGGREGATE_TYPES } from '..';
 import { featureFlags } from './test-helpers';
 
-jest.mock('amplify-prompts');
-
 const getObjectType = (
   doc: DocumentNode,
   type: string,

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/utils/warnings.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/utils/warnings.test.ts
@@ -1,15 +1,17 @@
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
-import { printer } from 'amplify-prompts';
+import { IPrinter } from '@aws-amplify/graphql-transformer-interfaces';
 import { AuthTransformer } from '../../graphql-auth-transformer';
 import { showDefaultIdentityClaimWarning } from '../../utils/warnings';
 
-jest.mock('amplify-prompts', () => ({
-  printer: {
-    warn: jest.fn(),
-    debug: jest.fn(),
-  },
-}));
+const printer: IPrinter = {
+  warn: jest.fn(),
+  debug: jest.fn(),
+  info: jest.fn(),
+  blankLine: jest.fn(),
+  success: jest.fn(),
+  error: jest.fn(),
+};
 
 describe('showDefaultIdentityClaimWarning', () => {
   describe('owner based @auth', () => {
@@ -21,6 +23,7 @@ describe('showDefaultIdentityClaimWarning', () => {
             getNumber: jest.fn(),
             getObject: jest.fn(),
           },
+          printer,
         };
 
         showDefaultIdentityClaimWarning(context, [{ allow: 'owner' }]);
@@ -38,6 +41,7 @@ describe('showDefaultIdentityClaimWarning', () => {
               getNumber: jest.fn(),
               getObject: jest.fn(),
             },
+            printer,
           };
           showDefaultIdentityClaimWarning(context, [{ allow: 'owner', identityClaim: 'cognito:username' }]);
 
@@ -53,6 +57,7 @@ describe('showDefaultIdentityClaimWarning', () => {
               getNumber: jest.fn(),
               getObject: jest.fn(),
             },
+            printer,
           };
           showDefaultIdentityClaimWarning(context, [{ allow: 'owner', identityClaim: 'username' }]);
 
@@ -70,6 +75,7 @@ describe('showDefaultIdentityClaimWarning', () => {
               getNumber: jest.fn(),
               getObject: jest.fn(),
             },
+            printer,
           };
           showDefaultIdentityClaimWarning(context, [{ allow: 'owner', identityClaim: 'cognito:username' }]);
 
@@ -85,6 +91,7 @@ describe('showDefaultIdentityClaimWarning', () => {
               getNumber: jest.fn(),
               getObject: jest.fn(),
             },
+            printer,
           };
           showDefaultIdentityClaimWarning(context, [{ allow: 'owner', identityClaim: 'username' }]);
 
@@ -101,6 +108,7 @@ describe('showDefaultIdentityClaimWarning', () => {
             getNumber: jest.fn(),
             getObject: jest.fn(),
           },
+          printer,
         };
         showDefaultIdentityClaimWarning(context, [{ allow: 'owner' }]);
 
@@ -141,6 +149,7 @@ describe('showOwnerCanReassignWarning', () => {
         getNumber: jest.fn(),
         getObject: jest.fn(),
       },
+      printer,
     });
 
     transformer.transform(schema);
@@ -289,6 +298,7 @@ describe('showOwnerFieldCaseWarning', () => {
         getNumber: jest.fn(),
         getObject: jest.fn(),
       },
+      printer,
     });
     transformer.transform(schema);
   };

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -225,7 +225,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
 
   after = (context: TransformerContextProvider): void => {
     showDefaultIdentityClaimWarning(context, this.rules);
-    showOwnerCanReassignWarning(this.authModelConfig);
+    showOwnerCanReassignWarning(context.printer, this.authModelConfig);
   };
 
   field = (
@@ -1074,7 +1074,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     const ownerFieldsToAdd = ownerFields.filter((field) => !existingFields.includes(field));
     ownerFieldsToAdd.forEach((ownerField) => {
       const warningField = existingFields.find((field) => field.toLowerCase() === ownerField.toLowerCase());
-      if (warningField) showOwnerFieldCaseWarning(ownerField, warningField, modelName);
+      if (warningField) showOwnerFieldCaseWarning(ctx.printer, ownerField, warningField, modelName);
       (modelObject as any).fields.push(makeField(ownerField, [], makeNamedType('String')));
     });
     ctx.output.putType(modelObject);

--- a/packages/amplify-graphql-auth-transformer/src/utils/warnings.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/warnings.ts
@@ -1,5 +1,4 @@
-import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { printer } from 'amplify-prompts';
+import { IPrinter, TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { AuthRule } from '.';
 import { AccessControlMatrix } from '../accesscontrol';
 
@@ -16,7 +15,7 @@ export const showDefaultIdentityClaimWarning = (context: TransformerContextProvi
 
     if (hasFeatureFlagEnabled) return;
 
-    printer.warn(
+    context.printer.warn(
       ' WARNING: Amplify CLI will change the default identity claim from \'username\' '
         + 'to use \'sub::username\'. To continue using only usernames, set \'identityClaim: "username"\' on your '
         + '\'owner\' rules on your schema. The default will be officially switched with v9.0.0. To read '
@@ -27,9 +26,11 @@ export const showDefaultIdentityClaimWarning = (context: TransformerContextProvi
 
 /**
  * Display a warning when an 'owner' has access to update their own owner field.
+ * @param printer the printer to use for rendering warning message
  * @param authModelConfig The model to ACM map we generate for the given ruleset.
  */
 export const showOwnerCanReassignWarning = (
+  printer: IPrinter,
   authModelConfig: Map<string, AccessControlMatrix>,
 ): void => {
   try {
@@ -67,7 +68,7 @@ export const showOwnerCanReassignWarning = (
   }
 };
 
-export const showOwnerFieldCaseWarning = (ownerField: string, warningField: string, modelName: string): void => {
+export const showOwnerFieldCaseWarning = (printer: IPrinter, ownerField: string, warningField: string, modelName: string): void => {
   printer.warn(
     `WARNING: Schema field "${warningField}" and ownerField "${ownerField}" in type ${modelName} are getting added to your schema but could be referencing the same owner field. `
     + 'If this is not intentional, you may want to change one of the fields to the correct name.\n',

--- a/packages/amplify-graphql-index-transformer/src/graphql-index-transformer.ts
+++ b/packages/amplify-graphql-index-transformer/src/graphql-index-transformer.ts
@@ -69,7 +69,7 @@ export class IndexTransformer extends TransformerPluginBase {
   public after = (ctx: TransformerContextProvider): void => {
     if (!ctx.isProjectUsingDataStore()) return;
 
-    const overriddenResources = getResourceOverrides([this], ctx?.stackManager);
+    const overriddenResources = getResourceOverrides(ctx.printer, [this], ctx?.stackManager);
     // construct sync VTL code
     this.resolverMap.forEach((syncVTLContent, resource) => {
       if (syncVTLContent) {

--- a/packages/amplify-graphql-index-transformer/src/graphql-primary-key-transformer.ts
+++ b/packages/amplify-graphql-index-transformer/src/graphql-primary-key-transformer.ts
@@ -81,7 +81,7 @@ export class PrimaryKeyTransformer extends TransformerPluginBase {
   public after = (ctx: TransformerContextProvider): void => {
     if (!ctx.isProjectUsingDataStore()) return;
 
-    const overriddenResources = getResourceOverrides([this], ctx?.stackManager);
+    const overriddenResources = getResourceOverrides(ctx.printer, [this], ctx?.stackManager);
     // construct sync VTL code
     this.resolverMap.forEach((syncVTLContent, resource) => {
       if (syncVTLContent) {

--- a/packages/amplify-graphql-migration-tests/package.json
+++ b/packages/amplify-graphql-migration-tests/package.json
@@ -56,8 +56,5 @@
     "graphql-key-transformer": "3.2.47",
     "graphql-transformer-core": "7.6.10",
     "graphql-versioned-transformer": "5.2.47"
-  },
-  "peerDependencies": {
-    "amplify-prompts": "^2.0.1"
   }
 }

--- a/packages/amplify-graphql-migration-tests/src/migrate-schema-wrapper.ts
+++ b/packages/amplify-graphql-migration-tests/src/migrate-schema-wrapper.ts
@@ -1,19 +1,15 @@
 import { runMigration } from '@aws-amplify/graphql-transformer-migrator';
 import * as fs from 'fs-extra';
-import { prompter } from 'amplify-prompts';
 
 jest.mock('fs-extra');
-jest.mock('amplify-prompts');
 
 const fs_mock = fs as jest.Mocked<typeof fs>;
-const prompter_mock = prompter as jest.Mocked<typeof prompter>;
 
 export type AuthMode = 'apiKey' | 'iam' | 'userPools' | 'oidc';
 
 export const migrateSchema = async (schema: string, authMode: AuthMode = 'apiKey'): Promise<string> => {
   const pathHash = Date.now().toLocaleString().replace(/,/g, '');
   fs_mock.writeFile.mockClear();
-  prompter_mock.pick.mockResolvedValue('Yes');
   await runMigration([{ schema, filePath: pathHash }], authMode);
   const transformedSchema = fs_mock.writeFile.mock.calls.find(([hash]) => hash === pathHash)?.[1];
   expect(typeof transformedSchema).toBe('string');

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-many-to-many-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-many-to-many-transformer.test.ts
@@ -8,8 +8,6 @@ import { DocumentNode, ObjectTypeDefinitionNode, parse } from 'graphql';
 import { HasOneTransformer, ManyToManyTransformer } from '..';
 import { featureFlags, hasGeneratedDirective, hasGeneratedField } from './test-helpers';
 
-jest.mock('amplify-prompts');
-
 test('fails if @manyToMany was used on an object that is not a model type', () => {
   const inputSchema = `
     type Foo {

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/relational-auth.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/relational-auth.test.ts
@@ -10,8 +10,6 @@ import {
 import { HasManyTransformer, BelongsToTransformer, HasOneTransformer } from '..';
 import { featureFlags } from './test-helpers';
 
-jest.mock('amplify-prompts');
-
 const iamDefaultConfig: AppSyncAuthConfiguration = {
   defaultAuthentication: {
     authenticationType: 'AWS_IAM',

--- a/packages/amplify-graphql-searchable-transformer/package.json
+++ b/packages/amplify-graphql-searchable-transformer/package.json
@@ -47,8 +47,7 @@
     "@types/node": "^12.12.6"
   },
   "peerDependencies": {
-    "amplify-cli-core": "3.7.0-rc.b80571744.0",
-    "amplify-prompts": "^2.0.1"
+    "amplify-cli-core": "3.7.0-rc.b80571744.0"
   },
   "jest": {
     "transform": {

--- a/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
@@ -297,7 +297,7 @@ export class SearchableModelTransformer extends TransformerPluginBase {
 
     const parameterMap = createParametersInStack(context.stackManager.rootStack);
 
-    const nodeToNodeEncryption = this.apiName ? shouldEnableNodeToNodeEncryption(this.apiName) : false;
+    const nodeToNodeEncryption = this.apiName ? shouldEnableNodeToNodeEncryption(context.printer, this.apiName) : false;
 
     const domain = createSearchableDomain(stack, parameterMap, context.api.apiId, nodeToNodeEncryption);
 

--- a/packages/amplify-graphql-searchable-transformer/src/nodeToNodeEncryption.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/nodeToNodeEncryption.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import { TransformConfig } from '@aws-amplify/graphql-transformer-core/lib';
 import { TRANSFORM_CONFIG_FILE_NAME } from 'graphql-transformer-core';
-import { printer } from 'amplify-prompts';
+import { IPrinter } from "@aws-amplify/graphql-transformer-interfaces";
 
 /**
  * Return whether or not NodeToNodeEncryption should be enabled for the API.
@@ -15,12 +15,12 @@ import { printer } from 'amplify-prompts';
  * @param apiName the name of the api to attempt and pull the flag from.
  * @returns whether or not NodeToNodeEncryption should be enabled on a searchable instance.
  */
-export const shouldEnableNodeToNodeEncryption = (apiName: string): boolean => {
+export const shouldEnableNodeToNodeEncryption = (printer: IPrinter, apiName: string): boolean => {
   try {
     const nodeToNodeEncryptionParameter = getNodeToNodeEncryptionConfigValue(apiName);
     const doesExistingBackendHaveNodeToNodeEncryption = getCurrentCloudBackendStackFiles(apiName).some(definition => hasNodeToNodeEncryptionOptions(definition));
 
-    warnOnExistingNodeToNodeEncryption(doesExistingBackendHaveNodeToNodeEncryption);
+    warnOnExistingNodeToNodeEncryption(printer, doesExistingBackendHaveNodeToNodeEncryption);
 
     if (nodeToNodeEncryptionParameter !== undefined) {
       return nodeToNodeEncryptionParameter;
@@ -33,7 +33,7 @@ export const shouldEnableNodeToNodeEncryption = (apiName: string): boolean => {
   }
 };
 
-const warnOnExistingNodeToNodeEncryption = (doesExistingBackendHaveNodeToNodeEncryption: boolean): void => {
+const warnOnExistingNodeToNodeEncryption = (printer: IPrinter, doesExistingBackendHaveNodeToNodeEncryption: boolean): void => {
   if (!doesExistingBackendHaveNodeToNodeEncryption) {
     return;
   }

--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -30,6 +30,7 @@ import { CfnResource } from '@aws-cdk/core';
 import { CfnRole } from '@aws-cdk/aws-iam';
 import { CfnStack } from '@aws-cdk/core';
 import { CfnTable } from '@aws-cdk/aws-dynamodb';
+import { Color } from '@aws-amplify/graphql-transformer-interfaces';
 import { Construct } from '@aws-cdk/core';
 import { DataSourceInstance } from '@aws-amplify/graphql-transformer-interfaces';
 import { DataSourceProvider } from '@aws-amplify/graphql-transformer-interfaces';
@@ -54,6 +55,7 @@ import { InputObjectTypeExtensionNode } from 'graphql';
 import { InputValueDefinitionNode } from 'graphql';
 import { InterfaceTypeDefinitionNode } from 'graphql';
 import { InterfaceTypeExtensionNode } from 'graphql';
+import { IPrinter } from '@aws-amplify/graphql-transformer-interfaces';
 import { IStackSynthesizer } from '@aws-cdk/core';
 import { ISynthesisSession } from '@aws-cdk/core';
 import { Location as Location_2 } from 'graphql';
@@ -144,6 +146,11 @@ export const enum ConflictHandlerType {
     // (undocumented)
     OPTIMISTIC = "OPTIMISTIC_CONCURRENCY"
 }
+
+// Warning: (ae-forgotten-export) The symbol "ConsolePrinter" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export const consolePrinter: ConsolePrinter;
 
 // @public (undocumented)
 function createSyncLambdaIAMPolicy(context: TransformerContextProvider, stack: cdk.Stack, name: string, region?: string): iam.Policy;
@@ -263,6 +270,8 @@ export interface GraphQLTransformOptions {
     readonly host?: TransformHostProvider;
     // (undocumented)
     readonly overrideConfig?: OverrideConfig;
+    // (undocumented)
+    readonly printer?: IPrinter;
     // (undocumented)
     readonly resolverConfig?: ResolverConfig;
     // (undocumented)

--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -63,9 +63,6 @@
     "ts-dedent": "^2.0.0",
     "vm2": "^3.9.8"
   },
-  "peerDependencies": {
-    "amplify-prompts": "^2.0.1"
-  },
   "devDependencies": {
     "@types/fs-extra": "^8.0.1",
     "@types/md5": "^2.3.1",

--- a/packages/amplify-graphql-transformer-core/src/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/index.ts
@@ -36,6 +36,7 @@ export {
   DirectiveWrapper,
   IAM_AUTH_ROLE_PARAMETER,
   IAM_UNAUTH_ROLE_PARAMETER,
+  consolePrinter,
 } from './utils';
 export * from './utils/operation-names';
 export * from './errors';
@@ -49,9 +50,7 @@ export { TransformerResolver, StackManager } from './transformer-context';
 /**
  * Returns the extra set of directives that are supported by AppSync service.
  */
-export const getAppSyncServiceExtraDirectives = (): string => {
-  return print(EXTRA_DIRECTIVES_DOCUMENT);
-};
+export const getAppSyncServiceExtraDirectives = (): string => print(EXTRA_DIRECTIVES_DOCUMENT);
 
 export { MappingTemplate, TransformerNestedStack } from './cdk-compat';
 export {

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
@@ -6,6 +6,7 @@ import {
   TransformerContextProvider,
   TransformerDataSourceManagerProvider,
   AppSyncAuthConfiguration,
+  IPrinter,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import { TransformerContextMetadataProvider } from '@aws-amplify/graphql-transformer-interfaces/src/transformer-context/transformer-context-provider';
 import { App } from '@aws-cdk/core';
@@ -59,6 +60,7 @@ export class TransformerContext implements TransformerContextProvider {
     public readonly inputDocument: DocumentNode,
     stackMapping: Record<string, string>,
     authConfig: AppSyncAuthConfiguration,
+    public printer: IPrinter,
     sandboxModeEnabled?: boolean,
     featureFlags?: FeatureFlagProvider,
     resolverConfig?: ResolverConfig,

--- a/packages/amplify-graphql-transformer-core/src/utils/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/index.ts
@@ -4,3 +4,4 @@ export { stripDirectives } from './strip-directives';
 export { getTable, getKeySchema, getSortKeyFieldNames } from './schema-utils';
 export { DEFAULT_SCHEMA_DEFINITION } from './defaultSchema';
 export { IAM_AUTH_ROLE_PARAMETER, IAM_UNAUTH_ROLE_PARAMETER } from './authType';
+export * from './printer';

--- a/packages/amplify-graphql-transformer-core/src/utils/printer.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/printer.ts
@@ -1,0 +1,33 @@
+/* eslint-disable class-methods-use-this */
+import { IPrinter, Color } from '@aws-amplify/graphql-transformer-interfaces';
+
+/**
+ * No-op printer that uses console.
+ */
+export class ConsolePrinter implements IPrinter {
+  debug(line: string): void {
+    console.debug(line);
+  }
+
+  info(line: string, _?: Color): void {
+    console.info(line);
+  }
+
+  blankLine(): void {
+    console.log();
+  }
+
+  success(line: string): void {
+    console.log(line);
+  }
+
+  warn(line: string): void {
+    console.warn(line);
+  }
+
+  error(line: string): void {
+    console.error(line);
+  }
+}
+
+export const consolePrinter = new ConsolePrinter();

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -127,6 +127,9 @@ export interface AppSyncFunctionConfigurationProvider extends IConstruct {
     readonly functionId: string;
 }
 
+// @public (undocumented)
+export type Color = 'green' | 'blue' | 'yellow' | 'red' | 'reset';
+
 // Warning: (ae-forgotten-export) The symbol "NoneDataSourceProvider" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -195,6 +198,16 @@ export interface InlineMappingTemplateProvider {
     // (undocumented)
     type: MappingTemplateType.INLINE;
 }
+
+// @public (undocumented)
+export type IPrinter = {
+    debug: (line: string) => void;
+    info: (line: string, color?: Color) => void;
+    blankLine: () => void;
+    success: (line: string) => void;
+    warn: (line: string) => void;
+    error: (line: string) => void;
+};
 
 // @public (undocumented)
 export type MappingTemplateProvider = InlineMappingTemplateProvider | S3MappingTemplateProvider;
@@ -384,6 +397,8 @@ export interface TransformerContextProvider {
     metadata: TransformerContextMetadataProvider;
     // (undocumented)
     output: TransformerContextOutputProvider;
+    // (undocumented)
+    printer: IPrinter;
     // (undocumented)
     providerRegistry: TransformerProviderRegistry;
     // (undocumented)
@@ -621,7 +636,7 @@ export type TransformerSchemaVisitStepContextProvider = Pick<TransformerContextP
 export type TransformerTransformSchemaStepContextProvider = TransformerValidationStepContextProvider;
 
 // @public (undocumented)
-export type TransformerValidationStepContextProvider = Pick<TransformerContextProvider, 'inputDocument' | 'output' | 'providerRegistry' | 'dataSources' | 'featureFlags' | 'isProjectUsingDataStore' | 'getResolverConfig' | 'metadata' | 'authConfig' | 'sandboxModeEnabled' | 'resourceHelper' | 'resolvers' | 'stackManager'>;
+export type TransformerValidationStepContextProvider = Pick<TransformerContextProvider, 'inputDocument' | 'output' | 'providerRegistry' | 'dataSources' | 'featureFlags' | 'isProjectUsingDataStore' | 'getResolverConfig' | 'metadata' | 'authConfig' | 'sandboxModeEnabled' | 'resourceHelper' | 'resolvers' | 'stackManager' | 'printer'>;
 
 // @public (undocumented)
 export interface TransformHostProvider {

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/index.ts
@@ -19,3 +19,4 @@ export {
 export { TransformerSchemaHelperProvider } from './schema-helper-provider';
 export { TransformerPreProcessContextProvider } from './transformer-preprocess-context-provider';
 export { StackManagerProvider } from './stack-manager-provider';
+export * from './printer';

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/printer.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/printer.ts
@@ -1,0 +1,13 @@
+export type Color = 'green' | 'blue' | 'yellow' | 'red' | 'reset';
+
+/**
+ * Printer interface which can either be implemented by the Amplify printer, console, etc.
+ */
+export type IPrinter = {
+  debug: (line: string) => void;
+  info: (line: string, color?: Color) => void;
+  blankLine: () => void;
+  success: (line: string) => void;
+  warn: (line: string) => void;
+  error: (line: string) => void;
+};

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
@@ -7,6 +7,7 @@ import { StackManagerProvider } from './stack-manager-provider';
 import { AppSyncAuthConfiguration, GraphQLAPIProvider } from '../graphql-api-provider';
 import { TransformerResourceHelperProvider } from './resource-resource-provider';
 import { FeatureFlagProvider } from '../feature-flag-provider';
+import { IPrinter } from './printer';
 
 export interface TransformerContextMetadataProvider {
   set<T>(key: string, value: T): void;
@@ -28,6 +29,7 @@ export interface TransformerContextProvider {
   featureFlags: FeatureFlagProvider;
   authConfig: AppSyncAuthConfiguration;
   sandboxModeEnabled: boolean;
+  printer: IPrinter;
 
   isProjectUsingDataStore(): boolean;
   getResolverConfig<ResolverConfig>(): ResolverConfig | undefined;
@@ -65,6 +67,7 @@ export type TransformerValidationStepContextProvider = Pick<
   | 'resourceHelper'
   | 'resolvers'
   | 'stackManager'
+  | 'printer'
 >;
 export type TransformerPrepareStepContextProvider = TransformerValidationStepContextProvider;
 export type TransformerTransformSchemaStepContextProvider = TransformerValidationStepContextProvider;

--- a/packages/amplify-graphql-transformer-migrator/package.json
+++ b/packages/amplify-graphql-transformer-migrator/package.json
@@ -36,8 +36,7 @@
   },
   "peerDependencies": {
     "@aws-amplify/amplify-environment-parameters": "^1.1.0",
-    "amplify-cli-core": "3.7.0-rc.b80571744.0",
-    "amplify-prompts": "^2.0.1"
+    "amplify-cli-core": "3.7.0-rc.b80571744.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.1",

--- a/packages/amplify-graphql-transformer-migrator/src/prompter.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/prompter.ts
@@ -1,0 +1,3 @@
+export type IPrompter = {
+  confirmContinue: (message?: string) => Promise<boolean>;
+};

--- a/packages/amplify-graphql-transformer-migrator/src/schema-migrator.ts
+++ b/packages/amplify-graphql-transformer-migrator/src/schema-migrator.ts
@@ -5,7 +5,7 @@ import { migrateAuth } from './migrators/auth';
 import { migrateConnection } from './migrators/connection';
 import { combineSchemas, getDefaultAuth, replaceFile, SchemaDocument } from './utils';
 import { DocumentNode } from 'graphql/language';
-import { printer, prompter } from 'amplify-prompts';
+import { IPrompter } from './prompter';
 import * as path from 'path';
 import {
   authRuleUsesQueriesOrMutations,
@@ -23,6 +23,7 @@ import { GRAPHQL_DIRECTIVES_SCHEMA } from './constants/graphql-directives';
 import * as os from 'os';
 import { backupLocation, backupSchemas, doesBackupExist, restoreSchemas } from './schema-backup';
 import * as glob from 'glob';
+import { IPrinter } from '@aws-amplify/graphql-transformer-interfaces';
 
 const cliToMigratorAuthMap: Map<string, string> = new Map<string, string>([
   ['API_KEY', 'apiKey'],
@@ -33,7 +34,7 @@ const cliToMigratorAuthMap: Map<string, string> = new Map<string, string>([
 
 const MIGRATION_DOCS_URL = 'https://docs.amplify.aws/cli/migration/transformer-migration/';
 
-export async function attemptV2TransformerMigration(resourceDir: string, apiName: string, envName?: string): Promise<void> {
+export async function attemptV2TransformerMigration(printer: IPrinter, resourceDir: string, apiName: string, envName?: string): Promise<void> {
   const schemaDocs = await getSchemaDocs(resourceDir);
   const fullSchema = combineSchemas(schemaDocs);
   const autoMigrationDetectionResult = await canAutoMigrate(fullSchema, apiName, resourceDir);
@@ -81,7 +82,7 @@ export async function attemptV2TransformerMigration(resourceDir: string, apiName
   printer.info(`To revert the migration run 'amplify migrate api --revert'`);
 }
 
-export async function revertV2Migration(resourceDir: string, envName: string) {
+export async function revertV2Migration(printer: IPrinter, prompter: IPrompter, resourceDir: string, envName: string) {
   if (!doesBackupExist(resourceDir)) {
     printer.error(`No backup found at ${backupLocation(resourceDir)}`);
     return;

--- a/packages/amplify-util-mock/src/__e2e__/model-with-maps-to.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/model-with-maps-to.e2e.test.ts
@@ -31,7 +31,7 @@ beforeAll(async () => {
         },
         getNumber: jest.fn(),
         getObject: jest.fn(),
-      }
+      },
     });
     const out = transformer.transform(validSchema);
 

--- a/packages/amplify-util-mock/src/__e2e_v2__/model-relational-with-key-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e_v2__/model-relational-with-key-transformer.e2e.test.ts
@@ -86,8 +86,8 @@ describe("@model with relational transformers", () => {
             }
 
             return defaultValue;
-          }
-        } as FeatureFlagProvider
+          },
+        } as FeatureFlagProvider,
       });
       const out = transformer.transform(validSchema);
 

--- a/packages/amplify-util-mock/src/__tests__/velocity/admin-auth.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/velocity/admin-auth.test.ts
@@ -8,8 +8,6 @@ import {
 } from '../../velocity';
 import { featureFlags } from './test-helper';
 
-jest.mock('amplify-prompts');
-
 describe('admin roles query checks', () => {
   const ADMIN_UI_ROLE = 'us-fake-1_uuid_Full-access/CognitoIdentityCredentials';
   let vtlTemplate: VelocityTemplateSimulator;

--- a/packages/amplify-util-mock/src/__tests__/velocity/model-auth.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/velocity/model-auth.test.ts
@@ -7,8 +7,6 @@ import { AmplifyAppSyncSimulatorAuthenticationType, AppSyncGraphQLExecutionConte
 import { VelocityTemplateSimulator, AppSyncVTLContext, getJWTToken } from "../../velocity";
 import { featureFlags } from "./test-helper";
 
-jest.mock("amplify-prompts");
-
 const USER_POOL_ID = "us-fake-1ID";
 
 describe("@model owner mutation checks", () => {

--- a/packages/amplify-util-mock/src/__tests__/velocity/multi-auth.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/velocity/multi-auth.test.ts
@@ -6,8 +6,6 @@ import { AmplifyAppSyncSimulatorAuthenticationType, AppSyncGraphQLExecutionConte
 import { VelocityTemplateSimulator, AppSyncVTLContext, getGenericToken } from '../../velocity';
 import { featureFlags } from './test-helper';
 
-jest.mock('amplify-prompts');
-
 // oidc needs claim values to know where to check in the token otherwise it will use cognito defaults precendence order below
 // - owner: 'username' -> 'cognito:username' -> default to null
 // - group: 'cognito:groups' -> default to null or empty list

--- a/packages/amplify-util-mock/src/__tests__/velocity/relational-auth.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/velocity/relational-auth.test.ts
@@ -8,8 +8,6 @@ import { AmplifyAppSyncSimulatorAuthenticationType, AppSyncGraphQLExecutionConte
 import { featureFlags } from '@aws-amplify/graphql-auth-transformer/src/__tests__/test-helpers';
 import { VelocityTemplateSimulator, getJWTToken, getIAMToken } from '../../velocity';
 
-jest.mock('amplify-prompts');
-
 const USER_POOL_ID = 'us-fake-1ID';
 
 describe('relational tests', () => {

--- a/packages/graphql-transformer-core/API.md
+++ b/packages/graphql-transformer-core/API.md
@@ -86,10 +86,10 @@ export const CLOUDFORMATION_FILE_NAME = "cloudformation-template.json";
 export function collectDirectiveNames(sdl: string): string[];
 
 // @public (undocumented)
-export function collectDirectivesByType(sdl: string): Object;
+export function collectDirectivesByType(printer: IPrinter, sdl: string): Object;
 
 // @public (undocumented)
-export function collectDirectivesByTypeNames(sdl: string): {
+export function collectDirectivesByTypeNames(printer: IPrinter, sdl: string): {
     types: Object;
     directives: string[];
 };
@@ -106,6 +106,27 @@ export const enum ConflictHandlerType {
     // (undocumented)
     OPTIMISTIC = "OPTIMISTIC_CONCURRENCY"
 }
+
+// @public (undocumented)
+export class ConsolePrinter implements IPrinter {
+    // (undocumented)
+    blankLine(): void;
+    // (undocumented)
+    debug(line: string): void;
+    // (undocumented)
+    error(line: string): void;
+    // Warning: (ae-forgotten-export) The symbol "Color" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    info(line: string, _?: Color): void;
+    // (undocumented)
+    success(line: string): void;
+    // (undocumented)
+    warn(line: string): void;
+}
+
+// @public (undocumented)
+export const consolePrinter: ConsolePrinter;
 
 // Warning: (ae-forgotten-export) The symbol "ResolversFunctionsAndSchema" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "NestedStacks" needs to be exported by the entry point index.d.ts
@@ -164,7 +185,7 @@ export function getSanityCheckRules(isNewAppSyncAPI: boolean, ff: FeatureFlagPro
 };
 
 // @public (undocumented)
-export function getTableNameForModel(sdl: string, modelName: string): string;
+export function getTableNameForModel(printer: IPrinter, sdl: string, modelName: string): string;
 
 // @public (undocumented)
 export function gql(literals: TemplateStringsArray, ...placeholders: string[]): DocumentNode;
@@ -206,6 +227,16 @@ export class InvalidMigrationError extends Error {
 export class InvalidTransformerError extends Error {
     constructor(message: string);
 }
+
+// @public (undocumented)
+export type IPrinter = {
+    debug: (line: string) => void;
+    info: (line: string, color?: Color) => void;
+    blankLine: () => void;
+    success: (line: string) => void;
+    warn: (line: string) => void;
+    error: (line: string) => void;
+};
 
 // @public (undocumented)
 export const isDataStoreEnabled: (projectDir: string) => Promise<boolean>;

--- a/packages/graphql-transformer-core/src/collectDirectives.ts
+++ b/packages/graphql-transformer-core/src/collectDirectives.ts
@@ -12,7 +12,8 @@ import {
   parse,
   Kind,
 } from 'graphql';
-import { printer } from 'amplify-prompts';
+import { IPrinter } from './printer';
+
 export function collectDirectiveNames(sdl: string): string[] {
   const dirs = collectDirectives(sdl);
   return dirs.map(d => d.name.value);
@@ -47,8 +48,8 @@ export function collectDirectives(sdl: string): DirectiveNode[] {
   return directives;
 }
 
-export function collectDirectivesByTypeNames(sdl: string) {
-  let types = collectDirectivesByType(sdl);
+export function collectDirectivesByTypeNames(printer: IPrinter, sdl: string) {
+  let types = collectDirectivesByType(printer, sdl);
   const directives: Set<string> = new Set();
   Object.keys(types).forEach(dir => {
     let set: Set<string> = new Set();
@@ -61,7 +62,7 @@ export function collectDirectivesByTypeNames(sdl: string) {
   return { types, directives: Array.from(directives) };
 }
 
-export function collectDirectivesByType(sdl: string): Object {
+export function collectDirectivesByType(printer: IPrinter, sdl: string): Object {
   if (!sdl) {
     return {};
   }

--- a/packages/graphql-transformer-core/src/index.ts
+++ b/packages/graphql-transformer-core/src/index.ts
@@ -42,7 +42,7 @@ export function getAppSyncServiceExtraDirectives(): string {
   return print(EXTRA_DIRECTIVES_DOCUMENT);
 }
 export { FeatureFlagProvider } from './FeatureFlags';
-
+export * from './printer';
 export {
   GraphQLTransform,
   TransformConfig,

--- a/packages/graphql-transformer-core/src/printer.ts
+++ b/packages/graphql-transformer-core/src/printer.ts
@@ -1,0 +1,8 @@
+export type IPrinter = {
+  debug: (line: string) => void;
+  info: (line: string, color?: 'green' | 'blue' | 'yellow' | 'red' | 'reset') => void;
+  blankLine: () => void;
+  success: (line: string) => void;
+  warn: (line: string) => void;
+  error: (line: string) => void;
+};

--- a/packages/graphql-transformer-core/src/tableNameMap.ts
+++ b/packages/graphql-transformer-core/src/tableNameMap.ts
@@ -1,4 +1,5 @@
-import { InvalidDirectiveError } from '.';
+import { InvalidDirectiveError } from './errors';
+import { IPrinter } from './printer';
 import { collectDirectivesByType } from './collectDirectives';
 
 // this must be kept in sync with the directive name defined in the MapsToTransformer
@@ -10,8 +11,8 @@ const directiveName = 'mapsTo';
  * @param modelName The model name to translate
  * @returns The modelName if the type does not have an @mapsTo directive on it. Otherwise it returns the name specified in @mapsTo
  */
-export function getTableNameForModel(sdl: string, modelName: string): string {
-  const directivesByType = collectDirectivesByType(sdl);
+export function getTableNameForModel(printer: IPrinter, sdl: string, modelName: string): string {
+  const directivesByType = collectDirectivesByType(printer, sdl);
   const mapsToDirective = directivesByType?.[modelName]?.find(directive => directive.name.value === directiveName);
   if (!mapsToDirective) {
     return modelName;


### PR DESCRIPTION
#### Description of changes
Refactor usage of amplify prompts (either printer or prompter) to not depend on the singletons exported by Amplify CLI, and to instead use constructor injection where necessary to pass down a printer/prompter as part of the input or context params. This means that there's only a single peerDep for the `amplify-prompts` library which is the API category, taking a step towards decoupling transformer libs from the CLI core libraries, and disentangling our circular release cycle.

##### CDK / CloudFormation Parameters Changed
N/A - no CDK or CFN changes in this PR.

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit + e2e tests

E2E Test Run: https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api/4532/workflows/dd79fb6a-3bdf-4a35-be88-e7f9643f4484

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
