### PR TITLE
Schema Validation

### DIFF
--- a/packages/amplify-schema-validator/src/__tests__/schemas/valid-reserved-type-name.graphql
+++ b/packages/amplify-schema-validator/src/__tests__/schemas/valid-reserved-type-name.graphql
@@ -1,0 +1,4 @@
+type Query {
+    id: ID!
+    str: String
+}

--- a/packages/amplify-schema-validator/src/__tests__/validates-reserved-type-name.test.ts
+++ b/packages/amplify-schema-validator/src/__tests__/validates-reserved-type-name.test.ts
@@ -7,4 +7,9 @@ describe('Validate Schema', () => {
     const errorRegex = 'Query is a reserved type name and currently in use within the default schema element.';
     expect(() => validateSchema(schema)).toThrow(errorRegex);
   });
+
+  it('passed validation when reserved words are not used in model names', () => {
+    const schema = readSchema('valid-reserved-type-name.graphql');
+    expect(() => validateSchema(schema)).not.toThrow();
+  });
 });

--- a/packages/amplify-schema-validator/src/validators/reserved-type-name.ts
+++ b/packages/amplify-schema-validator/src/validators/reserved-type-name.ts
@@ -19,7 +19,8 @@ export const validateReservedTypeNames = (schema: DocumentNode): Error[] => {
   ) as ObjectTypeDefinitionNode[];
   objectTypeDefinitions.forEach((objectTypeDefinition) => {
     const objectName = objectTypeDefinition.name.value;
-    if (reservedWords.includes(objectName)) {
+    const directives = objectTypeDefinition.directives?.map((directive) => directive.name.value);
+    if (directives && directives.includes('model') && reservedWords.includes(objectName)) {
       errors.push(new ValidationError(
         `${objectName} is a reserved type name and currently in use within the default schema element.`,
       ));


### PR DESCRIPTION
#### Description of changes
This PR fixes the existing validation 'Reserved names can not be used as type name'
Issue: Currently the validation fails if Query, Mutation and Subscription keywords are used as type names.
Expected behavior: The validation should fail only if the keywords are used as model names
Fix: Add an additional check in the validation to check for @model directive 

##### CDK / CloudFormation Parameters Changed
None

#### Issue #, if available
N/A

#### Description of how you validated changes

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
