### PR TITLE
fix(graphql): renamed subscription should generate auth resolver

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/auth-operations.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/auth-operations.test.ts.snap
@@ -215,3 +215,54 @@ $util.unauthorized()
 $util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
 ## [End] Authorization Steps. **"
 `;
+
+exports[`renamed subscriptions should generate auth resolver 1`] = `
+"## [Start] Authorization Steps. **
+$util.qr($ctx.stash.put(\\"hasAuth\\", true))
+#set( $isAuthorized = false )
+#if( $util.authType() == \\"API Key Authorization\\" )
+
+#end
+#if( $util.authType() == \\"User Pool Authorization\\" )
+  #set( $isAuthorized = true )
+  #set( $hasValidOwnerArgument = false )
+  #set( $authRuntimeFilter = [] )
+  #set( $authOwnerRuntimeFilter = [] )
+  #set( $authGroupRuntimeFilter = [] )
+  ## Apply dynamic roles auth if not previously authorized by static groups and owner argument **
+  #if( $authOwnerRuntimeFilter.size() > 0 )
+    $util.qr($authRuntimeFilter.addAll($authOwnerRuntimeFilter))
+  #end
+  #if( $authGroupRuntimeFilter.size() > 0 )
+    $util.qr($authRuntimeFilter.addAll($authGroupRuntimeFilter))
+  #end
+  #set( $filterArgsSize = 0 )
+  #if( !$util.isNullOrEmpty($ctx.args.filter) )
+    #set( $filterArgsSize = $ctx.args.filter.size() )
+  #end
+  #set( $isOwnerAuthAuthorizedAndNoOtherFilters = $hasValidOwnerArgument && $authRuntimeFilter.size() == 1 && $filterArgsSize == 0 )
+  #set( $isOwnerOrDynamicAuthAuthorizedWithFilters = (!$isAuthorized || $hasValidOwnerArgument) && $authRuntimeFilter.size() > 0 )
+  #if( !$isOwnerAuthAuthorizedAndNoOtherFilters && $isOwnerOrDynamicAuthAuthorizedWithFilters )
+    #if( $util.isNullOrEmpty($ctx.args.filter) )
+      #set( $ctx.args.filter = { \\"or\\": $authRuntimeFilter } )
+    #else
+      #set( $ctx.args.filter = { \\"and\\": [ { \\"or\\": $authRuntimeFilter }, $ctx.args.filter ]} )
+    #end
+    #set( $isAuthorized = true )
+  #end
+#end
+#if( !$isAuthorized )
+$util.unauthorized()
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Authorization Steps. **"
+`;
+
+exports[`renamed subscriptions should generate auth resolver 2`] = `
+"## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **"
+`;

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/utils/warnings.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/utils/warnings.test.ts
@@ -215,7 +215,8 @@ describe('ownerCanReassignWarning', () => {
       test('malformed field-level auth will continue to warn', () => {
         const transform = transformTestSchema(`
           type Todo @model(subscriptions: null) @auth(rules: [
-            { allow: owner, provider: ${provider} ownerField: "writer" }
+            { allow: owner, provider: ${provider}, ownerField: "writer" }
+            { allow: owner, provider: ${provider}, operations: [read] }
           ]) {
             id: ID!
             description: String

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -409,7 +409,8 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
           this.protectFieldResolver(context, def, modelName, field.name.value, allowedRoles);
         }
       });
-      if (errorFields.length > 0 && modelNameConfig.subscriptions?.level === SubscriptionLevel.on) {
+      const subscriptionLevel = modelNameConfig.subscriptions?.level ?? SubscriptionLevel.on;
+      if (errorFields.length > 0 && subscriptionLevel === SubscriptionLevel.on) {
         throw new InvalidDirectiveError("When using field-level authorization rules you need to add rules to all of the model's required fields with at least read permissions. "
         + `Found model "${def.name.value}" with required fields ${JSON.stringify(errorFields)} missing field-level authorization rules.\n\n`
         + 'For more information visit https://docs.amplify.aws/cli/graphql/authorization-rules/#field-level-authorization-rules');
@@ -556,24 +557,25 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     }
 
     const subscriptions = modelConfig?.subscriptions;
-    if (subscriptions?.level === SubscriptionLevel.on) {
+    const subscriptionLevel = subscriptions?.level ?? SubscriptionLevel.on;
+    if (subscriptionLevel === SubscriptionLevel.on) {
       const subscriptionArguments = acm
         .getRolesPerOperation('listen')
         .map((role) => this.roleMap.get(role)!)
         .filter((roleDef) => roleDef.strategy === 'owner' && !fieldIsList(def.fields ?? [], roleDef.entity!));
-      if (subscriptions.onCreate && modelConfig?.mutations?.create) {
+      if (subscriptions?.onCreate && modelConfig?.mutations?.create) {
         subscriptions.onCreate.forEach((onCreateSub) => {
           addServiceDirective(ctx.output.getSubscriptionTypeName()!, 'listen', onCreateSub);
           addSubscriptionArguments(ctx, onCreateSub, subscriptionArguments);
         });
       }
-      if (subscriptions.onUpdate && modelConfig?.mutations?.update) {
+      if (subscriptions?.onUpdate && modelConfig?.mutations?.update) {
         subscriptions.onUpdate.forEach((onUpdateSub) => {
           addServiceDirective(ctx.output.getSubscriptionTypeName()!, 'listen', onUpdateSub);
           addSubscriptionArguments(ctx, onUpdateSub, subscriptionArguments);
         });
       }
-      if (subscriptions.onDelete && modelConfig?.mutations?.delete) {
+      if (subscriptions?.onDelete && modelConfig?.mutations?.delete) {
         subscriptions.onDelete.forEach((onDeleteSub) => {
           addServiceDirective(ctx.output.getSubscriptionTypeName()!, 'listen', onDeleteSub);
           addSubscriptionArguments(ctx, onDeleteSub, subscriptionArguments);

--- a/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
@@ -345,32 +345,35 @@ export const getSubscriptionFieldNames = (
     typeName: string;
   }> = new Set();
 
-  if (modelDirectiveConfig?.subscriptions?.level === SubscriptionLevel.on) {
-    if (modelDirectiveConfig?.subscriptions?.onCreate && modelDirectiveConfig.mutations?.create) {
-      for (const fieldName of modelDirectiveConfig.subscriptions.onCreate) {
-        fields.add({
-          typeName: 'Subscription',
-          fieldName,
-        });
-      }
-    }
+  const subscriptionLevel = modelDirectiveConfig?.subscriptions?.level ?? SubscriptionLevel.on;
+  if (subscriptionLevel !== SubscriptionLevel.on) {
+    return fields;
+  }
 
-    if (modelDirectiveConfig?.subscriptions?.onUpdate && modelDirectiveConfig.mutations?.update) {
-      for (const fieldName of modelDirectiveConfig.subscriptions.onUpdate) {
-        fields.add({
-          typeName: 'Subscription',
-          fieldName,
-        });
-      }
+  if (modelDirectiveConfig?.subscriptions?.onCreate && modelDirectiveConfig.mutations?.create) {
+    for (const fieldName of modelDirectiveConfig.subscriptions.onCreate) {
+      fields.add({
+        typeName: 'Subscription',
+        fieldName,
+      });
     }
+  }
 
-    if (modelDirectiveConfig?.subscriptions?.onDelete && modelDirectiveConfig.mutations?.delete) {
-      for (const fieldName of modelDirectiveConfig.subscriptions.onDelete) {
-        fields.add({
-          typeName: 'Subscription',
-          fieldName,
-        });
-      }
+  if (modelDirectiveConfig?.subscriptions?.onUpdate && modelDirectiveConfig.mutations?.update) {
+    for (const fieldName of modelDirectiveConfig.subscriptions.onUpdate) {
+      fields.add({
+        typeName: 'Subscription',
+        fieldName,
+      });
+    }
+  }
+
+  if (modelDirectiveConfig?.subscriptions?.onDelete && modelDirectiveConfig.mutations?.delete) {
+    for (const fieldName of modelDirectiveConfig.subscriptions.onDelete) {
+      fields.add({
+        typeName: 'Subscription',
+        fieldName,
+      });
     }
   }
 

--- a/packages/amplify-graphql-model-transformer/src/resources/model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/model-resource-generator.ts
@@ -167,7 +167,7 @@ export abstract class ModelResourceGenerator {
         context.resolvers.addResolver(mutation.typeName, mutation.fieldName, resolver);
       });
 
-      const subscriptionLevel = this.modelDirectiveMap.get(def.name.value)?.subscriptions?.level;
+      const subscriptionLevel = this.modelDirectiveMap.get(def.name.value)?.subscriptions?.level ?? SubscriptionLevel.on;
       // in order to create subscription resolvers the level needs to be on
       if (subscriptionLevel !== SubscriptionLevel.off) {
         const subscriptionFields = this.getSubscriptionFieldNames(def!);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

While renaming subscriptions, transformers do not generate auth resolvers for the operation. This PR fixes the issue.

**For example:** For the below schema, currently no auth resolvers are generated for `onNoteUpdate` subscription.

```graphql
type Note 
  @model(subscriptions: { onUpdate: ["onNoteUpdate"] }) 
  @auth(rules: [{ allow: owner }]) 
{
  noteId: String! @primaryKey
  comments: String
}
```

##### CDK / CloudFormation Parameters Changed

NA

#### Issue #, if available

Internal ticket

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
