### PR TITLE
chore: remove force from source run after CLI v11 release

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -726,7 +726,6 @@ commands:
                 shell: bash.exe
                 command: |
                   source .circleci/local_publish_helpers.sh
-                  forceFromSourceRun
                   cd packages/amplify-e2e-tests
                   retry yarn run e2e --detectOpenHandles --maxWorkers=3 $TEST_SUITE
                 no_output_timeout: 60m
@@ -741,7 +740,6 @@ commands:
                   source $BASH_ENV
                   source .circleci/local_publish_helpers.sh
                   amplify version
-                  forceFromSourceRun
                   retry runE2eTest
                 no_output_timeout: 90m
   scan_e2e_test_artifacts:

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -198,25 +198,3 @@ function emitCanaryFailureMetric {
             --region us-west-2
     fi
 }
-
-function forceFromSourceRun {
-    if [[ "$TEST_SUITE" == "src/__tests__/amplify-app.test.ts" ]]; then
-        echo "Not forcing run from source for $TEST_SUITE"
-        return
-    fi
-
-    if [[ "$TEST_SUITE" == "src/__tests__/datastore-modelgen.test.ts" ]]; then
-        echo "Not forcing run from source for $TEST_SUITE"
-        return
-    fi
-
-    yarn add-cli-no-save
-    if [[ "$OSTYPE" == "msys" ]]; then
-        # windows provided by circleci has this OSTYPE
-        yarn hoist-cli-win
-        export AMPLIFY_PATH=C:/home/circleci/repo/node_modules/amplify-cli-internal/bin/amplify
-    else
-        yarn hoist-cli
-        export AMPLIFY_PATH=/home/circleci/repo/node_modules/amplify-cli-internal/bin/amplify
-    fi
-}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Removes the workaround that was forcing e2e tests to run from source.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

E2E test run https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api/4978/workflows/578d2b2b-9451-45ec-a1b5-daab99d01049 .

There's one test that's failing consistently also on main branch. Not related to the change.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
