### PR TITLE
fix(api): use scan and query correctly on sync operation

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/graphql-v2/sync_query_datastore.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/graphql-v2/sync_query_datastore.test.ts
@@ -110,7 +110,14 @@ describe('Sync query V2 resolver tests', () => {
         testSong.lastChangedAt = createResult.data.createSong._lastChangedAt;
 
         // able to sync songs without lastSync specified. This will do a query on base table.
-        const syncResult = await syncSongs(null, { genre: { eq: testSong.genre } });
+        // GSI is queried only if the filter is enclosed in an "and" condition.
+        const syncResult = await syncSongs(null,
+            {
+                and: [
+                    { genre: { eq: testSong.genre } },
+                ]
+            },
+        );
         verifySyncQueryResult(syncResult, testSong, 'syncSongs');
     });
 
@@ -128,7 +135,14 @@ describe('Sync query V2 resolver tests', () => {
         testSong.lastChangedAt = createResult.data.createSongWithSortKey._lastChangedAt;
 
         // able to sync songs without lastSync specified. This will do a query on base table.
-        const syncResult = await syncSongWithSortKeys(null, { name: { eq: testSong.name } });
+        // GSI is queried only if the filter is enclosed in an "and" condition.
+        const syncResult = await syncSongWithSortKeys(null,
+            {
+                and: [
+                    { name: { eq: testSong.name } },
+                ]
+            },
+        );
         verifySyncQueryResult(syncResult, testSong, 'syncSongWithSortKeys');
     });
 
@@ -146,7 +160,14 @@ describe('Sync query V2 resolver tests', () => {
         testSong.lastChangedAt = createResult.data.createSongWithSortKey._lastChangedAt;
 
         // able to sync songs without lastSync specified. This will do a query on base table.
-        const syncResult = await syncSongWithSortKeys(null, { and: { name: { eq: testSong.name }, genre: { eq: testSong.genre } } });
+        const syncResult = await syncSongWithSortKeys(null,
+            {
+                and: [
+                    { name: { eq: testSong.name } }, 
+                    { genre: { eq: testSong.genre } },
+                ],
+            },
+        );
         verifySyncQueryResult(syncResult, testSong, 'syncSongWithSortKeys');
     });
   

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
@@ -3635,15 +3635,22 @@ $util.toJson({})
 #set( $filterMap = {} )
 #set( $QueryMap = {} )
 #set( $PkMap = {} )
+#set( $SkMap = {} )
 #set( $filterArgsMap = {} )
+#if( $ctx.stash.QueryRequest )
+  #return
+#end
+#set( $queryRequestVariables = {} )
 ## [End] Set map initialization for @key **
 ## [Start] Set query expression for @key **
 $util.qr($QueryMap.put('status+createdAt' , 'ByStatus'))
 $util.qr($PkMap.put('status' , 'ByStatus'))
+$util.qr($SkMap.put(\\"ByStatus\\", [\\"createdAt\\"]))
 ## [End] Set query expression for @key **
 ## [Start] Set query expression for @key **
 $util.qr($QueryMap.put('createdAt+status' , 'ByCreatedAt'))
 $util.qr($PkMap.put('createdAt' , 'ByCreatedAt'))
+$util.qr($SkMap.put(\\"ByCreatedAt\\", [\\"status\\"]))
 ## [End] Set query expression for @key **
 ## [Start] Set query expression for @key **
 #set( $filterArgsMap = $ctx.args.filter.get(\\"and\\") )
@@ -3660,6 +3667,10 @@ $util.qr($PkMap.put('createdAt' , 'ByCreatedAt'))
       #if( $ind == 0 && !$util.isNullOrEmpty($entry.value.eq) && !$util.isNullOrEmpty($PkMap.get($entry.key)) )
         #set( $pk = $entry.key )
         #set( $scan = false )
+        #set( $queryRequestVariables.partitionKey = $pk )
+        #set( $queryRequestVariables.sortKeys = $SkMap.get($PkMap.get($pk)) )
+        #set( $queryRequestVariables.partitionKeyFilter = {} )
+        $util.qr($queryRequestVariables.partitionKeyFilter.put($pk, {'eq': $entry.value.eq}))
         $util.qr($ctx.args.put($pk,$entry.value.eq))
         #set( $index = $PkMap.get($pk) )
       #end
@@ -3731,7 +3742,8 @@ $util.qr($PkMap.put('createdAt' , 'ByCreatedAt'))
 ## [Start]  Set query expression for @key **
 #if( !$scan )
   #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
-  #set( $QueryRequest = {
+  #set( $ctx.stash.QueryRequestVariables = $queryRequestVariables )
+  #set( $ctx.stash.QueryRequest = {
   \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"Sync\\",
   \\"limit\\": $limit,
@@ -3740,32 +3752,19 @@ $util.qr($PkMap.put('createdAt' , 'ByCreatedAt'))
 } )
   #if( !$util.isNull($ctx.args.sortDirection)
                     && $ctx.args.sortDirection == \\"DESC\\" )
-    #set( $QueryRequest.scanIndexForward = false )
+    #set( $ctx.stash.QueryRequest.scanIndexForward = false )
   #else
-    #set( $QueryRequest.scanIndexForward = true )
+    #set( $ctx.stash.QueryRequest.scanIndexForward = true )
   #end
-#if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-  #if( !$util.isNullOrEmpty($filterMap) )
-    #set( $QueryRequest.filter = $util.parseJson($util.transform.toDynamoDBFilterExpression($filterMap)) )
+#if( $context.args.nextToken ) #set( $ctx.stash.QueryRequest.nextToken = $context.args.nextToken ) #end
+  #if( !$util.isNullOrEmpty($filterMap) && $util.toJson($filterMap) != $util.toJson({}) )
+    #set( $ctx.stash.QueryRequest.filter = $filterMap )
   #end
   #if( $index != \\"dbTable\\" )
-    #set( $QueryRequest.index = $index )
+    #set( $ctx.stash.QueryRequest.index = $index )
   #end
-  $util.toJson($QueryRequest)
-#else
-{
-      \\"version\\": \\"2018-05-29\\",
-      \\"operation\\": \\"Sync\\",
-      \\"limit\\": $util.defaultIfNull($ctx.args.limit, 100),
-      \\"nextToken\\": $util.toJson($util.defaultIfNull($ctx.args.nextToken, null)),
-      \\"lastSync\\": $util.toJson($util.defaultIfNull($ctx.args.lastSync, null)),
-      \\"filter\\":     #if( !$util.isNullOrEmpty($ctx.args.filter) )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
-    #else
-null
-    #end
-  }
 #end
+$util.toJson({})
 ## [End]  Set query expression for @key **
 ",
   "Query.syncItems.preAuth.2.req.vtl": "## [Start] Set map initialization for @key **
@@ -3774,11 +3773,17 @@ null
 #set( $filterMap = {} )
 #set( $QueryMap = {} )
 #set( $PkMap = {} )
+#set( $SkMap = {} )
 #set( $filterArgsMap = {} )
+#if( $ctx.stash.QueryRequest )
+  #return
+#end
+#set( $queryRequestVariables = {} )
 ## [End] Set map initialization for @key **
 ## [Start] Set query expression for @key **
 $util.qr($QueryMap.put('orderId+status+createdAt' , 'dbTable'))
 $util.qr($PkMap.put('orderId' , 'dbTable'))
+$util.qr($SkMap.put(\\"dbTable\\", [\\"status\\", \\"createdAt\\"]))
 ## [End] Set query expression for @key **
 ## [Start] Set query expression for @key **
 #set( $filterArgsMap = $ctx.args.filter.get(\\"and\\") )
@@ -3795,6 +3800,10 @@ $util.qr($PkMap.put('orderId' , 'dbTable'))
       #if( $ind == 0 && !$util.isNullOrEmpty($entry.value.eq) && !$util.isNullOrEmpty($PkMap.get($entry.key)) )
         #set( $pk = $entry.key )
         #set( $scan = false )
+        #set( $queryRequestVariables.partitionKey = $pk )
+        #set( $queryRequestVariables.sortKeys = $SkMap.get($PkMap.get($pk)) )
+        #set( $queryRequestVariables.partitionKeyFilter = {} )
+        $util.qr($queryRequestVariables.partitionKeyFilter.put($pk, {'eq': $entry.value.eq}))
         $util.qr($ctx.args.put($pk,$entry.value.eq))
         #set( $index = $PkMap.get($pk) )
       #end
@@ -3866,7 +3875,8 @@ $util.qr($PkMap.put('orderId' , 'dbTable'))
 ## [Start]  Set query expression for @key **
 #if( !$scan )
   #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
-  #set( $QueryRequest = {
+  #set( $ctx.stash.QueryRequestVariables = $queryRequestVariables )
+  #set( $ctx.stash.QueryRequest = {
   \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"Sync\\",
   \\"limit\\": $limit,
@@ -3875,38 +3885,63 @@ $util.qr($PkMap.put('orderId' , 'dbTable'))
 } )
   #if( !$util.isNull($ctx.args.sortDirection)
                     && $ctx.args.sortDirection == \\"DESC\\" )
-    #set( $QueryRequest.scanIndexForward = false )
+    #set( $ctx.stash.QueryRequest.scanIndexForward = false )
   #else
-    #set( $QueryRequest.scanIndexForward = true )
+    #set( $ctx.stash.QueryRequest.scanIndexForward = true )
   #end
-#if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-  #if( !$util.isNullOrEmpty($filterMap) )
-    #set( $QueryRequest.filter = $util.parseJson($util.transform.toDynamoDBFilterExpression($filterMap)) )
+#if( $context.args.nextToken ) #set( $ctx.stash.QueryRequest.nextToken = $context.args.nextToken ) #end
+  #if( !$util.isNullOrEmpty($filterMap) && $util.toJson($filterMap) != $util.toJson({}) )
+    #set( $ctx.stash.QueryRequest.filter = $filterMap )
   #end
   #if( $index != \\"dbTable\\" )
-    #set( $QueryRequest.index = $index )
+    #set( $ctx.stash.QueryRequest.index = $index )
   #end
-  $util.toJson($QueryRequest)
-#else
-{
-      \\"version\\": \\"2018-05-29\\",
-      \\"operation\\": \\"Sync\\",
-      \\"limit\\": $util.defaultIfNull($ctx.args.limit, 100),
-      \\"nextToken\\": $util.toJson($util.defaultIfNull($ctx.args.nextToken, null)),
-      \\"lastSync\\": $util.toJson($util.defaultIfNull($ctx.args.lastSync, null)),
-      \\"filter\\":     #if( !$util.isNullOrEmpty($ctx.args.filter) )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
-    #else
-null
-    #end
-  }
 #end
+$util.toJson({})
 ## [End]  Set query expression for @key **
 ",
   "Query.syncItems.req.vtl": "## [Start] Sync Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+#set( $queryFilterContainsAuthField = false )
+#set( $authFilterContainsSortKey = false )
+#set( $useScan = true )
+#if( $util.isNullOrEmpty($ctx.stash.authFilter) && $ctx.stash.QueryRequest )
+  #set( $useScan = false )
+#end
 #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
   #set( $filter = $ctx.stash.authFilter )
+  #if( $ctx.stash.QueryRequestVariables.partitionKey )
+    #foreach( $filterItem in $ctx.stash.authFilter.or )
+      #if( $filterItem.get($ctx.stash.QueryRequestVariables.partitionKey) )
+        #set( $queryFilterContainsAuthField = true )
+      #end
+    #end
+    #if( !$queryFilterContainsAuthField )
+      #foreach( $filterItem in $ctx.stash.authFilter.or )
+        #foreach( $sortKey in $ctx.stash.QueryRequestVariables.sortKeys )
+          #if( $filterItem.get($sortKey) )
+            #set( $authFilterContainsSortKey = true )
+          #end
+        #end
+      #end
+      #if( !$authFilterContainsSortKey )
+        #if( !$util.isNullOrEmpty($ctx.stash.QueryRequest.filter) )
+          #set( $ctx.stash.QueryRequest.filter = {
+  \\"and\\":   [$ctx.stash.QueryRequest.filter, $ctx.stash.authFilter]
+} )
+        #else
+          #set( $ctx.stash.QueryRequest.filter = $ctx.stash.authFilter )
+        #end
+        #set( $useScan = false )
+      #end
+    #else
+      #foreach( $filterItem in $ctx.stash.authFilter.or )
+        #if( $util.toJson($filterItem) == $util.toJson($ctx.stash.QueryRequestVariables.partitionKeyFilter) )
+          #set( $useScan = false )
+        #end
+      #end
+    #end
+  #end
   #if( !$util.isNullOrEmpty($args.filter) )
     #set( $filter = {
   \\"and\\":   [$filter, $args.filter]
@@ -3926,18 +3961,25 @@ null
     #set( $filter = $filterExpression )
   #end
 #end
+#if( !$useScan )
+  #if( $ctx.stash.QueryRequest.filter )
+    #set( $ctx.stash.QueryRequest.filter = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.QueryRequest.filter)) )
+  #end
+  $util.toJson($ctx.stash.QueryRequest)
+#else
 {
-  \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"Sync\\",
-  \\"filter\\":   #if( $filter )
+      \\"version\\": \\"2018-05-29\\",
+      \\"operation\\": \\"Sync\\",
+      \\"filter\\":     #if( $filter )
 $util.toJson($filter)
-  #else
+    #else
 null
-  #end,
-  \\"limit\\": $util.defaultIfNull($args.limit, 100),
-  \\"lastSync\\": $util.toJson($util.defaultIfNull($args.lastSync, null)),
-  \\"nextToken\\": $util.toJson($util.defaultIfNull($args.nextToken, null))
-}
+    #end,
+      \\"limit\\": $util.defaultIfNull($args.limit, 100),
+      \\"lastSync\\": $util.toJson($util.defaultIfNull($args.lastSync, null)),
+      \\"nextToken\\": $util.toJson($util.defaultIfNull($args.nextToken, null))
+  }
+#end
 ## [End] Sync Request template. **",
   "Query.syncItems.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
@@ -4526,11 +4568,17 @@ $util.toJson({})
 #set( $filterMap = {} )
 #set( $QueryMap = {} )
 #set( $PkMap = {} )
+#set( $SkMap = {} )
 #set( $filterArgsMap = {} )
+#if( $ctx.stash.QueryRequest )
+  #return
+#end
+#set( $queryRequestVariables = {} )
 ## [End] Set map initialization for @key **
 ## [Start] Set query expression for @key **
 $util.qr($QueryMap.put('genre' , 'byGenre'))
 $util.qr($PkMap.put('genre' , 'byGenre'))
+$util.qr($SkMap.put(\\"byGenre\\", []))
 ## [End] Set query expression for @key **
 ## [Start] Set query expression for @key **
 #set( $filterArgsMap = $ctx.args.filter.get(\\"and\\") )
@@ -4547,6 +4595,10 @@ $util.qr($PkMap.put('genre' , 'byGenre'))
       #if( $ind == 0 && !$util.isNullOrEmpty($entry.value.eq) && !$util.isNullOrEmpty($PkMap.get($entry.key)) )
         #set( $pk = $entry.key )
         #set( $scan = false )
+        #set( $queryRequestVariables.partitionKey = $pk )
+        #set( $queryRequestVariables.sortKeys = $SkMap.get($PkMap.get($pk)) )
+        #set( $queryRequestVariables.partitionKeyFilter = {} )
+        $util.qr($queryRequestVariables.partitionKeyFilter.put($pk, {'eq': $entry.value.eq}))
         $util.qr($ctx.args.put($pk,$entry.value.eq))
         #set( $index = $PkMap.get($pk) )
       #end
@@ -4618,7 +4670,8 @@ $util.qr($PkMap.put('genre' , 'byGenre'))
 ## [Start]  Set query expression for @key **
 #if( !$scan )
   #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
-  #set( $QueryRequest = {
+  #set( $ctx.stash.QueryRequestVariables = $queryRequestVariables )
+  #set( $ctx.stash.QueryRequest = {
   \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"Sync\\",
   \\"limit\\": $limit,
@@ -4627,38 +4680,63 @@ $util.qr($PkMap.put('genre' , 'byGenre'))
 } )
   #if( !$util.isNull($ctx.args.sortDirection)
                     && $ctx.args.sortDirection == \\"DESC\\" )
-    #set( $QueryRequest.scanIndexForward = false )
+    #set( $ctx.stash.QueryRequest.scanIndexForward = false )
   #else
-    #set( $QueryRequest.scanIndexForward = true )
+    #set( $ctx.stash.QueryRequest.scanIndexForward = true )
   #end
-#if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-  #if( !$util.isNullOrEmpty($filterMap) )
-    #set( $QueryRequest.filter = $util.parseJson($util.transform.toDynamoDBFilterExpression($filterMap)) )
+#if( $context.args.nextToken ) #set( $ctx.stash.QueryRequest.nextToken = $context.args.nextToken ) #end
+  #if( !$util.isNullOrEmpty($filterMap) && $util.toJson($filterMap) != $util.toJson({}) )
+    #set( $ctx.stash.QueryRequest.filter = $filterMap )
   #end
   #if( $index != \\"dbTable\\" )
-    #set( $QueryRequest.index = $index )
+    #set( $ctx.stash.QueryRequest.index = $index )
   #end
-  $util.toJson($QueryRequest)
-#else
-{
-      \\"version\\": \\"2018-05-29\\",
-      \\"operation\\": \\"Sync\\",
-      \\"limit\\": $util.defaultIfNull($ctx.args.limit, 100),
-      \\"nextToken\\": $util.toJson($util.defaultIfNull($ctx.args.nextToken, null)),
-      \\"lastSync\\": $util.toJson($util.defaultIfNull($ctx.args.lastSync, null)),
-      \\"filter\\":     #if( !$util.isNullOrEmpty($ctx.args.filter) )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
-    #else
-null
-    #end
-  }
 #end
+$util.toJson({})
 ## [End]  Set query expression for @key **
 ",
   "Query.syncSongs.req.vtl": "## [Start] Sync Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+#set( $queryFilterContainsAuthField = false )
+#set( $authFilterContainsSortKey = false )
+#set( $useScan = true )
+#if( $util.isNullOrEmpty($ctx.stash.authFilter) && $ctx.stash.QueryRequest )
+  #set( $useScan = false )
+#end
 #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
   #set( $filter = $ctx.stash.authFilter )
+  #if( $ctx.stash.QueryRequestVariables.partitionKey )
+    #foreach( $filterItem in $ctx.stash.authFilter.or )
+      #if( $filterItem.get($ctx.stash.QueryRequestVariables.partitionKey) )
+        #set( $queryFilterContainsAuthField = true )
+      #end
+    #end
+    #if( !$queryFilterContainsAuthField )
+      #foreach( $filterItem in $ctx.stash.authFilter.or )
+        #foreach( $sortKey in $ctx.stash.QueryRequestVariables.sortKeys )
+          #if( $filterItem.get($sortKey) )
+            #set( $authFilterContainsSortKey = true )
+          #end
+        #end
+      #end
+      #if( !$authFilterContainsSortKey )
+        #if( !$util.isNullOrEmpty($ctx.stash.QueryRequest.filter) )
+          #set( $ctx.stash.QueryRequest.filter = {
+  \\"and\\":   [$ctx.stash.QueryRequest.filter, $ctx.stash.authFilter]
+} )
+        #else
+          #set( $ctx.stash.QueryRequest.filter = $ctx.stash.authFilter )
+        #end
+        #set( $useScan = false )
+      #end
+    #else
+      #foreach( $filterItem in $ctx.stash.authFilter.or )
+        #if( $util.toJson($filterItem) == $util.toJson($ctx.stash.QueryRequestVariables.partitionKeyFilter) )
+          #set( $useScan = false )
+        #end
+      #end
+    #end
+  #end
   #if( !$util.isNullOrEmpty($args.filter) )
     #set( $filter = {
   \\"and\\":   [$filter, $args.filter]
@@ -4678,18 +4756,25 @@ null
     #set( $filter = $filterExpression )
   #end
 #end
+#if( !$useScan )
+  #if( $ctx.stash.QueryRequest.filter )
+    #set( $ctx.stash.QueryRequest.filter = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.QueryRequest.filter)) )
+  #end
+  $util.toJson($ctx.stash.QueryRequest)
+#else
 {
-  \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"Sync\\",
-  \\"filter\\":   #if( $filter )
+      \\"version\\": \\"2018-05-29\\",
+      \\"operation\\": \\"Sync\\",
+      \\"filter\\":     #if( $filter )
 $util.toJson($filter)
-  #else
+    #else
 null
-  #end,
-  \\"limit\\": $util.defaultIfNull($args.limit, 100),
-  \\"lastSync\\": $util.toJson($util.defaultIfNull($args.lastSync, null)),
-  \\"nextToken\\": $util.toJson($util.defaultIfNull($args.nextToken, null))
-}
+    #end,
+      \\"limit\\": $util.defaultIfNull($args.limit, 100),
+      \\"lastSync\\": $util.toJson($util.defaultIfNull($args.lastSync, null)),
+      \\"nextToken\\": $util.toJson($util.defaultIfNull($args.nextToken, null))
+  }
+#end
 ## [End] Sync Request template. **",
   "Query.syncSongs.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
@@ -5278,11 +5363,17 @@ $util.toJson({})
 #set( $filterMap = {} )
 #set( $QueryMap = {} )
 #set( $PkMap = {} )
+#set( $SkMap = {} )
 #set( $filterArgsMap = {} )
+#if( $ctx.stash.QueryRequest )
+  #return
+#end
+#set( $queryRequestVariables = {} )
 ## [End] Set map initialization for @key **
 ## [Start] Set query expression for @key **
 $util.qr($QueryMap.put('genre' , 'byGenre'))
 $util.qr($PkMap.put('genre' , 'byGenre'))
+$util.qr($SkMap.put(\\"byGenre\\", []))
 ## [End] Set query expression for @key **
 ## [Start] Set query expression for @key **
 #set( $filterArgsMap = $ctx.args.filter.get(\\"and\\") )
@@ -5299,6 +5390,10 @@ $util.qr($PkMap.put('genre' , 'byGenre'))
       #if( $ind == 0 && !$util.isNullOrEmpty($entry.value.eq) && !$util.isNullOrEmpty($PkMap.get($entry.key)) )
         #set( $pk = $entry.key )
         #set( $scan = false )
+        #set( $queryRequestVariables.partitionKey = $pk )
+        #set( $queryRequestVariables.sortKeys = $SkMap.get($PkMap.get($pk)) )
+        #set( $queryRequestVariables.partitionKeyFilter = {} )
+        $util.qr($queryRequestVariables.partitionKeyFilter.put($pk, {'eq': $entry.value.eq}))
         $util.qr($ctx.args.put($pk,$entry.value.eq))
         #set( $index = $PkMap.get($pk) )
       #end
@@ -5370,7 +5465,8 @@ $util.qr($PkMap.put('genre' , 'byGenre'))
 ## [Start]  Set query expression for @key **
 #if( !$scan )
   #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
-  #set( $QueryRequest = {
+  #set( $ctx.stash.QueryRequestVariables = $queryRequestVariables )
+  #set( $ctx.stash.QueryRequest = {
   \\"version\\": \\"2018-05-29\\",
   \\"operation\\": \\"Sync\\",
   \\"limit\\": $limit,
@@ -5379,38 +5475,63 @@ $util.qr($PkMap.put('genre' , 'byGenre'))
 } )
   #if( !$util.isNull($ctx.args.sortDirection)
                     && $ctx.args.sortDirection == \\"DESC\\" )
-    #set( $QueryRequest.scanIndexForward = false )
+    #set( $ctx.stash.QueryRequest.scanIndexForward = false )
   #else
-    #set( $QueryRequest.scanIndexForward = true )
+    #set( $ctx.stash.QueryRequest.scanIndexForward = true )
   #end
-#if( $context.args.nextToken ) #set( $QueryRequest.nextToken = $context.args.nextToken ) #end
-  #if( !$util.isNullOrEmpty($filterMap) )
-    #set( $QueryRequest.filter = $util.parseJson($util.transform.toDynamoDBFilterExpression($filterMap)) )
+#if( $context.args.nextToken ) #set( $ctx.stash.QueryRequest.nextToken = $context.args.nextToken ) #end
+  #if( !$util.isNullOrEmpty($filterMap) && $util.toJson($filterMap) != $util.toJson({}) )
+    #set( $ctx.stash.QueryRequest.filter = $filterMap )
   #end
   #if( $index != \\"dbTable\\" )
-    #set( $QueryRequest.index = $index )
+    #set( $ctx.stash.QueryRequest.index = $index )
   #end
-  $util.toJson($QueryRequest)
-#else
-{
-      \\"version\\": \\"2018-05-29\\",
-      \\"operation\\": \\"Sync\\",
-      \\"limit\\": $util.defaultIfNull($ctx.args.limit, 100),
-      \\"nextToken\\": $util.toJson($util.defaultIfNull($ctx.args.nextToken, null)),
-      \\"lastSync\\": $util.toJson($util.defaultIfNull($ctx.args.lastSync, null)),
-      \\"filter\\":     #if( !$util.isNullOrEmpty($ctx.args.filter) )
-$util.transform.toDynamoDBFilterExpression($ctx.args.filter)
-    #else
-null
-    #end
-  }
 #end
+$util.toJson({})
 ## [End]  Set query expression for @key **
 ",
   "Query.syncSongs.req.vtl": "## [Start] Sync Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+#set( $queryFilterContainsAuthField = false )
+#set( $authFilterContainsSortKey = false )
+#set( $useScan = true )
+#if( $util.isNullOrEmpty($ctx.stash.authFilter) && $ctx.stash.QueryRequest )
+  #set( $useScan = false )
+#end
 #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
   #set( $filter = $ctx.stash.authFilter )
+  #if( $ctx.stash.QueryRequestVariables.partitionKey )
+    #foreach( $filterItem in $ctx.stash.authFilter.or )
+      #if( $filterItem.get($ctx.stash.QueryRequestVariables.partitionKey) )
+        #set( $queryFilterContainsAuthField = true )
+      #end
+    #end
+    #if( !$queryFilterContainsAuthField )
+      #foreach( $filterItem in $ctx.stash.authFilter.or )
+        #foreach( $sortKey in $ctx.stash.QueryRequestVariables.sortKeys )
+          #if( $filterItem.get($sortKey) )
+            #set( $authFilterContainsSortKey = true )
+          #end
+        #end
+      #end
+      #if( !$authFilterContainsSortKey )
+        #if( !$util.isNullOrEmpty($ctx.stash.QueryRequest.filter) )
+          #set( $ctx.stash.QueryRequest.filter = {
+  \\"and\\":   [$ctx.stash.QueryRequest.filter, $ctx.stash.authFilter]
+} )
+        #else
+          #set( $ctx.stash.QueryRequest.filter = $ctx.stash.authFilter )
+        #end
+        #set( $useScan = false )
+      #end
+    #else
+      #foreach( $filterItem in $ctx.stash.authFilter.or )
+        #if( $util.toJson($filterItem) == $util.toJson($ctx.stash.QueryRequestVariables.partitionKeyFilter) )
+          #set( $useScan = false )
+        #end
+      #end
+    #end
+  #end
   #if( !$util.isNullOrEmpty($args.filter) )
     #set( $filter = {
   \\"and\\":   [$filter, $args.filter]
@@ -5430,18 +5551,25 @@ null
     #set( $filter = $filterExpression )
   #end
 #end
+#if( !$useScan )
+  #if( $ctx.stash.QueryRequest.filter )
+    #set( $ctx.stash.QueryRequest.filter = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.QueryRequest.filter)) )
+  #end
+  $util.toJson($ctx.stash.QueryRequest)
+#else
 {
-  \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"Sync\\",
-  \\"filter\\":   #if( $filter )
+      \\"version\\": \\"2018-05-29\\",
+      \\"operation\\": \\"Sync\\",
+      \\"filter\\":     #if( $filter )
 $util.toJson($filter)
-  #else
+    #else
 null
-  #end,
-  \\"limit\\": $util.defaultIfNull($args.limit, 100),
-  \\"lastSync\\": $util.toJson($util.defaultIfNull($args.lastSync, null)),
-  \\"nextToken\\": $util.toJson($util.defaultIfNull($args.nextToken, null))
-}
+    #end,
+      \\"limit\\": $util.defaultIfNull($args.limit, 100),
+      \\"lastSync\\": $util.toJson($util.defaultIfNull($args.lastSync, null)),
+      \\"nextToken\\": $util.toJson($util.defaultIfNull($args.nextToken, null))
+  }
+#end
 ## [End] Sync Request template. **",
   "Query.syncSongs.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )

--- a/packages/amplify-graphql-index-transformer/src/resolvers/resolvers.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers/resolvers.ts
@@ -624,6 +624,11 @@ export function constructSyncVTL(syncVTLContent: string, resolver: TransformerRe
   addIndexToResolverSlot(resolver, checks, true);
 }
 
+/**
+ * This function generates the VTL snippet to check whether a GSI/table can be queried to apply the sync filter.
+ * The filter must enclosed in an 'and' condition.
+ * { filter: { and: [ { genre: { eq: testSong.genre } } ] } }
+ */
 function setSyncQueryFilterSnippet(deltaSyncTableTtl: number) {
   const expressions: Expression[] = [];
   expressions.push(

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -1254,8 +1254,46 @@ $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
   "Query.syncPosts.req.vtl": "## [Start] Sync Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+#set( $queryFilterContainsAuthField = false )
+#set( $authFilterContainsSortKey = false )
+#set( $useScan = true )
+#if( $util.isNullOrEmpty($ctx.stash.authFilter) && $ctx.stash.QueryRequest )
+  #set( $useScan = false )
+#end
 #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
   #set( $filter = $ctx.stash.authFilter )
+  #if( $ctx.stash.QueryRequestVariables.partitionKey )
+    #foreach( $filterItem in $ctx.stash.authFilter.or )
+      #if( $filterItem.get($ctx.stash.QueryRequestVariables.partitionKey) )
+        #set( $queryFilterContainsAuthField = true )
+      #end
+    #end
+    #if( !$queryFilterContainsAuthField )
+      #foreach( $filterItem in $ctx.stash.authFilter.or )
+        #foreach( $sortKey in $ctx.stash.QueryRequestVariables.sortKeys )
+          #if( $filterItem.get($sortKey) )
+            #set( $authFilterContainsSortKey = true )
+          #end
+        #end
+      #end
+      #if( !$authFilterContainsSortKey )
+        #if( !$util.isNullOrEmpty($ctx.stash.QueryRequest.filter) )
+          #set( $ctx.stash.QueryRequest.filter = {
+  \\"and\\":   [$ctx.stash.QueryRequest.filter, $ctx.stash.authFilter]
+} )
+        #else
+          #set( $ctx.stash.QueryRequest.filter = $ctx.stash.authFilter )
+        #end
+        #set( $useScan = false )
+      #end
+    #else
+      #foreach( $filterItem in $ctx.stash.authFilter.or )
+        #if( $util.toJson($filterItem) == $util.toJson($ctx.stash.QueryRequestVariables.partitionKeyFilter) )
+          #set( $useScan = false )
+        #end
+      #end
+    #end
+  #end
   #if( !$util.isNullOrEmpty($args.filter) )
     #set( $filter = {
   \\"and\\":   [$filter, $args.filter]
@@ -1275,18 +1313,25 @@ $util.toJson({})
     #set( $filter = $filterExpression )
   #end
 #end
+#if( !$useScan )
+  #if( $ctx.stash.QueryRequest.filter )
+    #set( $ctx.stash.QueryRequest.filter = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.QueryRequest.filter)) )
+  #end
+  $util.toJson($ctx.stash.QueryRequest)
+#else
 {
-  \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"Sync\\",
-  \\"filter\\":   #if( $filter )
+      \\"version\\": \\"2018-05-29\\",
+      \\"operation\\": \\"Sync\\",
+      \\"filter\\":     #if( $filter )
 $util.toJson($filter)
-  #else
+    #else
 null
-  #end,
-  \\"limit\\": $util.defaultIfNull($args.limit, 100),
-  \\"lastSync\\": $util.toJson($util.defaultIfNull($args.lastSync, null)),
-  \\"nextToken\\": $util.toJson($util.defaultIfNull($args.nextToken, null))
-}
+    #end,
+      \\"limit\\": $util.defaultIfNull($args.limit, 100),
+      \\"lastSync\\": $util.toJson($util.defaultIfNull($args.lastSync, null)),
+      \\"nextToken\\": $util.toJson($util.defaultIfNull($args.nextToken, null))
+  }
+#end
 ## [End] Sync Request template. **",
   "Query.syncPosts.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
@@ -1796,8 +1841,46 @@ $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
   "Query.syncPosts.req.vtl": "## [Start] Sync Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+#set( $queryFilterContainsAuthField = false )
+#set( $authFilterContainsSortKey = false )
+#set( $useScan = true )
+#if( $util.isNullOrEmpty($ctx.stash.authFilter) && $ctx.stash.QueryRequest )
+  #set( $useScan = false )
+#end
 #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
   #set( $filter = $ctx.stash.authFilter )
+  #if( $ctx.stash.QueryRequestVariables.partitionKey )
+    #foreach( $filterItem in $ctx.stash.authFilter.or )
+      #if( $filterItem.get($ctx.stash.QueryRequestVariables.partitionKey) )
+        #set( $queryFilterContainsAuthField = true )
+      #end
+    #end
+    #if( !$queryFilterContainsAuthField )
+      #foreach( $filterItem in $ctx.stash.authFilter.or )
+        #foreach( $sortKey in $ctx.stash.QueryRequestVariables.sortKeys )
+          #if( $filterItem.get($sortKey) )
+            #set( $authFilterContainsSortKey = true )
+          #end
+        #end
+      #end
+      #if( !$authFilterContainsSortKey )
+        #if( !$util.isNullOrEmpty($ctx.stash.QueryRequest.filter) )
+          #set( $ctx.stash.QueryRequest.filter = {
+  \\"and\\":   [$ctx.stash.QueryRequest.filter, $ctx.stash.authFilter]
+} )
+        #else
+          #set( $ctx.stash.QueryRequest.filter = $ctx.stash.authFilter )
+        #end
+        #set( $useScan = false )
+      #end
+    #else
+      #foreach( $filterItem in $ctx.stash.authFilter.or )
+        #if( $util.toJson($filterItem) == $util.toJson($ctx.stash.QueryRequestVariables.partitionKeyFilter) )
+          #set( $useScan = false )
+        #end
+      #end
+    #end
+  #end
   #if( !$util.isNullOrEmpty($args.filter) )
     #set( $filter = {
   \\"and\\":   [$filter, $args.filter]
@@ -1817,18 +1900,25 @@ $util.toJson({})
     #set( $filter = $filterExpression )
   #end
 #end
+#if( !$useScan )
+  #if( $ctx.stash.QueryRequest.filter )
+    #set( $ctx.stash.QueryRequest.filter = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.QueryRequest.filter)) )
+  #end
+  $util.toJson($ctx.stash.QueryRequest)
+#else
 {
-  \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"Sync\\",
-  \\"filter\\":   #if( $filter )
+      \\"version\\": \\"2018-05-29\\",
+      \\"operation\\": \\"Sync\\",
+      \\"filter\\":     #if( $filter )
 $util.toJson($filter)
-  #else
+    #else
 null
-  #end,
-  \\"limit\\": $util.defaultIfNull($args.limit, 100),
-  \\"lastSync\\": $util.toJson($util.defaultIfNull($args.lastSync, null)),
-  \\"nextToken\\": $util.toJson($util.defaultIfNull($args.nextToken, null))
-}
+    #end,
+      \\"limit\\": $util.defaultIfNull($args.limit, 100),
+      \\"lastSync\\": $util.toJson($util.defaultIfNull($args.lastSync, null)),
+      \\"nextToken\\": $util.toJson($util.defaultIfNull($args.nextToken, null))
+  }
+#end
 ## [End] Sync Request template. **",
   "Query.syncPosts.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
@@ -2338,8 +2428,46 @@ $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
   "Query.syncPosts.req.vtl": "## [Start] Sync Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+#set( $queryFilterContainsAuthField = false )
+#set( $authFilterContainsSortKey = false )
+#set( $useScan = true )
+#if( $util.isNullOrEmpty($ctx.stash.authFilter) && $ctx.stash.QueryRequest )
+  #set( $useScan = false )
+#end
 #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
   #set( $filter = $ctx.stash.authFilter )
+  #if( $ctx.stash.QueryRequestVariables.partitionKey )
+    #foreach( $filterItem in $ctx.stash.authFilter.or )
+      #if( $filterItem.get($ctx.stash.QueryRequestVariables.partitionKey) )
+        #set( $queryFilterContainsAuthField = true )
+      #end
+    #end
+    #if( !$queryFilterContainsAuthField )
+      #foreach( $filterItem in $ctx.stash.authFilter.or )
+        #foreach( $sortKey in $ctx.stash.QueryRequestVariables.sortKeys )
+          #if( $filterItem.get($sortKey) )
+            #set( $authFilterContainsSortKey = true )
+          #end
+        #end
+      #end
+      #if( !$authFilterContainsSortKey )
+        #if( !$util.isNullOrEmpty($ctx.stash.QueryRequest.filter) )
+          #set( $ctx.stash.QueryRequest.filter = {
+  \\"and\\":   [$ctx.stash.QueryRequest.filter, $ctx.stash.authFilter]
+} )
+        #else
+          #set( $ctx.stash.QueryRequest.filter = $ctx.stash.authFilter )
+        #end
+        #set( $useScan = false )
+      #end
+    #else
+      #foreach( $filterItem in $ctx.stash.authFilter.or )
+        #if( $util.toJson($filterItem) == $util.toJson($ctx.stash.QueryRequestVariables.partitionKeyFilter) )
+          #set( $useScan = false )
+        #end
+      #end
+    #end
+  #end
   #if( !$util.isNullOrEmpty($args.filter) )
     #set( $filter = {
   \\"and\\":   [$filter, $args.filter]
@@ -2359,18 +2487,25 @@ $util.toJson({})
     #set( $filter = $filterExpression )
   #end
 #end
+#if( !$useScan )
+  #if( $ctx.stash.QueryRequest.filter )
+    #set( $ctx.stash.QueryRequest.filter = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.QueryRequest.filter)) )
+  #end
+  $util.toJson($ctx.stash.QueryRequest)
+#else
 {
-  \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"Sync\\",
-  \\"filter\\":   #if( $filter )
+      \\"version\\": \\"2018-05-29\\",
+      \\"operation\\": \\"Sync\\",
+      \\"filter\\":     #if( $filter )
 $util.toJson($filter)
-  #else
+    #else
 null
-  #end,
-  \\"limit\\": $util.defaultIfNull($args.limit, 100),
-  \\"lastSync\\": $util.toJson($util.defaultIfNull($args.lastSync, null)),
-  \\"nextToken\\": $util.toJson($util.defaultIfNull($args.nextToken, null))
-}
+    #end,
+      \\"limit\\": $util.defaultIfNull($args.limit, 100),
+      \\"lastSync\\": $util.toJson($util.defaultIfNull($args.lastSync, null)),
+      \\"nextToken\\": $util.toJson($util.defaultIfNull($args.nextToken, null))
+  }
+#end
 ## [End] Sync Request template. **",
   "Query.syncPosts.res.vtl": "## [Start] ResponseTemplate. **
 #if( $ctx.error )
@@ -4818,8 +4953,46 @@ $util.toJson($UpdateItem)
 exports[`ModelTransformer:  the datastore table should be configured 1`] = `
 "## [Start] Sync Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+#set( $queryFilterContainsAuthField = false )
+#set( $authFilterContainsSortKey = false )
+#set( $useScan = true )
+#if( $util.isNullOrEmpty($ctx.stash.authFilter) && $ctx.stash.QueryRequest )
+  #set( $useScan = false )
+#end
 #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
   #set( $filter = $ctx.stash.authFilter )
+  #if( $ctx.stash.QueryRequestVariables.partitionKey )
+    #foreach( $filterItem in $ctx.stash.authFilter.or )
+      #if( $filterItem.get($ctx.stash.QueryRequestVariables.partitionKey) )
+        #set( $queryFilterContainsAuthField = true )
+      #end
+    #end
+    #if( !$queryFilterContainsAuthField )
+      #foreach( $filterItem in $ctx.stash.authFilter.or )
+        #foreach( $sortKey in $ctx.stash.QueryRequestVariables.sortKeys )
+          #if( $filterItem.get($sortKey) )
+            #set( $authFilterContainsSortKey = true )
+          #end
+        #end
+      #end
+      #if( !$authFilterContainsSortKey )
+        #if( !$util.isNullOrEmpty($ctx.stash.QueryRequest.filter) )
+          #set( $ctx.stash.QueryRequest.filter = {
+  \\"and\\":   [$ctx.stash.QueryRequest.filter, $ctx.stash.authFilter]
+} )
+        #else
+          #set( $ctx.stash.QueryRequest.filter = $ctx.stash.authFilter )
+        #end
+        #set( $useScan = false )
+      #end
+    #else
+      #foreach( $filterItem in $ctx.stash.authFilter.or )
+        #if( $util.toJson($filterItem) == $util.toJson($ctx.stash.QueryRequestVariables.partitionKeyFilter) )
+          #set( $useScan = false )
+        #end
+      #end
+    #end
+  #end
   #if( !$util.isNullOrEmpty($args.filter) )
     #set( $filter = {
   \\"and\\":   [$filter, $args.filter]
@@ -4839,18 +5012,25 @@ exports[`ModelTransformer:  the datastore table should be configured 1`] = `
     #set( $filter = $filterExpression )
   #end
 #end
+#if( !$useScan )
+  #if( $ctx.stash.QueryRequest.filter )
+    #set( $ctx.stash.QueryRequest.filter = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.QueryRequest.filter)) )
+  #end
+  $util.toJson($ctx.stash.QueryRequest)
+#else
 {
-  \\"version\\": \\"2018-05-29\\",
-  \\"operation\\": \\"Sync\\",
-  \\"filter\\":   #if( $filter )
+      \\"version\\": \\"2018-05-29\\",
+      \\"operation\\": \\"Sync\\",
+      \\"filter\\":     #if( $filter )
 $util.toJson($filter)
-  #else
+    #else
 null
-  #end,
-  \\"limit\\": $util.defaultIfNull($args.limit, 100),
-  \\"lastSync\\": $util.toJson($util.defaultIfNull($args.lastSync, null)),
-  \\"nextToken\\": $util.toJson($util.defaultIfNull($args.nextToken, null))
-}
+    #end,
+      \\"limit\\": $util.defaultIfNull($args.limit, 100),
+      \\"lastSync\\": $util.toJson($util.defaultIfNull($args.lastSync, null)),
+      \\"nextToken\\": $util.toJson($util.defaultIfNull($args.nextToken, null))
+  }
+#end
 ## [End] Sync Request template. **"
 `;
 

--- a/packages/amplify-graphql-model-transformer/src/resolvers/dynamodb/query.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/dynamodb/query.ts
@@ -172,6 +172,13 @@ export const generateSyncRequestTemplate = (): string => {
       setArgs,
       set(ref('queryFilterContainsAuthField'), bool(false)),
       set(ref('useScan'), bool(true)),
+      iff(
+        and([
+          isNullOrEmpty(authFilter),
+          ref('ctx.stash.QueryRequest'),
+        ]),
+        set(ref('useScan'), bool(false)),
+      ),
       ifElse(
         not(isNullOrEmpty(authFilter)),
         compoundExpression([

--- a/packages/amplify-graphql-model-transformer/src/resolvers/dynamodb/query.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/dynamodb/query.ts
@@ -187,6 +187,8 @@ export const generateSyncRequestTemplate = (): string => {
           iff(
             ref('ctx.stash.QueryRequestVariables.partitionKey'),
             compoundExpression([
+              // Check if the auth filter contains the QueryRequest's partition key.
+              // If yes, then the filter on auth field must match one of the Auth filter to perform a query.
               forEach(ref('filterItem'), ref('ctx.stash.authFilter.or'), [
                 iff(
                   raw('$filterItem.get($ctx.stash.QueryRequestVariables.partitionKey)'),
@@ -195,6 +197,8 @@ export const generateSyncRequestTemplate = (): string => {
               ]),
               ifElse(
                 not(ref('queryFilterContainsAuthField')),
+                // If the auth filter is not on an auth field, check if the QueryRequest's sort keys contain an auth field.
+                // If yes, perform a scan. Otherwise, query the GSI/table.
                 compoundExpression([
                   forEach(ref('filterItem'), ref('ctx.stash.authFilter.or'), [
                     forEach(ref('sortKey'), ref('ctx.stash.QueryRequestVariables.sortKeys'), [


### PR DESCRIPTION
#### Description of changes

Currently Sync operation is scanning the table several times when a model has a custom primary key or GSI (2 preAuth slots and 1 data resolver slot). This change is intended to fix this behavior.

Going forward, the `preAuth` slot will run against NONE_DS instead of the DDB table datasource. `PreAuth` slot will only construct the DDB query (place it on `$ctx.stash.QueryRequest`) and the data resolver will determine whether to use the query or perform a table scan. 

With this PR, sync operation will,
- Use query if sync filter is on a GSI/table's partition key (partition key and sort key(s) aren't auth field).
- Use query if sync filter is on a partition key and it matches with one of the auto generated auth filter. 

In all other cases, table will be scanned once.


#### Issue #, if available

Fixes https://github.com/aws-amplify/amplify-category-api/issues/1413

#### Description of how you validated changes
- E2E Test
- Manual test
- Unit test snapshots updated

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
