### PR TITLE
fix(auth): owner & group field as sort key field of GSI

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/group-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/group-auth.test.ts.snap
@@ -44,8 +44,18 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
     #end
   #end
   #if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && !$primaryFieldMap.isEmpty() )
+    #set( $sortKeyFields = [] )
     #foreach( $entry in $primaryFieldMap.entrySet() )
-      $util.qr($ctx.args.put($entry.key, $entry.value))
+      #if( $sortKeyFields.contains($entry.key) )
+        #set( $entryVal = $entry.value )
+        #set( $lastIdx = $entryVal.size() - 1 )
+        #set( $lastItem = $entryVal.get($lastIdx) )
+        $util.qr($ctx.args.put($entry.key, {
+  \\"eq\\": $lastItem
+}))
+      #else
+        $util.qr($ctx.args.put($entry.key, $entry.value))
+      #end
       #set( $isAuthorized = true )
     #end
   #end

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/group-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/group-auth.test.ts.snap
@@ -1,0 +1,125 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Group field as part of secondary index group field as GSI field 1`] = `
+"## [Start] Authorization Steps. **
+$util.qr($ctx.stash.put(\\"hasAuth\\", true))
+#set( $isAuthorized = false )
+#set( $primaryFieldMap = {} )
+#if( $util.authType() == \\"User Pool Authorization\\" )
+  #set( $groupClaim = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), null) )
+  #if( !$util.isNull($groupClaim) )
+
+    #set( $ownerClaimsList0 = [] )
+    #if( $util.isString($groupClaim) )
+      #if( $util.isList($util.parseJson($groupClaim)) )
+        #set( $groupClaim = $util.parseJson($groupClaim) )
+      #else
+        #set( $groupClaim = [$groupClaim] )
+      #end
+    #end
+    $util.qr($ownerClaimsList0.addAll($groupClaim))
+    #if( !$util.isNull($ctx.args.group) )
+      #if( $util.isString($ctx.args.group) )
+        #set( $groupCondition = (($groupClaim == $ctx.args.group) || $ownerClaimsList0.contains($ctx.args.group)) )
+      #else
+        #set( $groupCondition = ($groupClaim == $util.defaultIfNull($ctx.args.group.get(\\"eq\\"), null) || $ownerClaimsList0.contains($util.defaultIfNull($ctx.args.group.get(\\"eq\\"), null))) )
+        #if( !$groupCondition )
+          #set( $entityValues = 0 )
+          #foreach( $argEntity in $ctx.args.group.get(\\"eq\\") )
+            #if( $ownerClaimsList0.contains($argEntity) )
+              #set( $entityValues = $entityValues + 1 )
+            #end
+          #end
+          #if( $entityValues == $ctx.args.group.get(\\"eq\\").size() )
+            #set( $groupCondition = true )
+          #end
+        #end
+      #end
+      #if( $groupCondition )
+        #set( $isAuthorized = true )
+        $util.qr($ctx.stash.put(\\"authFilter\\", null))
+      #end
+    #else
+      $util.qr($primaryFieldMap.put(\\"group\\", $groupClaim))
+    #end
+  #end
+  #if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && !$primaryFieldMap.isEmpty() )
+    #foreach( $entry in $primaryFieldMap.entrySet() )
+      $util.qr($ctx.args.put($entry.key, $entry.value))
+      #set( $isAuthorized = true )
+    #end
+  #end
+#end
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) )
+$util.unauthorized()
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Authorization Steps. **"
+`;
+
+exports[`Group field as part of secondary index group field as sort key field of GSI 1`] = `
+"## [Start] Authorization Steps. **
+$util.qr($ctx.stash.put(\\"hasAuth\\", true))
+#set( $isAuthorized = false )
+#set( $primaryFieldMap = {} )
+#if( $util.authType() == \\"User Pool Authorization\\" )
+  #set( $groupClaim = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), null) )
+  #if( !$util.isNull($groupClaim) )
+
+    #set( $ownerClaimsList0 = [] )
+    #if( $util.isString($groupClaim) )
+      #if( $util.isList($util.parseJson($groupClaim)) )
+        #set( $groupClaim = $util.parseJson($groupClaim) )
+      #else
+        #set( $groupClaim = [$groupClaim] )
+      #end
+    #end
+    $util.qr($ownerClaimsList0.addAll($groupClaim))
+    #if( !$util.isNull($ctx.args.group) )
+      #if( $util.isString($ctx.args.group) )
+        #set( $groupCondition = (($groupClaim == $ctx.args.group) || $ownerClaimsList0.contains($ctx.args.group)) )
+      #else
+        #set( $groupCondition = ($groupClaim == $util.defaultIfNull($ctx.args.group.get(\\"eq\\"), null) || $ownerClaimsList0.contains($util.defaultIfNull($ctx.args.group.get(\\"eq\\"), null))) )
+        #if( !$groupCondition )
+          #set( $entityValues = 0 )
+          #foreach( $argEntity in $ctx.args.group.get(\\"eq\\") )
+            #if( $ownerClaimsList0.contains($argEntity) )
+              #set( $entityValues = $entityValues + 1 )
+            #end
+          #end
+          #if( $entityValues == $ctx.args.group.get(\\"eq\\").size() )
+            #set( $groupCondition = true )
+          #end
+        #end
+      #end
+      #if( $groupCondition )
+        #set( $isAuthorized = true )
+        $util.qr($ctx.stash.put(\\"authFilter\\", null))
+      #end
+    #else
+      $util.qr($primaryFieldMap.put(\\"group\\", $groupClaim))
+    #end
+  #end
+  #if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && !$primaryFieldMap.isEmpty() )
+    #set( $sortKeyFields = [\\"group\\"] )
+    #foreach( $entry in $primaryFieldMap.entrySet() )
+      #if( $sortKeyFields.contains($entry.key) )
+        #set( $entryVal = $entry.value )
+        #set( $lastIdx = $entryVal.size() - 1 )
+        #set( $lastItem = $entryVal.get($lastIdx) )
+        $util.qr($ctx.args.put($entry.key, {
+  \\"eq\\": $lastItem
+}))
+      #else
+        $util.qr($ctx.args.put($entry.key, $entry.value))
+      #end
+      #set( $isAuthorized = true )
+    #end
+  #end
+#end
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) )
+$util.unauthorized()
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Authorization Steps. **"
+`;

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
@@ -647,8 +647,18 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
     #end
   #end
   #if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && !$primaryFieldMap.isEmpty() )
+    #set( $sortKeyFields = [] )
     #foreach( $entry in $primaryFieldMap.entrySet() )
-      $util.qr($ctx.args.put($entry.key, $entry.value))
+      #if( $sortKeyFields.contains($entry.key) )
+        #set( $entryVal = $entry.value )
+        #set( $lastIdx = $entryVal.size() - 1 )
+        #set( $lastItem = $entryVal.get($lastIdx) )
+        $util.qr($ctx.args.put($entry.key, {
+  \\"eq\\": $lastItem
+}))
+      #else
+        $util.qr($ctx.args.put($entry.key, $entry.value))
+      #end
       #set( $isAuthorized = true )
     #end
   #end
@@ -704,8 +714,18 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
     #end
   #end
   #if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && !$primaryFieldMap.isEmpty() )
+    #set( $sortKeyFields = [] )
     #foreach( $entry in $primaryFieldMap.entrySet() )
-      $util.qr($ctx.args.put($entry.key, $entry.value))
+      #if( $sortKeyFields.contains($entry.key) )
+        #set( $entryVal = $entry.value )
+        #set( $lastIdx = $entryVal.size() - 1 )
+        #set( $lastItem = $entryVal.get($lastIdx) )
+        $util.qr($ctx.args.put($entry.key, {
+  \\"eq\\": $lastItem
+}))
+      #else
+        $util.qr($ctx.args.put($entry.key, $entry.value))
+      #end
       #set( $isAuthorized = true )
     #end
   #end

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
@@ -600,7 +600,7 @@ exports[`owner based @auth owner where field is "::" delimited with only mutatio
 ## [End] Parse owner field auth for Get. **"
 `;
 
-exports[`owner based @auth sort key fields on @auth owner field sortKeyFields of global secondary index handles ownerfield as GSI field with default identity claim  1`] = `
+exports[`owner based @auth sort key fields on @auth owner field owner field as part of global secondary index handles ownerfield as GSI field with default identity claim  1`] = `
 "## [Start] Authorization Steps. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $isAuthorized = false )
@@ -660,7 +660,7 @@ $util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
 ## [End] Authorization Steps. **"
 `;
 
-exports[`owner based @auth sort key fields on @auth owner field sortKeyFields of global secondary index handles ownerfield as GSI field with username identity claim  1`] = `
+exports[`owner based @auth sort key fields on @auth owner field owner field as part of global secondary index handles ownerfield as GSI field with username identity claim  1`] = `
 "## [Start] Authorization Steps. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $isAuthorized = false )
@@ -717,7 +717,7 @@ $util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
 ## [End] Authorization Steps. **"
 `;
 
-exports[`owner based @auth sort key fields on @auth owner field sortKeyFields of global secondary index handles ownerfield as part of sortKeyFields of GSI with default identity claim  1`] = `
+exports[`owner based @auth sort key fields on @auth owner field owner field as part of global secondary index handles ownerfield as part of sortKeyFields of GSI with default identity claim  1`] = `
 "## [Start] Authorization Steps. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $isAuthorized = false )
@@ -787,7 +787,7 @@ $util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
 ## [End] Authorization Steps. **"
 `;
 
-exports[`owner based @auth sort key fields on @auth owner field sortKeyFields of global secondary index handles ownerfield as part of sortKeyFields of GSI with username identity claim  1`] = `
+exports[`owner based @auth sort key fields on @auth owner field owner field as part of global secondary index handles ownerfield as part of sortKeyFields of GSI with username identity claim  1`] = `
 "## [Start] Authorization Steps. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $isAuthorized = false )

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
@@ -600,6 +600,260 @@ exports[`owner based @auth owner where field is "::" delimited with only mutatio
 ## [End] Parse owner field auth for Get. **"
 `;
 
+exports[`owner based @auth sort key fields on @auth owner field sortKeyFields of global secondary index handles ownerfield as GSI field with default identity claim  1`] = `
+"## [Start] Authorization Steps. **
+$util.qr($ctx.stash.put(\\"hasAuth\\", true))
+#set( $isAuthorized = false )
+#set( $primaryFieldMap = {} )
+#if( $util.authType() == \\"User Pool Authorization\\" )
+  #set( $ownerClaim = $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), null) )
+  #set( $currentClaim1 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), null)) )
+  #if( !$util.isNull($ownerClaim) && !$util.isNull($currentClaim1) )
+    #set( $ownerClaim = \\"$ownerClaim::$currentClaim1\\" )
+    #set( $ownerClaimsList0 = [] )
+    $util.qr($ownerClaimsList0.add($util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), null)))
+    $util.qr($ownerClaimsList0.add($util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), null))))
+    #if( $util.isString($ownerClaim) )
+      #if( $util.isList($util.parseJson($ownerClaim)) )
+        #set( $ownerClaim = $util.parseJson($ownerClaim) )
+      #else
+        #set( $ownerClaim = [$ownerClaim] )
+      #end
+    #end
+    $util.qr($ownerClaimsList0.addAll($ownerClaim))
+    #if( !$util.isNull($ctx.args.owner) )
+      #if( $util.isString($ctx.args.owner) )
+        #set( $ownerCondition = (($ownerClaim == $ctx.args.owner) || $ownerClaimsList0.contains($ctx.args.owner)) )
+      #else
+        #set( $ownerCondition = ($ownerClaim == $util.defaultIfNull($ctx.args.owner.get(\\"eq\\"), null) || $ownerClaimsList0.contains($util.defaultIfNull($ctx.args.owner.get(\\"eq\\"), null))) )
+        #if( !$ownerCondition )
+          #set( $entityValues = 0 )
+          #foreach( $argEntity in $ctx.args.owner.get(\\"eq\\") )
+            #if( $ownerClaimsList0.contains($argEntity) )
+              #set( $entityValues = $entityValues + 1 )
+            #end
+          #end
+          #if( $entityValues == $ctx.args.owner.get(\\"eq\\").size() )
+            #set( $ownerCondition = true )
+          #end
+        #end
+      #end
+      #if( $ownerCondition )
+        #set( $isAuthorized = true )
+        $util.qr($ctx.stash.put(\\"authFilter\\", null))
+      #end
+    #else
+      $util.qr($primaryFieldMap.put(\\"owner\\", $ownerClaimsList0))
+    #end
+  #end
+  #if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && !$primaryFieldMap.isEmpty() )
+    #foreach( $entry in $primaryFieldMap.entrySet() )
+      $util.qr($ctx.args.put($entry.key, $entry.value))
+      #set( $isAuthorized = true )
+    #end
+  #end
+#end
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) )
+$util.unauthorized()
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Authorization Steps. **"
+`;
+
+exports[`owner based @auth sort key fields on @auth owner field sortKeyFields of global secondary index handles ownerfield as GSI field with username identity claim  1`] = `
+"## [Start] Authorization Steps. **
+$util.qr($ctx.stash.put(\\"hasAuth\\", true))
+#set( $isAuthorized = false )
+#set( $primaryFieldMap = {} )
+#if( $util.authType() == \\"User Pool Authorization\\" )
+  #set( $ownerClaim = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), null)) )
+  #if( !$util.isNull($ownerClaim) )
+
+    #set( $ownerClaimsList0 = [] )
+    #if( $util.isString($ownerClaim) )
+      #if( $util.isList($util.parseJson($ownerClaim)) )
+        #set( $ownerClaim = $util.parseJson($ownerClaim) )
+      #else
+        #set( $ownerClaim = [$ownerClaim] )
+      #end
+    #end
+    $util.qr($ownerClaimsList0.addAll($ownerClaim))
+    #if( !$util.isNull($ctx.args.owner) )
+      #if( $util.isString($ctx.args.owner) )
+        #set( $ownerCondition = (($ownerClaim == $ctx.args.owner) || $ownerClaimsList0.contains($ctx.args.owner)) )
+      #else
+        #set( $ownerCondition = ($ownerClaim == $util.defaultIfNull($ctx.args.owner.get(\\"eq\\"), null) || $ownerClaimsList0.contains($util.defaultIfNull($ctx.args.owner.get(\\"eq\\"), null))) )
+        #if( !$ownerCondition )
+          #set( $entityValues = 0 )
+          #foreach( $argEntity in $ctx.args.owner.get(\\"eq\\") )
+            #if( $ownerClaimsList0.contains($argEntity) )
+              #set( $entityValues = $entityValues + 1 )
+            #end
+          #end
+          #if( $entityValues == $ctx.args.owner.get(\\"eq\\").size() )
+            #set( $ownerCondition = true )
+          #end
+        #end
+      #end
+      #if( $ownerCondition )
+        #set( $isAuthorized = true )
+        $util.qr($ctx.stash.put(\\"authFilter\\", null))
+      #end
+    #else
+      $util.qr($primaryFieldMap.put(\\"owner\\", $ownerClaim))
+    #end
+  #end
+  #if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && !$primaryFieldMap.isEmpty() )
+    #foreach( $entry in $primaryFieldMap.entrySet() )
+      $util.qr($ctx.args.put($entry.key, $entry.value))
+      #set( $isAuthorized = true )
+    #end
+  #end
+#end
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) )
+$util.unauthorized()
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Authorization Steps. **"
+`;
+
+exports[`owner based @auth sort key fields on @auth owner field sortKeyFields of global secondary index handles ownerfield as part of sortKeyFields of GSI with default identity claim  1`] = `
+"## [Start] Authorization Steps. **
+$util.qr($ctx.stash.put(\\"hasAuth\\", true))
+#set( $isAuthorized = false )
+#set( $primaryFieldMap = {} )
+#if( $util.authType() == \\"User Pool Authorization\\" )
+  #set( $ownerClaim = $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), null) )
+  #set( $currentClaim1 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), null)) )
+  #if( !$util.isNull($ownerClaim) && !$util.isNull($currentClaim1) )
+    #set( $ownerClaim = \\"$ownerClaim::$currentClaim1\\" )
+    #set( $ownerClaimsList0 = [] )
+    $util.qr($ownerClaimsList0.add($util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), null)))
+    $util.qr($ownerClaimsList0.add($util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), null))))
+    #if( $util.isString($ownerClaim) )
+      #if( $util.isList($util.parseJson($ownerClaim)) )
+        #set( $ownerClaim = $util.parseJson($ownerClaim) )
+      #else
+        #set( $ownerClaim = [$ownerClaim] )
+      #end
+    #end
+    $util.qr($ownerClaimsList0.addAll($ownerClaim))
+    #if( !$util.isNull($ctx.args.owner) )
+      #if( $util.isString($ctx.args.owner) )
+        #set( $ownerCondition = (($ownerClaim == $ctx.args.owner) || $ownerClaimsList0.contains($ctx.args.owner)) )
+      #else
+        #set( $ownerCondition = ($ownerClaim == $util.defaultIfNull($ctx.args.owner.get(\\"eq\\"), null) || $ownerClaimsList0.contains($util.defaultIfNull($ctx.args.owner.get(\\"eq\\"), null))) )
+        #if( !$ownerCondition )
+          #set( $entityValues = 0 )
+          #foreach( $argEntity in $ctx.args.owner.get(\\"eq\\") )
+            #if( $ownerClaimsList0.contains($argEntity) )
+              #set( $entityValues = $entityValues + 1 )
+            #end
+          #end
+          #if( $entityValues == $ctx.args.owner.get(\\"eq\\").size() )
+            #set( $ownerCondition = true )
+          #end
+        #end
+      #end
+      #if( $ownerCondition )
+        #set( $isAuthorized = true )
+        $util.qr($ctx.stash.put(\\"authFilter\\", null))
+      #end
+    #else
+      $util.qr($primaryFieldMap.put(\\"owner\\", $ownerClaimsList0))
+    #end
+  #end
+  #if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && !$primaryFieldMap.isEmpty() )
+    #set( $sortKeyFields = [\\"owner\\"] )
+    #foreach( $entry in $primaryFieldMap.entrySet() )
+      #if( $sortKeyFields.contains($entry.key) )
+        #set( $entryVal = $entry.value )
+        #set( $lastIdx = $entryVal.size() - 1 )
+        #set( $lastItem = $entryVal.get($lastIdx) )
+        $util.qr($ctx.args.put($entry.key, {
+  \\"eq\\": $lastItem
+}))
+      #else
+        $util.qr($ctx.args.put($entry.key, $entry.value))
+      #end
+      #set( $isAuthorized = true )
+    #end
+  #end
+#end
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) )
+$util.unauthorized()
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Authorization Steps. **"
+`;
+
+exports[`owner based @auth sort key fields on @auth owner field sortKeyFields of global secondary index handles ownerfield as part of sortKeyFields of GSI with username identity claim  1`] = `
+"## [Start] Authorization Steps. **
+$util.qr($ctx.stash.put(\\"hasAuth\\", true))
+#set( $isAuthorized = false )
+#set( $primaryFieldMap = {} )
+#if( $util.authType() == \\"User Pool Authorization\\" )
+  #set( $ownerClaim = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), null)) )
+  #if( !$util.isNull($ownerClaim) )
+
+    #set( $ownerClaimsList0 = [] )
+    #if( $util.isString($ownerClaim) )
+      #if( $util.isList($util.parseJson($ownerClaim)) )
+        #set( $ownerClaim = $util.parseJson($ownerClaim) )
+      #else
+        #set( $ownerClaim = [$ownerClaim] )
+      #end
+    #end
+    $util.qr($ownerClaimsList0.addAll($ownerClaim))
+    #if( !$util.isNull($ctx.args.owner) )
+      #if( $util.isString($ctx.args.owner) )
+        #set( $ownerCondition = (($ownerClaim == $ctx.args.owner) || $ownerClaimsList0.contains($ctx.args.owner)) )
+      #else
+        #set( $ownerCondition = ($ownerClaim == $util.defaultIfNull($ctx.args.owner.get(\\"eq\\"), null) || $ownerClaimsList0.contains($util.defaultIfNull($ctx.args.owner.get(\\"eq\\"), null))) )
+        #if( !$ownerCondition )
+          #set( $entityValues = 0 )
+          #foreach( $argEntity in $ctx.args.owner.get(\\"eq\\") )
+            #if( $ownerClaimsList0.contains($argEntity) )
+              #set( $entityValues = $entityValues + 1 )
+            #end
+          #end
+          #if( $entityValues == $ctx.args.owner.get(\\"eq\\").size() )
+            #set( $ownerCondition = true )
+          #end
+        #end
+      #end
+      #if( $ownerCondition )
+        #set( $isAuthorized = true )
+        $util.qr($ctx.stash.put(\\"authFilter\\", null))
+      #end
+    #else
+      $util.qr($primaryFieldMap.put(\\"owner\\", $ownerClaim))
+    #end
+  #end
+  #if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) && !$primaryFieldMap.isEmpty() )
+    #set( $sortKeyFields = [\\"owner\\"] )
+    #foreach( $entry in $primaryFieldMap.entrySet() )
+      #if( $sortKeyFields.contains($entry.key) )
+        #set( $entryVal = $entry.value )
+        #set( $lastIdx = $entryVal.size() - 1 )
+        #set( $lastItem = $entryVal.get($lastIdx) )
+        $util.qr($ctx.args.put($entry.key, {
+  \\"eq\\": $lastItem
+}))
+      #else
+        $util.qr($ctx.args.put($entry.key, $entry.value))
+      #end
+      #set( $isAuthorized = true )
+    #end
+  #end
+#end
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) )
+$util.unauthorized()
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Authorization Steps. **"
+`;
+
 exports[`owner based @auth with identity claim feature flag disabled owner field where the field is a list 1`] = `
 "## [Start] Authorization Steps. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
@@ -1142,6 +1142,141 @@ describe('owner based @auth', () => {
         "The primary key's sort key type 'myOwnerField' cannot be used as an owner @auth field too. Please use another field for the sort key.",
       );
     });
+
+    describe.only('sortKeyFields of global secondary index', () => {
+      test('handles ownerfield as part of sortKeyFields of GSI with default identity claim ', () => {
+        const schema = `
+          type Note @model @auth(rules: [{ allow: owner }]) 
+          {  
+            noteId: String! @primaryKey
+            noteType: String! @index(name: "byNoteType", queryField: "notesByNoteTypeAndOwner", sortKeyFields:["owner"])  
+            content: String
+            owner: String
+          }
+        `;
+
+        const transformer = new GraphQLTransform({
+          authConfig,
+          transformers: [
+            new ModelTransformer(),
+            new PrimaryKeyTransformer(),
+            new AuthTransformer(),
+            new IndexTransformer(),
+          ],
+          featureFlags: ({
+            getBoolean: (featureName: string, defaultValue: boolean) => {
+              if (featureName === 'useSubUsernameForDefaultIdentityClaim') {
+                return true;
+              }
+
+              return defaultValue;
+            },
+          } as FeatureFlagProvider),
+        });
+
+        const out = transformer.transform(schema);
+        expect(out.resolvers['Note.notesByNoteTypeAndOwner.auth.1.req.vtl']).toMatchSnapshot();
+      });
+      test('handles ownerfield as part of sortKeyFields of GSI with username identity claim ', () => {
+        const schema = `
+          type Note @model @auth(rules: [{ allow: owner, identityClaim: "username" }]) 
+          {  
+            noteId: String! @primaryKey
+            noteType: String! @index(name: "byNoteType", queryField: "notesByNoteTypeAndOwner", sortKeyFields:["owner"])  
+            content: String
+            owner: String
+          }
+        `;
+
+        const transformer = new GraphQLTransform({
+          authConfig,
+          transformers: [
+            new ModelTransformer(),
+            new PrimaryKeyTransformer(),
+            new AuthTransformer(),
+            new IndexTransformer(),
+          ],
+          featureFlags: ({
+            getBoolean: (featureName: string, defaultValue: boolean) => {
+              if (featureName === 'useSubUsernameForDefaultIdentityClaim') {
+                return true;
+              }
+
+              return defaultValue;
+            },
+          } as FeatureFlagProvider),
+        });
+
+        const out = transformer.transform(schema);
+        expect(out.resolvers['Note.notesByNoteTypeAndOwner.auth.1.req.vtl']).toMatchSnapshot();
+      });
+      test('handles ownerfield as GSI field with default identity claim ', () => {
+        const schema = `
+          type Note @model @auth(rules: [{ allow: owner }]) 
+          {  
+            noteId: String! @primaryKey
+            noteType: String!
+            content: String
+            owner: String! @index(name: "byOwner", queryField: "notesByOwner") 
+          }
+        `;
+
+        const transformer = new GraphQLTransform({
+          authConfig,
+          transformers: [
+            new ModelTransformer(),
+            new PrimaryKeyTransformer(),
+            new AuthTransformer(),
+            new IndexTransformer(),
+          ],
+          featureFlags: ({
+            getBoolean: (featureName: string, defaultValue: boolean) => {
+              if (featureName === 'useSubUsernameForDefaultIdentityClaim') {
+                return true;
+              }
+
+              return defaultValue;
+            },
+          } as FeatureFlagProvider),
+        });
+
+        const out = transformer.transform(schema);
+        expect(out.resolvers['Note.notesByOwner.auth.1.req.vtl']).toMatchSnapshot();
+      });
+      test('handles ownerfield as GSI field with username identity claim ', () => {
+        const schema = `
+          type Note @model @auth(rules: [{ allow: owner, identityClaim: "username" }]) 
+          {  
+            noteId: String! @primaryKey
+            noteType: String!
+            content: String
+            owner: String! @index(name: "byOwner", queryField: "notesByOwner") 
+          }
+        `;
+
+        const transformer = new GraphQLTransform({
+          authConfig,
+          transformers: [
+            new ModelTransformer(),
+            new PrimaryKeyTransformer(),
+            new AuthTransformer(),
+            new IndexTransformer(),
+          ],
+          featureFlags: ({
+            getBoolean: (featureName: string, defaultValue: boolean) => {
+              if (featureName === 'useSubUsernameForDefaultIdentityClaim') {
+                return true;
+              }
+
+              return defaultValue;
+            },
+          } as FeatureFlagProvider),
+        });
+
+        const out = transformer.transform(schema);
+        expect(out.resolvers['Note.notesByOwner.auth.1.req.vtl']).toMatchSnapshot();
+      });
+    })
   });
 
   describe('with populateOwnerFieldForStaticGroupAuth feature flag disabled', () => {

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
@@ -1143,7 +1143,7 @@ describe('owner based @auth', () => {
       );
     });
 
-    describe.only('sortKeyFields of global secondary index', () => {
+    describe('owner field as part of global secondary index', () => {
       test('handles ownerfield as part of sortKeyFields of GSI with default identity claim ', () => {
         const schema = `
           type Note @model @auth(rules: [{ allow: owner }]) 

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -586,13 +586,12 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     const resolver = ctx.resolvers.getResolver(typeName, fieldName) as TransformerResolverProvider;
     const roleDefinitions = acm.getRolesPerOperation('get').map((r) => this.roleMap.get(r)!);
     const tableKeySchema = getTable(ctx, def).keySchema;
-    const primaryFields = tableKeySchema.map((att) => att.attributeName);
     const primaryKey = getPartitionKey(tableKeySchema);
     const authExpression = generateAuthExpressionForQueries(
       this.configuredAuthProviders,
       roleDefinitions,
       def.fields ?? [],
-      primaryFields,
+      tableKeySchema,
       false,
       primaryKey,
     );
@@ -612,17 +611,18 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
   ): void => {
     const resolver = ctx.resolvers.getResolver(typeName, fieldName) as TransformerResolverProvider;
     const roleDefinitions = acm.getRolesPerOperation('list').map((r) => this.roleMap.get(r)!);
-    let primaryFields: Array<string>;
+    // let primaryFields: Array<string>;
+    let keySchema: any;
     let partitionKey: string;
     const table = getTable(ctx, def);
     try {
       if (indexName) {
         /* eslint-disable @typescript-eslint/no-explicit-any */
-        primaryFields = getKeySchema(table, indexName).map((att: any) => att.attributeName);
+        keySchema = getKeySchema(table,indexName);
         /* eslint-enable */
       } else {
         /* eslint-disable @typescript-eslint/no-explicit-any */
-        primaryFields = table.keySchema.map((att: any) => att.attributeName);
+        keySchema = table.keySchema;
         partitionKey = getPartitionKey(table.keySchema);
         /* eslint-enable */
       }
@@ -633,7 +633,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
       this.configuredAuthProviders,
       roleDefinitions,
       def.fields ?? [],
-      primaryFields,
+      keySchema,
       !!indexName,
       partitionKey,
     );
@@ -712,12 +712,12 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     if (ctx.isProjectUsingDataStore()) {
       const resolver = ctx.resolvers.getResolver(typeName, fieldName) as TransformerResolverProvider;
       const roleDefinitions = acm.getRolesPerOperation('sync').map((r) => this.roleMap.get(r)!);
-      const primaryFields = getTable(ctx, def).keySchema.map((att) => att.attributeName);
+      const keySchema = getTable(ctx, def).keySchema;
       const authExpression = generateAuthExpressionForQueries(
         this.configuredAuthProviders,
         roleDefinitions,
         def.fields ?? [],
-        primaryFields,
+        keySchema,
       );
       resolver.addToSlot(
         'auth',

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/IndexWithAuthV2WithFF.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/IndexWithAuthV2WithFF.e2e.test.ts
@@ -271,7 +271,7 @@ test('listX with primaryKey', async () => {
 
   listResponse = await listFamilyMembersByParent(GRAPHQL_CLIENT_2, { parent: USERNAME1 });
   items = listResponse.data.byParent.items;
-  expect(items).toHaveLength(2);
+  expect(items).toHaveLength(1);
   expect(items[0]).toEqual(
     expect.objectContaining({
       parent: USERNAME1,

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/IndexWithClaimFieldAsSortKeyAuth.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/IndexWithClaimFieldAsSortKeyAuth.e2e.test.ts
@@ -9,7 +9,7 @@ import { cleanupStackAfterTest, deploy } from "../deployNestedStacks";
 import { S3Client } from "../S3Client";
 import { S3, CognitoIdentityServiceProvider as CognitoClient } from "aws-sdk";
 import { default as moment } from "moment";
-import { authenticateUser, configureAmplify, createUserPool, createUserPoolClient, signupUser } from "../cognitoUtils";
+import { addUserToGroup, authenticateUser, configureAmplify, createGroup, createUserPool, createUserPoolClient, signupUser } from "../cognitoUtils";
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require("node-fetch");
 import { resolveTestRegion } from "../testSetup";
@@ -25,9 +25,9 @@ const customS3Client = new S3Client(region);
 const awsS3Client = new S3({ region: region });
 const cognitoClient = new CognitoClient({ apiVersion: "2016-04-19", region: region });
 const BUILD_TIMESTAMP = moment().format("YYYYMMDDHHmmss");
-const STACK_NAME = `IndexWithOwnerFieldAsSortKeyAuthTest-${BUILD_TIMESTAMP}`;
-const BUCKET_NAME = `appsync-index-with-owner-field-as-sk-test-${BUILD_TIMESTAMP}`;
-const LOCAL_FS_BUILD_DIR = "/tmp/index_owner_auth_transformer_tests/";
+const STACK_NAME = `IndexWithClaimFieldAsSortKeyAuthTest-${BUILD_TIMESTAMP}`;
+const BUCKET_NAME = `appsync-index-with-claim-field-as-sk-test-${BUILD_TIMESTAMP}`;
+const LOCAL_FS_BUILD_DIR = "/tmp/index_sortkey_auth_transformer_tests/";
 const S3_ROOT_DIR_KEY = "deployments";
 
 let GRAPHQL_ENDPOINT: string;
@@ -37,10 +37,16 @@ let USER_POOL_AUTH_CLIENT_2: AWSAppSyncClient<any>;
 
 let USER_POOL_ID: string;
 
+let USER_1_SUB: string;
+let USER_2_SUB: string;
+
 const USERNAME1 = "user1@test.com";
 const USERNAME2 = "user2@test.com";
 const TMP_PASSWORD = "Password123!";
 const REAL_PASSWORD = "Password1234!";
+
+const ADMIN_GROUP_NAME = 'Admin';
+const DEVS_GROUP_NAME = 'Devs';
 
 function outputValueSelector(key: string) {
   return (outputs: Output[]) => {
@@ -65,6 +71,13 @@ beforeAll(async () => {
       noteType: String! @index(name: "notesByNoteType", queryField:"note2sByNoteTypeAndOwner", sortKeyFields:["owner"])  
       owner: String
     } 
+    type Note3 @model
+    @auth(rules: [{ allow: groups, groupsField: "group" }])
+    {
+      noteId: String! @primaryKey
+      noteType: String! @index(name: "notesByNoteType", queryField:"note3sByNoteTypeAndGroup", sortKeyFields:["group"])  
+      group: String
+    }
   `;
   let out;
   try {
@@ -135,12 +148,17 @@ beforeAll(async () => {
     expect(GRAPHQL_ENDPOINT).toBeTruthy();
     expect(USER_POOL_ID).toBeTruthy();
     expect(userPoolClientId).toBeTruthy();
-
-    // Configure Amplify, create users, and sign in.
+    // Configure Amplify
     configureAmplify(USER_POOL_ID, userPoolClientId);
+    // Create groups
+    await createGroup(USER_POOL_ID, ADMIN_GROUP_NAME);
+    await createGroup(USER_POOL_ID, DEVS_GROUP_NAME);
+    // Sign up users, and sign in.
     await signupUser(USER_POOL_ID, USERNAME1, TMP_PASSWORD);
+    await addUserToGroup(ADMIN_GROUP_NAME, USERNAME1, USER_POOL_ID);
     const authRes1 = await authenticateUser(USERNAME1, TMP_PASSWORD, REAL_PASSWORD);
     const idToken1 = authRes1.getIdToken().getJwtToken();
+    USER_1_SUB = authRes1.idToken.payload.sub;
     USER_POOL_AUTH_CLIENT_1 = new AWSAppSyncClient({
       url: GRAPHQL_ENDPOINT,
       region,
@@ -151,8 +169,10 @@ beforeAll(async () => {
       disableOffline: true
     });
     await signupUser(USER_POOL_ID, USERNAME2, TMP_PASSWORD);
+    await addUserToGroup(DEVS_GROUP_NAME, USERNAME2, USER_POOL_ID);
     const authRes2 = await authenticateUser(USERNAME2, TMP_PASSWORD, REAL_PASSWORD);
     const idToken2 = authRes2.getIdToken().getJwtToken();
+    USER_2_SUB = authRes2.idToken.payload.sub;
     USER_POOL_AUTH_CLIENT_2 = new AWSAppSyncClient({
       url: GRAPHQL_ENDPOINT,
       region,
@@ -180,10 +200,20 @@ test("when identity claim is sub::username, user1 should not access user2 record
   await createNote1(USER_POOL_AUTH_CLIENT_1, { noteId: "i1-u1", noteType: "t1" });
   await createNote1(USER_POOL_AUTH_CLIENT_1, { noteId: "i2-u1", noteType: "t1" });
   await createNote1(USER_POOL_AUTH_CLIENT_1, { noteId: "i3-u1", noteType: "t1" });
-  await createNote1(USER_POOL_AUTH_CLIENT_2, { noteId: "i1-i2", noteType: "t1" });
+  await createNote1(USER_POOL_AUTH_CLIENT_2, { noteId: "i1-u2", noteType: "t1" });
 
+  let resultItems;
+  // query without sk
   const note1IndexQueryResponse = await note1ByNoteTypeAndOwner(USER_POOL_AUTH_CLIENT_1, { noteType: 't1' });
-  const resultItems = note1IndexQueryResponse.data.note1sByNoteTypeAndOwner.items;
+  resultItems = note1IndexQueryResponse.data.note1sByNoteTypeAndOwner.items;
+  expect(resultItems).toBeDefined();
+  expect(resultItems.filter(item => item.owner === USERNAME1).length).toBe(3);
+  expect(resultItems.filter(item => item.owner === USERNAME2).length).toBe(0);
+  // query with sk
+  const note1IndexQueryWithSortKeyResponse = await note1ByNoteTypeAndOwner(
+    USER_POOL_AUTH_CLIENT_1, { noteType: 't1', owner: { eq: `${USER_1_SUB}::${USERNAME1}` } }
+    );
+  resultItems = note1IndexQueryWithSortKeyResponse.data.note1sByNoteTypeAndOwner.items;
   expect(resultItems).toBeDefined();
   expect(resultItems.filter(item => item.owner === USERNAME1).length).toBe(3);
   expect(resultItems.filter(item => item.owner === USERNAME2).length).toBe(0);
@@ -193,13 +223,42 @@ test("when identity claim is username, user1 should not access user2 records whe
   await createNote2(USER_POOL_AUTH_CLIENT_1, { noteId: "i1-u1", noteType: "t1", owner: USERNAME1 });
   await createNote2(USER_POOL_AUTH_CLIENT_1, { noteId: "i2-u1", noteType: "t1", owner: USERNAME1 });
   await createNote2(USER_POOL_AUTH_CLIENT_1, { noteId: "i3-u1", noteType: "t1", owner: USERNAME1 });
-  await createNote2(USER_POOL_AUTH_CLIENT_2, { noteId: "i1-i2", noteType: "t1", owner: USERNAME2 });
-
+  await createNote2(USER_POOL_AUTH_CLIENT_2, { noteId: "i1-u2", noteType: "t1", owner: USERNAME2 });
+  
+  let resultItems;
   const note2IndexQueryResponse = await note2ByNoteTypeAndOwner(USER_POOL_AUTH_CLIENT_1, { noteType: 't1' });
-  const resultItems = note2IndexQueryResponse.data.note2sByNoteTypeAndOwner.items;
+  resultItems = note2IndexQueryResponse.data.note2sByNoteTypeAndOwner.items;
   expect(resultItems).toBeDefined();
   expect(resultItems.filter(item => item.owner === USERNAME1).length).toBe(3);
   expect(resultItems.filter(item => item.owner === USERNAME2).length).toBe(0);
+  const note2IndexQueryWithSortKeyResponse = await note2ByNoteTypeAndOwner(
+    USER_POOL_AUTH_CLIENT_1, { noteType: 't1', owner: { eq: USERNAME1 } }
+    );
+  resultItems = note2IndexQueryWithSortKeyResponse.data.note2sByNoteTypeAndOwner.items;
+  expect(resultItems).toBeDefined();
+  expect(resultItems.filter(item => item.owner === USERNAME1).length).toBe(3);
+  expect(resultItems.filter(item => item.owner === USERNAME2).length).toBe(0);
+});
+
+test("when dynamic group auth is applied, user1 should not access user2 records when logging in with user1 and querying with GSI ", async () => {
+  await createNote3(USER_POOL_AUTH_CLIENT_1, { noteId: "i1-u1", noteType: "t1", group: ADMIN_GROUP_NAME });
+  await createNote3(USER_POOL_AUTH_CLIENT_1, { noteId: "i2-u1", noteType: "t1", group: ADMIN_GROUP_NAME });
+  await createNote3(USER_POOL_AUTH_CLIENT_1, { noteId: "i3-u1", noteType: "t1", group: ADMIN_GROUP_NAME });
+  await createNote3(USER_POOL_AUTH_CLIENT_2, { noteId: "i1-u2", noteType: "t1", group: DEVS_GROUP_NAME });
+  
+  let resultItems;
+  const note3IndexQueryResponse = await note3ByNoteTypeAndGroup(USER_POOL_AUTH_CLIENT_1, { noteType: 't1' });
+  resultItems = note3IndexQueryResponse.data.note3sByNoteTypeAndGroup.items;
+  expect(resultItems).toBeDefined();
+  expect(resultItems.filter(item => item.group === ADMIN_GROUP_NAME).length).toBe(3);
+  expect(resultItems.filter(item => item.group === DEVS_GROUP_NAME).length).toBe(0);
+  const note3IndexQueryWithSortKeyResponse = await note3ByNoteTypeAndGroup(
+    USER_POOL_AUTH_CLIENT_1, { noteType: 't1', group: { eq: ADMIN_GROUP_NAME } }
+    );
+  resultItems = note3IndexQueryWithSortKeyResponse.data.note3sByNoteTypeAndGroup.items;
+  expect(resultItems).toBeDefined();
+  expect(resultItems.filter(item => item.group === ADMIN_GROUP_NAME).length).toBe(3);
+  expect(resultItems.filter(item => item.group === DEVS_GROUP_NAME).length).toBe(0);
 });
 
 /**
@@ -247,14 +306,35 @@ const createNote2 = async (
   });
   return result;
 }
+const createNote3 = async (
+  client: AWSAppSyncClient<any>, 
+  variables: { noteId: string, noteType: string, group: string },
+  ): Promise<any> => {
+  const result = await client.mutate<any>({
+    mutation: gql`
+      mutation CreateNote3($input: CreateNote3Input!){
+        createNote3(input: $input) {
+            noteId
+            noteType
+            group
+        }
+      }
+    `,
+    variables: {
+      input: variables
+    },
+    fetchPolicy: "no-cache"
+  });
+  return result;
+}
 const note1ByNoteTypeAndOwner = async (
   client: AWSAppSyncClient<any>,
-  variables: { noteType: string },
+  variables: { noteType: string, owner?: { eq?: string } },
 ): Promise<any> => {
   const result = await client.query<any>({
     query: gql`
-      query Note1ByNoteTypeAndOwner($noteType: String!) {
-        note1sByNoteTypeAndOwner(noteType: $noteType) {
+      query Note1ByNoteTypeAndOwner($noteType: String!, $owner: ModelStringKeyConditionInput) {
+        note1sByNoteTypeAndOwner(noteType: $noteType, owner: $owner) {
           items {
             noteId
             noteType
@@ -269,16 +349,36 @@ const note1ByNoteTypeAndOwner = async (
 }
 const note2ByNoteTypeAndOwner = async (
   client: AWSAppSyncClient<any>,
-  variables: { noteType: string },
+  variables: { noteType: string, owner?: { eq?: string } },
 ): Promise<any> => {
   const result = await client.query<any>({
     query: gql`
-      query Note2ByNoteTypeAndOwner($noteType: String!) {
-        note2sByNoteTypeAndOwner(noteType: $noteType) {
+      query Note2ByNoteTypeAndOwner($noteType: String!, $owner: ModelStringKeyConditionInput) {
+        note2sByNoteTypeAndOwner(noteType: $noteType, owner: $owner) {
           items {
             noteId
             noteType
             owner
+          }
+        }
+      }
+    `,
+    variables,
+  });
+  return result;
+}
+const note3ByNoteTypeAndGroup = async (
+  client: AWSAppSyncClient<any>,
+  variables: { noteType: string, group?: { eq?: string } },
+): Promise<any> => {
+  const result = await client.query<any>({
+    query: gql`
+      query Note3ByNoteTypeAndGroup($noteType: String!, $group: ModelStringKeyConditionInput) {
+        note3sByNoteTypeAndGroup(noteType: $noteType, group: $group) {
+          items {
+            noteId
+            noteType
+            group
           }
         }
       }

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/IndexWithOwnerFieldAsSortKeyAuth.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/IndexWithOwnerFieldAsSortKeyAuth.e2e.test.ts
@@ -1,0 +1,289 @@
+import { IndexTransformer, PrimaryKeyTransformer } from "@aws-amplify/graphql-index-transformer";
+import { ModelTransformer } from "@aws-amplify/graphql-model-transformer";
+import { AuthTransformer } from "@aws-amplify/graphql-auth-transformer";
+import { GraphQLTransform } from "@aws-amplify/graphql-transformer-core";
+import { ResourceConstants } from "graphql-transformer-common";
+import { CloudFormationClient } from "../CloudFormationClient";
+import { Output } from "aws-sdk/clients/cloudformation";
+import { cleanupStackAfterTest, deploy } from "../deployNestedStacks";
+import { S3Client } from "../S3Client";
+import { S3, CognitoIdentityServiceProvider as CognitoClient } from "aws-sdk";
+import { default as moment } from "moment";
+import { authenticateUser, configureAmplify, createUserPool, createUserPoolClient, signupUser } from "../cognitoUtils";
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require("node-fetch");
+import { resolveTestRegion } from "../testSetup";
+import AWSAppSyncClient, { AUTH_TYPE } from "aws-appsync";
+import gql from "graphql-tag";
+
+const region = resolveTestRegion();
+
+jest.setTimeout(2000000);
+
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
+const cognitoClient = new CognitoClient({ apiVersion: "2016-04-19", region: region });
+const BUILD_TIMESTAMP = moment().format("YYYYMMDDHHmmss");
+const STACK_NAME = `IndexWithOwnerFieldAsSortKeyAuthTest-${BUILD_TIMESTAMP}`;
+const BUCKET_NAME = `appsync-index-with-owner-field-as-sk-test-${BUILD_TIMESTAMP}`;
+const LOCAL_FS_BUILD_DIR = "/tmp/index_owner_auth_transformer_tests/";
+const S3_ROOT_DIR_KEY = "deployments";
+
+let GRAPHQL_ENDPOINT: string;
+
+let USER_POOL_AUTH_CLIENT_1: AWSAppSyncClient<any>;
+let USER_POOL_AUTH_CLIENT_2: AWSAppSyncClient<any>;
+
+let USER_POOL_ID: string;
+
+const USERNAME1 = "user1@test.com";
+const USERNAME2 = "user2@test.com";
+const TMP_PASSWORD = "Password123!";
+const REAL_PASSWORD = "Password1234!";
+
+function outputValueSelector(key: string) {
+  return (outputs: Output[]) => {
+    const output = outputs.find((o: Output) => o.OutputKey === key);
+    return output ? output.OutputValue : null;
+  };
+}
+
+beforeAll(async () => {
+  const validSchema = `
+    type Note1 @model
+    @auth(rules: [{ allow: owner }]) 
+    {  
+      noteId: String! @primaryKey
+      noteType: String! @index(name: "notesByNoteType", queryField:"note1sByNoteTypeAndOwner", sortKeyFields:["owner"])  
+      owner: String
+    }
+    type Note2 @model
+    @auth(rules: [{ allow: owner, identityClaim: "username" }]) 
+    {  
+      noteId: String! @primaryKey
+      noteType: String! @index(name: "notesByNoteType", queryField:"note2sByNoteTypeAndOwner", sortKeyFields:["owner"])  
+      owner: String
+    } 
+  `;
+  let out;
+  try {
+    const modelTransformer = new ModelTransformer();
+    const indexTransformer = new IndexTransformer();
+    const authTransformer = new AuthTransformer();
+    const primaryKeyTransformer = new PrimaryKeyTransformer();
+    const transformer = new GraphQLTransform({
+      authConfig: {
+        defaultAuthentication: {
+          authenticationType: "AMAZON_COGNITO_USER_POOLS"
+        },
+        additionalAuthenticationProviders: []
+      },
+      transformers: [modelTransformer, primaryKeyTransformer, indexTransformer, authTransformer],
+      featureFlags: {
+        getBoolean(value: string) {
+          if (value === "useSubUsernameForDefaultIdentityClaim") {
+            return true;
+          } else if (value === "secondaryKeyAsGSI") {
+            return true;
+          }
+          return false;
+        },
+        getNumber: jest.fn(),
+        getObject: jest.fn()
+      }
+    });
+    out = transformer.transform(validSchema);
+  } catch (e) {
+    console.error(`Failed to transform schema: ${e}`);
+    expect(true).toEqual(false);
+  }
+  try {
+    await awsS3Client
+      .createBucket({
+        Bucket: BUCKET_NAME
+      })
+      .promise();
+  } catch (e) {
+    console.error(`Failed to create S3 bucket: ${e}`);
+    expect(true).toEqual(false);
+  }
+  const userPoolResponse = await createUserPool(cognitoClient, `UserPool${STACK_NAME}`);
+  USER_POOL_ID = userPoolResponse.UserPool?.Id!;
+  const userPoolClientResponse = await createUserPoolClient(cognitoClient, USER_POOL_ID, `UserPool${STACK_NAME}`);
+  const userPoolClientId = userPoolClientResponse.UserPoolClient?.ClientId!;
+  try {
+    const finishedStack = await deploy(
+      customS3Client,
+      cf,
+      STACK_NAME,
+      out,
+      { AuthCognitoUserPoolId: USER_POOL_ID },
+      LOCAL_FS_BUILD_DIR,
+      BUCKET_NAME,
+      S3_ROOT_DIR_KEY,
+      BUILD_TIMESTAMP
+    );
+    expect(finishedStack).toBeDefined();
+    const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput);
+    const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput);
+    const apiKey = getApiKey(finishedStack.Outputs!);
+    GRAPHQL_ENDPOINT = getApiEndpoint(finishedStack.Outputs!)!;
+    expect(apiKey).not.toBeTruthy();
+
+    // Verify we have all the details
+    expect(GRAPHQL_ENDPOINT).toBeTruthy();
+    expect(USER_POOL_ID).toBeTruthy();
+    expect(userPoolClientId).toBeTruthy();
+
+    // Configure Amplify, create users, and sign in.
+    configureAmplify(USER_POOL_ID, userPoolClientId);
+    await signupUser(USER_POOL_ID, USERNAME1, TMP_PASSWORD);
+    const authRes1 = await authenticateUser(USERNAME1, TMP_PASSWORD, REAL_PASSWORD);
+    const idToken1 = authRes1.getIdToken().getJwtToken();
+    USER_POOL_AUTH_CLIENT_1 = new AWSAppSyncClient({
+      url: GRAPHQL_ENDPOINT,
+      region,
+      auth: {
+        type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
+        jwtToken: () => idToken1
+      },
+      disableOffline: true
+    });
+    await signupUser(USER_POOL_ID, USERNAME2, TMP_PASSWORD);
+    const authRes2 = await authenticateUser(USERNAME2, TMP_PASSWORD, REAL_PASSWORD);
+    const idToken2 = authRes2.getIdToken().getJwtToken();
+    USER_POOL_AUTH_CLIENT_2 = new AWSAppSyncClient({
+      url: GRAPHQL_ENDPOINT,
+      region,
+      auth: {
+        type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
+        jwtToken: () => idToken2
+      },
+      disableOffline: true
+    });
+  } catch (e) {
+    console.error(e);
+    expect(true).toEqual(false);
+  }
+});
+
+afterAll(async () => {
+  await cleanupStackAfterTest(BUCKET_NAME, STACK_NAME, cf, { cognitoClient, userPoolId: USER_POOL_ID });
+});
+
+/**
+ * Test queries below
+ */
+
+test("when identity claim is sub::username, user1 should not access user2 records when logging in with user1 and querying with GSI ", async () => {
+  await createNote1(USER_POOL_AUTH_CLIENT_1, { noteId: "i1-u1", noteType: "t1" });
+  await createNote1(USER_POOL_AUTH_CLIENT_1, { noteId: "i2-u1", noteType: "t1" });
+  await createNote1(USER_POOL_AUTH_CLIENT_1, { noteId: "i3-u1", noteType: "t1" });
+  await createNote1(USER_POOL_AUTH_CLIENT_2, { noteId: "i1-i2", noteType: "t1" });
+
+  const note1IndexQueryResponse = await note1ByNoteTypeAndOwner(USER_POOL_AUTH_CLIENT_1, { noteType: 't1' });
+  const resultItems = note1IndexQueryResponse.data.note1sByNoteTypeAndOwner.items;
+  expect(resultItems).toBeDefined();
+  expect(resultItems.filter(item => item.owner === USERNAME1).length).toBe(3);
+  expect(resultItems.filter(item => item.owner === USERNAME2).length).toBe(0);
+});
+
+test("when identity claim is username, user1 should not access user2 records when logging in with user1 and querying with GSI ", async () => {
+  await createNote2(USER_POOL_AUTH_CLIENT_1, { noteId: "i1-u1", noteType: "t1", owner: USERNAME1 });
+  await createNote2(USER_POOL_AUTH_CLIENT_1, { noteId: "i2-u1", noteType: "t1", owner: USERNAME1 });
+  await createNote2(USER_POOL_AUTH_CLIENT_1, { noteId: "i3-u1", noteType: "t1", owner: USERNAME1 });
+  await createNote2(USER_POOL_AUTH_CLIENT_2, { noteId: "i1-i2", noteType: "t1", owner: USERNAME2 });
+
+  const note2IndexQueryResponse = await note2ByNoteTypeAndOwner(USER_POOL_AUTH_CLIENT_1, { noteType: 't1' });
+  const resultItems = note2IndexQueryResponse.data.note2sByNoteTypeAndOwner.items;
+  expect(resultItems).toBeDefined();
+  expect(resultItems.filter(item => item.owner === USERNAME1).length).toBe(3);
+  expect(resultItems.filter(item => item.owner === USERNAME2).length).toBe(0);
+});
+
+/**
+ * Helper function
+ */
+const createNote1 = async (
+  client: AWSAppSyncClient<any>, 
+  variables: { noteId: string, noteType: string },
+  ): Promise<any> => {
+  const result = await client.mutate<any>({
+    mutation: gql`
+      mutation CreateNote1($input: CreateNote1Input!){
+        createNote1(input: $input) {
+            noteId
+            noteType
+            owner
+        }
+      }
+    `,
+    variables: {
+      input: variables
+    },
+    fetchPolicy: "no-cache"
+  });
+  return result;
+}
+const createNote2 = async (
+  client: AWSAppSyncClient<any>, 
+  variables: { noteId: string, noteType: string, owner: string },
+  ): Promise<any> => {
+  const result = await client.mutate<any>({
+    mutation: gql`
+      mutation CreateNote2($input: CreateNote2Input!){
+        createNote2(input: $input) {
+            noteId
+            noteType
+            owner
+        }
+      }
+    `,
+    variables: {
+      input: variables
+    },
+    fetchPolicy: "no-cache"
+  });
+  return result;
+}
+const note1ByNoteTypeAndOwner = async (
+  client: AWSAppSyncClient<any>,
+  variables: { noteType: string },
+): Promise<any> => {
+  const result = await client.query<any>({
+    query: gql`
+      query Note1ByNoteTypeAndOwner($noteType: String!) {
+        note1sByNoteTypeAndOwner(noteType: $noteType) {
+          items {
+            noteId
+            noteType
+            owner
+          }
+        }
+      }
+    `,
+    variables,
+  });
+  return result;
+}
+const note2ByNoteTypeAndOwner = async (
+  client: AWSAppSyncClient<any>,
+  variables: { noteType: string },
+): Promise<any> => {
+  const result = await client.query<any>({
+    query: gql`
+      query Note2ByNoteTypeAndOwner($noteType: String!) {
+        note2sByNoteTypeAndOwner(noteType: $noteType) {
+          items {
+            noteId
+            noteType
+            owner
+          }
+        }
+      }
+    `,
+    variables,
+  });
+  return result;
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

- Pass the key schema infos when generating auth expressions
- Add owner/group auth field with `eq` when it is part of index sort key and missing in the args input
  - When the field is missing in input, it will retrieve the last item of claim list by default
- Add unit/e2e tests

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Unit & e2e tests
AppSync Console testing
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
