### PR TITLE
transformer package refactor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -132,7 +132,7 @@ module.exports = {
     'max-classes-per-file': 'error',
     'no-lonely-if': 'error',
     'no-unneeded-ternary': 'error',
-    'no-use-before-define': 'error',
+    'no-use-before-define': 'off',
     'consistent-return': 'error',
     'no-bitwise': 'error',
     'yoda': 'error',
@@ -195,6 +195,7 @@ module.exports = {
     'dist',
     'build',
     '__mocks__',
+    '__tests__',
     'coverage',
 
     // Forked package

--- a/depcheck.config.js
+++ b/depcheck.config.js
@@ -48,7 +48,7 @@ module.exports = {
     },
     project: ['tsconfig.base.json'],
   },
-  plugins: ['@typescript-eslint'],
+  plugins: ['@typescript-eslint', 'spellcheck', 'import', 'jsdoc', 'prefer-arrow'],
   settings: {
     'import/parsers': { '@typescript-eslint/parser': ['.ts', '.tsx'] },
     'import/resolver': { typescript: {} },

--- a/packages/amplify-category-api/API.md
+++ b/packages/amplify-category-api/API.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { $TSContext } from '@aws-amplify/amplify-cli-core';
-import { AmplifyApiGraphQlResourceStackTemplate } from '@aws-amplify/graphql-transformer-interfaces';
 import * as cdk from 'aws-cdk-lib';
 import * as cloudmap from 'aws-cdk-lib/aws-servicediscovery';
 import { Construct } from 'constructs';
@@ -15,8 +14,6 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { ResolverConfig } from 'graphql-transformer-core';
-import { StackManager } from '@aws-amplify/graphql-transformer-core';
-import { UserDefinedSlot } from '@aws-amplify/graphql-transformer-core';
 
 // @public (undocumented)
 export function addAdminQueriesApi(context: $TSContext, apiProps: {
@@ -53,9 +50,6 @@ export type ApiResource = {
         port: number;
     };
 };
-
-// @public (undocumented)
-export function applyOverride(stackManager: StackManager, overrideDir: string): AmplifyApiGraphQlResourceStackTemplate;
 
 // @public (undocumented)
 export const checkForcedUpdates: (context: $TSContext) => Promise<void>;
@@ -152,9 +146,6 @@ export const migrate: (context: $TSContext, serviceName?: string) => Promise<voi
 export const NETWORK_STACK_LOGICAL_ID = "NetworkStack";
 
 // @public (undocumented)
-export function parseUserDefinedSlots(userDefinedTemplates: Record<string, string>): Record<string, UserDefinedSlot[]>;
-
-// @public (undocumented)
 export function processDockerConfig(context: $TSContext, resource: ApiResource, srcPath: string, askForExposedContainer?: boolean): Promise<{
     containersPorts: number[];
     containers: Container[];
@@ -172,9 +163,6 @@ export function promptToAddApiKey(context: $TSContext): Promise<any>;
 
 // @public (undocumented)
 export const showApiAuthAcm: (context: $TSContext, modelName: string) => Promise<void>;
-
-// @public (undocumented)
-export const SLOT_NAMES: Set<string>;
 
 // @public (undocumented)
 export const transformCategoryStack: (context: $TSContext, resource: Record<string, any>) => Promise<void>;

--- a/packages/amplify-category-api/src/__tests__/amplify-graphql-transform/graphql-transformer-v2.test.ts
+++ b/packages/amplify-category-api/src/__tests__/amplify-graphql-transform/graphql-transformer-v2.test.ts
@@ -3,7 +3,7 @@ import { constructTransformerChain } from '../../amplify-graphql-transform/graph
 
 describe('constructTransformerChain', () => {
     it('returns 14 transformers when no custom transformers are provided', () => {
-        expect(constructTransformerChain([]).length).toEqual(14);
+        expect(constructTransformerChain({ authConfig: {}, customTransformers: [] }).length).toEqual(14);
     });
 
 
@@ -12,6 +12,6 @@ describe('constructTransformerChain', () => {
             {} as unknown as TransformerPluginProvider,
             {} as unknown as TransformerPluginProvider,
         ];
-        expect(constructTransformerChain(customTransformers).length).toEqual(16);
+        expect(constructTransformerChain({ authConfig: {}, customTransformers }).length).toEqual(16);
     });
 });

--- a/packages/amplify-category-api/src/__tests__/amplify-graphql-transform/graphql-transformer-v2.test.ts
+++ b/packages/amplify-category-api/src/__tests__/amplify-graphql-transform/graphql-transformer-v2.test.ts
@@ -1,0 +1,17 @@
+import { TransformerPluginProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { constructTransformerChain } from '../../amplify-graphql-transform/graphql-transformer-v2';
+
+describe('constructTransformerChain', () => {
+    it('returns 14 transformers when no custom transformers are provided', () => {
+        expect(constructTransformerChain([]).length).toEqual(14);
+    });
+
+
+    it('returns 16 transformers when 2 custom transformers are provided', () => {
+        const customTransformers: TransformerPluginProvider[] = [
+            {} as unknown as TransformerPluginProvider,
+            {} as unknown as TransformerPluginProvider,
+        ];
+        expect(constructTransformerChain(customTransformers).length).toEqual(16);
+    });
+});

--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/override/amplify-graphql-function-transformer-override.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/override/amplify-graphql-function-transformer-override.test.ts
@@ -1,6 +1,6 @@
 import { GraphQLTransform, StackManager } from '@aws-amplify/graphql-transformer-core';
 import { stateManager } from '@aws-amplify/amplify-cli-core';
-import { applyOverride } from '../../../graphql-transformer/override';
+import { applyFileBasedOverride } from '../../../graphql-transformer/override';
 import { parse } from 'graphql';
 import * as path from 'path';
 import { FunctionTransformer } from '@aws-amplify/graphql-function-transformer';
@@ -18,9 +18,7 @@ test('it ovderrides the expected resources', () => {
   const transformer = new GraphQLTransform({
     transformers: [new FunctionTransformer()],
     overrideConfig: {
-      applyOverride: (stackManager: StackManager) => {
-        return applyOverride(stackManager, path.join(__dirname, 'function-overrides'))
-      },
+      applyOverride: (stackManager: StackManager) => applyFileBasedOverride(stackManager, path.join(__dirname, 'function-overrides')),
       overrideFlag: true,
     },
   });
@@ -43,9 +41,7 @@ test('it skips override if override file does not exist', () => {
   const transformer = new GraphQLTransform({
     transformers: [new FunctionTransformer()],
     overrideConfig: {
-      applyOverride: (stackManager: StackManager) => (
-        applyOverride(stackManager, path.join(__dirname, 'non-existing-override-directory'))
-      ),
+      applyOverride: (stackManager: StackManager) => applyFileBasedOverride(stackManager, path.join(__dirname, 'non-existing-override-directory')),
       overrideFlag: true,
     },
   });

--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/override/amplify-graphql-http-transformer-override.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/override/amplify-graphql-http-transformer-override.test.ts
@@ -2,7 +2,7 @@ import { GraphQLTransform, StackManager } from '@aws-amplify/graphql-transformer
 import { parse } from 'graphql';
 import path from 'path';
 import { stateManager } from '@aws-amplify/amplify-cli-core';
-import { applyOverride } from '../../../graphql-transformer/override';
+import { applyFileBasedOverride } from '../../../graphql-transformer/override';
 import { HttpTransformer } from '@aws-amplify/graphql-http-transformer';
 
 jest.spyOn(stateManager, 'getLocalEnvInfo').mockReturnValue({ envName: 'testEnvName' });
@@ -22,9 +22,7 @@ test('it generates the overrided resources', () => {
   const transformer = new GraphQLTransform({
     transformers: [new HttpTransformer()],
     overrideConfig: {
-      applyOverride: (stackManager: StackManager) => {
-        return applyOverride(stackManager, path.join(__dirname, 'http-overrides'))
-      },
+      applyOverride: (stackManager: StackManager) => applyFileBasedOverride(stackManager, path.join(__dirname, 'http-overrides')),
       overrideFlag: true,
     },
   });
@@ -50,9 +48,7 @@ test('it skips override if file does not exist', () => {
   const transformer = new GraphQLTransform({
     transformers: [new HttpTransformer()],
     overrideConfig: {
-      applyOverride: (stackManager: StackManager) => {
-        return applyOverride(stackManager, path.join(__dirname, 'non-existing-override-dir'))
-      },
+      applyOverride: (stackManager: StackManager) => applyFileBasedOverride(stackManager, path.join(__dirname, 'non-existing-override-dir')),
       overrideFlag: true,
     },
   });

--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/override/amplify-graphql-predictions-transformer-override.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/override/amplify-graphql-predictions-transformer-override.test.ts
@@ -2,7 +2,7 @@ import { GraphQLTransform, StackManager } from '@aws-amplify/graphql-transformer
 import * as path from 'path';
 import { PredictionsTransformer } from '@aws-amplify/graphql-predictions-transformer';
 import { stateManager } from '@aws-amplify/amplify-cli-core';
-import { applyOverride } from '../../../graphql-transformer/override';
+import { applyFileBasedOverride } from '../../../graphql-transformer/override';
 
 jest.spyOn(stateManager, 'getLocalEnvInfo').mockReturnValue({ envName: 'testEnvName' });
 jest.spyOn(stateManager, 'getProjectConfig').mockReturnValue({ projectName: 'testProjectName' });
@@ -17,9 +17,7 @@ test('it generates resources with overrides', () => {
   const transformer = new GraphQLTransform({
     transformers: [new PredictionsTransformer({ bucketName: 'myStorage${hash}-${env}' })],
     overrideConfig: {
-      applyOverride: (stackManager: StackManager) => {
-        return applyOverride(stackManager, path.join(__dirname, 'predictions-overrides'))
-      },
+      applyOverride: (stackManager: StackManager) => applyFileBasedOverride(stackManager, path.join(__dirname, 'predictions-overrides')),
       overrideFlag: true,
     },
   });
@@ -39,9 +37,7 @@ test('it skips override if override file does not exist', () => {
   const transformer = new GraphQLTransform({
     transformers: [new PredictionsTransformer({ bucketName: 'myStorage${hash}-${env}' })],
     overrideConfig: {
-      applyOverride: (stackManager: StackManager) => {
-        return applyOverride(stackManager, path.join(__dirname, 'non-existing-override-directory'))
-      },
+      applyOverride: (stackManager: StackManager) => applyFileBasedOverride(stackManager, path.join(__dirname, 'non-existing-override-directory')),
       overrideFlag: true,
     },
   });

--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/override/amplify-graphql-searchable-transformer-override.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/override/amplify-graphql-searchable-transformer-override.test.ts
@@ -4,7 +4,7 @@ import { Match, Template } from 'aws-cdk-lib/assertions';
 import * as path from 'path';
 import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-transformer';
 import { stateManager } from '@aws-amplify/amplify-cli-core';
-import { applyOverride } from '../../../graphql-transformer/override';
+import { applyFileBasedOverride } from '../../../graphql-transformer/override';
 
 jest.spyOn(stateManager, 'getLocalEnvInfo').mockReturnValue({ envName: 'testEnvName' });
 jest.spyOn(stateManager, 'getProjectConfig').mockReturnValue({ projectName: 'testProjectName' });
@@ -37,9 +37,7 @@ test('it overrides expected resources', () => {
     transformers: [new ModelTransformer(), new SearchableModelTransformer()],
     featureFlags,
     overrideConfig: {
-      applyOverride: (stackManager: StackManager) => {
-        return applyOverride(stackManager, path.join(__dirname, 'searchable-overrides'))
-      },
+      applyOverride: (stackManager: StackManager) => applyFileBasedOverride(stackManager, path.join(__dirname, 'searchable-overrides')),
       overrideFlag: true,
     },
   });

--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/override/model-transformer-override.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/override/model-transformer-override.test.ts
@@ -2,7 +2,7 @@ import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { GraphQLTransform, StackManager } from '@aws-amplify/graphql-transformer-core';
 import path from 'path';
 import { stateManager } from '@aws-amplify/amplify-cli-core';
-import { applyOverride } from '@aws-amplify/amplify-category-api';
+import { applyFileBasedOverride } from '../../../graphql-transformer/override';
 
 jest.spyOn(stateManager, 'getLocalEnvInfo').mockReturnValue({ envName: 'testEnvName' });
 jest.spyOn(stateManager, 'getProjectConfig').mockReturnValue({ projectName: 'testProjectName' });
@@ -28,9 +28,7 @@ describe('ModelTransformer: ', () => {
     const transformer = new GraphQLTransform({
       transformers: [new ModelTransformer()],
       overrideConfig: {
-        applyOverride: (stackManager: StackManager) => {
-          return applyOverride(stackManager, path.join(__dirname, 'model-overrides'))
-        },
+        applyOverride: (stackManager: StackManager) => applyFileBasedOverride(stackManager, path.join(__dirname, 'model-overrides')),
         overrideFlag: true,
       },
       featureFlags,
@@ -58,9 +56,7 @@ describe('ModelTransformer: ', () => {
     const transformer = new GraphQLTransform({
       transformers: [new ModelTransformer()],
       overrideConfig: {
-        applyOverride: (stackManager: StackManager) => {
-          return applyOverride(stackManager, path.join(__dirname, 'non-existing-override-directory'))
-        },
+        applyOverride: (stackManager: StackManager) => applyFileBasedOverride(stackManager, path.join(__dirname, 'non-existing-override-directory')),
         overrideFlag: true,
       },
       featureFlags,

--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/transform-graphql-schema-v2.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/transform-graphql-schema-v2.test.ts
@@ -3,7 +3,7 @@ import { printer } from "@aws-amplify/amplify-prompts";
 import { ApiCategoryFacade } from "@aws-amplify/amplify-cli-core";
 import { transformGraphQLSchemaV2 } from "../../graphql-transformer/transform-graphql-schema-v2";
 import { generateTransformerOptions } from "../../graphql-transformer/transformer-options-v2";
-import { getTransformerFactory } from "../../graphql-transformer/transformer-factory";
+import { getTransformerFactoryV2 } from "../../graphql-transformer/transformer-factory";
 import { getAppSyncAPIName } from "../../provider-utils/awscloudformation/utils/amplify-meta-utils";
 
 jest.mock("@aws-amplify/amplify-cli-core");
@@ -61,7 +61,7 @@ describe("transformGraphQLSchemaV2", () => {
         `,
         config: { StackMapping: {} },
       },
-      transformersFactory: await getTransformerFactory(contextMock, "resourceDir"),
+      transformersFactory: await getTransformerFactoryV2("resourceDir"),
       transformersFactoryArgs: {},
       dryRun: true,
       projectDirectory: __dirname,

--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/transform-graphql-schema-v2.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/transform-graphql-schema-v2.test.ts
@@ -3,8 +3,8 @@ import { printer } from "@aws-amplify/amplify-prompts";
 import { ApiCategoryFacade } from "@aws-amplify/amplify-cli-core";
 import { transformGraphQLSchemaV2 } from "../../graphql-transformer/transform-graphql-schema-v2";
 import { generateTransformerOptions } from "../../graphql-transformer/transformer-options-v2";
-import { getTransformerFactoryV2 } from "../../graphql-transformer/transformer-factory";
 import { getAppSyncAPIName } from "../../provider-utils/awscloudformation/utils/amplify-meta-utils";
+import { constructTransformerChain } from "../../amplify-graphql-transform/graphql-transformer-v2";
 
 jest.mock("@aws-amplify/amplify-cli-core");
 jest.mock("@aws-amplify/amplify-prompts");
@@ -61,7 +61,7 @@ describe("transformGraphQLSchemaV2", () => {
         `,
         config: { StackMapping: {} },
       },
-      transformersFactory: await getTransformerFactoryV2("resourceDir"),
+      transformersFactory: constructTransformerChain({ authConfig: {}, customTransformers: [] }),
       transformersFactoryArgs: {},
       dryRun: true,
       projectDirectory: __dirname,

--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/user-defined-slots.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/user-defined-slots.test.ts
@@ -1,4 +1,4 @@
-import { SLOT_NAMES, parseUserDefinedSlots } from '../../graphql-transformer';
+import { SLOT_NAMES, parseUserDefinedSlots } from '../../graphql-transformer/user-defined-slots';
 
 describe('user defined slots', () => {
   describe('const SLOT_NAMES', () => {

--- a/packages/amplify-category-api/src/amplify-graphql-transform/graphql-transformer-v2.ts
+++ b/packages/amplify-category-api/src/amplify-graphql-transform/graphql-transformer-v2.ts
@@ -1,0 +1,48 @@
+import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { DefaultValueTransformer } from '@aws-amplify/graphql-default-value-transformer';
+import { FunctionTransformer } from '@aws-amplify/graphql-function-transformer';
+import { HttpTransformer } from '@aws-amplify/graphql-http-transformer';
+import { IndexTransformer, PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
+import { MapsToTransformer } from '@aws-amplify/graphql-maps-to-transformer';
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { PredictionsTransformer } from '@aws-amplify/graphql-predictions-transformer';
+import {
+  BelongsToTransformer,
+  HasManyTransformer,
+  HasOneTransformer,
+  ManyToManyTransformer,
+} from '@aws-amplify/graphql-relational-transformer';
+import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-transformer';
+import { TransformerPluginProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { TransformerFactoryArgs } from '../graphql-transformer/transformer-options-types';
+
+export const constructTransformerChain = (
+  customTransformers: TransformerPluginProvider[],
+  options?: TransformerFactoryArgs,
+): TransformerPluginProvider[] => {
+  const modelTransformer = new ModelTransformer();
+  const authTransformer = new AuthTransformer({
+    adminRoles: options?.adminRoles ?? [],
+    identityPoolId: options?.identityPoolId,
+  });
+  const indexTransformer = new IndexTransformer();
+  const hasOneTransformer = new HasOneTransformer();
+
+  return [
+    modelTransformer,
+    new FunctionTransformer(),
+    new HttpTransformer(),
+    new PredictionsTransformer(options?.storageConfig),
+    new PrimaryKeyTransformer(),
+    indexTransformer,
+    new HasManyTransformer(),
+    hasOneTransformer,
+    new ManyToManyTransformer(modelTransformer, indexTransformer, hasOneTransformer, authTransformer),
+    new BelongsToTransformer(),
+    new DefaultValueTransformer(),
+    authTransformer,
+    new MapsToTransformer(),
+    new SearchableModelTransformer({ enableNodeToNodeEncryption: options?.searchConfig?.enableNodeToNodeEncryption }),
+    ...customTransformers,
+  ];
+};

--- a/packages/amplify-category-api/src/amplify-graphql-transform/graphql-transformer-v2.ts
+++ b/packages/amplify-category-api/src/amplify-graphql-transform/graphql-transformer-v2.ts
@@ -14,10 +14,13 @@ import {
 } from '@aws-amplify/graphql-relational-transformer';
 import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-transformer';
 import { TransformerPluginProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { TransformerFactoryArgs } from '../graphql-transformer/transformer-options-types';
+import { GraphQLTransform, StackManager } from '@aws-amplify/graphql-transformer-core';
+import { TransformerFactoryArgs, TransformerProjectOptions } from '../graphql-transformer/transformer-options-types';
+import { AmplifyCLIFeatureFlagAdapter } from '../graphql-transformer/amplify-cli-feature-flag-adapter';
+import { applyFileBasedOverride } from '../graphql-transformer/override';
+import { parseUserDefinedSlotsFromProject } from '../graphql-transformer/user-defined-slots';
 
 export const constructTransformerChain = (
-  customTransformers: TransformerPluginProvider[],
   options?: TransformerFactoryArgs,
 ): TransformerPluginProvider[] => {
   const modelTransformer = new ModelTransformer();
@@ -27,6 +30,8 @@ export const constructTransformerChain = (
   });
   const indexTransformer = new IndexTransformer();
   const hasOneTransformer = new HasOneTransformer();
+
+  const customTransformers = options?.customTransformers ?? [];
 
   return [
     modelTransformer,
@@ -46,3 +51,20 @@ export const constructTransformerChain = (
     ...customTransformers,
   ];
 };
+
+export const constructTransform = (opts: TransformerProjectOptions): GraphQLTransform => new GraphQLTransform({
+  transformers: constructTransformerChain(opts.transformersFactoryArgs),
+  stackMapping: opts.projectConfig.config.StackMapping,
+  transformConfig: opts.projectConfig.config,
+  authConfig: opts.authConfig,
+  buildParameters: opts.buildParameters,
+  stacks: opts.projectConfig.stacks || {},
+  featureFlags: new AmplifyCLIFeatureFlagAdapter(),
+  sandboxModeEnabled: opts.sandboxModeEnabled,
+  userDefinedSlots: parseUserDefinedSlotsFromProject(opts.projectConfig),
+  resolverConfig: opts.resolverConfig,
+  overrideConfig: {
+    applyOverride: (stackManager: StackManager) => applyFileBasedOverride(stackManager),
+    ...opts.overrideConfig,
+  },
+});

--- a/packages/amplify-category-api/src/amplify-graphql-transform/index.ts
+++ b/packages/amplify-category-api/src/amplify-graphql-transform/index.ts
@@ -1,0 +1,1 @@
+export { constructTransformerChain } from './graphql-transformer-v2';

--- a/packages/amplify-category-api/src/category-utils/schema-reader.ts
+++ b/packages/amplify-category-api/src/category-utils/schema-reader.ts
@@ -9,13 +9,13 @@ import {
   AmplifyError,
   ApiCategoryFacade,
 } from '@aws-amplify/amplify-cli-core';
-import { constructGraphQLTransformV2 } from '../graphql-transformer/transformer-factory';
 import {
   SCHEMA_DIR_NAME,
   SCHEMA_FILENAME,
 } from '../graphql-transformer/constants';
 import { generateTransformerOptions } from '../graphql-transformer/transformer-options-v2';
 import { contextUtil } from './context-util';
+import { constructTransform } from '../amplify-graphql-transform/graphql-transformer-v2';
 
 /**
  * SchemaReader is a utility point to consolidate and abstract GraphQL Schema reading
@@ -90,7 +90,7 @@ export class SchemaReader {
 
     if (preProcessSchema && !this.preProcessedSchemaDocument) {
       const transformerOptions = await generateTransformerOptions(context, options);
-      const transform = await constructGraphQLTransformV2(transformerOptions);
+      const transform = constructTransform(transformerOptions);
       this.preProcessedSchemaDocument = transform.preProcessSchema(this.schemaDocument);
     }
 

--- a/packages/amplify-category-api/src/graphql-transformer/directive-definitions.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/directive-definitions.ts
@@ -1,12 +1,10 @@
-import {
-  getAppSyncServiceExtraDirectives,
-} from '@aws-amplify/graphql-transformer-core';
-import {
-  $TSContext,
-} from '@aws-amplify/amplify-cli-core';
+import { getAppSyncServiceExtraDirectives } from '@aws-amplify/graphql-transformer-core';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
 import { print } from 'graphql';
-import { getTransformerFactoryV2, getTransformerFactoryV1 } from './transformer-factory';
+import { TransformerPluginProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { getTransformerFactoryV1, loadCustomTransformersV2 } from './transformer-factory';
 import { getTransformerVersion } from './transformer-version';
+import { constructTransformerChain } from '../amplify-graphql-transform';
 
 /**
  * Return the set of directive definitions for the project, includes both appsync and amplify supported directives.
@@ -15,12 +13,17 @@ import { getTransformerVersion } from './transformer-version';
 export const getDirectiveDefinitions = async (context: $TSContext, resourceDir: string): Promise<string> => {
   const transformerVersion = await getTransformerVersion(context);
   const transformList = transformerVersion === 2
-    ? await (await getTransformerFactoryV2(resourceDir))({ authConfig: {} })
-    : await (await getTransformerFactoryV1(context, resourceDir))(true);
+    ? await getTransformListV2(resourceDir)
+    : await getTransformerFactoryV1(context, resourceDir)(true);
 
   const transformDirectives = transformList
     .map((transform) => [transform.directive, ...transform.typeDefinitions].map((node) => print(node)).join('\n'))
     .join('\n');
 
   return [getAppSyncServiceExtraDirectives(), transformDirectives].join('\n');
+};
+
+const getTransformListV2 = async (resourceDir: string): Promise<TransformerPluginProvider[]> => {
+  const customTransformers = await loadCustomTransformersV2(resourceDir);
+  return constructTransformerChain({ authConfig: {}, customTransformers });
 };

--- a/packages/amplify-category-api/src/graphql-transformer/index.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/index.ts
@@ -1,5 +1,3 @@
 export { getDirectiveDefinitions } from './directive-definitions';
 export { getTransformerVersion } from './transformer-version';
-export { SLOT_NAMES, parseUserDefinedSlots } from './user-defined-slots';
 export { transformGraphQLSchema } from './transform-graphql-schema';
-export { applyOverride } from './override';

--- a/packages/amplify-category-api/src/graphql-transformer/override.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/override.ts
@@ -3,18 +3,20 @@ import * as fs from "fs-extra";
 import * as vm from "vm2";
 import * as path from "path";
 import _ from "lodash";
-import { stateManager } from "@aws-amplify/amplify-cli-core";
+import { pathManager, stateManager } from "@aws-amplify/amplify-cli-core";
 import { StackManager } from "@aws-amplify/graphql-transformer-core";
 import { AmplifyApiGraphQlResourceStackTemplate } from "@aws-amplify/graphql-transformer-interfaces";
 import { ConstructResourceMeta } from "./types/types";
 import { convertToAppsyncResourceObj, getStackMeta } from "./types/utils";
+import { getAppSyncAPIName } from "../provider-utils/awscloudformation/utils/amplify-meta-utils";
 
 /**
  *
  * @param stackManager
  * @param overrideDir
  */
-export function applyOverride(stackManager: StackManager, overrideDir: string): AmplifyApiGraphQlResourceStackTemplate {
+export function applyFileBasedOverride(stackManager: StackManager, overrideDirPath?: string): AmplifyApiGraphQlResourceStackTemplate {
+  const overrideDir = overrideDirPath ?? path.join(pathManager.getBackendDirPath(), 'api', getAppSyncAPIName());
   const overrideFilePath = path.join(overrideDir, "build", "override.js");
   if (!fs.existsSync(overrideFilePath)) {
     return {};

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v1.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v1.ts
@@ -32,7 +32,7 @@ import {
 } from 'graphql-transformer-core';
 import { exitOnNextTick } from '@aws-amplify/amplify-cli-core';
 import { searchablePushChecks } from './api-utils';
-import { getTransformerFactory } from './transformer-factory';
+import { getTransformerFactoryV1 } from './transformer-factory';
 
 const apiCategory = 'api';
 const parametersFileName = 'parameters.json';
@@ -361,7 +361,7 @@ export async function transformGraphQLSchemaV1(context, options) {
 
   await transformerVersionCheck(context, resourceDir, previouslyDeployedBackendDir, resourcesToBeUpdated, directiveMap.directives);
 
-  const transformerListFactory = await getTransformerFactory(context, resourceDir, authConfig);
+  const transformerListFactory = await getTransformerFactoryV1(context, resourceDir, authConfig);
 
   let searchableTransformerFlag = false;
 

--- a/packages/amplify-category-api/src/graphql-transformer/transformer-options-types.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transformer-options-types.ts
@@ -45,6 +45,10 @@ type SanityCheckRules = {
   projectRules: ProjectRule[];
 };
 
+export type TransformerSearchConfig = {
+  enableNodeToNodeEncryption?: boolean;
+};
+
 /**
  * Arguments passed into a TransformerFactory
  * Used to determine how to create a new GraphQLTransform
@@ -54,4 +58,5 @@ export type TransformerFactoryArgs = {
   storageConfig?: any;
   adminRoles?: Array<string>;
   identityPoolId?: string;
+  searchConfig?: TransformerSearchConfig;
 };

--- a/packages/amplify-category-api/src/graphql-transformer/transformer-options-types.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transformer-options-types.ts
@@ -4,7 +4,7 @@
 import {
   AppSyncAuthConfiguration,
   TransformerPluginProvider,
-  Template
+  Template,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import {
   OverrideConfig,
@@ -16,17 +16,18 @@ import {
   ProjectRule,
 } from 'graphql-transformer-core';
 
+type BuildParameters = {
+  S3DeploymentBucket: string;
+  S3DeploymentRootKey: string;
+};
+
 /**
  * Transformer Options used to create a GraphQL Transform and compile a GQL API
  */
-export type TransformerProjectOptions<T> = {
-  buildParameters: {
-    S3DeploymentBucket: string;
-    S3DeploymentRootKey: string;
-  };
+export type TransformerProjectOptions = {
+  buildParameters: BuildParameters;
   projectDirectory: string;
-  transformersFactory: (options: T) => Promise<TransformerPluginProvider[]>;
-  transformersFactoryArgs: T;
+  transformersFactoryArgs: TransformerFactoryArgs;
   rootStackFileName: 'cloudformation-template.json';
   currentCloudBackendDirectory?: string;
   lastDeployedProjectConfig?: TransformerProjectConfig;
@@ -59,4 +60,5 @@ export type TransformerFactoryArgs = {
   adminRoles?: Array<string>;
   identityPoolId?: string;
   searchConfig?: TransformerSearchConfig;
+  customTransformers: TransformerPluginProvider[];
 };

--- a/packages/amplify-category-api/src/graphql-transformer/user-defined-slots.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/user-defined-slots.ts
@@ -1,4 +1,4 @@
-import { UserDefinedSlot, UserDefinedResolver } from '@aws-amplify/graphql-transformer-core';
+import { UserDefinedSlot, UserDefinedResolver, TransformerProjectConfig } from '@aws-amplify/graphql-transformer-core';
 import _ from 'lodash';
 
 export const SLOT_NAMES = new Set([
@@ -15,6 +15,16 @@ export const SLOT_NAMES = new Set([
 ]);
 
 const EXCLUDE_FILES = new Set(['README.md']);
+
+/**
+ * Given a project config, parse all amplify user defined slots from it.
+ */
+export const parseUserDefinedSlotsFromProject = (
+  { pipelineFunctions, resolvers }: TransformerProjectConfig,
+): Record<string, UserDefinedSlot[]> => ({
+  ...parseUserDefinedSlots(pipelineFunctions),
+  ...parseUserDefinedSlots(resolvers),
+});
 
 export function parseUserDefinedSlots(userDefinedTemplates: Record<string, string>): Record<string, UserDefinedSlot[]> {
   type ResolverKey = string;


### PR DESCRIPTION
- chore: refactor v2 transformer chain into a separate set of utilities
- chore: minimal refactor construction of the graphql transform out into the separate package

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
