### PR TITLE
Schema validations

### DIFF
--- a/packages/amplify-schema-validator/src/__tests__/schemas/invalid-use-belongsto-when-datastore-inuse.graphql
+++ b/packages/amplify-schema-validator/src/__tests__/schemas/invalid-use-belongsto-when-datastore-inuse.graphql
@@ -1,0 +1,9 @@
+type Blog @model {
+    id: ID!
+    posts: [Post] @hasMany
+}
+
+type Post @model {
+    id: ID!
+    blog: Blog @hasOne
+}

--- a/packages/amplify-schema-validator/src/__tests__/schemas/invalid-use-directives-from-newer-transformer-version.graphql
+++ b/packages/amplify-schema-validator/src/__tests__/schemas/invalid-use-directives-from-newer-transformer-version.graphql
@@ -1,0 +1,11 @@
+type Post {
+    id: ID! @primaryKey
+    title: String! @index
+    blog: Blog! @hasOne
+}
+
+type Blog {
+    id: ID!
+    name: String!
+    posts: [Post]! @hasMany
+}

--- a/packages/amplify-schema-validator/src/__tests__/schemas/invalid-use-directives-from-newer-transformer-version.graphql
+++ b/packages/amplify-schema-validator/src/__tests__/schemas/invalid-use-directives-from-newer-transformer-version.graphql
@@ -1,11 +1,5 @@
 type Post {
     id: ID! @primaryKey
     title: String! @index
-    blog: Blog! @hasOne
-}
-
-type Blog {
-    id: ID!
-    name: String!
-    posts: [Post]! @hasMany
+    blog: String!
 }

--- a/packages/amplify-schema-validator/src/__tests__/schemas/invalid-use-directives-from-older-transformer-version.graphql
+++ b/packages/amplify-schema-validator/src/__tests__/schemas/invalid-use-directives-from-older-transformer-version.graphql
@@ -1,0 +1,11 @@
+type Post @key {
+    id: ID!
+    title: String!
+    blog: Blog! @connection
+}
+
+type Blog @versioned {
+    id: ID!
+    name: String!
+    posts: [Post]! @connection
+}

--- a/packages/amplify-schema-validator/src/__tests__/validates-use-belongsto-when-datastore-inuse.test.ts
+++ b/packages/amplify-schema-validator/src/__tests__/validates-use-belongsto-when-datastore-inuse.test.ts
@@ -1,5 +1,6 @@
-import { ValidateSchemaProps, validateSchemaWithContext } from '..';
+import { validateSchemaWithContext } from '..';
 import { readSchema } from './helpers/readSchema';
+import { ValidateSchemaProps } from '../helpers/schema-validator-props';
 
 describe('Validate Schema', () => {
   it('fails validation when hasOne and hasMany relation is used when datastore is enabled', () => {

--- a/packages/amplify-schema-validator/src/__tests__/validates-use-belongsto-when-datastore-inuse.test.ts
+++ b/packages/amplify-schema-validator/src/__tests__/validates-use-belongsto-when-datastore-inuse.test.ts
@@ -1,0 +1,15 @@
+import { validateSchema } from '..';
+import { readSchema } from './helpers/readSchema';
+
+describe('Validate Schema', () => {
+  it('fails validation when hasOne and hasMany relation is used when datastore is enabled', () => {
+    const schema = readSchema('invalid-use-belongsto-when-datastore-inuse.graphql');
+    const errorRegex = 'InvalidDirectiveError - Post and Blog cannot refer to each other via @hasOne or @hasMany when DataStore is in use. Use @belongsTo instead. See https://docs.amplify.aws/cli/graphql/data-modeling/#belongs-to-relationship';
+    expect(() => validateSchema(schema, undefined, true)).toThrow(errorRegex);
+  });
+
+  it('passes validation when hasOne and hasMany relation is used when datastore is disabled', () => {
+    const schema = readSchema('invalid-use-belongsto-when-datastore-inuse.graphql');
+    expect(() => validateSchema(schema, undefined, false)).not.toThrow();
+  });
+});

--- a/packages/amplify-schema-validator/src/__tests__/validates-use-belongsto-when-datastore-inuse.test.ts
+++ b/packages/amplify-schema-validator/src/__tests__/validates-use-belongsto-when-datastore-inuse.test.ts
@@ -1,15 +1,23 @@
-import { validateSchema } from '..';
+import { ValidateSchemaProps, validateSchemaWithContext } from '..';
 import { readSchema } from './helpers/readSchema';
 
 describe('Validate Schema', () => {
   it('fails validation when hasOne and hasMany relation is used when datastore is enabled', () => {
+    const schemaProps: ValidateSchemaProps = {
+      graphqlTransformerVersion: 2,
+      isDataStoreEnabled: true,
+    };
     const schema = readSchema('invalid-use-belongsto-when-datastore-inuse.graphql');
     const errorRegex = 'InvalidDirectiveError - Post and Blog cannot refer to each other via @hasOne or @hasMany when DataStore is in use. Use @belongsTo instead. See https://docs.amplify.aws/cli/graphql/data-modeling/#belongs-to-relationship';
-    expect(() => validateSchema(schema, undefined, true)).toThrow(errorRegex);
+    expect(() => validateSchemaWithContext(schema, schemaProps)).toThrow(errorRegex);
   });
 
   it('passes validation when hasOne and hasMany relation is used when datastore is disabled', () => {
+    const schemaProps: ValidateSchemaProps = {
+      graphqlTransformerVersion: 2,
+      isDataStoreEnabled: false,
+    };
     const schema = readSchema('invalid-use-belongsto-when-datastore-inuse.graphql');
-    expect(() => validateSchema(schema, undefined, false)).not.toThrow();
+    expect(() => validateSchemaWithContext(schema, schemaProps)).not.toThrow();
   });
 });

--- a/packages/amplify-schema-validator/src/__tests__/validates-use-directives-from-newer-transformer-version.test.ts
+++ b/packages/amplify-schema-validator/src/__tests__/validates-use-directives-from-newer-transformer-version.test.ts
@@ -1,5 +1,6 @@
-import { ValidateSchemaProps, validateSchemaWithContext } from '..';
+import { validateSchemaWithContext } from '..';
 import { readSchema } from './helpers/readSchema';
+import { ValidateSchemaProps } from '../helpers/schema-validator-props';
 
 const schemaProps: ValidateSchemaProps = {
   graphqlTransformerVersion: 1,
@@ -9,7 +10,7 @@ const schemaProps: ValidateSchemaProps = {
 describe('Validate Schema', () => {
   it('fails validation when schema uses new directives in old transformer version', () => {
     const schema = readSchema('invalid-use-directives-from-newer-transformer-version.graphql');
-    const errorRegex = 'InvalidDirectiveError - Your GraphQL Schema is using @primaryKey, @index, @hasOne, @hasMany directives from a newer version of the GraphQL Transformer. Visit https://docs.amplify.aws/cli/migration/transformer-migration/ to learn how to migrate your GraphQL schema.';
+    const errorRegex = 'InvalidDirectiveError - Your GraphQL Schema is using @primaryKey, @index directives from a newer version of the GraphQL Transformer. Visit https://docs.amplify.aws/cli/migration/transformer-migration/ to learn how to migrate your GraphQL schema.';
     expect(() => validateSchemaWithContext(schema, schemaProps)).toThrow(errorRegex);
   });
 });

--- a/packages/amplify-schema-validator/src/__tests__/validates-use-directives-from-newer-transformer-version.test.ts
+++ b/packages/amplify-schema-validator/src/__tests__/validates-use-directives-from-newer-transformer-version.test.ts
@@ -1,0 +1,18 @@
+import { validateSchema } from '..';
+import { readSchema } from './helpers/readSchema';
+
+const featureFlags = `{
+  "features": {
+    "graphqltransformer": {
+      "transformerversion": 1
+    }
+  }
+}`;
+
+describe('Validate Schema', () => {
+  it('fails validation when schema uses new directives in old transformer version', () => {
+    const schema = readSchema('invalid-use-directives-from-newer-transformer-version.graphql');
+    const errorRegex = 'InvalidDirectiveError - Your GraphQL Schema is using @primaryKey, @index, @hasOne, @hasMany directives from a newer version of the GraphQL Transformer. Visit https://docs.amplify.aws/cli/migration/transformer-migration/ to learn how to migrate your GraphQL schema.';
+    expect(() => validateSchema(schema, featureFlags)).toThrow(errorRegex);
+  });
+});

--- a/packages/amplify-schema-validator/src/__tests__/validates-use-directives-from-newer-transformer-version.test.ts
+++ b/packages/amplify-schema-validator/src/__tests__/validates-use-directives-from-newer-transformer-version.test.ts
@@ -1,18 +1,15 @@
-import { validateSchema } from '..';
+import { ValidateSchemaProps, validateSchemaWithContext } from '..';
 import { readSchema } from './helpers/readSchema';
 
-const featureFlags = `{
-  "features": {
-    "graphqltransformer": {
-      "transformerversion": 1
-    }
-  }
-}`;
+const schemaProps: ValidateSchemaProps = {
+  graphqlTransformerVersion: 1,
+  isDataStoreEnabled: true,
+};
 
 describe('Validate Schema', () => {
   it('fails validation when schema uses new directives in old transformer version', () => {
     const schema = readSchema('invalid-use-directives-from-newer-transformer-version.graphql');
     const errorRegex = 'InvalidDirectiveError - Your GraphQL Schema is using @primaryKey, @index, @hasOne, @hasMany directives from a newer version of the GraphQL Transformer. Visit https://docs.amplify.aws/cli/migration/transformer-migration/ to learn how to migrate your GraphQL schema.';
-    expect(() => validateSchema(schema, featureFlags)).toThrow(errorRegex);
+    expect(() => validateSchemaWithContext(schema, schemaProps)).toThrow(errorRegex);
   });
 });

--- a/packages/amplify-schema-validator/src/__tests__/validates-use-directives-from-older-transformer-version.test.ts
+++ b/packages/amplify-schema-validator/src/__tests__/validates-use-directives-from-older-transformer-version.test.ts
@@ -1,4 +1,5 @@
-import { ValidateSchemaProps, validateSchemaWithContext } from '..';
+import { validateSchemaWithContext } from '..';
+import { ValidateSchemaProps } from '../helpers/schema-validator-props';
 import { readSchema } from './helpers/readSchema';
 
 const schemaProps: ValidateSchemaProps = {

--- a/packages/amplify-schema-validator/src/__tests__/validates-use-directives-from-older-transformer-version.test.ts
+++ b/packages/amplify-schema-validator/src/__tests__/validates-use-directives-from-older-transformer-version.test.ts
@@ -1,18 +1,15 @@
-import { validateSchema } from '..';
+import { ValidateSchemaProps, validateSchemaWithContext } from '..';
 import { readSchema } from './helpers/readSchema';
 
-const featureFlags = `{
-  "features": {
-    "graphqltransformer": {
-      "transformerversion": 2
-    }
-  }
-}`;
+const schemaProps: ValidateSchemaProps = {
+  graphqlTransformerVersion: 2,
+  isDataStoreEnabled: true,
+};
 
 describe('Validate Schema', () => {
   it('fails validation when schema uses old directives in new transformer version', () => {
     const schema = readSchema('invalid-use-directives-from-older-transformer-version.graphql');
     const errorRegex = 'InvalidDirectiveError - Your GraphQL Schema is using @key, @connection, @versioned directives from an older version of the GraphQL Transformer. Visit https://docs.amplify.aws/cli/migration/transformer-migration/ to learn how to migrate your GraphQL schema.';
-    expect(() => validateSchema(schema, featureFlags)).toThrow(errorRegex);
+    expect(() => validateSchemaWithContext(schema, schemaProps)).toThrow(errorRegex);
   });
 });

--- a/packages/amplify-schema-validator/src/__tests__/validates-use-directives-from-older-transformer-version.test.ts
+++ b/packages/amplify-schema-validator/src/__tests__/validates-use-directives-from-older-transformer-version.test.ts
@@ -1,0 +1,18 @@
+import { validateSchema } from '..';
+import { readSchema } from './helpers/readSchema';
+
+const featureFlags = `{
+  "features": {
+    "graphqltransformer": {
+      "transformerversion": 2
+    }
+  }
+}`;
+
+describe('Validate Schema', () => {
+  it('fails validation when schema uses old directives in new transformer version', () => {
+    const schema = readSchema('invalid-use-directives-from-older-transformer-version.graphql');
+    const errorRegex = 'InvalidDirectiveError - Your GraphQL Schema is using @key, @connection, @versioned directives from an older version of the GraphQL Transformer. Visit https://docs.amplify.aws/cli/migration/transformer-migration/ to learn how to migrate your GraphQL schema.';
+    expect(() => validateSchema(schema, featureFlags)).toThrow(errorRegex);
+  });
+});

--- a/packages/amplify-schema-validator/src/helpers/schema-validator-props.ts
+++ b/packages/amplify-schema-validator/src/helpers/schema-validator-props.ts
@@ -1,0 +1,4 @@
+export type ValidateSchemaProps = {
+    graphqlTransformerVersion: number;
+    isDataStoreEnabled: boolean;
+};

--- a/packages/amplify-schema-validator/src/helpers/transformer-validation.ts
+++ b/packages/amplify-schema-validator/src/helpers/transformer-validation.ts
@@ -1,0 +1,16 @@
+import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
+
+export const transformerValidationErrors = (directivesInUse: Set<string>, graphqlTransformerVersion: number): Error[] => {
+    const errors: Error[] = [];
+    if (directivesInUse.size > 0) {
+        const errorMessage = `Your GraphQL Schema is using ${Array.from(directivesInUse.values())
+            .map((directive) => `${directive}`)
+            .join(', ')} ${directivesInUse.size > 1 ? 'directives' : 'directive'
+            } from ${graphqlTransformerVersion === 1 ? 'a newer' : 'an older'} version of the GraphQL Transformer. Visit https://docs.amplify.aws/cli/migration/transformer-migration/ to learn how to migrate your GraphQL schema.`;
+        errors.push(new InvalidDirectiveError(
+            errorMessage,
+        ));
+    }
+
+    return errors;
+}

--- a/packages/amplify-schema-validator/src/index.ts
+++ b/packages/amplify-schema-validator/src/index.ts
@@ -23,6 +23,7 @@ import { validateKeyExistsInRelatedModel } from './validators/key-exists-in-rela
 import { validateBelongsToIsUsedWhenDatastoreInUse } from './validators/use-belongsto-when-datastore-inuse';
 import { validateDirectivesFromOlderTransformerVersionAreNotUsed } from './validators/use-directives-from-older-transformer-version';
 import { validateDirectivesFromNewerTransformerVersionAreNotUsed } from './validators/use-directives-from-newer-transformer-version';
+import { ValidateSchemaProps } from './helpers/schema-validator-props';
 
 const allValidators = [
   validateIndexScalarTypes,
@@ -50,11 +51,6 @@ const allValidatorsWithContext = [
   validateDirectivesFromNewerTransformerVersionAreNotUsed,
 ];
 
-export type ValidateSchemaProps = {
-  graphqlTransformerVersion: number;
-  isDataStoreEnabled: boolean;
-};
-
 /**
  * The primary export of this library
  * runs all validators and throws a ValidationException with all failure reasons
@@ -73,9 +69,10 @@ export const validateSchema = (schemaString: string): void => {
 
 /**
  * The primary export of this library
- * runs all validators and throws a ValidationException with all failure reasons
+ * runs all validators which require context and throws a ValidationException with all failure reasons
  *
  * @param schemaString the graphql schema
+ * @param props feature flags that are required for validation
  * @returns void
  */
 export const validateSchemaWithContext = (schemaString: string, props: ValidateSchemaProps): void => {

--- a/packages/amplify-schema-validator/src/index.ts
+++ b/packages/amplify-schema-validator/src/index.ts
@@ -20,6 +20,9 @@ import { validateIndexIsDefinedOnce } from './validators/index-is-defined-once-i
 import { validateIndexExistsInRelatedModel } from './validators/index-exists-in-related-model';
 import { validateEnumIsDefinedOnce } from './validators/enum-is-defined-once';
 import { validateKeyExistsInRelatedModel } from './validators/key-exists-in-related-model';
+import { validateBelongsToIsUsedWhenDatastoreInUse } from './validators/use-belongsto-when-datastore-inuse';
+import { validateDirectivesFromOlderTransformerVersionAreNotUsed } from './validators/use-directives-from-older-transformer-version';
+import { validateDirectivesFromNewerTransformerVersionAreNotUsed } from './validators/use-directives-from-newer-transformer-version';
 
 const allValidators = [
   validateIndexScalarTypes,
@@ -39,6 +42,9 @@ const allValidators = [
   validateIndexExistsInRelatedModel,
   validateEnumIsDefinedOnce,
   validateKeyExistsInRelatedModel,
+  validateBelongsToIsUsedWhenDatastoreInUse,
+  validateDirectivesFromOlderTransformerVersionAreNotUsed,
+  validateDirectivesFromNewerTransformerVersionAreNotUsed,
 ];
 
 /**
@@ -48,9 +54,9 @@ const allValidators = [
  * @param schemaString the graphql schema
  * @returns void
  */
-export const validateSchema = (schemaString: string): void => {
+export const validateSchema = (schemaString: string, amplifyFeatureFlags?: string, dataStoreEnabled?: boolean): void => {
   const schema = parse(schemaString);
-  const validationErrors = allValidators.flatMap((validate) => validate(schema));
+  const validationErrors = allValidators.flatMap((validate) => validate(schema, amplifyFeatureFlags, dataStoreEnabled));
   if (validationErrors.length > 0) {
     const allErrorMessages = validationErrors.map((error: Error) => `${error.name} - ${error.message}`);
     throw new ValidationError(allErrorMessages.join('\n'));

--- a/packages/amplify-schema-validator/src/index.ts
+++ b/packages/amplify-schema-validator/src/index.ts
@@ -42,10 +42,18 @@ const allValidators = [
   validateIndexExistsInRelatedModel,
   validateEnumIsDefinedOnce,
   validateKeyExistsInRelatedModel,
+];
+
+const allValidatorsWithContext = [
   validateBelongsToIsUsedWhenDatastoreInUse,
   validateDirectivesFromOlderTransformerVersionAreNotUsed,
   validateDirectivesFromNewerTransformerVersionAreNotUsed,
 ];
+
+export type ValidateSchemaProps = {
+  graphqlTransformerVersion: number;
+  isDataStoreEnabled: boolean;
+};
 
 /**
  * The primary export of this library
@@ -54,9 +62,25 @@ const allValidators = [
  * @param schemaString the graphql schema
  * @returns void
  */
-export const validateSchema = (schemaString: string, amplifyFeatureFlags?: string, dataStoreEnabled?: boolean): void => {
+export const validateSchema = (schemaString: string): void => {
   const schema = parse(schemaString);
-  const validationErrors = allValidators.flatMap((validate) => validate(schema, amplifyFeatureFlags, dataStoreEnabled));
+  const validationErrors = allValidators.flatMap((validate) => validate(schema));
+  if (validationErrors.length > 0) {
+    const allErrorMessages = validationErrors.map((error: Error) => `${error.name} - ${error.message}`);
+    throw new ValidationError(allErrorMessages.join('\n'));
+  }
+};
+
+/**
+ * The primary export of this library
+ * runs all validators and throws a ValidationException with all failure reasons
+ *
+ * @param schemaString the graphql schema
+ * @returns void
+ */
+export const validateSchemaWithContext = (schemaString: string, props: ValidateSchemaProps): void => {
+  const schema = parse(schemaString);
+  const validationErrors = allValidatorsWithContext.flatMap((validate) => validate(schema, props));
   if (validationErrors.length > 0) {
     const allErrorMessages = validationErrors.map((error: Error) => `${error.name} - ${error.message}`);
     throw new ValidationError(allErrorMessages.join('\n'));

--- a/packages/amplify-schema-validator/src/validators/auth-must-be-annotated-with-model.ts
+++ b/packages/amplify-schema-validator/src/validators/auth-must-be-annotated-with-model.ts
@@ -11,7 +11,11 @@ import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
    * @param schema graphql schema
    * @returns true if types annotated with @auth are also be annotated with @model.
    */
-export const validateAuthIsAnnotatedWithModel = (schema: DocumentNode): Error[] => {
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateAuthIsAnnotatedWithModel = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/auth-must-be-annotated-with-model.ts
+++ b/packages/amplify-schema-validator/src/validators/auth-must-be-annotated-with-model.ts
@@ -12,10 +12,7 @@ import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
    * @returns true if types annotated with @auth are also be annotated with @model.
    */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const validateAuthIsAnnotatedWithModel = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
-): Error[] => {
+export const validateAuthIsAnnotatedWithModel = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/belongs-to-fields-match-related-type-primary-key.ts
+++ b/packages/amplify-schema-validator/src/validators/belongs-to-fields-match-related-type-primary-key.ts
@@ -16,10 +16,7 @@ import { getObjectWithName } from '../helpers/get-object-with-name';
  * @returns true if @belongsTo fields match related type primary key
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const validateBelongsToFieldsMatchRelatedTypePrimaryKey = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
-): Error[] => {
+export const validateBelongsToFieldsMatchRelatedTypePrimaryKey = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/belongs-to-fields-match-related-type-primary-key.ts
+++ b/packages/amplify-schema-validator/src/validators/belongs-to-fields-match-related-type-primary-key.ts
@@ -15,7 +15,11 @@ import { getObjectWithName } from '../helpers/get-object-with-name';
  * @param schema graphql schema
  * @returns true if @belongsTo fields match related type primary key
  */
-export const validateBelongsToFieldsMatchRelatedTypePrimaryKey = (schema: DocumentNode): Error[] => {
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateBelongsToFieldsMatchRelatedTypePrimaryKey = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/correct-type-in-many-to-many-relation.ts
+++ b/packages/amplify-schema-validator/src/validators/correct-type-in-many-to-many-relation.ts
@@ -13,7 +13,11 @@ import { resolveFieldTypeName } from '../helpers/resolve-field-type-name';
  * @param schema graphql schema
  * @returns true if @manyToMany relation has correct type
  */
-export const validateCorrectTypeInManyToManyRelation = (schema: DocumentNode): Error[] => {
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateCorrectTypeInManyToManyRelation = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/correct-type-in-many-to-many-relation.ts
+++ b/packages/amplify-schema-validator/src/validators/correct-type-in-many-to-many-relation.ts
@@ -14,10 +14,7 @@ import { resolveFieldTypeName } from '../helpers/resolve-field-type-name';
  * @returns true if @manyToMany relation has correct type
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const validateCorrectTypeInManyToManyRelation = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
-): Error[] => {
+export const validateCorrectTypeInManyToManyRelation = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/enum-is-defined-once.ts
+++ b/packages/amplify-schema-validator/src/validators/enum-is-defined-once.ts
@@ -11,7 +11,11 @@ import { ValidationError } from '../exceptions/validation-error';
  * @param schema graphql schema
  * @returns true if an enum is defined once
  */
-export const validateEnumIsDefinedOnce = (schema: DocumentNode): Error[] => {
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateEnumIsDefinedOnce = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
   const errors: Error[] = [];
   const enumTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.ENUM_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/enum-is-defined-once.ts
+++ b/packages/amplify-schema-validator/src/validators/enum-is-defined-once.ts
@@ -12,10 +12,7 @@ import { ValidationError } from '../exceptions/validation-error';
  * @returns true if an enum is defined once
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const validateEnumIsDefinedOnce = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
-): Error[] => {
+export const validateEnumIsDefinedOnce = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const enumTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.ENUM_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/field-is-defined-once.ts
+++ b/packages/amplify-schema-validator/src/validators/field-is-defined-once.ts
@@ -11,7 +11,11 @@ import { ValidationError } from '../exceptions/validation-error';
  * @param schema graphql schema
  * @returns true if a field is defined once in a model
  */
-export const validateFieldIsDefinedOnce = (schema: DocumentNode): Error[] => {
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateFieldIsDefinedOnce = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/field-is-defined-once.ts
+++ b/packages/amplify-schema-validator/src/validators/field-is-defined-once.ts
@@ -12,10 +12,7 @@ import { ValidationError } from '../exceptions/validation-error';
  * @returns true if a field is defined once in a model
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const validateFieldIsDefinedOnce = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
-): Error[] => {
+export const validateFieldIsDefinedOnce = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/fields-match-in-parent-model.ts
+++ b/packages/amplify-schema-validator/src/validators/fields-match-in-parent-model.ts
@@ -14,10 +14,7 @@ import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
  * @returns true if fields match in parent model
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const validateFieldsMatchInParentModel = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
-): Error[] => {
+export const validateFieldsMatchInParentModel = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/fields-match-in-parent-model.ts
+++ b/packages/amplify-schema-validator/src/validators/fields-match-in-parent-model.ts
@@ -13,7 +13,11 @@ import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
  * @param schema graphql schema
  * @returns true if fields match in parent model
  */
-export const validateFieldsMatchInParentModel = (schema: DocumentNode): Error[] => {
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateFieldsMatchInParentModel = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/index-exists-in-related-model.ts
+++ b/packages/amplify-schema-validator/src/validators/index-exists-in-related-model.ts
@@ -14,7 +14,11 @@ import { resolveFieldTypeName } from '../helpers/resolve-field-type-name';
  * @param schema graphql schema
  * @returns true if index exists in the related model
  */
-export const validateIndexExistsInRelatedModel = (schema: DocumentNode): Error[] => {
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateIndexExistsInRelatedModel = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/index-exists-in-related-model.ts
+++ b/packages/amplify-schema-validator/src/validators/index-exists-in-related-model.ts
@@ -15,10 +15,7 @@ import { resolveFieldTypeName } from '../helpers/resolve-field-type-name';
  * @returns true if index exists in the related model
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const validateIndexExistsInRelatedModel = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
-): Error[] => {
+export const validateIndexExistsInRelatedModel = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/index-is-defined-once-in-model.ts
+++ b/packages/amplify-schema-validator/src/validators/index-is-defined-once-in-model.ts
@@ -13,10 +13,7 @@ import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
    * @returns true if an index with same name exists only once in a model
    */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const validateIndexIsDefinedOnce = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
-): Error[] => {
+export const validateIndexIsDefinedOnce = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/index-is-defined-once-in-model.ts
+++ b/packages/amplify-schema-validator/src/validators/index-is-defined-once-in-model.ts
@@ -12,7 +12,11 @@ import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
    * @param schema graphql schema
    * @returns true if an index with same name exists only once in a model
    */
-export const validateIndexIsDefinedOnce = (schema: DocumentNode): Error[] => {
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateIndexIsDefinedOnce = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/index-scalar-types.ts
+++ b/packages/amplify-schema-validator/src/validators/index-scalar-types.ts
@@ -16,10 +16,7 @@ import { getTypeDefinitionsOfKind } from '../helpers/get-type-definitions-of-kin
  * @returns true
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const validateIndexScalarTypes = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
-): Error[] => {
+export const validateIndexScalarTypes = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/index-scalar-types.ts
+++ b/packages/amplify-schema-validator/src/validators/index-scalar-types.ts
@@ -15,7 +15,11 @@ import { getTypeDefinitionsOfKind } from '../helpers/get-type-definitions-of-kin
  * @param schema graphql schema
  * @returns true
  */
-export const validateIndexScalarTypes = (schema: DocumentNode): Error[] => {
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateIndexScalarTypes = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/key-exists-in-related-model.ts
+++ b/packages/amplify-schema-validator/src/validators/key-exists-in-related-model.ts
@@ -9,12 +9,16 @@ import { getObjectWithName } from '../helpers/get-object-with-name';
 import { resolveFieldTypeName } from '../helpers/resolve-field-type-name';
 
 /**
-     * Validates that key exists in the related model
-     *
-     * @param schema graphql schema
-     * @returns true if key exists in the related model
-     */
-export const validateKeyExistsInRelatedModel = (schema: DocumentNode): Error[] => {
+   * Validates that key exists in the related model
+   *
+   * @param schema graphql schema
+   * @returns true if key exists in the related model
+   */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateKeyExistsInRelatedModel = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/key-exists-in-related-model.ts
+++ b/packages/amplify-schema-validator/src/validators/key-exists-in-related-model.ts
@@ -15,10 +15,7 @@ import { resolveFieldTypeName } from '../helpers/resolve-field-type-name';
    * @returns true if key exists in the related model
    */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const validateKeyExistsInRelatedModel = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
-): Error[] => {
+export const validateKeyExistsInRelatedModel = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/relation-required-with-belongs-to.ts
+++ b/packages/amplify-schema-validator/src/validators/relation-required-with-belongs-to.ts
@@ -14,10 +14,7 @@ import { resolveFieldTypeName } from '../helpers/resolve-field-type-name';
  * @returns true
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const validateRequireBelongsToRelation = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
-): Error[] => {
+export const validateRequireBelongsToRelation = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/relation-required-with-belongs-to.ts
+++ b/packages/amplify-schema-validator/src/validators/relation-required-with-belongs-to.ts
@@ -13,7 +13,11 @@ import { resolveFieldTypeName } from '../helpers/resolve-field-type-name';
  * @param schema graphql schema
  * @returns true
  */
-export const validateRequireBelongsToRelation = (schema: DocumentNode): Error[] => {
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateRequireBelongsToRelation = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/relationname-doesnot-conflict-with-typename.ts
+++ b/packages/amplify-schema-validator/src/validators/relationname-doesnot-conflict-with-typename.ts
@@ -14,10 +14,7 @@ import { getGraphqlName, toUpper } from '../helpers/util';
  * @returns true if relation name does not conflict with an existing type name
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const validateRelationNameDoesNotConflictWithTypeName = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
-): Error[] => {
+export const validateRelationNameDoesNotConflictWithTypeName = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/relationname-doesnot-conflict-with-typename.ts
+++ b/packages/amplify-schema-validator/src/validators/relationname-doesnot-conflict-with-typename.ts
@@ -8,12 +8,16 @@ import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
 import { getGraphqlName, toUpper } from '../helpers/util';
 
 /**
-   * Validates that relation name does not conflict with an existing type name
-   *
-   * @param schema graphql schema
-   * @returns true if relation name does not conflict with an existing type name
-   */
-export const validateRelationNameDoesNotConflictWithTypeName = (schema: DocumentNode): Error[] => {
+ * Validates that relation name does not conflict with an existing type name
+ *
+ * @param schema graphql schema
+ * @returns true if relation name does not conflict with an existing type name
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateRelationNameDoesNotConflictWithTypeName = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/reserved-field-name.ts
+++ b/packages/amplify-schema-validator/src/validators/reserved-field-name.ts
@@ -12,10 +12,7 @@ import { ValidationError } from '../exceptions/validation-error';
  * @returns true if reserved words are not used in field names
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const validateReservedFieldNames = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
-): Error[] => {
+export const validateReservedFieldNames = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const reservedWords = ['_version', '_changedAt', '_deleted'];
   const objectTypeDefinitions = schema.definitions.filter(

--- a/packages/amplify-schema-validator/src/validators/reserved-field-name.ts
+++ b/packages/amplify-schema-validator/src/validators/reserved-field-name.ts
@@ -6,12 +6,16 @@ import {
 import { ValidationError } from '../exceptions/validation-error';
 
 /**
-   * Reserved words are not used in field names
-   *
-   * @param schema graphql schema
-   * @returns true if reserved words are not used in field names
-   */
-export const validateReservedFieldNames = (schema: DocumentNode): Error[] => {
+ * Reserved words are not used in field names
+ *
+ * @param schema graphql schema
+ * @returns true if reserved words are not used in field names
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateReservedFieldNames = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
   const errors: Error[] = [];
   const reservedWords = ['_version', '_changedAt', '_deleted'];
   const objectTypeDefinitions = schema.definitions.filter(

--- a/packages/amplify-schema-validator/src/validators/reserved-type-name.ts
+++ b/packages/amplify-schema-validator/src/validators/reserved-type-name.ts
@@ -12,10 +12,7 @@ import { ValidationError } from '../exceptions/validation-error';
  * @returns true if reserved words are not used in type names
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const validateReservedTypeNames = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
-): Error[] => {
+export const validateReservedTypeNames = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const reservedWords = ['Query', 'Mutation', 'Subscription'];
   const objectTypeDefinitions = schema.definitions.filter(

--- a/packages/amplify-schema-validator/src/validators/reserved-type-name.ts
+++ b/packages/amplify-schema-validator/src/validators/reserved-type-name.ts
@@ -6,12 +6,16 @@ import {
 import { ValidationError } from '../exceptions/validation-error';
 
 /**
-   * Reserved words are not used in type names
-   *
-   * @param schema graphql schema
-   * @returns true if reserved words are not used in type names
-   */
-export const validateReservedTypeNames = (schema: DocumentNode): Error[] => {
+ * Reserved words are not used in type names
+ *
+ * @param schema graphql schema
+ * @returns true if reserved words are not used in type names
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateReservedTypeNames = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
   const errors: Error[] = [];
   const reservedWords = ['Query', 'Mutation', 'Subscription'];
   const objectTypeDefinitions = schema.definitions.filter(

--- a/packages/amplify-schema-validator/src/validators/sort-key-field-exists.ts
+++ b/packages/amplify-schema-validator/src/validators/sort-key-field-exists.ts
@@ -14,10 +14,7 @@ import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
  * @returns true if sort key fields exists in model
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const verifyIndexSortKeyFieldsExistInModel = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
-): Error[] => {
+export const verifyIndexSortKeyFieldsExistInModel = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/sort-key-field-exists.ts
+++ b/packages/amplify-schema-validator/src/validators/sort-key-field-exists.ts
@@ -8,12 +8,16 @@ import {
 import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
 
 /**
-   * Validates that sort key fields exists in model
-   *
-   * @param schema graphql schema
-   * @returns true if sort key fields exists in model
-   */
-export const verifyIndexSortKeyFieldsExistInModel = (schema: DocumentNode): Error[] => {
+ * Validates that sort key fields exists in model
+ *
+ * @param schema graphql schema
+ * @returns true if sort key fields exists in model
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const verifyIndexSortKeyFieldsExistInModel = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/two-many-to-many-locations.ts
+++ b/packages/amplify-schema-validator/src/validators/two-many-to-many-locations.ts
@@ -13,7 +13,11 @@ import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
  * @param schema graphql schema
  * @returns true
  */
-export const validateManyToManyTwoLocations = (schema: DocumentNode): Error[] => {
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateManyToManyTwoLocations = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/two-many-to-many-locations.ts
+++ b/packages/amplify-schema-validator/src/validators/two-many-to-many-locations.ts
@@ -14,10 +14,7 @@ import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
  * @returns true
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const validateManyToManyTwoLocations = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
-): Error[] => {
+export const validateManyToManyTwoLocations = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/type-is-defined-once.ts
+++ b/packages/amplify-schema-validator/src/validators/type-is-defined-once.ts
@@ -12,10 +12,7 @@ import { ValidationError } from '../exceptions/validation-error';
  * @returns true if a type is defined once in the schema
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const validateTypeIsDefinedOnce = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
-): Error[] => {
+export const validateTypeIsDefinedOnce = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/type-is-defined-once.ts
+++ b/packages/amplify-schema-validator/src/validators/type-is-defined-once.ts
@@ -11,7 +11,11 @@ import { ValidationError } from '../exceptions/validation-error';
  * @param schema graphql schema
  * @returns true if a type is defined once in the schema
  */
-export const validateTypeIsDefinedOnce = (schema: DocumentNode): Error[] => {
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateTypeIsDefinedOnce = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/use-belongsto-when-datastore-inuse.ts
+++ b/packages/amplify-schema-validator/src/validators/use-belongsto-when-datastore-inuse.ts
@@ -14,11 +14,15 @@ import { resolveFieldTypeName } from '../helpers/resolve-field-type-name';
  * @returns true if models do not refer each other with @hasMany/@hasOne relation when dataStore is enabled
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
+type ValidateSchemaProps = {
+  graphqlTransformerVersion: number;
+  isDataStoreEnabled: boolean;
+};
+
 export const validateBelongsToIsUsedWhenDatastoreInUse = (
-  schema: DocumentNode, _amplifyFeatureFlags?: string, dataStoreEnabled?: boolean,
+  schema: DocumentNode, props: ValidateSchemaProps,
 ): Error[] => {
-  if (!dataStoreEnabled) {
+  if (!props.isDataStoreEnabled) {
     return [];
   }
 

--- a/packages/amplify-schema-validator/src/validators/use-belongsto-when-datastore-inuse.ts
+++ b/packages/amplify-schema-validator/src/validators/use-belongsto-when-datastore-inuse.ts
@@ -6,6 +6,7 @@ import {
 import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
 import { getObjectWithName } from '../helpers/get-object-with-name';
 import { resolveFieldTypeName } from '../helpers/resolve-field-type-name';
+import { ValidateSchemaProps } from '../helpers/schema-validator-props';
 
 /**
  * Validates that models do not refer each other with @hasMany/@hasOne relation when dataStore is enabled
@@ -13,11 +14,6 @@ import { resolveFieldTypeName } from '../helpers/resolve-field-type-name';
  * @param schema graphql schema
  * @returns true if models do not refer each other with @hasMany/@hasOne relation when dataStore is enabled
  */
-
-type ValidateSchemaProps = {
-  graphqlTransformerVersion: number;
-  isDataStoreEnabled: boolean;
-};
 
 export const validateBelongsToIsUsedWhenDatastoreInUse = (
   schema: DocumentNode, props: ValidateSchemaProps,

--- a/packages/amplify-schema-validator/src/validators/use-belongsto-when-datastore-inuse.ts
+++ b/packages/amplify-schema-validator/src/validators/use-belongsto-when-datastore-inuse.ts
@@ -1,0 +1,71 @@
+import {
+  DocumentNode,
+  Kind,
+  ObjectTypeDefinitionNode,
+} from 'graphql';
+import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
+import { getObjectWithName } from '../helpers/get-object-with-name';
+import { resolveFieldTypeName } from '../helpers/resolve-field-type-name';
+
+/**
+ * Validates that models do not refer each other with @hasMany/@hasOne relation when dataStore is enabled
+ *
+ * @param schema graphql schema
+ * @returns true if models do not refer each other with @hasMany/@hasOne relation when dataStore is enabled
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateBelongsToIsUsedWhenDatastoreInUse = (
+  schema: DocumentNode, _amplifyFeatureFlags?: string, dataStoreEnabled?: boolean,
+): Error[] => {
+  if (!dataStoreEnabled) {
+    return [];
+  }
+
+  const errors: Error[] = [];
+  const objectTypeDefinitions = schema.definitions.filter(
+    (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,
+  ) as ObjectTypeDefinitionNode[];
+  for (let i = 0; i < objectTypeDefinitions.length; i++) {
+    const objectTypeDefinition = objectTypeDefinitions[i];
+    const directiveFields = objectTypeDefinition.fields?.filter((objectField) => objectField.directives?.find(
+      (directive) => directive.name.value === 'hasOne' || directive.name.value === 'hasMany',
+    ));
+
+    const objectName = objectTypeDefinition.name.value;
+    directiveFields?.forEach((directiveField) => {
+      const typeName = resolveFieldTypeName(directiveField.type);
+      const relatedObject = getObjectWithName(schema, typeName);
+
+      if (relatedObject?.name.value === objectName) {
+        /* istanbul ignore next */
+        return;
+      }
+
+      const relatedObjectdirectiveFields = relatedObject?.fields?.filter((objectField) => objectField.directives?.find(
+        (directive) => directive.name.value === 'hasOne' || directive.name.value === 'hasMany',
+      ));
+
+      if (!relatedObjectdirectiveFields) {
+        /* istanbul ignore next */
+        return;
+      }
+
+      for (let j = 0; j < relatedObjectdirectiveFields.length; j++) {
+        const relatedObjectdirectiveField = relatedObjectdirectiveFields[j];
+        const typeName1 = resolveFieldTypeName(relatedObjectdirectiveField.type);
+        const relatedObject1 = getObjectWithName(schema, typeName1);
+        if (relatedObject1?.name.value === objectName) {
+          errors.push(new InvalidDirectiveError(
+            `${relatedObject?.name.value} and ${objectName} cannot refer to each other via @hasOne or @hasMany when DataStore is in use. Use @belongsTo instead. See https://docs.amplify.aws/cli/graphql/data-modeling/#belongs-to-relationship`,
+          ));
+          break;
+        }
+      }
+    });
+    if (errors.length > 0) {
+      break;
+    }
+  }
+  return errors;
+};

--- a/packages/amplify-schema-validator/src/validators/use-directives-from-newer-transformer-version.ts
+++ b/packages/amplify-schema-validator/src/validators/use-directives-from-newer-transformer-version.ts
@@ -12,19 +12,19 @@ import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
  * @returns true if correct directives are used
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
+type ValidateSchemaProps = {
+  graphqlTransformerVersion: number;
+  isDataStoreEnabled: boolean;
+};
+
 const GRAPHQL_TRANSFORMER_V2_DIRECTIVES = ['hasOne', 'index', 'primaryKey', 'belongsTo', 'manyToMany', 'hasMany', 'default'];
 export const validateDirectivesFromNewerTransformerVersionAreNotUsed = (
-  schema: DocumentNode, amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+  schema: DocumentNode, props: ValidateSchemaProps,
 ): Error[] => {
-  if (!amplifyFeatureFlags) {
+  if (props.graphqlTransformerVersion !== 1) {
     return [];
   }
-  const featureFlags = JSON.parse(amplifyFeatureFlags);
-  const transformerVersion = featureFlags.features.graphqltransformer.transformerversion;
-  if (transformerVersion !== 1) {
-    return [];
-  }
+
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,

--- a/packages/amplify-schema-validator/src/validators/use-directives-from-newer-transformer-version.ts
+++ b/packages/amplify-schema-validator/src/validators/use-directives-from-newer-transformer-version.ts
@@ -1,0 +1,61 @@
+import {
+  DocumentNode,
+  Kind,
+  ObjectTypeDefinitionNode,
+} from 'graphql';
+import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
+
+/**
+ * Validates that @belongsTo, @connection directives from older graphql transformer version is not used in version 1.0
+ *
+ * @param schema graphql schema
+ * @returns true if correct directives are used
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+const GRAPHQL_TRANSFORMER_V2_DIRECTIVES = ['hasOne', 'index', 'primaryKey', 'belongsTo', 'manyToMany', 'hasMany', 'default'];
+export const validateDirectivesFromNewerTransformerVersionAreNotUsed = (
+  schema: DocumentNode, amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
+  if (!amplifyFeatureFlags) {
+    return [];
+  }
+  const featureFlags = JSON.parse(amplifyFeatureFlags);
+  const transformerVersion = featureFlags.features.graphqltransformer.transformerversion;
+  if (transformerVersion !== 1) {
+    return [];
+  }
+  const errors: Error[] = [];
+  const objectTypeDefinitions = schema.definitions.filter(
+    (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,
+  ) as ObjectTypeDefinitionNode[];
+  const v2DirectivesInUse = new Set<string>();
+
+  objectTypeDefinitions.forEach((objectTypeDefinition) => {
+    const directiveFields = objectTypeDefinition.fields?.filter((objectField) => objectField.directives?.find(
+      (directive) => GRAPHQL_TRANSFORMER_V2_DIRECTIVES.includes(directive.name.value),
+    ));
+
+    directiveFields?.forEach((directiveField) => {
+      const { directives } = directiveField;
+
+      directives?.forEach((directive) => {
+        const directiveName = directive.name.value;
+        if (GRAPHQL_TRANSFORMER_V2_DIRECTIVES.includes(directiveName)) {
+          v2DirectivesInUse.add(`@${directiveName}`);
+        }
+      });
+    });
+  });
+  if (v2DirectivesInUse.size > 0) {
+    const errorMessage = `Your GraphQL Schema is using ${Array.from(v2DirectivesInUse.values())
+      .map((directive) => `${directive}`)
+      .join(', ')} ${
+      v2DirectivesInUse.size > 1 ? 'directives' : 'directive'
+    } from a newer version of the GraphQL Transformer. Visit https://docs.amplify.aws/cli/migration/transformer-migration/ to learn how to migrate your GraphQL schema.`;
+    errors.push(new InvalidDirectiveError(
+      errorMessage,
+    ));
+  }
+  return errors;
+};

--- a/packages/amplify-schema-validator/src/validators/use-directives-from-older-transformer-version.ts
+++ b/packages/amplify-schema-validator/src/validators/use-directives-from-older-transformer-version.ts
@@ -1,0 +1,60 @@
+import {
+  DocumentNode,
+  Kind,
+  ObjectTypeDefinitionNode,
+} from 'graphql';
+import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
+
+/**
+ * Validates that @key, @connection directives from older graphql transformer version is not used in version 2.0
+ *
+ * @param schema graphql schema
+ * @returns true if correct directives are used
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const validateDirectivesFromOlderTransformerVersionAreNotUsed = (
+  schema: DocumentNode, amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+): Error[] => {
+  if (!amplifyFeatureFlags) {
+    return [];
+  }
+  const featureFlags = JSON.parse(amplifyFeatureFlags);
+  const transformerVersion = featureFlags.features.graphqltransformer.transformerversion;
+  console.log('transformerVersion -- ', transformerVersion);
+  if (transformerVersion !== 2) {
+    return [];
+  }
+  const errors: Error[] = [];
+  const objectTypeDefinitions = schema.definitions.filter(
+    (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,
+  ) as ObjectTypeDefinitionNode[];
+  const v1DirectivesInUse = new Set<string>();
+
+  objectTypeDefinitions.forEach((objectTypeDefinition) => {
+    const objectDirectives = objectTypeDefinition.directives?.map((directive) => directive.name.value);
+    const directiveFields = objectTypeDefinition.fields?.filter((objectField) => objectField.directives?.find(
+      (directive) => directive.name.value === 'connection',
+    ));
+    if (objectDirectives?.includes('key')) {
+      v1DirectivesInUse.add('@key');
+    }
+    if (objectDirectives?.includes('versioned')) {
+      v1DirectivesInUse.add('@versioned');
+    }
+    if (directiveFields && directiveFields.length > 0) {
+      v1DirectivesInUse.add('@connection');
+    }
+  });
+  if (v1DirectivesInUse.size > 0) {
+    const errorMessage = `Your GraphQL Schema is using ${Array.from(v1DirectivesInUse.values())
+      .map((directive) => `${directive}`)
+      .join(', ')} ${
+      v1DirectivesInUse.size > 1 ? 'directives' : 'directive'
+    } from an older version of the GraphQL Transformer. Visit https://docs.amplify.aws/cli/migration/transformer-migration/ to learn how to migrate your GraphQL schema.`;
+    errors.push(new InvalidDirectiveError(
+      errorMessage,
+    ));
+  }
+  return errors;
+};

--- a/packages/amplify-schema-validator/src/validators/use-directives-from-older-transformer-version.ts
+++ b/packages/amplify-schema-validator/src/validators/use-directives-from-older-transformer-version.ts
@@ -12,19 +12,18 @@ import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
  * @returns true if correct directives are used
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
+type ValidateSchemaProps = {
+  graphqlTransformerVersion: number;
+  isDataStoreEnabled: boolean;
+};
+
 export const validateDirectivesFromOlderTransformerVersionAreNotUsed = (
-  schema: DocumentNode, amplifyFeatureFlags?: string, _dataStoreEnabled?: boolean,
+  schema: DocumentNode, props: ValidateSchemaProps,
 ): Error[] => {
-  if (!amplifyFeatureFlags) {
+  if (props.graphqlTransformerVersion !== 2) {
     return [];
   }
-  const featureFlags = JSON.parse(amplifyFeatureFlags);
-  const transformerVersion = featureFlags.features.graphqltransformer.transformerversion;
-  console.log('transformerVersion -- ', transformerVersion);
-  if (transformerVersion !== 2) {
-    return [];
-  }
+
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
     (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,


### PR DESCRIPTION
#### Description of changes
This PR adds below mentioned schema validations:

1) XX and YY cannot refer to each other via @hasOne or @hasMany when DataStore is in use. Use @belongsTo instead
2) Schema should not use directives from an older version of the GraphQL Transformer when the version used is 2.
3) Schema should not use directives from a newer version of the GraphQL Transformer when the version used is 1.

##### CDK / CloudFormation Parameters Changed
Nona

#### Issue #, if available
N/A

#### Description of how you validated changes
Added unit tests

#### Checklist

- [x] PR description include
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
