### PR TITLE
fix(api): correct container code build policy

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/pipeline-with-awaiter.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/pipeline-with-awaiter.ts
@@ -156,7 +156,7 @@ export class PipelineWithAwaiter extends cdk.Construct {
         actions: [
           'ecr:GetAuthorizationToken',
           'ecr:BatchGetImage',
-          'ecr:BatchGetDownloadUrlForLayer',
+          'ecr:GetDownloadUrlForLayer',
           'ecr:InitiateLayerUpload',
           'ecr:BatchCheckLayerAvailability',
           'ecr:UploadLayerPart',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Correct the policy for downloading ECR image used by codebuild for container enabled API. This removes the incorrect one `BatchGetDownloadUrlForLayer` and adds the correct one `GetDownloadUrlForLayer`.

#### Issue #, if available

Fixes https://github.com/aws-amplify/amplify-category-api/issues/1255

#### Description of how you validated changes
- Manual test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
