### PR TITLE
chore: adding depcheck step to post-commit hook

### DIFF
--- a/depcheck.config.js
+++ b/depcheck.config.js
@@ -1,0 +1,78 @@
+/**
+ * README
+ * This file contains a subset of critical dependency validation rules for the transformer packages.
+ * There are certain dependencies we need to be careful of introducing as we refactor the transformers,
+ * including access to @aws-amplify/* namespaced packages (namely core, printer),
+ * but we also wish to limit imports to `fs`, and a few other particular places.
+ */
+
+// List of v2 transformer directories.
+const GQL_V2_TRANSFORMER_PACKAGES = [
+  'amplify-graphql-auth-transformer',
+  'amplify-graphql-default-value-transformer',
+  'amplify-graphql-function-transformer',
+  'amplify-graphql-http-transformer',
+  'amplify-graphql-index-transformer',
+  'amplify-graphql-maps-to-transformer',
+  'amplify-graphql-model-transformer',
+  'amplify-graphql-predictions-transformer',
+  'amplify-graphql-relational-transformer',
+  'amplify-graphql-searchable-transformer',
+  'amplify-graphql-transformer-core',
+  'amplify-graphql-transformer-interfaces',
+  'graphql-transformer-common',
+  'graphql-mapping-template',
+];
+
+const TRANSFORMER_RESTRICTED_IMPORTS = [
+  'fs',
+  'fs-extra',
+  '@aws-amplify/amplify-cli-core',
+  '@aws-amplify/amplify-prompts',
+];
+
+module.exports = {
+  parser: '@typescript-eslint/parser', // Specifies the ESLint parser
+  env: {
+    es6: true,
+    node: true,
+    jest: true,
+  },
+  parserOptions: {
+    ecmaVersion: 2020, // Allows for the parsing of modern ECMAScript features
+    sourceType: 'module', // Allows for the use of imports
+    ecmaFeatures: {
+      arrowFunctions: true,
+      modules: true,
+      module: true,
+    },
+    project: ['tsconfig.base.json'],
+  },
+  plugins: ['@typescript-eslint'],
+  settings: {
+    'import/parsers': { '@typescript-eslint/parser': ['.ts', '.tsx'] },
+    'import/resolver': { typescript: {} },
+  },
+  ignorePatterns: [
+    '__tests__/**',
+    '*.test.ts',
+    'lib/**',
+    'node_modules',
+    '*/node_modules',
+  ],
+  overrides: [
+    {
+      files: GQL_V2_TRANSFORMER_PACKAGES.map((packageName) => `packages/${packageName}/src/**`),
+      excludedFiles: [
+        '__tests__/**',
+        '*.test.ts',
+      ],
+      rules: {
+        'no-restricted-imports': ['error', ...TRANSFORMER_RESTRICTED_IMPORTS.map((importName) => ({
+          name: importName,
+          message: `${importName} is not allowed in transformer v2 packages`,
+        }))],
+      },
+    },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "update-cli-packages": "./scripts/update-cli-dependencies.sh && yarn",
     "extract-api": "lerna run extract-api",
     "verify-api-extract": "yarn extract-api && ./scripts/verify-extract-api.sh",
-    "verify-yarn-lock": "./scripts/verify-yarn-lock.sh"
+    "verify-yarn-lock": "./scripts/verify-yarn-lock.sh",
+    "lint-deps": "git diff --name-only --cached --diff-filter d | grep -E '\\.(js|jsx|ts|tsx)$' | xargs eslint --no-eslintrc --config depcheck.config.js"
   },
   "bugs": {
     "url": "https://github.com/aws-amplify/amplify-category-api/issues"
@@ -62,7 +63,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "yarn verify-commit && yarn lint-fix"
+      "pre-commit": "yarn verify-commit && yarn lint-fix && yarn lint-deps"
     }
   },
   "author": "Amazon Web Services",


### PR DESCRIPTION
#### Description of changes
Adding depcheck step to post-commit hook. This is intended to validate we don't reintroduce key dependencies into the GQLV2 dependency chain. There are other ways to do this, but this was just something we can add ASAP while we're touching the deps.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Test-committed file w/ `fs` as an import.

<img width="561" alt="Screenshot 2023-05-31 at 9 07 30 AM" src="https://github.com/aws-amplify/amplify-category-api/assets/91494052/adfd18e1-7cd7-4956-ace5-53caf2bf881b">

<img width="959" alt="Screenshot 2023-05-31 at 9 07 25 AM" src="https://github.com/aws-amplify/amplify-category-api/assets/91494052/35b9b93a-9a9f-4dbb-a7a0-602e11875472">


#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
