### PR TITLE
feature: expose isDataStoreEnabled utility given amplify context

### DIFF
--- a/packages/amplify-category-api/API.md
+++ b/packages/amplify-category-api/API.md
@@ -140,6 +140,9 @@ export const handleAmplifyEvent: (_: $TSContext, args: any) => Promise<void>;
 export const initEnv: (context: $TSContext) => Promise<void>;
 
 // @public (undocumented)
+export const isDataStoreEnabled: (context: $TSContext) => Promise<boolean>;
+
+// @public (undocumented)
 export const migrate: (context: $TSContext, serviceName?: string) => Promise<void>;
 
 // @public (undocumented)

--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -83,7 +83,8 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.0",
     "@types/node": "^12.12.6",
-    "amplify-util-headless-input": "^1.9.10"
+    "amplify-util-headless-input": "^1.9.10",
+    "ts-jest": "26.4.4"
   },
   "jest": {
     "testURL": "http://localhost",

--- a/packages/amplify-category-api/src/__tests__/category-utils/is-datastore-enabled.test.ts
+++ b/packages/amplify-category-api/src/__tests__/category-utils/is-datastore-enabled.test.ts
@@ -1,0 +1,40 @@
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
+import { isDataStoreEnabled as isDataStoreEnabledAtDirectory } from 'graphql-transformer-core';
+import { mocked } from 'ts-jest';
+import { isDataStoreEnabled } from '../../category-utils/is-datastore-enabled';
+import { contextUtil } from '../../category-utils/context-util';
+
+jest.mock('graphql-transformer-core');
+jest.mock('../../category-utils/context-util');
+
+const isDataStoreEnabledAtDirectoryMock = mocked(isDataStoreEnabledAtDirectory);
+const contextUtilMock = mocked(contextUtil);
+
+const MOCK_RESOURCE_DIR = 'resource/dir';
+const MOCK_CONTEXT = {} as unknown as $TSContext;
+
+describe('isDataStoreEnabled', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('invokes the underlying utility methods, and returns true if utility returns true', async () => {
+    contextUtilMock.getResourceDir.mockResolvedValue(MOCK_RESOURCE_DIR);
+    isDataStoreEnabledAtDirectoryMock.mockResolvedValue(true);
+
+    await expect(isDataStoreEnabled(MOCK_CONTEXT)).resolves.toEqual(true);
+
+    expect(contextUtilMock.getResourceDir).toHaveBeenCalledWith(MOCK_CONTEXT, { forceCompile: true });
+    expect(isDataStoreEnabledAtDirectoryMock).toHaveBeenCalledWith(MOCK_RESOURCE_DIR);
+  });
+
+  it('invokes the underlying utility methods, and returns false if utility returns false', async () => {
+    contextUtilMock.getResourceDir.mockResolvedValue(MOCK_RESOURCE_DIR);
+    isDataStoreEnabledAtDirectoryMock.mockResolvedValue(false);
+
+    await expect(isDataStoreEnabled(MOCK_CONTEXT)).resolves.toEqual(false);
+
+    expect(contextUtilMock.getResourceDir).toHaveBeenCalledWith(MOCK_CONTEXT, { forceCompile: true });
+    expect(isDataStoreEnabledAtDirectoryMock).toHaveBeenCalledWith(MOCK_RESOURCE_DIR);
+  });
+});

--- a/packages/amplify-category-api/src/category-utils/is-datastore-enabled.ts
+++ b/packages/amplify-category-api/src/category-utils/is-datastore-enabled.ts
@@ -1,0 +1,14 @@
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
+import { isDataStoreEnabled as isDataStoreEnabledAtDirectory } from 'graphql-transformer-core';
+import { contextUtil } from './context-util';
+
+/**
+ * Given an input Amplify context retrieve the resource directory (we use forceCompile in order to check unchanged packages as well)
+ * and return whether or not the customer has conflict resolution enabled on their project.
+ * @param context the amplify context to extract project directories from
+ * @returns true if customer has conflict resolution enabled on their project
+ */
+export const isDataStoreEnabled = async (context: $TSContext): Promise<boolean> => {
+  const resourceDirectory = await contextUtil.getResourceDir(context, { forceCompile: true });
+  return isDataStoreEnabledAtDirectory(resourceDirectory);
+};

--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -45,6 +45,7 @@ export { getGitHubOwnerRepoFromPath } from './provider-utils/awscloudformation/u
 export * from './graphql-transformer';
 export * from './force-updates';
 export { showApiAuthAcm } from './category-utils/show-auth-acm';
+export { isDataStoreEnabled } from './category-utils/is-datastore-enabled';
 
 const category = AmplifyCategories.API;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6710,20 +6710,20 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^24.0.18":
-  version "24.9.1"
-  resolved "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz#02baf9573c78f1b9974a5f36778b366aa77bd534"
-  integrity sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==
-  dependencies:
-    jest-diff "^24.3.0"
-
-"@types/jest@^26.0.20":
+"@types/jest@26.x", "@types/jest@^26.0.20":
   version "26.0.24"
   resolved "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz#943d11976b16739185913a1936e0de0c4a7d595a"
   integrity sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
+
+"@types/jest@^24.0.18":
+  version "24.9.1"
+  resolved "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz#02baf9573c78f1b9974a5f36778b366aa77bd534"
+  integrity sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==
+  dependencies:
+    jest-diff "^24.3.0"
 
 "@types/js-yaml@^4.0.0":
   version "4.0.5"
@@ -18534,6 +18534,23 @@ ts-invariant@^0.4.0:
   integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
   dependencies:
     tslib "^1.9.3"
+
+ts-jest@26.4.4:
+  version "26.4.4"
+  resolved "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.4.tgz#61f13fb21ab400853c532270e52cc0ed7e502c49"
+  integrity sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==
+  dependencies:
+    "@types/jest" "26.x"
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^26.1.0"
+    json5 "2.x"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    mkdirp "1.x"
+    semver "7.x"
+    yargs-parser "20.x"
 
 ts-jest@^26.4.4:
   version "26.5.6"


### PR DESCRIPTION
#### Description of changes
Expose a utility method from the API Category to proxy calls to `isDataStoreEnabled` in the `graphql-transformer-core` package given just the context object.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Added some unit tests.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
