### PR TITLE
Separate windows build job to unblock linux based tests

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -493,29 +493,31 @@ workflows:
   build_test_deploy:
     jobs:
       - build:
-          matrix:
-            parameters:
-              os:
-                - l
-                - w
+          name: build_linux
+          parameters:
+            os: l
+      - build:
+          name: build_windows
+          parameters:
+            os: w
       - lint:
           requires:
-            - build
+            - build_linux
       - validate_cdk_version:
           requires:
-            - build
+            - build_linux
       - verify-api-extract:
           requires:
-            - build
+            - build_linux
       - verify-yarn-lock:
           requires:
-            - build
+            - build_linux
       - test:
           requires:
-            - build
+            - build_linux
       - mock_e2e_tests:
           requires:
-            - build
+            - build_linux
       - graphql_e2e_tests:
           context:
             - api-e2e-test-context
@@ -537,7 +539,7 @@ workflows:
                 - /tagged-release-without-e2e-tests\/.*/
                 - /run-e2e\/.*/
           requires:
-            - build
+            - build_linux
       - amplify_e2e_tests:
           context:
             - api-cleanup-resources
@@ -608,7 +610,7 @@ workflows:
             - api-cleanup-resources
             - api-e2e-test-context
           requires:
-            - build
+            - build_linux
           filters:
             branches:
               only:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -494,12 +494,11 @@ workflows:
     jobs:
       - build:
           name: build_linux
-          parameters:
-            os: l
+          os: l
+            
       - build:
           name: build_windows
-          parameters:
-            os: w
+          os: w
       - lint:
           requires:
             - build_linux

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -636,6 +636,7 @@ workflows:
             - api-npm-publish
           requires:
             - test
+            - build_windows
             - mock_e2e_tests
             - graphql_e2e_tests
             - amplify_e2e_tests


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Building on windows is currently blocking the test jobs that run on linux making the development cycle longer.
This change uncouples windows build job but retains the dependency of `deploy` on it.

Link to updated workflow: https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api/4870/workflows/76d66a9d-601a-4ac8-91dd-44cc53c13a1f

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
