### PR TITLE
chore: enable strict linting on dependencies in gqlv2 transformers and package-json on build

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -139,6 +139,30 @@ jobs:
       - restore_cache:
           key: amplify-category-api-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{ arch }}
       - run: chmod +x .circleci/lint_pr.sh && ./.circleci/lint_pr.sh
+    environment:
+      NODE_OPTIONS: --max-old-space-size=5120
+
+  lint-deps:
+    <<: *linux-e2e-executor
+    steps:
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: amplify-category-api-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{ arch }}
+      - run: yarn lint:deps:check
+    environment:
+      NODE_OPTIONS: --max-old-space-size=5120
+
+  lint-package-json:
+    <<: *linux-e2e-executor
+    steps:
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: amplify-category-api-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{ arch }}
+      - run: yarn lint:package-json:check
+    environment:
+      NODE_OPTIONS: --max-old-space-size=5120
 
   verify-api-extract:
     <<: *linux-e2e-executor
@@ -519,6 +543,12 @@ workflows:
           name: build_windows
           os: w
       - lint:
+          requires:
+            - build_linux
+      - lint-deps:
+          requires:
+            - build_linux
+      - lint-package-json:
           requires:
             - build_linux
       - validate_cdk_version:

--- a/.eslint.depcheck.js
+++ b/.eslint.depcheck.js
@@ -59,6 +59,11 @@ module.exports = {
     'lib/**',
     'node_modules',
     '*/node_modules',
+    '.eslintrc.js',
+    'dist',
+    'build',
+    '__mocks__',
+    'coverage',
   ],
   overrides: [
     {
@@ -66,6 +71,14 @@ module.exports = {
       excludedFiles: [
         '__tests__/**',
         '*.test.ts',
+        'lib/**',
+        'node_modules',
+        '*/node_modules',
+        '.eslintrc.js',
+        'dist',
+        'build',
+        '__mocks__',
+        'coverage',
       ],
       rules: {
         'no-restricted-imports': ['error', ...TRANSFORMER_RESTRICTED_IMPORTS.map((importName) => ({

--- a/.eslint.package.js
+++ b/.eslint.package.js
@@ -1,0 +1,9 @@
+module.exports = {
+  root: true,
+  parser: 'eslint-plugin-package-json-dependencies',
+  plugins: ['package-json-dependencies'],
+  rules: {
+    'package-json-dependencies/alphabetically-sorted-dependencies': 'error',
+  },
+  ignorePatterns: ['node_modules'],
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "test-ci": "lerna run test --concurrency 1 -- --ci -i",
     "e2e": "lerna run e2e",
     "cloud-e2e": "CURR_BRANCH=$(git branch | awk '/\\*/{printf \"%s\", $2}') && UPSTREAM_BRANCH=run-e2e/$USER/$CURR_BRANCH && git push $(git remote -v | grep aws-amplify/amplify-category-api | head -n1 | awk '{print $1;}') $CURR_BRANCH:$UPSTREAM_BRANCH --no-verify --force-with-lease && echo \"\n\n 🏃 E2E test are running at:\nhttps://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api?branch=$UPSTREAM_BRANCH\"",
-    "lint-fix": "git diff --name-only --cached --diff-filter d | grep -E '\\.(js|jsx|ts|tsx)$' | xargs eslint --fix --quiet",
     "clean": "lerna run clean && lerna exec yarn rimraf tsconfig.tsbuildinfo && lerna clean --yes && yarn rimraf node_modules",
     "check-version-conflicts:beta": "yarn ts-node ./scripts/check-version.ts beta",
     "check-version-conflicts:release": "yarn ts-node ./scripts/check-version.ts",
@@ -48,7 +47,12 @@
     "extract-api": "lerna run extract-api",
     "verify-api-extract": "yarn extract-api && ./scripts/verify-extract-api.sh",
     "verify-yarn-lock": "./scripts/verify-yarn-lock.sh",
-    "lint-deps": "git diff --name-only --cached --diff-filter d | grep -E '\\.(js|jsx|ts|tsx)$' | xargs eslint --no-eslintrc --config depcheck.config.js"
+    "lint:fix": "git diff --name-only --cached --diff-filter d | grep -E '\\.(js|jsx|ts|tsx)$' | xargs eslint --fix --quiet",
+    "lint:check": "eslint ./packages --ext .js,.jsx,.ts,.tsx --max-warnings=0",
+    "lint:deps:fix": "git diff --name-only --cached --diff-filter d | grep -E '\\.(js|jsx|ts|tsx)$' | xargs eslint --no-eslintrc --config .eslint.depcheck.js --fix --quiet",
+    "lint:deps:check": "eslint ./packages --no-eslintrc --config .eslint.depcheck.js",
+    "lint:package-json:fix": "eslint --no-eslintrc --config .eslint.package.js '**/package.json' --fix --quiet",
+    "lint:package-json:check": "eslint --no-eslintrc --config .eslint.package.js '**/package.json'"
   },
   "bugs": {
     "url": "https://github.com/aws-amplify/amplify-category-api/issues"
@@ -63,7 +67,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "yarn verify-commit && yarn lint-fix && yarn lint-deps"
+      "pre-commit": "yarn lint:package-json:fix && yarn lint:deps:fix && yarn lint:fix && yarn verify-commit"
     }
   },
   "author": "Amazon Web Services",
@@ -110,6 +114,7 @@
     "eslint-plugin-jest": "^26.1.1",
     "eslint-plugin-jsdoc": "^40.1.0",
     "eslint-plugin-jsx-a11y": "^6.5.1",
+    "eslint-plugin-package-json-dependencies": "^1.0.17",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-spellcheck": "^0.0.17",

--- a/packages/graphql-transformers-e2e-tests/resources/jsonServer/package.json
+++ b/packages/graphql-transformers-e2e-tests/resources/jsonServer/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "version": "1.0.0",
   "devDependencies": {
-    "aws-cdk": "~2.68.0",
     "@types/node": "^12.12.6",
+    "aws-cdk": "~2.68.0",
     "typescript": "^3.8.3"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7945,6 +7945,11 @@ array-includes@^3.1.5, array-includes@^3.1.6:
     get-intrinsic "^1.1.3"
     is-string "^1.0.7"
 
+array-timsort@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz#3c9e4199e54fb2b9c3fe5976396a21614ef0d926"
+  integrity sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
@@ -9328,6 +9333,17 @@ commander@^9.1.0:
   resolved "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
   integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
 
+comment-json@~4.2.0:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/comment-json/-/comment-json-4.2.3.tgz#50b487ebbf43abe44431f575ebda07d30d015365"
+  integrity sha512-SsxdiOf064DWoZLH799Ata6u7iV658A11PlWtZATDlXPpKGJnbJZ5Z24ybixAi+LUUqJ/GKowAejtC5GFUG7Tw==
+  dependencies:
+    array-timsort "^1.0.3"
+    core-util-is "^1.0.3"
+    esprima "^4.0.1"
+    has-own-prop "^2.0.0"
+    repeat-string "^1.6.1"
+
 comment-parser@1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz#3d7ea3adaf9345594aedee6563f422348f165c1b"
@@ -9590,7 +9606,7 @@ core-js@^3.6.4:
   resolved "https://registry.npmjs.org/core-js/-/core-js-3.30.2.tgz#6528abfda65e5ad728143ea23f7a14f0dcf503fc"
   integrity sha512-uBJiDmwqsbJCWHAwjrx3cvjbMXP7xD72Dmsn5LOJpiRmE3WbBbN5rCqQ2Qh6Ek6/eOrjlWngEynBWo4VxerQhg==
 
-core-util-is@~1.0.0:
+core-util-is@^1.0.3, core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
@@ -10659,6 +10675,17 @@ eslint-plugin-jsx-a11y@^6.5.1:
     object.fromentries "^2.0.6"
     semver "^6.3.0"
 
+eslint-plugin-package-json-dependencies@^1.0.17:
+  version "1.0.17"
+  resolved "https://registry.npmjs.org/eslint-plugin-package-json-dependencies/-/eslint-plugin-package-json-dependencies-1.0.17.tgz#d12efb2b5c8dabb803c1e109fb6632b62ba3aa1e"
+  integrity sha512-8PjZIxPXo/VJL+l+UMMFDqJ+yH2nTiNvFUkVN72iECr/7e9pY5SXfstK+2lC2qbSn7ZzL78H8Fcdx8XNLjCp6Q==
+  dependencies:
+    comment-json "~4.2.0"
+    esprima "~4.0.0"
+    lodash "~4.17.0"
+    micromatch "~4.0.0"
+    semver "~7.3.0"
+
 eslint-plugin-prefer-arrow@^1.2.3:
   version "1.2.3"
   resolved "https://registry.npmjs.org/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz#e7fbb3fa4cd84ff1015b9c51ad86550e55041041"
@@ -10780,7 +10807,7 @@ espree@^9.5.2:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.4.1"
 
-esprima@^4.0.0, esprima@^4.0.1:
+esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -11938,6 +11965,11 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-own-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz#f0f95d58f65804f5d218db32563bb85b8e0417af"
+  integrity sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==
 
 has-property-descriptors@^1.0.0:
   version "1.0.0"
@@ -14850,7 +14882,7 @@ micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2, micromatch@^4.0.4:
+micromatch@^4.0.2, micromatch@^4.0.4, micromatch@~4.0.0:
   version "4.0.5"
   resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==


### PR DESCRIPTION
#### Description of changes
Enforce dep check on `build` workflow for gqlv2 dependency chain, and package.json rules.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Validated on this commit, and also verified that the build workflow running has the new lint rules attached.

#### Checklist
- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
