### PR TITLE
chore: refactor so legacyApiKey flag is a boolean in-transformer, not a number

### DIFF
--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/transformer-options-v2.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/transformer-options-v2.test.ts
@@ -1,0 +1,19 @@
+import { legacyApiKeyEnabledFromParameters } from '../../graphql-transformer/transformer-options-v2';
+
+describe('legacyApiKeyEnabledFromParameters', () => {
+  it('returns undefined if not defined in params', () => {
+    expect(legacyApiKeyEnabledFromParameters({})).toBeUndefined();
+  });
+
+  it('returns true if value is set to 1', () => {
+    expect(legacyApiKeyEnabledFromParameters({ CreateAPIKey: 1 })).toEqual(true);
+  });
+
+  it('returns false if value is set to 0', () => {
+    expect(legacyApiKeyEnabledFromParameters({ CreateAPIKey: 0 })).toEqual(false);
+  });
+
+  it('returns false if value is set to -1', () => {
+    expect(legacyApiKeyEnabledFromParameters({ CreateAPIKey: -1 })).toEqual(false);
+  });
+});

--- a/packages/amplify-category-api/src/graphql-transformer/transformer-options-types.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transformer-options-types.ts
@@ -40,7 +40,7 @@ export type TransformerProjectOptions = {
   sanityCheckRules: SanityCheckRules;
   overrideConfig: OverrideConfig;
   userDefinedSlots: Record<string, UserDefinedSlot[]>;
-  legacyApiKeyEnabled?: number;
+  legacyApiKeyEnabled?: boolean;
   disableResolverDeduping?: boolean;
   stackMapping: Record<string, string>;
   featureFlags: FeatureFlagProvider;

--- a/packages/amplify-category-api/src/graphql-transformer/transformer-options-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transformer-options-v2.ts
@@ -265,11 +265,18 @@ export const generateTransformerOptions = async (
     featureFlags: new AmplifyCLIFeatureFlagAdapter(),
     stacks: project.stacks,
     stackMapping: project.config.StackMapping,
-    legacyApiKeyEnabled: parameters.CreateAPIKey,
+    legacyApiKeyEnabled: legacyApiKeyEnabledFromParameters(parameters),
     disableResolverDeduping: (project.config as any).DisableResolverDeduping,
   };
 
   return buildConfig;
+};
+
+export const legacyApiKeyEnabledFromParameters = (parameters: any): boolean | undefined => {
+  if (!('CreateAPIKey' in parameters)) {
+    return undefined;
+  }
+  return parameters.CreateAPIKey === 1 || parameters.CreateAPIKey === '1';
 };
 
 /**

--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -239,7 +239,7 @@ export interface GraphQLTransformOptions {
     // (undocumented)
     readonly host?: TransformHostProvider;
     // (undocumented)
-    readonly legacyApiKeyEnabled?: number;
+    readonly legacyApiKeyEnabled?: boolean;
     // (undocumented)
     readonly overrideConfig?: OverrideConfig;
     // (undocumented)

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transformation/transform.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transformation/transform.test.ts
@@ -97,38 +97,28 @@ describe('GraphQLTransform', () => {
       invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: false });
     });
 
-    it('creates an api key for apps with API_KEY authorization if CreateApiKey is set to 1', () => {
+    it('creates an api key for apps with API_KEY authorization if legacyApiKeyEnabled is set to true', () => {
       const transform = new TestGraphQLTransform({
         transformers: [mockTransformer],
         authConfig: apiKeyAuthConfig,
-        legacyApiKeyEnabled: 1,
+        legacyApiKeyEnabled: true,
       });
       invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: true });
     });
 
-    it('does not create an api key for apps with API_KEY authorization if CreateApiKey is set to 0', () => {
+    it('does not create an api key for apps with API_KEY authorization if legacyApiKeyEnabled is undefined', () => {
       const transform = new TestGraphQLTransform({
         transformers: [mockTransformer],
         authConfig: apiKeyAuthConfig,
-        legacyApiKeyEnabled: 0,
       });
-      invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: false });
+      invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: true });
     });
 
-    it('does not create an api key for apps with API_KEY authorization if CreateApiKey is set to -1', () => {
+    it('does not create an api key for apps with API_KEY authorization if legacyApiKeyEnabled is set to false', () => {
       const transform = new TestGraphQLTransform({
         transformers: [mockTransformer],
         authConfig: apiKeyAuthConfig,
-        legacyApiKeyEnabled: -1,
-      });
-      invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: false });
-    });
-
-    it('does not create an api key for apps with API_KEY authorization if CreateApiKey is set to an empty string', () => {
-      const transform = new TestGraphQLTransform({
-        transformers: [mockTransformer],
-        authConfig: apiKeyAuthConfig,
-        legacyApiKeyEnabled: '' as unknown as number,
+        legacyApiKeyEnabled: false,
       });
       invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: false });
     });

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -84,7 +84,7 @@ export interface GraphQLTransformOptions {
   readonly userDefinedSlots?: Record<string, UserDefinedSlot[]>;
   readonly resolverConfig?: ResolverConfig;
   readonly overrideConfig?: OverrideConfig;
-  readonly legacyApiKeyEnabled?: number;
+  readonly legacyApiKeyEnabled?: boolean;
 }
 export type StackMapping = { [resourceId: string]: string };
 export class GraphQLTransform {
@@ -96,7 +96,7 @@ export class GraphQLTransform {
   private readonly userDefinedSlots: Record<string, UserDefinedSlot[]>;
   private readonly overrideConfig?: OverrideConfig;
   private readonly disableResolverDeduping?: boolean;
-  private readonly legacyApiKeyEnabled?: number;
+  private readonly legacyApiKeyEnabled?: boolean;
 
   // A map from `${directive}.${typename}.${fieldName?}`: true
   // that specifies we have run already run a directive at a given location.
@@ -340,11 +340,7 @@ export class GraphQLTransform {
       mode => mode?.authorizationType,
     );
 
-    const hasLegacyAPIKeyConfigDisabled = this.legacyApiKeyEnabled !== null
-      && this.legacyApiKeyEnabled !== undefined
-      && this.legacyApiKeyEnabled !== 1;
-
-    if (authModes.includes(AuthorizationType.API_KEY) && !hasLegacyAPIKeyConfigDisabled) {
+    if (authModes.includes(AuthorizationType.API_KEY) && this.legacyApiKeyEnabled !== false) {
       const apiKeyConfig: AuthorizationMode | undefined = [
         authorizationConfig.defaultAuthorization,
         ...(authorizationConfig.additionalAuthorizationModes || []),

--- a/packages/amplify-graphql-transformer/API.md
+++ b/packages/amplify-graphql-transformer/API.md
@@ -36,7 +36,7 @@ export type ExecuteTransformConfig = TransformConfig & {
 
 // @public (undocumented)
 export type TransformConfig = {
-    legacyApiKeyEnabled?: number;
+    legacyApiKeyEnabled?: boolean;
     disableResolverDeduping?: boolean;
     transformersFactoryArgs: TransformerFactoryArgs;
     resolverConfig?: ResolverConfig;

--- a/packages/amplify-graphql-transformer/src/graphql-transformer.ts
+++ b/packages/amplify-graphql-transformer/src/graphql-transformer.ts
@@ -52,7 +52,7 @@ export type TransformerFactoryArgs = {
  * Transformer Options used to create a GraphQL Transform and compile a GQL API
  */
 export type TransformConfig = {
-  legacyApiKeyEnabled?: number;
+  legacyApiKeyEnabled?: boolean;
   disableResolverDeduping?: boolean;
   transformersFactoryArgs: TransformerFactoryArgs;
   resolverConfig?: ResolverConfig;


### PR DESCRIPTION
#### Description of changes
Move number to param coercion into the API Category layer for a legacy flag we're passing into the transformer.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit + E2E Tests

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
