### PR TITLE
chore(api): change addDependsOn to addDependency

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
@@ -305,7 +305,7 @@ export class AmplifyApigwResourceStack extends cdk.Stack implements AmplifyApigw
       stageName: cdk.Fn.conditionIf('ShouldNotCreateEnvResources', 'Prod', cdk.Fn.ref('env')).toString(),
       restApiId: cdk.Fn.ref(apiName),
     });
-    dependencies.forEach((dep) => this.deploymentResource.addDependsOn(dep));
+    dependencies.forEach((dep) => this.deploymentResource.addDependency(dep));
   };
 }
 

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/ecs-alb-stack.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/ecs-alb-stack.ts
@@ -175,7 +175,7 @@ export class EcsAlbStack extends ContainersStack {
       certificates: [{ certificateArn: wildcardCertificate.ref }],
     });
 
-    this.ecsService.addDependsOn(listener);
+    this.ecsService.addDependency(listener);
 
     let actionsOrderCounter = 1;
     const listenerRule = new elb2.CfnListenerRule(this, 'AlbListenerRule', {
@@ -216,7 +216,7 @@ export class EcsAlbStack extends ContainersStack {
       ],
     });
 
-    this.ecsService.addDependsOn(listenerRule);
+    this.ecsService.addDependency(listenerRule);
 
     const originId = `${loadBalancer.logicalId}-origin`;
 

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -1295,7 +1295,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
     );
 
     const cfnDataSource = dataSource.node.defaultChild as CfnDataSource;
-    cfnDataSource.addDependsOn(role.node.defaultChild as CfnRole);
+    cfnDataSource.addDependency(role.node.defaultChild as CfnRole);
 
     if (context.isProjectUsingDataStore()) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/amplify-graphql-transformer-core/src/appsync-function.ts
+++ b/packages/amplify-graphql-transformer-core/src/appsync-function.ts
@@ -67,7 +67,7 @@ export class AppSyncFunctionConfiguration extends Construct {
 
     props.api.addSchemaDependency(this.function);
     if (props.dataSource instanceof BackedDataSource) {
-      this.function.addDependsOn(props.dataSource?.ds);
+      this.function.addDependency(props.dataSource?.ds);
     }
     this.arn = this.function.attrFunctionArn;
     this.functionId = this.function.attrFunctionId;

--- a/packages/amplify-graphql-transformer-core/src/graphql-api.ts
+++ b/packages/amplify-graphql-transformer-core/src/graphql-api.ts
@@ -218,7 +218,7 @@ export class GraphQLApi extends GraphqlApiBase implements GraphQLAPIProvider {
     if (props.createApiKey && hasApiKey) {
       const config = modes.find((mode: AuthorizationMode) => mode.authorizationType === AuthorizationType.API_KEY && mode.apiKeyConfig)?.apiKeyConfig;
       this.apiKeyResource = this.createAPIKey(config);
-      this.apiKeyResource.addDependsOn(this.schemaResource);
+      this.apiKeyResource.addDependency(this.schemaResource);
       this.apiKey = this.apiKeyResource.attrApiKey;
     }
 
@@ -308,7 +308,7 @@ export class GraphQLApi extends GraphqlApiBase implements GraphQLAPIProvider {
   }
 
   public addSchemaDependency(construct: CfnResource): boolean {
-    construct.addDependsOn(this.schemaResource);
+    construct.addDependency(this.schemaResource);
     return true;
   }
 


### PR DESCRIPTION
CDK method 'addDependsOn' is deprecated. This PR changes 'addDependsOn' method calls to 'addDependency'. 

#### Issue #, if available
NA

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Manual test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
