### PR TITLE
fix: use node18 instead of default image for all pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ parameters:
 executors:
   linux: &linux-e2e-executor
     docker:
-      - image: public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:latest
+      - image: public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:node18
     working_directory: ~/repo
     resource_class: large
     environment:
@@ -77,7 +77,7 @@ jobs:
             equal:
               - docker:
                   - image: >-
-                      public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:latest
+                      public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:node18
                 working_directory: ~/repo
                 resource_class: large
                 environment:
@@ -90,7 +90,7 @@ jobs:
                 paths: .
   cleanup_resources:
     docker:
-      - image: public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:latest
+      - image: public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:node18
     working_directory: ~/repo
     resource_class: large
     environment:
@@ -122,7 +122,7 @@ jobs:
           path: ~/repo/packages/amplify-e2e-tests/amplify-e2e-reports
   publish_to_local_registry:
     docker:
-      - image: public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:latest
+      - image: public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:node18
     working_directory: ~/repo
     resource_class: large
     environment:


### PR DESCRIPTION
#### Description of changes
use node18 instead of default image for all pipelines - this should address canary/e2e-resource-cleanup failures like [this failing canary run](https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api/6584/workflows/a977d4b9-e9b8-448d-aaa7-4eef0bb67ffb/jobs/129925)

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Running workflows from this branch:
* [Canary](https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api/6602/workflows/6b895792-4af2-45f6-8aa8-f1ca896dae24)
* [E2E Resource Cleanup](https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api/6603/workflows/972f8cc2-a991-4dae-bae2-40f718864942)

#### Checklist
- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
