### PR TITLE
Dynamic group sub fix

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/resolvers/__snapshots__/subscriptions.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/resolvers/__snapshots__/subscriptions.test.ts.snap
@@ -113,7 +113,9 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
     #if( $util.isList($util.parseJson($groupClaim1)) )
       #set( $groupClaim1 = $util.parseJson($groupClaim1) )
     #else
-      #set( $groupClaim1 = [$groupClaim1] )
+      #if( !$util.isNullOrEmpty($groupClaim1) )
+        #set( $groupClaim1 = [$groupClaim1] )
+      #end
     #end
   #end
   $util.qr($authGroupRuntimeFilter.add({ \\"group\\": { \\"in\\": $groupClaim1 } }))
@@ -185,7 +187,9 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
     #if( $util.isList($util.parseJson($groupClaim1)) )
       #set( $groupClaim1 = $util.parseJson($groupClaim1) )
     #else
-      #set( $groupClaim1 = [$groupClaim1] )
+      #if( !$util.isNullOrEmpty($groupClaim1) )
+        #set( $groupClaim1 = [$groupClaim1] )
+      #end
     #end
   #end
   $util.qr($authGroupRuntimeFilter.add({ \\"group\\": { \\"in\\": $groupClaim1 } }))
@@ -272,7 +276,9 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
     #if( $util.isList($util.parseJson($groupClaim1)) )
       #set( $groupClaim1 = $util.parseJson($groupClaim1) )
     #else
-      #set( $groupClaim1 = [$groupClaim1] )
+      #if( !$util.isNullOrEmpty($groupClaim1) )
+        #set( $groupClaim1 = [$groupClaim1] )
+      #end
     #end
   #end
   $util.qr($authGroupRuntimeFilter.add({ \\"group\\": { \\"in\\": $groupClaim1 } }))
@@ -382,7 +388,9 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
     #if( $util.isList($util.parseJson($groupClaim1)) )
       #set( $groupClaim1 = $util.parseJson($groupClaim1) )
     #else
-      #set( $groupClaim1 = [$groupClaim1] )
+      #if( !$util.isNullOrEmpty($groupClaim1) )
+        #set( $groupClaim1 = [$groupClaim1] )
+      #end
     #end
   #end
   $util.qr($authGroupRuntimeFilter.add({ \\"group\\": { \\"in\\": $groupClaim1 } }))

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/subscriptions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/subscriptions.ts
@@ -100,7 +100,10 @@ const dynamicRoleExpression = (roles: Array<RoleDefinition>): Array<Expression> 
           ifElse(
             methodCall(ref('util.isList'), methodCall(ref('util.parseJson'), ref(`groupClaim${idx}`))),
             set(ref(`groupClaim${idx}`), methodCall(ref('util.parseJson'), ref(`groupClaim${idx}`))),
-            set(ref(`groupClaim${idx}`), list([ref(`groupClaim${idx}`)])),
+            iff(
+              not(methodCall(ref('util.isNullOrEmpty'), ref(`groupClaim${idx}`))),
+              set(ref(`groupClaim${idx}`), list([ref(`groupClaim${idx}`)])),
+            ),
           ),
         ),
         qref(methodCall(ref('authGroupRuntimeFilter.add'), raw(`{ "${role.entity}": { "${role.isEntityList ? 'containsAny' : 'in'}": $groupClaim${idx} } }`))),

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts
@@ -2200,7 +2200,7 @@ describe('Runtime Filtering for Dynamic Group Auth', () => {
   describe('Test requests from users with no group membership', () => {
     test('Should return unauthorized when attempting to subscribe with no groups', async () => {
       reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
-      await Auth.signIn(USERNAME1, REAL_PASSWORD);
+      await Auth.signIn(USERNAME3, REAL_PASSWORD);
       const observer = API.graphql({
         // @ts-ignore
         query: gql`

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts
@@ -83,6 +83,11 @@ let GRAPHQL_CLIENT_1: AWSAppSyncClient<any> = undefined;
 let GRAPHQL_CLIENT_2: AWSAppSyncClient<any> = undefined;
 
 /**
+ * Client 3 is logged in and is a member no groups.
+ */
+let GRAPHQL_CLIENT_3: AWSAppSyncClient<any> = undefined;
+
+/**
  * Auth IAM Client
  */
 let GRAPHQL_IAM_AUTH_CLIENT: AWSAppSyncClient<any> = undefined;
@@ -366,6 +371,17 @@ beforeAll(async () => {
     auth: {
       type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
       jwtToken: idToken2,
+    },
+  });
+  const authRes3AfterGroup: any = await authenticateUser(USERNAME3, TMP_PASSWORD, REAL_PASSWORD);
+  const idToken3 = authRes3AfterGroup.getIdToken().getJwtToken();
+  GRAPHQL_CLIENT_3 = new AWSAppSyncClient({
+    url: GRAPHQL_ENDPOINT,
+    region: AWS_REGION,
+    disableOffline: true,
+    auth: {
+      type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
+      jwtToken: idToken3,
     },
   });
 
@@ -2178,6 +2194,46 @@ describe('Runtime Filtering for Dynamic Group Auth', () => {
       expect(result.description).toEqual('taskGroupDesc4');
       expect(result.priority).toEqual(3);
       expect(result.severity).toEqual(10);
+    });
+  });
+
+  describe('Test requests from users with no group membership', () => {
+    test('Should return unauthorized when attempting to subscribe with no groups', async () => {
+      reconfigureAmplifyAPI('AMAZON_COGNITO_USER_POOLS');
+      await Auth.signIn(USERNAME1, REAL_PASSWORD);
+      const observer = API.graphql({
+        // @ts-ignore
+        query: gql`
+          subscription OnDeleteTaskGroup(
+            $filter: ModelSubscriptionTaskGroupFilterInput
+          ) {
+            onDeleteTaskGroup(filter: $filter) {
+              id
+              title
+              description
+              priority
+              severity
+            }
+          }
+        `,
+        authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
+        variables:{},
+      }) as unknown as Observable<any>;
+      let subscription: ZenObservable.Subscription;
+      const subscriptionPromise = new Promise((resolve, reject) => {
+        subscription = observer.subscribe(
+          (event) => {
+            // will unsubscribe on the first available subscription data
+            const task = event.value.data.onDeleteTaskGroup;
+            subscription.unsubscribe();
+            resolve(task);
+          },
+          (err) => {
+            reject(err);
+          },
+        );
+      });
+      await expect(subscriptionPromise).rejects.toThrow();
     });
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Only add dynamic group filter to auth filter if the token in the request actually has groups. If there are no other authorization methods, it will respond unauthorized.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
