### PR TITLE
chore: remove filepaths from context

### DIFF
--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -1,17 +1,12 @@
 import {
   GraphQLTransform,
   RDSConnectionSecrets,
-  ImportedRDSType,
   MYSQL_DB_TYPE,
-  ResolverConfig,
-  TransformerProjectConfig,
   StackManager,
 } from '@aws-amplify/graphql-transformer-core';
 import {
   AppSyncAuthConfiguration,
   DeploymentResources,
-  Template,
-  TransformerPluginProvider,
   TransformerLogLevel,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import {
@@ -20,7 +15,6 @@ import {
   AmplifySupportedService,
   JSONUtilities,
   pathManager,
-  stateManager,
 } from '@aws-amplify/amplify-cli-core';
 import { printer } from '@aws-amplify/amplify-prompts';
 import fs from 'fs-extra';
@@ -39,7 +33,7 @@ import {
 } from './utils';
 import { generateTransformerOptions } from './transformer-options-v2';
 import { TransformerFactoryArgs, TransformerProjectOptions } from './transformer-options-types';
-import { getExistingConnectionSecretNames, getSecretsKey, getDatabaseName } from '../provider-utils/awscloudformation/utils/rds-secrets/database-secrets';
+import { getExistingConnectionSecretNames, getSecretsKey } from '../provider-utils/awscloudformation/utils/rds-secrets/database-secrets';
 import { getAppSyncAPIName } from '../provider-utils/awscloudformation/utils/amplify-meta-utils';
 import { applyOverride } from './override';
 
@@ -239,11 +233,6 @@ const _buildProject = async (context: $TSContext, opts: TransformerProjectOption
     buildParameters: opts.buildParameters,
     stacks: opts.projectConfig.stacks || {},
     featureFlags: new AmplifyCLIFeatureFlagAdapter(),
-    filepaths: {
-      getBackendDirPath: () => pathManager.getBackendDirPath(),
-      findProjectRoot: () => pathManager.findProjectRoot(),
-      getCurrentCloudBackendDirPath: () => pathManager.getCurrentCloudBackendDirPath(),
-    },
     sandboxModeEnabled: opts.sandboxModeEnabled,
     userDefinedSlots,
     resolverConfig: opts.resolverConfig,

--- a/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
@@ -9,7 +9,6 @@ import {
 import {
   FeatureFlagProvider,
   Template,
-  TransformerFilepathsProvider,
   AmplifyApiGraphQlResourceStackTemplate,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import { Template as AssertionTemplate } from 'aws-cdk-lib/assertions';
@@ -42,11 +41,6 @@ test('throws if @index is used in a non-@model type', () => {
         return defaultValue;
       },
     } as FeatureFlagProvider),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => {
@@ -72,11 +66,6 @@ test('throws if the same index name is defined multiple times on an object', () 
         return defaultValue;
       },
     } as FeatureFlagProvider),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => {
@@ -107,11 +96,6 @@ test('throws if an invalid LSI is created', () => {
         return defaultValue;
       },
     } as FeatureFlagProvider),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   const sortKeyFieldsError = 'Invalid @index \'index1\'. You may not create an index where the partition key is the same as that of the primary key unless the primary key has a sort field. You cannot have a local secondary index without a sort key in the primary key.';
@@ -151,11 +135,6 @@ test('throws if an LSI is missing sort fields', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
     featureFlags: generateFeatureFlagWithBooleanOverrides({ secondaryKeyAsGSI: false, useSubUsernameForDefaultIdentityClaim: true }),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   const sortKeyFieldsError = 'Invalid @index \'index1\'. You may not create an index where the partition key is the same as that of the primary key unless the index has a sort field. You cannot have a local secondary index without a sort key in the index.';
@@ -201,11 +180,6 @@ test('throws if @index is used on a non-scalar field', () => {
         return defaultValue;
       },
     } as FeatureFlagProvider),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => {
@@ -231,11 +205,6 @@ test('throws if @index uses a sort key field that does not exist', () => {
         return defaultValue;
       },
     } as FeatureFlagProvider),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => {
@@ -265,11 +234,6 @@ test('throws if @index uses a sort key field that is a non-scalar', () => {
         return defaultValue;
       },
     } as FeatureFlagProvider),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => {
@@ -295,11 +259,6 @@ test('throws if @index refers to itself', () => {
         return defaultValue;
       },
     } as FeatureFlagProvider),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => {
@@ -325,11 +284,6 @@ test('throws if @index is specified on a list', () => {
         return defaultValue;
       },
     } as FeatureFlagProvider),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => {
@@ -356,11 +310,6 @@ test('throws if @index sort key fields are a list', () => {
         return defaultValue;
       },
     } as FeatureFlagProvider),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => {
@@ -386,11 +335,6 @@ test('@index with multiple sort keys adds a query field and GSI correctly', () =
         return defaultValue;
       },
     } as FeatureFlagProvider),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
   const out = transformer.transform(inputSchema);
   const schema = parse(out.schema);
@@ -486,11 +430,6 @@ test('@index with a single sort key adds a query field and GSI correctly', () =>
         return defaultValue;
       },
     } as FeatureFlagProvider),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
   const out = transformer.transform(inputSchema);
   const schema = parse(out.schema);
@@ -565,11 +504,6 @@ test('@index with no sort key field adds a query field and GSI correctly', () =>
         return defaultValue;
       },
     } as FeatureFlagProvider),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
   const out = transformer.transform(inputSchema);
   const schema = parse(out.schema);
@@ -639,11 +573,6 @@ test('@index with no queryField does not generate a query field', () => {
         return defaultValue;
       },
     } as FeatureFlagProvider),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
   const out = transformer.transform(inputSchema);
   const schema = parse(out.schema);
@@ -677,11 +606,6 @@ test('creates a primary key and a secondary index', () => {
       getNumber: jest.fn(),
       getObject: jest.fn(),
     },
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
   const out = transformer.transform(inputSchema);
   const schema = parse(out.schema);
@@ -767,11 +691,6 @@ test('connection type is generated for custom query when queries is set to null'
         return defaultValue;
       },
     } as FeatureFlagProvider),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
   const out = transformer.transform(inputSchema);
   const schema = parse(out.schema);
@@ -804,11 +723,6 @@ test('does not remove default primary key when primary key is not overidden', ()
         return defaultValue;
       },
     } as FeatureFlagProvider),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
   const out = transformer.transform(inputSchema);
   const schema = parse(out.schema);
@@ -841,11 +755,6 @@ test('sort direction and filter input are generated if default list query does n
         return defaultValue;
       },
     } as FeatureFlagProvider),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
   const out = transformer.transform(inputSchema);
   const schema = parse(out.schema);
@@ -868,11 +777,6 @@ test('@index adds an LSI with secondaryKeyAsGSI FF set to false', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
     featureFlags: generateFeatureFlagWithBooleanOverrides({ secondaryKeyAsGSI: false, useSubUsernameForDefaultIdentityClaim: true }),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
   const out = transformer.transform(inputSchema);
   const schema = parse(out.schema);
@@ -919,11 +823,6 @@ test('@index adds a GSI with secondaryKeyAsGSI FF set to true', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
     featureFlags: generateFeatureFlagWithBooleanOverrides({ secondaryKeyAsGSI: true, useSubUsernameForDefaultIdentityClaim: true }),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
   const out = transformer.transform(inputSchema);
   const schema = parse(out.schema);
@@ -974,11 +873,6 @@ test('validate resolver code', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
     featureFlags: generateFeatureFlagWithBooleanOverrides({ secondaryKeyAsGSI: true, useSubUsernameForDefaultIdentityClaim: true }),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
   const out = transformer.transform(inputSchema);
   expect(out).toBeDefined();
@@ -1008,11 +902,6 @@ it('@model mutation with user defined null args', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
     featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
   const out = transformer.transform(inputSchema);
   expect(out).toBeDefined();
@@ -1047,11 +936,6 @@ it('@model mutation with user defined create args', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
     featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
   const out = transformer.transform(inputSchema);
   expect(out).toBeDefined();
@@ -1086,11 +970,6 @@ it('@model mutation with default', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
     featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
   const out = transformer.transform(inputSchema);
   expect(out).toBeDefined();
@@ -1133,11 +1012,6 @@ it('@model mutation with queries', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
     featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
   const out = transformer.transform(inputSchema);
   expect(out).toBeDefined();
@@ -1180,11 +1054,6 @@ it('id field should be optional in updateInputObjects when it is not a primary k
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
     featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
   const out = transformer.transform(inputSchema);
   expect(out).toBeDefined();
@@ -1216,11 +1085,6 @@ test('GSI composite sort keys are wrapped in conditional to check presence in mu
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
     featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
   const out = transformer.transform(inputSchema);
   expect(out).toBeDefined();
@@ -1255,11 +1119,6 @@ it('should support index/primary key with sync resolvers', () => {
       project: config,
     },
     featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   const out = transformer.transform(validSchema);
@@ -1292,11 +1151,6 @@ it('sync query resolver renders without overrides', () => {
       project: config,
     },
     featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   const out = transformer.transform(validSchema);
@@ -1331,11 +1185,6 @@ it('sync query resolver renders with deltaSyncTableTTL override', () => {
       project: config,
     },
     featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
     overrideConfig: {
       overrideFlag: true,
       applyOverride: (stackManager: StackManager) => ({
@@ -1376,11 +1225,6 @@ test('LSI creation regression test', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new IndexTransformer(), new PrimaryKeyTransformer()],
     featureFlags: generateFeatureFlagWithBooleanOverrides({ useSubUsernameForDefaultIdentityClaim: true }),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   const out = transformer.transform(inputSchema);
@@ -1399,11 +1243,6 @@ test('it throws an understandable error on boolean sort keys', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new IndexTransformer(), new PrimaryKeyTransformer()],
     featureFlags: generateFeatureFlagWithBooleanOverrides({ enableAutoIndexQueryNames: true }),
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => {
@@ -1420,11 +1259,6 @@ describe('automatic name generation', () => {
     const transformer = new GraphQLTransform({
       transformers: [new ModelTransformer(), new IndexTransformer()],
       featureFlags: generateFeatureFlagWithBooleanOverrides({ enableAutoIndexQueryNames }),
-      filepaths: {
-        getBackendDirPath: () => 'fake-backend-dir',
-        findProjectRoot: () => '.',
-        getCurrentCloudBackendDirPath: () => 'amplify/backend',
-      } as TransformerFilepathsProvider,
     });
     const transformerOutput = transformer.transform(inputSchema);
     const schema = parse(transformerOutput.schema);

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
@@ -1,7 +1,7 @@
 import { IndexTransformer, PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { ConflictHandlerType, GraphQLTransform, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
-import { FeatureFlagProvider, TransformerFilepathsProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { FeatureFlagProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { Kind, parse } from 'graphql';
 import { BelongsToTransformer, HasManyTransformer, HasOneTransformer } from '..';
 import { featureFlags, hasGeneratedField } from './test-helpers';
@@ -21,11 +21,6 @@ test('fails if used as a has one relation', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasManyTransformer()],
     featureFlags,
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => transformer.transform(inputSchema)).toThrowError('@hasMany must be used with a list. Use @hasOne for non-list types.');
@@ -47,11 +42,6 @@ test('fails if the provided indexName does not exist.', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasManyTransformer()],
     featureFlags,
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => transformer.transform(inputSchema)).toThrowError('Index notDefault does not exist for model Test1');
@@ -96,11 +86,6 @@ test('accepts @hasMany without a sort key', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new IndexTransformer(), new HasManyTransformer()],
     featureFlags,
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => transformer.transform(inputSchema)).not.toThrowError();
@@ -122,11 +107,6 @@ test('fails if provided sort key type does not match custom index sort key type'
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new IndexTransformer(), new HasManyTransformer()],
     featureFlags,
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => transformer.transform(inputSchema)).toThrowError('email field is not of type ID');
@@ -149,11 +129,6 @@ test('fails if partition key type passed in does not match custom index partitio
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new IndexTransformer(), new HasManyTransformer()],
     featureFlags,
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => transformer.transform(inputSchema)).toThrowError('email field is not of type ID');
@@ -174,11 +149,6 @@ test('fails if @hasMany was used on an object that is not a model type', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new HasManyTransformer()],
     featureFlags,
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => transformer.transform(inputSchema)).toThrowError('@hasMany must be on an @model object type field.');
@@ -199,11 +169,6 @@ test('fails if @hasMany was used with a related type that is not a model', () =>
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new HasManyTransformer()],
     featureFlags,
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => transformer.transform(inputSchema)).toThrowError('Object type Test1 must be annotated with @model.');
@@ -224,11 +189,6 @@ test('fails if the related type does not exist', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new HasManyTransformer()],
     featureFlags,
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => transformer.transform(inputSchema)).toThrowError('Unknown type "Test2". Did you mean "Test" or "Test1"?');
@@ -249,11 +209,6 @@ test('fails if an empty list of fields is passed in', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new HasManyTransformer()],
     featureFlags,
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => transformer.transform(inputSchema)).toThrowError('No fields passed to @hasMany directive.');
@@ -275,11 +230,6 @@ test('fails if any of the fields passed in are not in the parent model', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasManyTransformer()],
     featureFlags,
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => transformer.transform(inputSchema)).toThrowError('name is not a field in Test');
@@ -301,11 +251,6 @@ test('has many query case', () => {
   const transformer = new GraphQLTransform({
     featureFlags,
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasManyTransformer()],
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   const out = transformer.transform(inputSchema);
@@ -343,11 +288,6 @@ test('bidirectional has many query case', () => {
   const transformer = new GraphQLTransform({
     featureFlags,
     transformers: [new ModelTransformer(), new IndexTransformer(), new BelongsToTransformer(), new HasManyTransformer()],
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   const out = transformer.transform(inputSchema);
@@ -399,11 +339,6 @@ test('has many query with a composite sort key', () => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasManyTransformer()],
     featureFlags,
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   const out = transformer.transform(inputSchema);
@@ -444,11 +379,6 @@ test('has many query with a composite sort key passed in as an argument', () => 
   const transformer = new GraphQLTransform({
     featureFlags,
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasManyTransformer()],
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   const out = transformer.transform(inputSchema);
@@ -502,11 +432,6 @@ test('many to many query', () => {
       },
     },
     transformers: [new ModelTransformer(), new IndexTransformer(), new HasOneTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   const out = transformer.transform(inputSchema);
@@ -530,11 +455,6 @@ test('has many with implicit index and fields', () => {
   const transformer = new GraphQLTransform({
     featureFlags,
     transformers: [new ModelTransformer(), new HasManyTransformer()],
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   const out = transformer.transform(inputSchema);
@@ -584,11 +504,6 @@ test('has many with implicit index and fields and a user-defined primary key', (
   const transformer = new GraphQLTransform({
     featureFlags,
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasManyTransformer()],
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   const out = transformer.transform(inputSchema);
@@ -651,11 +566,6 @@ test('the limit of 100 is used by default', () => {
   const transformer = new GraphQLTransform({
     featureFlags,
     transformers: [new ModelTransformer(), new HasManyTransformer()],
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   const out = transformer.transform(inputSchema);
@@ -680,11 +590,6 @@ test('the default limit argument can be overridden', () => {
   const transformer = new GraphQLTransform({
     featureFlags,
     transformers: [new ModelTransformer(), new HasManyTransformer()],
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   const out = transformer.transform(inputSchema);
@@ -764,11 +669,6 @@ test('validates VTL of a complex schema', () => {
       new HasManyTransformer(),
       new BelongsToTransformer(),
     ],
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   const out = transformer.transform(inputSchema);
@@ -792,11 +692,6 @@ test('@hasMany and @hasMany can point at each other if DataStore is not enabled'
   const transformer = new GraphQLTransform({
     featureFlags,
     transformers: [new ModelTransformer(), new HasManyTransformer()],
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   const out = transformer.transform(inputSchema);
@@ -825,11 +720,6 @@ test('@hasMany and @hasMany cannot point at each other if DataStore is enabled',
       },
     },
     transformers: [new ModelTransformer(), new HasOneTransformer(), new HasManyTransformer()],
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   expect(() => transformer.transform(inputSchema)).toThrowError(
@@ -852,11 +742,6 @@ test('recursive @hasMany relationships are supported if DataStore is enabled', (
       },
     },
     transformers: [new ModelTransformer(), new HasManyTransformer()],
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
   });
 
   const out = transformer.transform(inputSchema);
@@ -876,11 +761,6 @@ test('has many with queries null generate correct filter input objects for scala
     }`;
   const transformer = new GraphQLTransform({
     featureFlags,
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasManyTransformer()],
   });
 
@@ -917,11 +797,6 @@ test('has many with queries null generate correct filter input objects for enum 
     }`;
   const transformer = new GraphQLTransform({
     featureFlags,
-    filepaths: {
-      getBackendDirPath: () => 'fake-backend-dir',
-      findProjectRoot: () => '.',
-      getCurrentCloudBackendDirPath: () => 'amplify/backend',
-    } as TransformerFilepathsProvider,
     transformers: [new ModelTransformer(), new HasManyTransformer()],
   });
 
@@ -944,11 +819,6 @@ describe('Pre Processing Has Many Tests', () => {
   beforeEach(() => {
     transformer = new GraphQLTransform({
       featureFlags,
-      filepaths: {
-        getBackendDirPath: () => 'fake-backend-dir',
-        findProjectRoot: () => '.',
-        getCurrentCloudBackendDirPath: () => 'amplify/backend',
-      } as TransformerFilepathsProvider,
       transformers: [new ModelTransformer(), new HasManyTransformer()],
     });
   });
@@ -1016,11 +886,6 @@ describe('@hasMany connection field nullability tests', () => {
     `;
     const transformer = new GraphQLTransform({
       featureFlags,
-      filepaths: {
-        getBackendDirPath: () => 'fake-backend-dir',
-        findProjectRoot: () => '.',
-        getCurrentCloudBackendDirPath: () => 'amplify/backend',
-      } as TransformerFilepathsProvider,
       transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasManyTransformer()],
     });
   

--- a/packages/amplify-graphql-schema-test-library/src/__tests__/index.test.ts
+++ b/packages/amplify-graphql-schema-test-library/src/__tests__/index.test.ts
@@ -13,7 +13,7 @@ import {
 } from '@aws-amplify/graphql-relational-transformer';
 import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-transformer';
 import { ConflictHandlerType, GraphQLTransform, GraphQLTransformOptions } from '@aws-amplify/graphql-transformer-core';
-import { FeatureFlagProvider, TransformerPluginProvider, TransformerFilepathsProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { FeatureFlagProvider, TransformerPluginProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import {
   schemas, TransformerPlatform, TransformerSchema, TransformerVersion,
 } from '..';
@@ -95,11 +95,6 @@ function createV2Transformer(options: Partial<Writeable<GraphQLTransformOptions>
     getNumber: jest.fn(),
     getObject: jest.fn(),
   } as FeatureFlagProvider;
-  options.filepaths = {
-    getBackendDirPath: () => 'fake-backend-dir',
-    findProjectRoot: () => '.',
-    getCurrentCloudBackendDirPath: () => 'amplify/backend',
-  } as TransformerFilepathsProvider;
 
   return new GraphQLTransform(options as GraphQLTransformOptions);
 }

--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -70,7 +70,6 @@ import { TransformerContextMetadataProvider } from '@aws-amplify/graphql-transfo
 import { TransformerContextOutputProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { TransformerDataSourceManagerProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { TransformerFilepathsProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { TransformerLog } from '@aws-amplify/graphql-transformer-interfaces';
 import { TransformerModelEnhancementProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { TransformerModelProvider } from '@aws-amplify/graphql-transformer-interfaces';
@@ -239,8 +238,6 @@ export interface GraphQLTransformOptions {
     readonly disableResolverDeduping?: boolean;
     // (undocumented)
     readonly featureFlags?: FeatureFlagProvider;
-    // (undocumented)
-    readonly filepaths?: TransformerFilepathsProvider;
     // (undocumented)
     readonly host?: TransformHostProvider;
     // (undocumented)

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -8,8 +8,6 @@ import {
   TransformerPluginProvider,
   TransformHostProvider,
   TransformerLog,
-  TransformerFilepathsProvider,
-  AmplifyApiGraphQlResourceStackTemplate
 } from '@aws-amplify/graphql-transformer-interfaces';
 import { AuthorizationMode, AuthorizationType } from 'aws-cdk-lib/aws-appsync';
 import {
@@ -29,7 +27,7 @@ import {
   TypeDefinitionNode,
   TypeExtensionNode,
   UnionTypeDefinitionNode,
-  print
+  print,
 } from 'graphql';
 import _ from 'lodash';
 import { ResolverConfig, TransformConfig } from '../config/transformer-config';
@@ -88,7 +86,6 @@ export interface GraphQLTransformOptions {
   readonly userDefinedSlots?: Record<string, UserDefinedSlot[]>;
   readonly resolverConfig?: ResolverConfig;
   readonly overrideConfig?: OverrideConfig;
-  readonly filepaths?: TransformerFilepathsProvider;
 }
 export type StackMapping = { [resourceId: string]: string };
 export class GraphQLTransform {
@@ -101,7 +98,6 @@ export class GraphQLTransform {
   private readonly buildParameters: Record<string, any>;
   private readonly userDefinedSlots: Record<string, UserDefinedSlot[]>;
   private readonly overrideConfig?: OverrideConfig;
-  private readonly filepaths: TransformerFilepathsProvider;
 
   // A map from `${directive}.${typename}.${fieldName?}`: true
   // that specifies we have run already run a directive at a given location.
@@ -136,11 +132,6 @@ export class GraphQLTransform {
     this.userDefinedSlots = options.userDefinedSlots || ({} as Record<string, UserDefinedSlot[]>);
     this.overrideConfig = options.overrideConfig;
     this.resolverConfig = options.resolverConfig || {};
-    this.filepaths = options.filepaths || {
-      getBackendDirPath: () => { throw new Error('Unable to get backend dir path.') },
-      findProjectRoot: () => { throw new Error('Unable to find project root.') },
-      getCurrentCloudBackendDirPath: () => { throw new Error('Unable to get current cloud backend dir path') },
-    };
 
     this.logs = [];
   }
@@ -194,7 +185,6 @@ export class GraphQLTransform {
       datasourceConfig?.modelToDatasourceMap ?? new Map<string, DatasourceType>(),
       this.stackMappingOverrides,
       this.authConfig,
-      this.filepaths,
       this.options.sandboxModeEnabled,
       this.options.featureFlags,
       this.resolverConfig,

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
@@ -6,7 +6,6 @@ import {
   TransformerContextProvider,
   TransformerDataSourceManagerProvider,
   AppSyncAuthConfiguration,
-  TransformerFilepathsProvider,
   OverridesProvider,
   AmplifyApiGraphQlResourceStackTemplate,
 } from '@aws-amplify/graphql-transformer-interfaces';
@@ -55,7 +54,6 @@ export class TransformerContext implements TransformerContextProvider {
   public readonly featureFlags: FeatureFlagProvider;
   public _api?: GraphQLAPIProvider;
   public readonly authConfig: AppSyncAuthConfiguration;
-  public readonly filepaths: TransformerFilepathsProvider;
   public readonly sandboxModeEnabled: boolean;
   private resolverConfig: ResolverConfig | undefined;
   public readonly modelToDatasourceMap: Map<string, DatasourceType>;
@@ -69,7 +67,6 @@ export class TransformerContext implements TransformerContextProvider {
     modelToDatasourceMap: Map<string, DatasourceType>,
     stackMapping: Record<string, string>,
     authConfig: AppSyncAuthConfiguration,
-    filepaths: TransformerFilepathsProvider,
     sandboxModeEnabled?: boolean,
     featureFlags?: FeatureFlagProvider,
     resolverConfig?: ResolverConfig,
@@ -83,7 +80,6 @@ export class TransformerContext implements TransformerContextProvider {
     const stackManager = new StackManager(app, stackMapping);
     this.stackManager = stackManager;
     this.authConfig = authConfig;
-    this.filepaths = filepaths;
     this.sandboxModeEnabled = sandboxModeEnabled ?? false;
     this.resourceHelper = new TransformerResourceHelper(stackManager);
     this.featureFlags = featureFlags ?? new NoopFeatureFlagProvider();

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -529,8 +529,6 @@ export interface TransformerContextProvider {
     // (undocumented)
     featureFlags: FeatureFlagProvider;
     // (undocumented)
-    filepaths: TransformerFilepathsProvider;
-    // (undocumented)
     getResolverConfig<ResolverConfig>(): ResolverConfig | undefined;
     // (undocumented)
     getResourceOverrides: OverridesProvider;
@@ -568,16 +566,6 @@ export interface TransformerDataSourceManagerProvider {
     get(type: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode): DataSourceInstance;
     // (undocumented)
     has(name: string): boolean;
-}
-
-// @public (undocumented)
-export interface TransformerFilepathsProvider {
-    // (undocumented)
-    findProjectRoot: () => string;
-    // (undocumented)
-    getBackendDirPath: () => string;
-    // (undocumented)
-    getCurrentCloudBackendDirPath: () => string;
 }
 
 // @public (undocumented)

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/index.ts
@@ -20,5 +20,4 @@ export {
 export { TransformerSchemaHelperProvider } from './schema-helper-provider';
 export { TransformerPreProcessContextProvider } from './transformer-preprocess-context-provider';
 export { StackManagerProvider } from './stack-manager-provider';
-export { TransformerFilepathsProvider } from './transformer-filepaths-provider';
 export { OverridesProvider } from './overrides-provider';

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
@@ -7,7 +7,6 @@ import { StackManagerProvider } from './stack-manager-provider';
 import { AppSyncAuthConfiguration, GraphQLAPIProvider } from '../graphql-api-provider';
 import { TransformerResourceHelperProvider } from './resource-resource-provider';
 import { FeatureFlagProvider } from '../feature-flag-provider';
-import { TransformerFilepathsProvider } from './transformer-filepaths-provider';
 import { OverridesProvider } from './overrides-provider';
 
 export interface TransformerContextMetadataProvider {
@@ -34,7 +33,6 @@ export interface TransformerContextProvider {
   featureFlags: FeatureFlagProvider;
   authConfig: AppSyncAuthConfiguration;
   sandboxModeEnabled: boolean;
-  filepaths: TransformerFilepathsProvider;
 
   isProjectUsingDataStore(): boolean;
   getResolverConfig<ResolverConfig>(): ResolverConfig | undefined;

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-filepaths-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-filepaths-provider.ts
@@ -1,5 +1,0 @@
-export interface TransformerFilepathsProvider {
-  getBackendDirPath: () => string;
-  findProjectRoot: () => string;
-  getCurrentCloudBackendDirPath: () => string;
-}


### PR DESCRIPTION
#### Description of changes
Remove the now-unused `filepaths` object from the v2 transformer context, and no longer pass down to the client.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit + E2E Tests

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
