### PR TITLE
chore: copy show-auth-acm and showApiAuthAcm from CLI core package

### DIFF
--- a/packages/amplify-category-api/API.md
+++ b/packages/amplify-category-api/API.md
@@ -165,6 +165,9 @@ export function processDockerConfig(context: $TSContext, resource: ApiResource, 
 export function promptToAddApiKey(context: $TSContext): Promise<any>;
 
 // @public (undocumented)
+export const showApiAuthAcm: (context: $TSContext, modelName: string) => Promise<void>;
+
+// @public (undocumented)
 export const SLOT_NAMES: Set<string>;
 
 // @public (undocumented)

--- a/packages/amplify-category-api/src/__tests__/category-utils/show-auth-acm.test.ts
+++ b/packages/amplify-category-api/src/__tests__/category-utils/show-auth-acm.test.ts
@@ -1,0 +1,99 @@
+import { DEFAULT_GROUP_CLAIM } from '@aws-amplify/graphql-auth-transformer';
+import { printACM } from '../../category-utils/show-auth-acm';
+
+jest.mock('amplify-cli-core', () => ({
+  ...(jest.requireActual('amplify-cli-core') as {}),
+  FeatureFlags: {
+    getBoolean: () => true,
+  },
+}));
+
+describe('show-auth-acm helper: ', () => {
+  let functionArguments: { sdl: string; node: 'Blog' };
+
+  it('...the show-auth-acm helper should be exported', () => {
+    expect(printACM).toBeDefined();
+  });
+
+  it('...should return a function', () => {
+    expect(typeof printACM).toEqual('function');
+  });
+
+  describe('case: where identical auth rules exist with default group claim', () => {
+    beforeEach(() => {
+      functionArguments = {
+        sdl: `type Blog 
+            @model 
+            @auth(rules: [
+              { allow: groups, groupsField: "tenantId" }
+              { allow: groups, groupsField: "tenantId" }
+            ])
+          {
+            id: ID!
+            name: String!
+            tenantId: String!
+          }`,
+        node: 'Blog',
+      };
+    });
+
+    it('...should throw a specific exception', () => {
+      expect(() => printACM(functionArguments.sdl, functionArguments.node)).toThrow(
+        `@auth userPools:dynamicGroup:${DEFAULT_GROUP_CLAIM}:tenantId already exists for Blog`,
+      );
+    });
+  });
+
+  describe('case: where identical auth rules exist with custom group claim', () => {
+    beforeEach(() => {
+      functionArguments = {
+        sdl: `type Blog 
+            @model 
+            @auth(rules: [
+              { allow: groups, groupsField: "tenantId", groupClaim: "custom:adminRole" }
+              { allow: groups, groupsField: "tenantId", groupClaim: "custom:adminRole" }
+              { allow: groups, groupsField: "tenantId", groupClaim: "custom:editorRole", operations: [read, update] }
+            ])
+          {
+            id: ID!
+            name: String!
+            tenantId: String!
+          }`,
+        node: 'Blog',
+      };
+    });
+
+    it('...should throw a specific exception', () => {
+      expect(() => printACM(functionArguments.sdl, functionArguments.node)).toThrow(
+        `@auth userPools:dynamicGroup:custom:adminRole:tenantId already exists for Blog`,
+      );
+    });
+  });
+
+  describe('case: auth rules with a custom groupField are distinguished by a custom group claim', () => {
+    beforeEach(() => {
+      functionArguments = {
+        sdl: `type Blog 
+            @model 
+            @auth(rules: [
+              { allow: groups, groupsField: "tenantId", groupClaim: "custom:adminRole" }
+              { allow: groups, groupsField: "tenantId", groupClaim: "custom:editorRole", operations: [read, update] }
+            ])
+          {
+            id: ID!
+            name: String!
+            tenantId: String!
+          }`,
+        node: 'Blog',
+      };
+    });
+
+    it('...should complete without exception', () => {
+      const callShowAcm = jest.fn(() => printACM(functionArguments.sdl, functionArguments.node));
+
+      callShowAcm();
+
+      expect(callShowAcm).toHaveReturned();
+    });
+  });
+});

--- a/packages/amplify-category-api/src/category-utils/show-auth-acm.ts
+++ b/packages/amplify-category-api/src/category-utils/show-auth-acm.ts
@@ -1,0 +1,148 @@
+import {
+  AccessControlMatrix,
+  AuthRule,
+  ModelOperation,
+  MODEL_OPERATIONS,
+  DEFAULT_GROUPS_FIELD,
+  DEFAULT_GROUP_CLAIM,
+  DEFAULT_OWNER_FIELD,
+  getAuthDirectiveRules,
+} from '@aws-amplify/graphql-auth-transformer';
+import { $TSContext, stateManager, pathManager, FeatureFlags } from '@aws-amplify/amplify-cli-core';
+import { parse, ObjectTypeDefinitionNode, DirectiveNode, FieldDefinitionNode } from 'graphql';
+import { printer } from '@aws-amplify/amplify-prompts';
+import { DirectiveWrapper } from '@aws-amplify/graphql-transformer-core';
+import { readProjectSchema } from 'graphql-transformer-core';
+import { getTransformerVersion } from '../graphql-transformer';
+import * as path from 'path';
+
+export const showApiAuthAcm = async (context: $TSContext, modelName: string): Promise<void> => {
+  const providerPlugin = await import(context.amplify.getProviderPlugins(context)?.awscloudformation);
+  const transformerVersion = await getTransformerVersion(context);
+
+  if (transformerVersion < 2) {
+    printer.error('This command requires version two or greater of the GraphQL transformer.');
+    return;
+  }
+
+  const apiNames = Object.entries(stateManager.getMeta()?.api || {})
+    .filter(([, apiResource]) => (apiResource as any).service === 'AppSync')
+    .map(([name]) => name);
+
+  if (apiNames.length === 0) {
+    printer.info('No GraphQL API configured in the project. To add a GraphQL API run `amplify add api`.');
+    return;
+  }
+
+  if (apiNames.length > 1) {
+    // this condition should never hit as we only allow a single GraphQL API per project.
+    printer.error('You have multiple GraphQL APIs in the project. Only one GraphQL API is allowed per project. Run `amplify remove api` to remove an API.');
+    return;
+  }
+
+  // Do a full schema compilation to make sure we are not printing an ACM for an invalid schema
+  try {
+    await providerPlugin.compileSchema(context, {
+      forceCompile: true,
+    });
+  } catch (error) {
+    printer.warn('ACM generation requires a valid schema, the provided schema is invalid.');
+
+    if (error.name) {
+      printer.error(`${error.name}: ${error.message?.trim()}`);
+    } else {
+      printer.error(`An error has occurred during schema compilation: ${error.message?.trim()}`);
+    }
+
+    return;
+  }
+
+  const apiName = apiNames[0];
+  const apiResourceDir = path.join(pathManager.getBackendDirPath(), 'api', apiName);
+  const schema = await readProjectSchema(apiResourceDir);
+
+  printACM(schema, modelName);
+};
+
+export function printACM(sdl: string, nodeName: string) {
+  const schema = parse(sdl);
+  const type = schema.definitions.find(
+    (node) =>
+      node.kind === 'ObjectTypeDefinition' && node.name.value === nodeName && node?.directives?.find((dir) => dir.name.value === 'model'),
+  ) as ObjectTypeDefinitionNode;
+  if (!type) {
+    throw new Error(`Model "${nodeName}" does not exist.`);
+  } else {
+    const fields: string[] = type.fields!.map((field: FieldDefinitionNode) => field.name.value);
+    const acm = new AccessControlMatrix({ name: type.name.value, operations: MODEL_OPERATIONS, resources: fields });
+    const parentAuthDirective = type.directives?.find((dir) => dir.name.value === 'auth');
+    if (parentAuthDirective) {
+      const authRules: AuthRule[] = getAuthDirectiveRules(new DirectiveWrapper(parentAuthDirective), {
+        isField: false,
+        deepMergeArguments: FeatureFlags.getBoolean('graphqltransformer.shouldDeepMergeDirectiveConfigDefaults'),
+      });
+      convertModelRulesToRoles(acm, authRules);
+    }
+    for (const fieldNode of type.fields || []) {
+      const fieldAuthDir = fieldNode.directives?.find((dir) => dir.name.value === 'auth') as DirectiveNode;
+      if (fieldAuthDir) {
+        if (parentAuthDirective) {
+          acm.resetAccessForResource(fieldNode.name.value);
+        }
+        const authRules: AuthRule[] = getAuthDirectiveRules(new DirectiveWrapper(fieldAuthDir));
+        convertModelRulesToRoles(acm, authRules, fieldNode.name.value);
+      }
+    }
+    const truthTable = acm.getAcmPerRole();
+
+    if (truthTable.size === 0) {
+      printer.warn(`No auth rules have been configured for the "${type.name.value}" model.`);
+    }
+
+    for (const [role, acm] of truthTable) {
+      console.group(role);
+      console.table(acm);
+      console.groupEnd();
+    }
+  }
+}
+
+function convertModelRulesToRoles(acm: AccessControlMatrix, authRules: AuthRule[], field?: string) {
+  for (const rule of authRules) {
+    const operations: ModelOperation[] = rule.operations || MODEL_OPERATIONS;
+    if (rule.groups && !rule.groupsField) {
+      rule.groups.forEach((group) => {
+        const roleName = `${rule.provider}:staticGroup:${group}`;
+        acm.setRole({ role: roleName, resource: field, operations });
+      });
+    } else {
+      let roleName: string;
+      switch (rule.provider) {
+        case 'apiKey':
+          roleName = 'apiKey:public';
+          break;
+        case 'iam':
+          roleName = `iam:${rule.allow}`;
+          break;
+        case 'oidc':
+        case 'userPools':
+          if (rule.allow === 'groups') {
+            const groupsField = rule.groupsField || DEFAULT_GROUPS_FIELD;
+            const groupsClaim = rule.groupClaim || DEFAULT_GROUP_CLAIM;
+            roleName = `${rule.provider}:dynamicGroup:${groupsClaim}:${groupsField}`;
+          } else if (rule.allow === 'owner') {
+            const ownerField = rule.ownerField || DEFAULT_OWNER_FIELD;
+            roleName = `${rule.provider}:owner:${ownerField}`;
+          } else if (rule.allow === 'private') {
+            roleName = `${rule.provider}:${rule.allow}`;
+          } else {
+            throw new Error(`Could not create a role from ${JSON.stringify(rule)}`);
+          }
+          break;
+        default:
+          throw new Error(`Could not create a role from ${JSON.stringify(rule)}`);
+      }
+      acm.setRole({ role: roleName, resource: field, operations });
+    }
+  }
+}

--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -44,6 +44,7 @@ export { getResolverConfig } from './provider-utils/awscloudformation/utils/get-
 export { getGitHubOwnerRepoFromPath } from './provider-utils/awscloudformation/utils/github';
 export * from './graphql-transformer';
 export * from './force-updates';
+export { showApiAuthAcm } from './category-utils/show-auth-acm';
 
 const category = AmplifyCategories.API;
 


### PR DESCRIPTION
#### Description of changes
Move https://github.com/aws-amplify/amplify-cli/blob/d0e60d149d1720bced15ec96c03bce22aade9d20/packages/amplify-cli/src/commands/status.ts#L50-L102 and https://github.com/aws-amplify/amplify-cli/blob/d0e60d149d1720bced15ec96c03bce22aade9d20/packages/amplify-cli/src/extensions/amplify-helpers/show-auth-acm.ts files/functions/tests over to the API category so CLI doesn't depend on transformers directly.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit tests pass, will validate in CLI refactor that things are working e2e.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
