### PR TITLE
fix: container resource name input validation pattern

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/containers-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/containers-walkthrough.ts
@@ -68,7 +68,7 @@ async function askResourceName(context: $TSContext, allDefaultValues: $TSObject)
       validate: amplify.inputValidation({
         validation: {
           operator: 'regex',
-          value: '^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*$',
+          value: '^[a-z0-9]+$',
           onErrorMsg: 'Resource name should be alphanumeric with no uppercase letters',
         },
         required: true,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Fixed container resource name input validation pattern to allow only alphanumeric with no uppercase letters.


#### Issue #, if available

#1489

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- Unit Testing (yarn test)
- Manual Testing
  - amplify-dev api add

```
amplify-dev add api    
? Select from one of the below mentioned services: REST
? Which service would you like to use API Gateway + AWS Fargate (Container-based)
? Provide a friendly name for your resource to be used as a label for this category in the project: test-container
>> Resource name should be alphanumeric with no uppercase letters
```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
