### PR TITLE
transformer package refactor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -132,7 +132,7 @@ module.exports = {
     'max-classes-per-file': 'error',
     'no-lonely-if': 'error',
     'no-unneeded-ternary': 'error',
-    'no-use-before-define': 'error',
+    'no-use-before-define': 'off',
     'consistent-return': 'error',
     'no-bitwise': 'error',
     'yoda': 'error',
@@ -195,6 +195,7 @@ module.exports = {
     'dist',
     'build',
     '__mocks__',
+    '__tests__',
     'coverage',
 
     // Forked package

--- a/depcheck.config.js
+++ b/depcheck.config.js
@@ -48,7 +48,7 @@ module.exports = {
     },
     project: ['tsconfig.base.json'],
   },
-  plugins: ['@typescript-eslint'],
+  plugins: ['@typescript-eslint', 'spellcheck', 'import', 'jsdoc', 'prefer-arrow'],
   settings: {
     'import/parsers': { '@typescript-eslint/parser': ['.ts', '.tsx'] },
     'import/resolver': { typescript: {} },

--- a/packages/amplify-category-api/src/__tests__/amplify-graphql-transform/graphql-transformer-v2.test.ts
+++ b/packages/amplify-category-api/src/__tests__/amplify-graphql-transform/graphql-transformer-v2.test.ts
@@ -2,16 +2,16 @@ import { TransformerPluginProvider } from '@aws-amplify/graphql-transformer-inte
 import { constructTransformerChain } from '../../amplify-graphql-transform/graphql-transformer-v2';
 
 describe('constructTransformerChain', () => {
-    it('returns 14 transformers when no custom transformers are provided', () => {
-        expect(constructTransformerChain([]).length).toEqual(14);
-    });
+  it('returns 14 transformers when no custom transformers are provided', () => {
+    expect(constructTransformerChain({ customTransformers: [] }).length).toEqual(14);
+  });
 
 
-    it('returns 16 transformers when 2 custom transformers are provided', () => {
-        const customTransformers: TransformerPluginProvider[] = [
-            {} as unknown as TransformerPluginProvider,
-            {} as unknown as TransformerPluginProvider,
-        ];
-        expect(constructTransformerChain(customTransformers).length).toEqual(16);
-    });
+  it('returns 16 transformers when 2 custom transformers are provided', () => {
+    const customTransformers: TransformerPluginProvider[] = [
+      {} as unknown as TransformerPluginProvider,
+      {} as unknown as TransformerPluginProvider,
+    ];
+    expect(constructTransformerChain({ customTransformers }).length).toEqual(16);
+  });
 });

--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/transform-graphql-schema-v2.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/transform-graphql-schema-v2.test.ts
@@ -3,8 +3,8 @@ import { printer } from "@aws-amplify/amplify-prompts";
 import { ApiCategoryFacade } from "@aws-amplify/amplify-cli-core";
 import { transformGraphQLSchemaV2 } from "../../graphql-transformer/transform-graphql-schema-v2";
 import { generateTransformerOptions } from "../../graphql-transformer/transformer-options-v2";
-import { getTransformerFactoryV2 } from "../../graphql-transformer/transformer-factory";
 import { getAppSyncAPIName } from "../../provider-utils/awscloudformation/utils/amplify-meta-utils";
+import { constructTransformerChain } from "../../amplify-graphql-transform/graphql-transformer-v2";
 
 jest.mock("@aws-amplify/amplify-cli-core");
 jest.mock("@aws-amplify/amplify-prompts");
@@ -61,7 +61,7 @@ describe("transformGraphQLSchemaV2", () => {
         `,
         config: { StackMapping: {} },
       },
-      transformersFactory: await getTransformerFactoryV2("resourceDir"),
+      transformersFactory: constructTransformerChain({ customTransformers: [] }),
       transformersFactoryArgs: {},
       dryRun: true,
       projectDirectory: __dirname,

--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/transform-graphql-schema-v2.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/transform-graphql-schema-v2.test.ts
@@ -5,6 +5,8 @@ import { transformGraphQLSchemaV2 } from "../../graphql-transformer/transform-gr
 import { generateTransformerOptions } from "../../graphql-transformer/transformer-options-v2";
 import { getAppSyncAPIName } from "../../provider-utils/awscloudformation/utils/amplify-meta-utils";
 import { constructTransformerChain } from "../../amplify-graphql-transform/graphql-transformer-v2";
+import { TransformerProjectOptions } from "../../graphql-transformer/transformer-options-types";
+import { AmplifyCLIFeatureFlagAdapter } from "../../graphql-transformer/amplify-cli-feature-flag-adapter";
 
 jest.mock("@aws-amplify/amplify-cli-core");
 jest.mock("@aws-amplify/amplify-prompts");
@@ -71,6 +73,7 @@ describe("transformGraphQLSchemaV2", () => {
           authenticationType: "AMAZON_COGNITO_USER_POOLS",
         },
       },
+      featureFlags: new AmplifyCLIFeatureFlagAdapter(),
     });
     getAppSyncAPINameMock.mockReturnValue(["testapi"]);
 

--- a/packages/amplify-category-api/src/amplify-graphql-transform/graphql-transformer-v2.ts
+++ b/packages/amplify-category-api/src/amplify-graphql-transform/graphql-transformer-v2.ts
@@ -13,12 +13,46 @@ import {
   ManyToManyTransformer,
 } from '@aws-amplify/graphql-relational-transformer';
 import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-transformer';
-import { TransformerPluginProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { GraphQLTransform, StackManager } from '@aws-amplify/graphql-transformer-core';
-import { TransformerFactoryArgs, TransformerProjectOptions } from '../graphql-transformer/transformer-options-types';
-import { AmplifyCLIFeatureFlagAdapter } from '../graphql-transformer/amplify-cli-feature-flag-adapter';
-import { applyFileBasedOverride } from '../graphql-transformer/override';
-import { parseUserDefinedSlotsFromProject } from '../graphql-transformer/user-defined-slots';
+import {
+  AppSyncAuthConfiguration, FeatureFlagProvider, Template, TransformerPluginProvider,
+} from '@aws-amplify/graphql-transformer-interfaces';
+import {
+  GraphQLTransform, OverrideConfig, ResolverConfig, UserDefinedSlot,
+} from '@aws-amplify/graphql-transformer-core';
+
+export type TransformerSearchConfig = {
+  enableNodeToNodeEncryption?: boolean;
+};
+
+/**
+ * Arguments passed into a TransformerFactory
+ * Used to determine how to create a new GraphQLTransform
+ */
+export type TransformerFactoryArgs = {
+  authConfig?: any;
+  storageConfig?: any;
+  adminRoles?: Array<string>;
+  identityPoolId?: string;
+  searchConfig?: TransformerSearchConfig;
+  customTransformers?: TransformerPluginProvider[];
+};
+
+/**
+ * Transformer Options used to create a GraphQL Transform and compile a GQL API
+ */
+export type TransformConfig = {
+  legacyApiKeyEnabled?: number;
+  disableResolverDeduping?: boolean;
+  transformersFactoryArgs: TransformerFactoryArgs;
+  resolverConfig?: ResolverConfig;
+  authConfig?: AppSyncAuthConfiguration;
+  stacks?: Record<string, Template>;
+  sandboxModeEnabled?: boolean;
+  overrideConfig?: OverrideConfig;
+  userDefinedSlots?: Record<string, UserDefinedSlot[]>;
+  stackMapping?: Record<string, string>;
+  featureFlags: FeatureFlagProvider;
+};
 
 export const constructTransformerChain = (
   options: TransformerFactoryArgs,
@@ -30,8 +64,6 @@ export const constructTransformerChain = (
   });
   const indexTransformer = new IndexTransformer();
   const hasOneTransformer = new HasOneTransformer();
-
-  const customTransformers = options.customTransformers ?? [];
 
   return [
     modelTransformer,
@@ -48,23 +80,38 @@ export const constructTransformerChain = (
     authTransformer,
     new MapsToTransformer(),
     new SearchableModelTransformer({ enableNodeToNodeEncryption: options.searchConfig?.enableNodeToNodeEncryption }),
-    ...customTransformers,
+    ...(options.customTransformers ?? []),
   ];
 };
 
-export const constructTransform = (opts: TransformerProjectOptions): GraphQLTransform => new GraphQLTransform({
-  transformers: constructTransformerChain(opts.transformersFactoryArgs),
-  stackMapping: opts.projectConfig.config.StackMapping,
-  transformConfig: opts.projectConfig.config,
-  authConfig: opts.authConfig,
-  buildParameters: opts.buildParameters,
-  stacks: opts.projectConfig.stacks || {},
-  featureFlags: new AmplifyCLIFeatureFlagAdapter(),
-  sandboxModeEnabled: opts.sandboxModeEnabled,
-  userDefinedSlots: parseUserDefinedSlotsFromProject(opts.projectConfig),
-  resolverConfig: opts.resolverConfig,
-  overrideConfig: {
-    applyOverride: (stackManager: StackManager) => applyFileBasedOverride(stackManager),
-    ...opts.overrideConfig,
-  },
-});
+export const constructTransform = (config: TransformConfig): GraphQLTransform => {
+  const {
+    transformersFactoryArgs,
+    authConfig,
+    sandboxModeEnabled,
+    resolverConfig,
+    overrideConfig,
+    userDefinedSlots,
+    legacyApiKeyEnabled,
+    disableResolverDeduping,
+    stacks,
+    stackMapping,
+    featureFlags,
+  } = config;
+
+  const transformers = constructTransformerChain(transformersFactoryArgs);
+
+  return new GraphQLTransform({
+    transformers,
+    stackMapping,
+    authConfig,
+    stacks,
+    featureFlags,
+    sandboxModeEnabled,
+    userDefinedSlots,
+    resolverConfig,
+    overrideConfig,
+    legacyApiKeyEnabled,
+    disableResolverDeduping,
+  });
+};

--- a/packages/amplify-category-api/src/amplify-graphql-transform/index.ts
+++ b/packages/amplify-category-api/src/amplify-graphql-transform/index.ts
@@ -1,1 +1,1 @@
-export { constructTransformerChain } from './graphql-transformer-v2';
+export { constructTransformerChain, constructTransform } from './graphql-transformer-v2';

--- a/packages/amplify-category-api/src/category-utils/schema-reader.ts
+++ b/packages/amplify-category-api/src/category-utils/schema-reader.ts
@@ -9,13 +9,13 @@ import {
   AmplifyError,
   ApiCategoryFacade,
 } from '@aws-amplify/amplify-cli-core';
-import { constructGraphQLTransformV2 } from '../graphql-transformer/transformer-factory';
 import {
   SCHEMA_DIR_NAME,
   SCHEMA_FILENAME,
 } from '../graphql-transformer/constants';
 import { generateTransformerOptions } from '../graphql-transformer/transformer-options-v2';
 import { contextUtil } from './context-util';
+import { constructTransform } from '../amplify-graphql-transform';
 
 /**
  * SchemaReader is a utility point to consolidate and abstract GraphQL Schema reading
@@ -90,7 +90,7 @@ export class SchemaReader {
 
     if (preProcessSchema && !this.preProcessedSchemaDocument) {
       const transformerOptions = await generateTransformerOptions(context, options);
-      const transform = await constructGraphQLTransformV2(transformerOptions);
+      const transform = constructTransform(transformerOptions);
       this.preProcessedSchemaDocument = transform.preProcessSchema(this.schemaDocument);
     }
 

--- a/packages/amplify-category-api/src/graphql-transformer/directive-definitions.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/directive-definitions.ts
@@ -1,12 +1,10 @@
-import {
-  getAppSyncServiceExtraDirectives,
-} from '@aws-amplify/graphql-transformer-core';
-import {
-  $TSContext,
-} from '@aws-amplify/amplify-cli-core';
+import { getAppSyncServiceExtraDirectives } from '@aws-amplify/graphql-transformer-core';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
 import { print } from 'graphql';
-import { getTransformerFactoryV2, getTransformerFactoryV1 } from './transformer-factory';
+import { TransformerPluginProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { getTransformerFactoryV1, loadCustomTransformersV2 } from './transformer-factory';
 import { getTransformerVersion } from './transformer-version';
+import { constructTransformerChain } from '../amplify-graphql-transform';
 
 /**
  * Return the set of directive definitions for the project, includes both appsync and amplify supported directives.
@@ -15,8 +13,8 @@ import { getTransformerVersion } from './transformer-version';
 export const getDirectiveDefinitions = async (context: $TSContext, resourceDir: string): Promise<string> => {
   const transformerVersion = await getTransformerVersion(context);
   const transformList = transformerVersion === 2
-    ? await (await getTransformerFactoryV2(resourceDir))({ authConfig: {} })
-    : await (await getTransformerFactoryV1(context, resourceDir))(true);
+    ? await getTransformListV2(resourceDir)
+    : await getTransformerFactoryV1(context, resourceDir)(true);
 
   const transformDirectives = transformList
     .map((transform) => [transform.directive, ...transform.typeDefinitions].map((node) => print(node)).join('\n'))
@@ -24,3 +22,12 @@ export const getDirectiveDefinitions = async (context: $TSContext, resourceDir: 
 
   return [getAppSyncServiceExtraDirectives(), transformDirectives].join('\n');
 };
+
+/**
+ * Get the list of v2 transformers, including custom transformers.
+ * @param resourceDir directory to search for custom transformer config in.
+ * @returns the list of transformers, including any defined custom transformers.
+ */
+const getTransformListV2 = async (resourceDir: string): Promise<TransformerPluginProvider[]> => constructTransformerChain({
+  customTransformers: await loadCustomTransformersV2(resourceDir),
+});

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -211,10 +211,10 @@ const buildAPIProject = async (
   return builtProject;
 };
 
-const buildProject = async (context: $TSContext, opts: TransformerProjectOptions): Promise<DeploymentResources> => {
-  const transform = constructTransform(opts);
+const buildProject = async (context: $TSContext, config: TransformerProjectOptions): Promise<DeploymentResources> => {
+  const transform = constructTransform(config);
 
-  const { schema, modelToDatasourceMap } = opts.projectConfig;
+  const { schema, modelToDatasourceMap } = config.projectConfig;
   const datasourceSecretMap = await getDatasourceSecretMap(context);
   try {
     const transformOutput = transform.transform(schema.toString(), {
@@ -222,7 +222,7 @@ const buildProject = async (context: $TSContext, opts: TransformerProjectOptions
       datasourceSecretParameterLocations: datasourceSecretMap,
     });
 
-    return mergeUserConfigWithTransformOutput(opts.projectConfig, transformOutput, opts);
+    return mergeUserConfigWithTransformOutput(config.projectConfig, transformOutput, config);
   } finally {
     printTransformLogs(transform);
   }

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -2,7 +2,6 @@ import {
   GraphQLTransform,
   RDSConnectionSecrets,
   MYSQL_DB_TYPE,
-  StackManager,
 } from '@aws-amplify/graphql-transformer-core';
 import {
   AppSyncAuthConfiguration,
@@ -25,17 +24,15 @@ import {
 import _ from 'lodash';
 import path from 'path';
 /* eslint-disable-next-line import/no-cycle */
-import { AmplifyCLIFeatureFlagAdapter } from './amplify-cli-feature-flag-adapter';
 import { isAuthModeUpdated } from './auth-mode-compare';
-import { parseUserDefinedSlots, parseUserDefinedSlotsFromProject } from './user-defined-slots';
 import {
   mergeUserConfigWithTransformOutput, writeDeploymentToDisk,
 } from './utils';
 import { generateTransformerOptions } from './transformer-options-v2';
-import { TransformerFactoryArgs, TransformerProjectOptions } from './transformer-options-types';
+import { TransformerProjectOptions } from './transformer-options-types';
 import { getExistingConnectionSecretNames, getSecretsKey } from '../provider-utils/awscloudformation/utils/rds-secrets/database-secrets';
 import { getAppSyncAPIName } from '../provider-utils/awscloudformation/utils/amplify-meta-utils';
-import { applyFileBasedOverride } from './override';
+import { constructTransform } from '../amplify-graphql-transform';
 
 const PARAMETERS_FILENAME = 'parameters.json';
 const SCHEMA_FILENAME = 'schema.graphql';
@@ -65,8 +62,8 @@ export const transformGraphQLSchemaV2 = async (context: $TSContext, options): Pr
   // cloud formation push will fail even if there is no changes in the GraphQL API
   // https://github.com/aws-amplify/amplify-console/issues/10
   const resourceNeedCompile = allResources
-    .filter(r => !resources.includes(r))
-    .filter(r => {
+    .filter((r) => !resources.includes(r))
+    .filter((r) => {
       const buildDir = path.normalize(path.join(backEndDir, AmplifyCategories.API, r.resourceName, 'build'));
       return !fs.existsSync(buildDir);
     });
@@ -75,7 +72,7 @@ export const transformGraphQLSchemaV2 = async (context: $TSContext, options): Pr
   if (forceCompile) {
     resources = resources.concat(allResources);
   }
-  resources = resources.filter(resource => resource.service === 'AppSync');
+  resources = resources.filter((resource) => resource.service === 'AppSync');
 
   if (!resourceDir) {
     // There can only be one appsync resource
@@ -159,7 +156,7 @@ export const transformGraphQLSchemaV2 = async (context: $TSContext, options): Pr
     fs.ensureDirSync(buildDir);
   }
 
-  const buildConfig: TransformerProjectOptions<TransformerFactoryArgs> = await generateTransformerOptions(context, options);
+  const buildConfig: TransformerProjectOptions = await generateTransformerOptions(context, options);
   if (!buildConfig) {
     return undefined;
   }
@@ -184,7 +181,7 @@ place .graphql files in a directory at ${schemaDirPath}`);
  */
 const buildAPIProject = async (
   context: $TSContext,
-  opts: TransformerProjectOptions<TransformerFactoryArgs>,
+  opts: TransformerProjectOptions,
 ): Promise<DeploymentResources|undefined> => {
   const schema = opts.projectConfig.schema.toString();
   // Skip building the project if the schema is blank
@@ -192,7 +189,7 @@ const buildAPIProject = async (
     return undefined;
   }
 
-  const builtProject = await _buildProject(context, opts);
+  const builtProject = await buildProject(context, opts);
 
   const buildLocation = path.join(opts.projectDirectory, 'build');
   const currentCloudLocation = opts.currentCloudBackendDirectory ? path.join(opts.currentCloudBackendDirectory, 'build') : undefined;
@@ -214,24 +211,8 @@ const buildAPIProject = async (
   return builtProject;
 };
 
-const _buildProject = async (context: $TSContext, opts: TransformerProjectOptions<TransformerFactoryArgs>): Promise<DeploymentResources> => {
-  const transformers = await opts.transformersFactory(opts.transformersFactoryArgs);
-  const transform = new GraphQLTransform({
-    transformers,
-    stackMapping: opts.projectConfig.config.StackMapping,
-    transformConfig: opts.projectConfig.config,
-    authConfig: opts.authConfig,
-    buildParameters: opts.buildParameters,
-    stacks: opts.projectConfig.stacks || {},
-    featureFlags: new AmplifyCLIFeatureFlagAdapter(),
-    sandboxModeEnabled: opts.sandboxModeEnabled,
-    userDefinedSlots: parseUserDefinedSlotsFromProject(opts.projectConfig),
-    resolverConfig: opts.resolverConfig,
-    overrideConfig: {
-      applyOverride: (stackManager: StackManager) => applyFileBasedOverride(stackManager),
-      ...opts.overrideConfig,
-    },
-  });
+const buildProject = async (context: $TSContext, opts: TransformerProjectOptions): Promise<DeploymentResources> => {
+  const transform = constructTransform(opts);
 
   const { schema, modelToDatasourceMap } = opts.projectConfig;
   const datasourceSecretMap = await getDatasourceSecretMap(context);
@@ -258,7 +239,7 @@ const getDatasourceSecretMap = async (context: $TSContext): Promise<Map<string, 
   return outputMap;
 };
 
-const printTransformLogs = (transform: GraphQLTransform) => {
+const printTransformLogs = (transform: GraphQLTransform): void => {
   transform.getLogs().forEach((log) => {
     switch (log.level) {
       case TransformerLogLevel.ERROR:
@@ -277,4 +258,4 @@ const printTransformLogs = (transform: GraphQLTransform) => {
         printer.error(log.message);
     }
   });
-}
+};

--- a/packages/amplify-category-api/src/graphql-transformer/transformer-options-types.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transformer-options-types.ts
@@ -3,18 +3,20 @@
  */
 import {
   AppSyncAuthConfiguration,
-  TransformerPluginProvider,
+  FeatureFlagProvider,
   Template,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import {
   OverrideConfig,
   ResolverConfig,
   TransformerProjectConfig,
+  UserDefinedSlot,
 } from '@aws-amplify/graphql-transformer-core';
 import {
   DiffRule,
   ProjectRule,
 } from 'graphql-transformer-core';
+import { TransformerFactoryArgs } from '../amplify-graphql-transform/graphql-transformer-v2';
 
 /**
  * Transformer Options used to create a GraphQL Transform and compile a GQL API
@@ -37,26 +39,14 @@ export type TransformerProjectOptions = {
   sandboxModeEnabled?: boolean;
   sanityCheckRules: SanityCheckRules;
   overrideConfig: OverrideConfig;
+  userDefinedSlots: Record<string, UserDefinedSlot[]>;
+  legacyApiKeyEnabled?: number;
+  disableResolverDeduping?: boolean;
+  stackMapping: Record<string, string>;
+  featureFlags: FeatureFlagProvider;
 };
 
 type SanityCheckRules = {
   diffRules: DiffRule[];
   projectRules: ProjectRule[];
-};
-
-export type TransformerSearchConfig = {
-  enableNodeToNodeEncryption?: boolean;
-};
-
-/**
- * Arguments passed into a TransformerFactory
- * Used to determine how to create a new GraphQLTransform
- */
-export type TransformerFactoryArgs = {
-  authConfig?: any;
-  storageConfig?: any;
-  adminRoles?: Array<string>;
-  identityPoolId?: string;
-  searchConfig?: TransformerSearchConfig;
-  customTransformers: TransformerPluginProvider[];
 };

--- a/packages/amplify-category-api/src/graphql-transformer/transformer-options-types.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transformer-options-types.ts
@@ -4,7 +4,7 @@
 import {
   AppSyncAuthConfiguration,
   TransformerPluginProvider,
-  Template
+  Template,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import {
   OverrideConfig,
@@ -19,14 +19,13 @@ import {
 /**
  * Transformer Options used to create a GraphQL Transform and compile a GQL API
  */
-export type TransformerProjectOptions<T> = {
+export type TransformerProjectOptions = {
   buildParameters: {
     S3DeploymentBucket: string;
     S3DeploymentRootKey: string;
   };
   projectDirectory: string;
-  transformersFactory: (options: T) => Promise<TransformerPluginProvider[]>;
-  transformersFactoryArgs: T;
+  transformersFactoryArgs: TransformerFactoryArgs;
   rootStackFileName: 'cloudformation-template.json';
   currentCloudBackendDirectory?: string;
   lastDeployedProjectConfig?: TransformerProjectConfig;
@@ -54,9 +53,10 @@ export type TransformerSearchConfig = {
  * Used to determine how to create a new GraphQLTransform
  */
 export type TransformerFactoryArgs = {
-  authConfig: any;
+  authConfig?: any;
   storageConfig?: any;
   adminRoles?: Array<string>;
   identityPoolId?: string;
   searchConfig?: TransformerSearchConfig;
+  customTransformers: TransformerPluginProvider[];
 };

--- a/packages/amplify-category-api/src/graphql-transformer/transformer-options-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transformer-options-v2.ts
@@ -19,12 +19,12 @@ import _ from 'lodash';
 import { printer } from '@aws-amplify/amplify-prompts';
 import { getAdminRoles, getIdentityPoolId } from './utils';
 import { schemaHasSandboxModeEnabled, showGlobalSandboxModeWarning, showSandboxModePrompts } from './sandbox-mode-helpers';
-import { getTransformerFactoryV2 } from './transformer-factory';
+import { loadCustomTransformersV2 } from './transformer-factory';
 import { AmplifyCLIFeatureFlagAdapter } from './amplify-cli-feature-flag-adapter';
 import {
-  DESTRUCTIVE_UPDATES_FLAG, PARAMETERS_FILENAME, PROVIDER_NAME, ROOT_APPSYNC_S3_KEY
+  DESTRUCTIVE_UPDATES_FLAG, PARAMETERS_FILENAME, PROVIDER_NAME, ROOT_APPSYNC_S3_KEY,
 } from './constants';
-import { TransformerFactoryArgs, TransformerProjectOptions } from './transformer-options-types';
+import { TransformerProjectOptions } from './transformer-options-types';
 import { contextUtil } from '../category-utils/context-util';
 import { searchablePushChecks } from './api-utils';
 import { shouldEnableNodeToNodeEncryption } from '../provider-utils/awscloudformation/current-backend-state/searchable-node-to-node-encryption';
@@ -53,7 +53,7 @@ const warnOnAuth = (map: Record<string, any>, docLink: string): void => {
 export const generateTransformerOptions = async (
   context: $TSContext,
   options: any,
-): Promise<TransformerProjectOptions<TransformerFactoryArgs>> => {
+): Promise<TransformerProjectOptions> => {
   let resourceName: string;
   const backEndDir = pathManager.getBackendDirPath();
   const flags = context.parameters.options;
@@ -182,8 +182,6 @@ export const generateTransformerOptions = async (
     || authConfig.additionalAuthenticationProviders.some((authProvider) => authProvider.authenticationType === 'API_KEY');
   const showSandboxModeMessage = sandboxModeEnabled && hasApiKey;
 
-  const transformerListFactory = await getTransformerFactoryV2(resourceDir);
-
   await searchablePushChecks(context, directiveMap.types, parameters[ResourceConstants.PARAMETERS.AppSyncApiName]);
 
   if (sandboxModeEnabled && options.promptApiKeyCreation) {
@@ -230,19 +228,17 @@ export const generateTransformerOptions = async (
     pathManager.getCurrentCloudBackendDirPath(),
   );
 
-  const buildConfig: TransformerProjectOptions<TransformerFactoryArgs> = {
+  const buildConfig: TransformerProjectOptions = {
     ...options,
     buildParameters,
     projectDirectory: resourceDir,
-    transformersFactory: transformerListFactory,
     transformersFactoryArgs: {
       storageConfig,
       authConfig,
       adminRoles,
       identityPoolId,
-      searchConfig: {
-        enableNodeToNodeEncryption,
-      },
+      searchConfig: { enableNodeToNodeEncryption },
+      customTransformers: await loadCustomTransformersV2(resourceDir),
     },
     rootStackFileName: 'cloudformation-template.json',
     currentCloudBackendDirectory: previouslyDeployedBackendDir,

--- a/packages/amplify-category-api/src/graphql-transformer/user-defined-slots.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/user-defined-slots.ts
@@ -1,4 +1,4 @@
-import { UserDefinedSlot, UserDefinedResolver, TransformerProjectConfig } from '@aws-amplify/graphql-transformer-core';
+import { UserDefinedSlot, UserDefinedResolver } from '@aws-amplify/graphql-transformer-core';
 import _ from 'lodash';
 
 export const SLOT_NAMES = new Set([
@@ -15,16 +15,6 @@ export const SLOT_NAMES = new Set([
 ]);
 
 const EXCLUDE_FILES = new Set(['README.md']);
-
-/**
- * Given a project config, parse all amplify user defined slots from it.
- */
-export const parseUserDefinedSlotsFromProject = (
-  { pipelineFunctions, resolvers }: TransformerProjectConfig,
-): Record<string, UserDefinedSlot[]> => ({
-  ...parseUserDefinedSlots(pipelineFunctions),
-  ...parseUserDefinedSlots(resolvers),
-});
 
 export function parseUserDefinedSlots(userDefinedTemplates: Record<string, string>): Record<string, UserDefinedSlot[]> {
   type ResolverKey = string;

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transformation/transform.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transformation/transform.test.ts
@@ -101,7 +101,7 @@ describe('GraphQLTransform', () => {
       const transform = new TestGraphQLTransform({
         transformers: [mockTransformer],
         authConfig: apiKeyAuthConfig,
-        buildParameters: { CreateAPIKey: 1 },
+        legacyApiKeyEnabled: 1,
       });
       invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: true });
     });
@@ -110,7 +110,7 @@ describe('GraphQLTransform', () => {
       const transform = new TestGraphQLTransform({
         transformers: [mockTransformer],
         authConfig: apiKeyAuthConfig,
-        buildParameters: { CreateAPIKey: 0 },
+        legacyApiKeyEnabled: 0,
       });
       invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: false });
     });
@@ -119,7 +119,7 @@ describe('GraphQLTransform', () => {
       const transform = new TestGraphQLTransform({
         transformers: [mockTransformer],
         authConfig: apiKeyAuthConfig,
-        buildParameters: { CreateAPIKey: -1 },
+        legacyApiKeyEnabled: -1,
       });
       invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: false });
     });
@@ -128,7 +128,7 @@ describe('GraphQLTransform', () => {
       const transform = new TestGraphQLTransform({
         transformers: [mockTransformer],
         authConfig: apiKeyAuthConfig,
-        buildParameters: { CreateAPIKey: '' },
+        legacyApiKeyEnabled: '' as unknown as number,
       });
       invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: false });
     });


### PR DESCRIPTION
- chore: minimal refactor construction of the graphql transform out into the separate package
- chore: use specific types in transform layer, and don't inject cli concerns

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
