### PR TITLE
Fix: Remplace {x} by * in api-gw Invoke IAM Policy

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
@@ -94,7 +94,8 @@ export class AmplifyApigwResourceStack extends cdk.Stack implements AmplifyApigw
 
   // eslint-disable-next-line class-methods-use-this
   private _craftPolicyDocument(apiResourceName: string, pathName: string, supportedOperations: string[]) {
-    const paths = [pathName, appendToUrlPath(pathName, '*')];
+    const iamPathName = pathName.replace(/{[a-zA-Z0-9-]+}/g, '*');
+    const paths = [iamPathName, appendToUrlPath(iamPathName, '*')];
     const resources = paths.flatMap((path) => supportedOperations.map((op) => cdk.Fn.join('', [
       'arn:aws:execute-api:',
       cdk.Fn.ref('AWS::Region'),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

When I create a REST API with path parameters + filtering by individual groups, the paths generated at the level of the IAM policies `execute-api:Invoke` for the Cognito groups contains the declaration of the path parameters as is (in the form "`{param}`" ) :

``` json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Action": "execute-api:Invoke",
            "Resource": [
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/POST/book/{isbn}",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/GET/book/{isbn}",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/PUT/book/{isbn}",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/PATCH/book/{isbn}",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/DELETE/book/{isbn}",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/POST/book/{isbn}/*",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/GET/book/{isbn}/*",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/PUT/book/{isbn}/*",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/PATCH/book/{isbn}/*",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/DELETE/book/{isbn}/*"
            ],
            "Effect": "Allow"
        }
    ]
}
```

Consequently, access to the API is denied, since IAM parses the path in a raw way :

`User: arn:aws:sts::******:assumed-role/******-adminGroupRole/CognitoIdentityCredentials is not authorized to perform: execute-api:Invoke on resource: arn:aws:execute-api:eu-west-3:********2399:******/staging/GET/book/f2e457ad-2e6a-4231-bb4f-5d891c38213e`

My modification is to replace the path parameters with "`*`" (I don't see any other solution) :

``` json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Action": "execute-api:Invoke",
            "Resource": [
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/POST/book/*",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/GET/book/*",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/PUT/book/*",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/PATCH/book/*",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/DELETE/book/*",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/POST/book/*/*",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/GET/book/*}/*",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/PUT/book/*/*",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/PATCH/book/*/*",
                "arn:aws:execute-api:eu-west-3:********2399:n4********/staging/DELETE/book/*/*"
            ],
            "Effect": "Allow"
        }
    ]
}
```

I found that a similar bug was fixed in 2020, but in the aws-amplify repository: https://github.com/aws-amplify/amplify-cli/pull/5092.

##### CDK / CloudFormation Parameters Changed

No CDK / CloudFormation Parameters Change.

#### Issue #, if available

No associated issue.

#### Description of how you validated changes
- Deployment of several REST APIs with different paths and permissions.
- Control of generated IAM policies.
- Checking correct API access with the Cognito user if access should be granted, and denial if not allowed.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
