### PR TITLE
[POC] feature: manage stack mappings to unblock api expansion over time

### DIFF
--- a/packages/amplify-category-api/amplify-plugin.json
+++ b/packages/amplify-category-api/amplify-plugin.json
@@ -12,7 +12,9 @@
     "rebuild",
     "remove",
     "update",
-    "help"
+    "help",
+    "snapshot-stack-mappings",
+    "assign-stack-mappings"
   ],
   "commandAliases": {
     "configure": "update"

--- a/packages/amplify-category-api/src/commands/api.ts
+++ b/packages/amplify-category-api/src/commands/api.ts
@@ -56,6 +56,14 @@ export const run = async (context: $TSContext) => {
       name: 'override',
       description: 'Generates overrides file to apply custom modifications to CloudFormation',
     },
+    {
+      name: 'snapshot-stack-mappings',
+      description: 'Snapshots the stack mappings for the current project',
+    },
+    {
+      name: 'assign-stack-mappings',
+      description: 'Assign stack mappings for the newly built resources',
+    },
   ];
 
   context.amplify.showHelp(header, commands);

--- a/packages/amplify-category-api/src/commands/api/assign-stack-mappings.ts
+++ b/packages/amplify-category-api/src/commands/api/assign-stack-mappings.ts
@@ -1,0 +1,15 @@
+import { $TSContext} from '@aws-amplify/amplify-cli-core';
+import { assignStackMappings } from '../../provider-utils/awscloudformation/stack-mapping-manager';
+
+/**
+ * Pull all resolver and functions from the current cloud backend and snapshot them in the transform.conf.json file.
+ * `amplify pull` may need to be run first.
+ */
+export const run = async (context: $TSContext): Promise<void> => {
+  const stackName = context.parameters?.options?.['stack-name'];
+  if (!stackName) {
+    throw new Error('need to provide --stack-name <STACK NAME>');
+  }
+
+  return assignStackMappings(stackName);
+};

--- a/packages/amplify-category-api/src/commands/api/snapshot-stack-mappings.ts
+++ b/packages/amplify-category-api/src/commands/api/snapshot-stack-mappings.ts
@@ -1,0 +1,8 @@
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
+import { snapshotStackMappings } from '../../provider-utils/awscloudformation/stack-mapping-manager';
+
+/**
+ * Pull all resolver and functions from the current cloud backend and snapshot them in the transform.conf.json file.
+ * `amplify pull` may need to be run first.
+ */
+export const run = async (context: $TSContext): Promise<void> => snapshotStackMappings();

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/stack-mapping-manager.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/stack-mapping-manager.ts
@@ -1,0 +1,108 @@
+import { pathManager, stateManager } from '@aws-amplify/amplify-cli-core';
+import { getAppSyncResourceName } from '../../provider-utils/awscloudformation/utils/amplify-meta-utils';
+import { readFromPath } from 'graphql-transformer-core/lib/util/fileUtils';
+import { loadConfig, writeConfig } from 'graphql-transformer-core';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+/**
+ * Pull all resolver and functions from the current cloud backend and snapshot them in the transform.conf.json file.
+ * `amplify pull` may need to be run first.
+ */
+export const snapshotStackMappings = async (): Promise<void> => {
+  const apiName = getAppSyncResourceName(stateManager.getMeta());
+  if (!apiName) {
+    throw new Error('Could not find api name.');
+  }
+
+  const currentApiStacksPath = path.join(pathManager.getCurrentCloudBackendDirPath(), 'api', apiName, 'build', 'stacks');
+  if (!fs.pathExistsSync(currentApiStacksPath)) {
+    throw new Error('Could not find current cloud backend api stacks path.');
+  }
+
+  const apiPath = path.join(pathManager.getAmplifyDirPath(), 'backend', 'api', apiName);
+  if (!fs.pathExistsSync(apiPath)) {
+    throw new Error('Could not find api path.');
+  }
+
+  const currentApiStacks: Record<string, string> = await readFromPath(currentApiStacksPath);
+
+  const getResourceIdsForTypes = (stackDefinition: any, resourceTypes: string[]): string[] => {
+    const resourceTypeSet = new Set(resourceTypes);
+    return Object.entries(stackDefinition.Resources)
+      .filter(([_, resource]: [string, any]) => resourceTypeSet.has(resource.Type))
+      .map(([resourceName, _]) => resourceName);
+  };
+
+  const stackMappings = Object.fromEntries(Object.entries(currentApiStacks).flatMap(([stackFileName, stackContentsString]) => {
+    const stackName = stackFileName.split('.')[0];
+    const stackContents = JSON.parse(stackContentsString);
+    return getResourceIdsForTypes(stackContents, ['AWS::AppSync::FunctionConfiguration', 'AWS::AppSync::Resolver'])
+      .map(id => [id, stackName]);
+  }));
+
+  const config: any = await loadConfig(apiPath);
+
+  Object.entries(stackMappings).forEach(([resourceId, stackName]) => {
+    if (!config.StackMapping) {
+      config.StackMapping = {};
+    }
+    if (!(resourceId in config.StackMapping)) {
+      config.StackMapping[resourceId] = stackName;
+    }
+  });
+
+  await writeConfig(apiPath, config);
+};
+
+/**
+ * Pull all resolver and functions from the current cloud backend and snapshot them in the transform.conf.json file.
+ * `amplify pull` may need to be run first.
+ */
+export const assignStackMappings = async (stackNameAssignment: string): Promise<void> => {
+  await snapshotStackMappings();
+
+  const apiName = getAppSyncResourceName(stateManager.getMeta());
+  if (!apiName) {
+    throw new Error('Could not find api name.');
+  }
+
+  const apiPath = path.join(pathManager.getAmplifyDirPath(), 'backend', 'api', apiName);
+  if (!fs.pathExistsSync(apiPath)) {
+    throw new Error('Could not find api path.');
+  }
+
+  const buildApiStacksPath = path.join(apiPath, 'build', 'stacks');
+  if (!fs.pathExistsSync(buildApiStacksPath)) {
+    throw new Error('need to build first, run `amplify api gql-compile`');
+  }
+
+  const apiStacks: Record<string, string> = await readFromPath(buildApiStacksPath);
+
+  const getResourceIdsForTypes = (stackDefinition: any, resourceTypes: string[]): string[] => {
+    const resourceTypeSet = new Set(resourceTypes);
+    return Object.entries(stackDefinition.Resources)
+      .filter(([_, resource]: [string, any]) => resourceTypeSet.has(resource.Type))
+      .map(([resourceName, _]) => resourceName);
+  };
+
+  const stackMappings = Object.fromEntries(Object.entries(apiStacks).flatMap(([stackFileName, stackContentsString]) => {
+    const stackName = stackFileName.split('.')[0];
+    const stackContents = JSON.parse(stackContentsString);
+    return getResourceIdsForTypes(stackContents, ['AWS::AppSync::FunctionConfiguration', 'AWS::AppSync::Resolver'])
+      .map(id => [id, stackName]);
+  }));
+
+  const config: any = await loadConfig(apiPath);
+
+  Object.entries(stackMappings).forEach(([resourceId, stackName]) => {
+    if (!config.StackMapping) {
+      config.StackMapping = {};
+    }
+    if (!(resourceId in config.StackMapping)) {
+      config.StackMapping[resourceId] = stackNameAssignment;
+    }
+  });
+
+  await writeConfig(apiPath, config);
+};


### PR DESCRIPTION
#### Description of changes
Thinking about how we can mitigate some of the `Multiple resolvers cannot be attached to a single field` issue, I was thinking about whether we may want to provide additional utilities to help customers manage stack mappings.

In my head the problems basically fall into this category.

1. I am migrating between GQLv1 and GQLv2, and the addition of many `AWS::AppSync::FunctionConfigurations` resources is causing me to hit my stack limit.
2. I am introducing relationships between models, causing my `ConnectionStack` to swell based on new tables, resolvers, and functions.
3. I am incorrectly trying to use StackMappings (or the system is on my behalf) migrate a resolver between stacks (which I have confirmed with the AppSync team is not feasible, they have no workaround other than detaching in iterative deploys, which we don't want to do).

In light of those three use-cases, I'd propose we vend a new utility (or set of utilities, as this is modelled right now) which make looking into my `#current-deployed-backend` and current proposed changes and freezing or assigning new resources in the `StackMapping` section of the `transform.conf.json` file.

In my mind, the flow could go something like:

1. `amplify pull` (ensure I have the latest view of the world).
2. `amplify api snapshot-stack-mappings` (freeze the current state of stack mappings into my transform file.
3. Make changes to my schema.
4. `amplify api assign-stack-mappings --stack-name <Blah>`
5. `amplify push`

This is a pretty involved flow, and in reality we can probably just consolidate the snapshot/assign separation, I'd just POC'ed them up separately initially.

Ultimately, if we allow consistently and correctly migration functions between stack, but not resolvers, then we might actually just want to change this functionality to be focused on that, but during my investigation it did not appear that the StackMappings correctly work on the FunctionConfiguration objects today, so that'll need to be something we fix as well I think.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
https://github.com/aws-amplify/amplify-category-api/issues/32

#### Description of how you validated changes
Currently just testing manually in a test app. Need to add unit and E2E tests.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
