### PR TITLE
fix(graphql): evaluate group claim - string vs array behavior

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
@@ -306,7 +306,14 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
   #if( !$util.isNull($parentClaim) )
 
     #set( $ownerClaimsList0 = [] )
-    $util.qr($ownerClaimsList0.add($parentClaim))
+    #if( $util.isString($parentClaim) )
+      #if( $util.isList($util.parseJson($parentClaim)) )
+        #set( $parentClaim = $util.parseJson($parentClaim) )
+      #else
+        #set( $parentClaim = [$parentClaim] )
+      #end
+    #end
+    $util.qr($ownerClaimsList0.addAll($parentClaim))
     #if( !$util.isNull($ctx.args.parent) )
       #if( $util.isString($ctx.args.parent) )
         #set( $parentCondition = (($parentClaim == $ctx.args.parent) || $ownerClaimsList0.contains($ctx.args.parent)) )
@@ -336,7 +343,14 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
   #if( !$util.isNull($childClaim) )
 
     #set( $ownerClaimsList1 = [] )
-    $util.qr($ownerClaimsList1.add($childClaim))
+    #if( $util.isString($childClaim) )
+      #if( $util.isList($util.parseJson($childClaim)) )
+        #set( $childClaim = $util.parseJson($childClaim) )
+      #else
+        #set( $childClaim = [$childClaim] )
+      #end
+    #end
+    $util.qr($ownerClaimsList1.addAll($childClaim))
     #if( !$util.isNull($ctx.args.child) )
       #if( $util.isString($ctx.args.child) )
         #set( $childCondition = (($childClaim == $ctx.args.child) || $ownerClaimsList1.contains($ctx.args.child)) )
@@ -732,7 +746,14 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
   #if( !$util.isNull($parentClaim) )
 
     #set( $ownerClaimsList0 = [] )
-    $util.qr($ownerClaimsList0.add($parentClaim))
+    #if( $util.isString($parentClaim) )
+      #if( $util.isList($util.parseJson($parentClaim)) )
+        #set( $parentClaim = $util.parseJson($parentClaim) )
+      #else
+        #set( $parentClaim = [$parentClaim] )
+      #end
+    #end
+    $util.qr($ownerClaimsList0.addAll($parentClaim))
     #if( !$util.isNull($ctx.args.parent) )
       #if( $util.isString($ctx.args.parent) )
         #set( $parentCondition = (($parentClaim == $ctx.args.parent) || $ownerClaimsList0.contains($ctx.args.parent)) )
@@ -762,7 +783,14 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
   #if( !$util.isNull($childClaim) )
 
     #set( $ownerClaimsList1 = [] )
-    $util.qr($ownerClaimsList1.add($childClaim))
+    #if( $util.isString($childClaim) )
+      #if( $util.isList($util.parseJson($childClaim)) )
+        #set( $childClaim = $util.parseJson($childClaim) )
+      #else
+        #set( $childClaim = [$childClaim] )
+      #end
+    #end
+    $util.qr($ownerClaimsList1.addAll($childClaim))
     #if( !$util.isNull($ctx.args.child) )
       #if( $util.isString($ctx.args.child) )
         #set( $childCondition = (($childClaim == $ctx.args.child) || $ownerClaimsList1.contains($ctx.args.child)) )

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
@@ -144,7 +144,15 @@ const generateAuthOnModelQueryExpression = (
             compoundExpression([
               generateOwnerMultiClaimExpression(role.claim!, `${role.entity}Claim`),
               generateOwnerClaimListExpression(role.claim!, `ownerClaimsList${idx}`),
-              qref(methodCall(ref(`ownerClaimsList${idx}.add`), ref(`${role.entity}Claim`))),
+              iff(
+                methodCall(ref('util.isString'), ref(`${role.entity}Claim`)),
+                ifElse(
+                  methodCall(ref('util.isList'), methodCall(ref('util.parseJson'), ref(`${role.entity}Claim`))),
+                  set(ref(`${role.entity}Claim`), methodCall(ref('util.parseJson'), ref(`${role.entity}Claim`))),
+                  set(ref(`${role.entity}Claim`), list([ref(`${role.entity}Claim`)])),
+                ),
+              ),
+              qref(methodCall(ref(`ownerClaimsList${idx}.addAll`), ref(`${role.entity}Claim`))),
               ifElse(
                 not(ref(`util.isNull($ctx.args.${role.entity})`)),
                 compoundExpression([
@@ -239,7 +247,15 @@ const generateAuthOnModelQueryExpression = (
             compoundExpression([
               generateOwnerMultiClaimExpression(role.claim!, `${role.entity}Claim`),
               generateOwnerClaimListExpression(role.claim!, `ownerClaimsList${idx}`),
-              qref(methodCall(ref(`ownerClaimsList${idx}.add`), ref(`${role.entity}Claim`))),
+              iff(
+                methodCall(ref('util.isString'), ref(`${role.entity}Claim`)),
+                ifElse(
+                  methodCall(ref('util.isList'), methodCall(ref('util.parseJson'), ref(`${role.entity}Claim`))),
+                  set(ref(`${role.entity}Claim`), methodCall(ref('util.parseJson'), ref(`${role.entity}Claim`))),
+                  set(ref(`${role.entity}Claim`), list([ref(`${role.entity}Claim`)])),
+                ),
+              ),
+              qref(methodCall(ref(`ownerClaimsList${idx}.addAll`), ref(`${role.entity}Claim`))),
               ifElse(
                 not(ref(`util.isNull($ctx.args.${role.entity})`)),
                 compoundExpression([

--- a/packages/amplify-util-mock/src/__tests__/velocity/model-auth.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/velocity/model-auth.test.ts
@@ -1575,8 +1575,8 @@ describe("with identity claim feature flag disabled", () => {
       expect(listAuthVTLRequest.stash.authFilter).toEqual(
         expect.objectContaining({
           or: expect.arrayContaining([
-            expect.objectContaining({ child: { eq: ownerRequest.jwt["cognito:username"] } }),
-            expect.objectContaining({ parent: { eq: ownerRequest.jwt["cognito:username"] } })
+            expect.objectContaining({ child: { in: expect.arrayContaining([ownerRequest.jwt["cognito:username"]]) } }),
+            expect.objectContaining({ parent: { in: expect.arrayContaining([ownerRequest.jwt["cognito:username"]]) } })
           ])
         })
       );


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR checks if the group claim is an array or string before evaluation for `@index` queries. This is something we already do for mutations and get & list queries. This PR applies the same logic to `@index` queries on `groupsField`.

##### CDK / CloudFormation Parameters Changed

NA

#### Issue #, if available

Fixes https://github.com/aws-amplify/amplify-category-api/issues/857, https://github.com/aws-amplify/amplify-category-api/issues/468

#### Description of how you validated changes
- Manual test
- E2E test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
