### PR TITLE
feat(graphql): patching rds lambda layer

### DIFF
--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/import-rds-utils/__snapshots__/globalAmplifyInputs.test.ts.snap
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/import-rds-utils/__snapshots__/globalAmplifyInputs.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Amplify Input read/write from schema constructs the global Amplify input from given config 1`] = `
-"input Amplify {
+"input AMPLIFY {
   engine: String = \\"mysql\\"
   globalAuthRule: AuthRule = {allow: public}
 }"
@@ -129,7 +129,7 @@ Object {
       "end": 13,
       "start": 6,
     },
-    "value": "Amplify",
+    "value": "AMPLIFY",
   },
 }
 `;

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/import-rds-utils/globalAmplifyInputs.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/import-rds-utils/globalAmplifyInputs.test.ts
@@ -28,7 +28,7 @@ describe('Amplify Input read/write from schema', () => {
   });
 
   it('constructs valid default input parameters for MySQL datasource with global auth rule', async () => {
-    const expectedGraphQLInputString = `input Amplify {
+    const expectedGraphQLInputString = `input AMPLIFY {
       engine: String = \"mysql\"
       globalAuthRule: AuthRule = { allow: public } # This "input" configures a global authorization rule to enable public access to all models in this schema. Learn more about authorization rules here:https://docs.amplify.aws/cli/graphql/authorization-rules 
     }`;
@@ -44,7 +44,7 @@ describe('Amplify Input read/write from schema', () => {
       database: 'mockdatabase'
     };
 
-    const mockInputSchema = `input Amplify {
+    const mockInputSchema = `input AMPLIFY {
       engine: String = \"${mockValidInputs.engine}\"  
       globalAuthRule: AuthRule = { allow: public } # This "input" configures a global authorization rule to enable public access to all models in this schema. Learn more about authorization rules here:https://docs.amplify.aws/cli/graphql/authorization-rules 
     }`;
@@ -64,7 +64,7 @@ describe('Amplify Input read/write from schema', () => {
       database: 'mockdatabase'
     };
 
-    const mockInputSchema = `input Amplify {
+    const mockInputSchema = `input AMPLIFY {
       engine: String = \"${mockValidInputs.engine}\" 
       globalAuthRule: AuthRule = { allow: public } # This "input" configures a global authorization rule to enable public access to all models in this schema. Learn more about authorization rules here:https://docs.amplify.aws/cli/graphql/authorization-rules 
     }`;

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-input-utils.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-input-utils.ts
@@ -45,7 +45,7 @@ export const constructDefaultGlobalAmplifyInput = async (context: $TSContext, da
   const inputsString = inputs.reduce((acc: string, input): string =>
     acc + ` ${input.name}: ${input.type} = ${input.type === 'String' ? '"'+ input.default + '"' : input.default} ${input.comment ? '# ' + input.comment: ''} \n`
   , '');
-  return `input Amplify {\n${inputsString}}\n`;
+  return `input AMPLIFY {\n${inputsString}}\n`;
 };
 
 export const readRDSGlobalAmplifyInput = async (pathToSchemaFile: string): Promise<InputObjectTypeDefinitionNode | undefined> => {

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-input-utils.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-input-utils.ts
@@ -63,7 +63,7 @@ export const readRDSGlobalAmplifyInput = async (pathToSchemaFile: string): Promi
     (definition) =>
       definition.kind === 'InputObjectTypeDefinition' &&
       definition.name &&
-      definition.name.value === 'Amplify'
+      definition.name.value === 'AMPLIFY',
   );
 
   if (inputNode) {

--- a/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
@@ -19,6 +19,13 @@ import gql from 'graphql-tag';
 import path from 'path';
 import { print } from 'graphql';
 
+const CDK_FUNCTION_TYPE = 'AWS::Lambda::Function';
+const CDK_SUBSCRIPTION_TYPE = 'AWS::SNS::Subscription';
+const APPSYNC_DATA_SOURCE_TYPE = 'AWS::AppSync::DataSource';
+
+const SNS_TOPIC_REGION = 'us-east-1';
+const SNS_TOPIC_ARN = 'arn:aws:sns:us-east-1:956468067974:AmplifyRDSLayerNotification';
+
 describe("RDS Tests", () => {
   const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
   
@@ -70,7 +77,7 @@ describe("RDS Tests", () => {
     await deleteDBInstance(identifier, region);
   };
 
-  it("import workflow of mysql relational database with public access", async () => {
+  it("import workflow of mysql relational database within vpc with no public access", async () => {
     const apiName = 'rdsapivpc';
     await initJSProjectWithProfile(projRoot, {
       disableAmplifyAppCreation: false,
@@ -120,15 +127,17 @@ describe("RDS Tests", () => {
     updateSchema(projRoot, apiName, print(updatedSchema), 'schema.rds.graphql');
     await apiGqlCompile(projRoot);
 
-    // Validate if the SQL lambda function has VPC configuration
+    // Validate the generated resources in the CloudFormation template
     const apisDirectory = path.join(projRoot, 'amplify', 'backend', 'api');
     const apiDirectory = path.join(apisDirectory, apiName);
     const cfnRDSTemplateFile = path.join(apiDirectory, 'build', 'stacks', `RdsApiStack.json`);
     const cfnTemplate = JSON.parse(readFileSync(cfnRDSTemplateFile, 'utf8'));
     console.log(JSON.stringify(cfnTemplate, null, 4));
     expect(cfnTemplate.Resources).toBeDefined();
-    const resources = Object.values(cfnTemplate.Resources);
-    const rdsLambdaFunction = resources.find((r: any) => r.Type === 'AWS::Lambda::Function') as any;
+    const resources = cfnTemplate.Resources;
+
+    // Validate if the SQL lambda function has VPC configuration
+    const rdsLambdaFunction = getResource(resources, 'RDSLambdaLogicalID', CDK_FUNCTION_TYPE);
     expect(rdsLambdaFunction).toBeDefined();
     expect(rdsLambdaFunction.Properties).toBeDefined();
     expect(rdsLambdaFunction.Properties.VpcConfig).toBeDefined();
@@ -137,6 +146,39 @@ describe("RDS Tests", () => {
     expect(rdsLambdaFunction.Properties.VpcConfig.SecurityGroupIds).toBeDefined();
     expect(rdsLambdaFunction.Properties.VpcConfig.SecurityGroupIds.length).toBeGreaterThan(0);
 
+    // Validate patching lambda and subscription
+    const rdsPatchingLambdaFunction = getResource(resources, 'RDSPatchingLambdaLogicalID', CDK_FUNCTION_TYPE);
+    expect(rdsPatchingLambdaFunction).toBeDefined();
+    expect(rdsPatchingLambdaFunction.Properties).toBeDefined();
+    expect(rdsPatchingLambdaFunction.Properties.Environment).toBeDefined();
+    expect(rdsPatchingLambdaFunction.Properties.Environment.Variables).toBeDefined();
+    expect(rdsPatchingLambdaFunction.Properties.Environment.Variables.LAMBDA_FUNCTION_ARN).toBeDefined();
+    const rdsDataSourceLambda = getResource(resources, 'RDSLambdaDataSource', APPSYNC_DATA_SOURCE_TYPE);
+    expect(rdsPatchingLambdaFunction.Properties.Environment.Variables.LAMBDA_FUNCTION_ARN).toEqual(rdsDataSourceLambda.Properties.LambdaConfig.LambdaFunctionArn);
+
+    // Validate subscription
+    const rdsPatchingSubscription = getResource(resources, 'RDSPatchingLambdaLogicalID', CDK_SUBSCRIPTION_TYPE);
+    expect(rdsPatchingSubscription).toBeDefined();
+    expect(rdsPatchingSubscription.Properties).toBeDefined();
+    expect(rdsPatchingSubscription.Properties.Protocol).toBeDefined();
+    expect(rdsPatchingSubscription.Properties.Protocol).toEqual('lambda');
+    expect(rdsPatchingSubscription.Properties.Endpoint).toBeDefined();
+    expect(rdsPatchingSubscription.Properties.TopicArn).toBeDefined();
+    expect(rdsPatchingSubscription.Properties.TopicArn).toEqual(SNS_TOPIC_ARN);
+    expect(rdsPatchingSubscription.Properties.Region).toEqual(SNS_TOPIC_REGION);
+    expect(rdsPatchingSubscription.Properties.FilterPolicy).toBeDefined();
+    expect(rdsPatchingSubscription.Properties.FilterPolicy.Region).toBeDefined();
+
     await amplifyPush(projRoot);
   });
 }); 
+
+const getResource = (resources: Map<string, any>, resourcePrefix: string, resourceType: string): any => {
+  const keys = Array.from(Object.keys(resources)).filter(key => key.startsWith(resourcePrefix));
+  for (const key of keys) {
+    const resource = resources[key];
+    if (resource.Type === resourceType) {
+      return resource;
+    }
+  }
+};

--- a/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
@@ -113,7 +113,7 @@ describe("RDS Tests", () => {
     expect(dbObjectType.directives.find(d => d.name.value === 'model')).toBeDefined();
 
     const updatedSchema = gql`
-      input Amplify {
+      input AMPLIFY {
         engine: String = "mysql"
         globalAuthRule: AuthRule = {allow: public}
       }

--- a/packages/amplify-graphql-model-transformer/package.json
+++ b/packages/amplify-graphql-model-transformer/package.json
@@ -21,9 +21,12 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc && cd rds-lambda && mkdir -p node_modules && rm -rf node_modules && npm install && tsc && cp -r node_modules lib && cd lib && bestzip --force node ../../lib/rds-lambda.zip ./*",
+    "build-rds-lambda": "cd rds-lambda && mkdir -p node_modules && rm -rf node_modules && npm install && tsc && cp -r node_modules lib && cd lib && bestzip --force node ../../lib/rds-lambda.zip ./* && cd ../..",
+    "build-rds-patching-lambda": "cd rds-patching-lambda && mkdir -p node_modules && rm -rf node_modules && npm install && tsc && cp -r node_modules lib && cd lib && bestzip --force node ../../lib/rds-patching-lambda.zip ./* && cd ../..",
+    "build-notification-lambda": "cd publish-notification-lambda && mkdir -p node_modules && rm -rf node_modules && npm install && tsc && cp -r node_modules lib && cd lib && bestzip --force node ../../lib/rds-notification-lambda.zip ./* && cd ../..",
+    "build": "tsc && yarn build-rds-lambda && yarn build-rds-patching-lambda && yarn build-notification-lambda",
     "watch": "tsc -w",
-    "clean": "rimraf ./lib",
+    "clean": "rimraf ./lib && rimraf ./rds-lambda/lib && rimraf ./rds-patching-lambda/lib && rimraf ./publish-notification-lambda/lib",
     "test": "jest",
     "test-watch": "jest --watch",
     "extract-api": "ts-node ../../scripts/extract-api.ts"

--- a/packages/amplify-graphql-model-transformer/publish-notification-lambda/.gitignore
+++ b/packages/amplify-graphql-model-transformer/publish-notification-lambda/.gitignore
@@ -1,0 +1,5 @@
+*.d.ts
+*.ts.map
+*.js
+*.js.map
+lib/*

--- a/packages/amplify-graphql-model-transformer/publish-notification-lambda/README.md
+++ b/packages/amplify-graphql-model-transformer/publish-notification-lambda/README.md
@@ -1,35 +1,39 @@
 # RDS Publish Notification Lambda
 
 ## Overview
+
 The purpose of this lambda is to publish a message in the configured SNS Topic to let customers know that there is a new RDS Lambda Layer version is available.
 
 ### Setup Instructions
-Lambda code resides in a zip file 'rds-patching-lambda' under lib folder of amplify-graphql-model-transformer package.
+
+Lambda code resides in a zip file `packages/amplify-graphql-model-transformer/lib/rds-patching-lambda.zip`.
 
 1. Create a new lambda function in the service account.
 2. Upload the zip file to update the code.
 3. Increase the function timeout to 1 minute.
-4. Add the below polices to the lambda's execution role.
-5. To notify customers, run the lambda with empty input `{}`.
+4. Set the environment variables `LAYER_NAME`, `SNS_TOPIC_ARN` and `SNS_TOPIC_REGION`. LAYER_NAME refers to the RDS Lambda Layer name.
+5. Add the below polices to the lambda's execution role.
+6. To notify customers, run the lambda with empty input `{}`.
 
 #### Required Lambda Policies
+
 ```json
 {
-            "Effect": "Allow",
-            "Action": [
-                "sns:Publish"
-            ],
-            "Resource": [
-                "<<REPLACE_WITH_SNS_TOPIC_ARN>>"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "lambda:ListLayerVersions"
-            ],
-            "Resource": [
-                "*"
-            ]
-        }
+  "Effect": "Allow",
+  "Action": [
+      "sns:Publish"
+  ],
+  "Resource": [
+      "<<REPLACE_WITH_SNS_TOPIC_ARN>>"
+  ]
+},
+{
+  "Effect": "Allow",
+  "Action": [
+      "lambda:ListLayerVersions"
+  ],
+  "Resource": [
+      "*"
+  ]
+}
 ```

--- a/packages/amplify-graphql-model-transformer/publish-notification-lambda/README.md
+++ b/packages/amplify-graphql-model-transformer/publish-notification-lambda/README.md
@@ -1,0 +1,35 @@
+# RDS Publish Notification Lambda
+
+## Overview
+The purpose of this lambda is to publish a message in the configured SNS Topic to let customers know that there is a new RDS Lambda Layer version is available.
+
+### Setup Instructions
+Lambda code resides in a zip file 'rds-patching-lambda' under lib folder of amplify-graphql-model-transformer package.
+
+1. Create a new lambda function in the service account.
+2. Upload the zip file to update the code.
+3. Increase the function timeout to 1 minute.
+4. Add the below polices to the lambda's execution role.
+5. To notify customers, run the lambda with empty input `{}`.
+
+#### Required Lambda Policies
+```json
+{
+            "Effect": "Allow",
+            "Action": [
+                "sns:Publish"
+            ],
+            "Resource": [
+                "<<REPLACE_WITH_SNS_TOPIC_ARN>>"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "lambda:ListLayerVersions"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+```

--- a/packages/amplify-graphql-model-transformer/publish-notification-lambda/package.json
+++ b/packages/amplify-graphql-model-transformer/publish-notification-lambda/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "Publish Notification Message",
+  "version": "1.0.0",
+  "description": "",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "npm run build && node ./lib/index.js",
+    "build": "tsc",
+    "release": "rm -f notification-lambda.zip && bestzip --force node ./notification-lambda.zip ./*"
+  },
+  "dependencies": {
+    "@aws-sdk/client-sns": "3.352.0",
+    "@aws-sdk/client-lambda": "3.352.0",
+    "bestzip": "2.2.1",
+    "typescript": "5.1.3"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/node": "^20.3.1"
+  }
+}

--- a/packages/amplify-graphql-model-transformer/publish-notification-lambda/package.json
+++ b/packages/amplify-graphql-model-transformer/publish-notification-lambda/package.json
@@ -11,13 +11,13 @@
   "dependencies": {
     "@aws-sdk/client-sns": "3.352.0",
     "@aws-sdk/client-lambda": "3.352.0",
-    "bestzip": "2.2.1",
     "typescript": "5.1.3"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "^20.3.1"
+    "@types/node": "^20.3.1",
+    "bestzip": "2.2.1"
   }
 }

--- a/packages/amplify-graphql-model-transformer/publish-notification-lambda/src/index.ts
+++ b/packages/amplify-graphql-model-transformer/publish-notification-lambda/src/index.ts
@@ -1,0 +1,100 @@
+import { LambdaClient, ListLayerVersionsCommand, ListLayerVersionsCommandOutput } from "@aws-sdk/client-lambda";
+import { PublishCommand, SNSClient } from "@aws-sdk/client-sns";
+
+const MAX_ITEMS = 50;
+const { LAYER_NAME, SNS_TOPIC_ARN, SNS_TOPIC_REGION } = process.env;
+
+const SUPPORTED_REGIONS = [
+  'us-east-1',
+  'us-west-2',
+  'us-west-1',
+  'eu-north-1',
+  'ap-south-1',
+  'eu-central-1',
+  'eu-west-1',
+  'sa-east-1',
+  'ap-southeast-1',
+  'ap-northeast-2',
+  'eu-west-2',
+  'us-east-2',
+  'ap-northeast-1',
+  'eu-west-3',
+  'ap-southeast-2',
+  'ca-central-1',
+  'ap-northeast-3',
+];
+
+type LayerConfig = {
+  layerArn: string | undefined;
+  region: string;
+};
+
+const getLatestVersion = async (layerName: string, region: string): Promise<LayerConfig> => {
+  const client = new LambdaClient({ region });
+  const versions = [];
+  let response: ListLayerVersionsCommandOutput | undefined;
+  do {
+    const command = new ListLayerVersionsCommand({
+      LayerName: layerName,
+      MaxItems: MAX_ITEMS,
+      Marker: response?.NextMarker,
+    });
+    // eslint-disable-next-line no-await-in-loop
+    response = await client.send(command);
+    if (response.LayerVersions) {
+      versions.push(...response.LayerVersions);
+    }
+  } while (response?.NextMarker);
+  const result = versions.sort((a, b) => b.Version! - a.Version!)[0];
+  return {
+    layerArn: result.LayerVersionArn,
+    region,
+  };
+};
+
+const getLatestVersions = async (): Promise<LayerConfig[]> => {
+  const promises = SUPPORTED_REGIONS.map((region) => getLatestVersion(LAYER_NAME!, region));
+  return Promise.all(promises);
+};
+
+const publishMessage = async (layerArn: string, region: string): Promise<void> => {
+  if (!layerArn || !region) {
+    console.log(`Layer ARN or region is missing - skipping notification for layer ${layerArn} in region ${region}`);
+    return;
+  }
+  const client = new SNSClient({ region: SNS_TOPIC_REGION });
+  const command = new PublishCommand({
+    TopicArn: SNS_TOPIC_ARN,
+    Message: 'New Lambda Layer version is available',
+    Subject: 'New Lambda Layer version is available',
+    MessageAttributes: {
+      LayerArn: {
+        DataType: 'String',
+        StringValue: layerArn,
+      },
+      Region: {
+        DataType: 'String',
+        StringValue: region,
+      },
+    },
+  });
+  await client.send(command);
+};
+
+const publishNotification = async (): Promise<void> => {
+  const layers = await getLatestVersions();
+  const promises: Promise<void>[] = [];
+  layers.forEach((layer) => {
+    if (!layer.layerArn || !layer.region) {
+      console.log('Layer Arn or region is missing in the notification event', layer);
+      return;
+    }
+    promises.push(publishMessage(layer.layerArn, layer.region));
+    console.log(`Published notification for layer ${layer.layerArn} in region ${layer.region}`);
+  });
+  await Promise.all(promises);
+};
+
+export const handler = async (): Promise<void> => {
+  await publishNotification();
+};

--- a/packages/amplify-graphql-model-transformer/publish-notification-lambda/tsconfig.json
+++ b/packages/amplify-graphql-model-transformer/publish-notification-lambda/tsconfig.json
@@ -1,0 +1,109 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": false,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "ES2015",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
+    "moduleResolution": "node",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    "outDir": "./lib",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}

--- a/packages/amplify-graphql-model-transformer/rds-patching-lambda/.gitignore
+++ b/packages/amplify-graphql-model-transformer/rds-patching-lambda/.gitignore
@@ -1,0 +1,5 @@
+*.d.ts
+*.ts.map
+*.js
+*.js.map
+lib/*

--- a/packages/amplify-graphql-model-transformer/rds-patching-lambda/package.json
+++ b/packages/amplify-graphql-model-transformer/rds-patching-lambda/package.json
@@ -10,13 +10,13 @@
   },
   "dependencies": {
     "@aws-sdk/client-lambda": "3.352.0",
-    "bestzip": "2.2.1",
     "typescript": "5.1.3"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "^20.3.1"
+    "@types/node": "^20.3.1",
+    "bestzip": "2.2.1"
   }
 }

--- a/packages/amplify-graphql-model-transformer/rds-patching-lambda/package.json
+++ b/packages/amplify-graphql-model-transformer/rds-patching-lambda/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "rdslayerstresstest",
+  "version": "1.0.0",
+  "description": "",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "npm run build && node ./lib/index.js",
+    "build": "tsc",
+    "release": "rm -f test-lambda.zip && bestzip --force node ./test-lambda.zip ./*"
+  },
+  "dependencies": {
+    "@aws-sdk/client-lambda": "3.352.0",
+    "bestzip": "2.2.1",
+    "typescript": "5.1.3"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/node": "^20.3.1"
+  }
+}

--- a/packages/amplify-graphql-model-transformer/rds-patching-lambda/src/index.ts
+++ b/packages/amplify-graphql-model-transformer/rds-patching-lambda/src/index.ts
@@ -3,8 +3,8 @@ import { LambdaClient, UpdateFunctionConfigurationCommand, UpdateFunctionConfigu
 const snsEventSource = 'aws:sns';
 
 type LayerConfig = {
-  layerArn: string;
-  region: string;
+  layerArn?: string;
+  region?: string;
 };
 
 const getLayerConfig = (event: any): LayerConfig => {

--- a/packages/amplify-graphql-model-transformer/rds-patching-lambda/src/index.ts
+++ b/packages/amplify-graphql-model-transformer/rds-patching-lambda/src/index.ts
@@ -1,0 +1,61 @@
+import { LambdaClient, UpdateFunctionConfigurationCommand, UpdateFunctionConfigurationCommandOutput } from "@aws-sdk/client-lambda";
+
+const snsEventSource = 'aws:sns';
+
+type LayerConfig = {
+  layerArn: string;
+  region: string;
+};
+
+const getLayerConfig = (event: any): LayerConfig => {
+  // Check layerArn in the event
+  const { Sns } = event.Records.find((record: any) => record.EventSource === snsEventSource);
+  if (!Sns) {
+    throw new Error('No SNS notification found in the event');
+  }
+
+  const layerArn = Sns?.MessageAttributes?.LayerArn?.Value;
+  const region = Sns?.MessageAttributes?.Region?.Value;
+
+  return {
+    layerArn,
+    region,
+  };
+};
+
+const updateFunction = async (layerArn: string): Promise<UpdateFunctionConfigurationCommandOutput> => {
+  const client = new LambdaClient({ region: process.env.AWS_REGION });
+  const lambdaFunctionArn = process.env.LAMBDA_FUNCTION_ARN;
+  const command = new UpdateFunctionConfigurationCommand({
+    FunctionName: lambdaFunctionArn,
+    Layers: [
+      layerArn,
+    ],
+  });
+  const response = await client.send(command);
+  return response;
+};
+
+export const handler = async (event: any): Promise<void> => {
+  // Record the received event in logs
+  console.log('Received event', JSON.stringify(event, null, 4));
+
+  const { layerArn, region } = getLayerConfig(event);
+  if (!layerArn || !region) {
+    throw new Error('Layer ARN or region is missing in the notification event');
+  }
+
+  if (region !== process.env.AWS_REGION) {
+    console.log(`Region ${region} in notification is not same as the current region ${process.env.AWS_REGION}. Skipping update.`);
+    return;
+  }
+
+  // Update the function configuration with the new layer version
+  try {
+    const response = await updateFunction(layerArn);
+    console.log(`Updated layer version to ${layerArn}`, response);
+  } catch (e) {
+    console.error('Error Updating layer', e);
+    throw e;
+  }
+};

--- a/packages/amplify-graphql-model-transformer/rds-patching-lambda/tsconfig.json
+++ b/packages/amplify-graphql-model-transformer/rds-patching-lambda/tsconfig.json
@@ -1,0 +1,109 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": false,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "ES2015",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
+    "moduleResolution": "node",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    "outDir": "./lib",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}

--- a/packages/amplify-graphql-model-transformer/src/resources/rds-model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/rds-model-resource-generator.ts
@@ -1,12 +1,23 @@
-import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { ResourceConstants } from 'graphql-transformer-common';
 import { MYSQL_DB_TYPE, RDSConnectionSecrets } from '@aws-amplify/graphql-transformer-core';
-import { ModelResourceGenerator } from './model-resource-generator';
+import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { Topic } from 'aws-cdk-lib/aws-sns';
+import { LambdaSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
+import { ResourceConstants } from 'graphql-transformer-common';
 import { ModelVTLGenerator, RDSModelVTLGenerator } from '../resolvers';
-import { createRdsLambda, createRdsLambdaRole, setRDSLayerMappings } from '../resolvers/rds';
+import {
+  createRdsLambda,
+  createRdsLambdaRole,
+  createRdsPatchingLambda,
+  createRdsPatchingLambdaRole,
+  setRDSLayerMappings,
+} from '../resolvers/rds';
+import { ModelResourceGenerator } from './model-resource-generator';
+import { Fn } from 'aws-cdk-lib';
+import { SubscriptionFilter } from 'aws-cdk-lib/aws-sns';
 
 export const RDS_STACK_NAME = 'RdsApiStack';
-
+// TODO: Need to change this to production SNS topic
+const RDS_PATCHING_SNS_TOPIC_ARN = 'arn:aws:sns:us-east-1:956468067974:AmplifyRDSLayerNotification';
 /**
  * An implementation of ModelResourceGenerator responsible for generated CloudFormation resources
  * for models backed by an RDS data source
@@ -19,8 +30,11 @@ export class RdsModelResourceGenerator extends ModelResourceGenerator {
       const secretEntry = context.datasourceSecretParameterLocations.get(MYSQL_DB_TYPE);
       const {
         RDSLambdaIAMRoleLogicalID,
+        RDSPatchingLambdaIAMRoleLogicalID,
         RDSLambdaLogicalID,
+        RDSPatchingLambdaLogicalID,
         RDSLambdaDataSourceLogicalID,
+        RDSPatchingSubscriptionLogicalID,
       } = ResourceConstants.RESOURCES;
       const lambdaRoleStack = context.stackManager.getStackFor(RDSLambdaIAMRoleLogicalID, RDS_STACK_NAME);
       const lambdaStack = context.stackManager.getStackFor(RDSLambdaLogicalID, RDS_STACK_NAME);
@@ -30,6 +44,7 @@ export class RdsModelResourceGenerator extends ModelResourceGenerator {
         lambdaRoleStack,
         secretEntry as RDSConnectionSecrets,
       );
+
       const lambda = createRdsLambda(
         lambdaStack,
         context.api,
@@ -43,6 +58,36 @@ export class RdsModelResourceGenerator extends ModelResourceGenerator {
         },
         context.sqlLambdaVpcConfig,
       );
+
+      const patchingLambdaRoleStack = context.stackManager.getStackFor(RDSPatchingLambdaIAMRoleLogicalID, RDS_STACK_NAME);
+      const patchingLambdaStack = context.stackManager.getStackFor(RDSPatchingLambdaLogicalID, RDS_STACK_NAME);
+      const patchingLambdaRole = createRdsPatchingLambdaRole(
+        context.resourceHelper.generateIAMRoleName(RDSPatchingLambdaIAMRoleLogicalID),
+        patchingLambdaRoleStack,
+        lambda.functionArn,
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const patchingLambda = createRdsPatchingLambda(
+        patchingLambdaStack,
+        context.api,
+        patchingLambdaRole,
+        {
+          LAMBDA_FUNCTION_ARN: lambda.functionArn,
+        },
+      );
+
+      // Add SNS subscription for patching notifications
+      const patchingSubscriptionStack = context.stackManager.getStackFor(RDSPatchingSubscriptionLogicalID, RDS_STACK_NAME);
+      const snsTopic = Topic.fromTopicArn(patchingSubscriptionStack, 'RDSPatchingTopic', RDS_PATCHING_SNS_TOPIC_ARN);
+      const subscription = new LambdaSubscription(patchingLambda, {
+        filterPolicy: {
+          Region: SubscriptionFilter.stringFilter({
+            allowlist: [Fn.ref('AWS::Region')],
+          }),
+        },
+      });
+      snsTopic.addSubscription(subscription);
 
       const lambdaDataSourceStack = context.stackManager.getStackFor(RDSLambdaDataSourceLogicalID, RDS_STACK_NAME);
       const rdsDatasource = context.api.host.addLambdaDataSource(

--- a/packages/graphql-transformer-common/API.md
+++ b/packages/graphql-transformer-common/API.md
@@ -387,9 +387,14 @@ export class ResourceConstants {
         OpenSearchStreamingLambdaFunctionLogicalID: string;
         OpenSearchDataSourceLogicalID: string;
         RDSLambdaIAMRoleLogicalID: string;
+        RDSLambdaLogAccessPolicy: string;
+        RDSPatchingLambdaIAMRoleLogicalID: string;
         RDSLambdaLogicalID: string;
+        RDSPatchingLambdaLogAccessPolicy: string;
+        RDSPatchingLambdaLogicalID: string;
         RDSLambdaDataSourceLogicalID: string;
         RDSLambdaDataSourceLogicalName: string;
+        RDSPatchingSubscriptionLogicalID: string;
         NoneDataSource: string;
         AuthCognitoUserPoolLogicalID: string;
         AuthCognitoUserPoolNativeClientLogicalID: string;

--- a/packages/graphql-transformer-common/src/ResourceConstants.ts
+++ b/packages/graphql-transformer-common/src/ResourceConstants.ts
@@ -29,9 +29,14 @@ export class ResourceConstants {
 
     // RDS
     RDSLambdaIAMRoleLogicalID: 'RDSLambdaIAMRole',
+    RDSLambdaLogAccessPolicy: 'RDSLambdaLogAccessPolicy',
+    RDSPatchingLambdaIAMRoleLogicalID: 'RDSPatchingLambdaIAMRole',
     RDSLambdaLogicalID: 'RDSLambdaLogicalID',
+    RDSPatchingLambdaLogAccessPolicy: 'RDSPatchingLambdaLogAccessPolicy',
+    RDSPatchingLambdaLogicalID: 'RDSPatchingLambdaLogicalID',
     RDSLambdaDataSourceLogicalID: 'RDSLambdaDataSource',
     RDSLambdaDataSourceLogicalName: 'RDSLambdaDatabase',
+    RDSPatchingSubscriptionLogicalID: 'RDSPatchingSubscriptionLogicalID',
 
     // Local. Try not to collide with model data sources.
     NoneDataSource: 'NoneDataSource',

--- a/packages/graphql-transformer-core/API.md
+++ b/packages/graphql-transformer-core/API.md
@@ -292,7 +292,7 @@ export const PARAMETERS_FILE_NAME = "parameters.json";
 export type ProjectRule = (diffs: Diff[], currentBuild: DiffableProject, nextBuild: DiffableProject) => void;
 
 // @public (undocumented)
-function readSchema(projectDirectory: string): Promise<{
+const readSchema: (projectDirectory: string) => Promise<{
     schema: string;
     modelToDatasourceMap: Map<string, DatasourceType>;
 }>;


### PR DESCRIPTION
#### Description of changes

- Adds patching mechanism for SQL lambda.
- Modifies RDS lambda runtime from Node 16.x to 18.x.
- Fixes a bug related to `input AMPLIFY` object. Now there is no need to have schema.graphql file to enable sandbox mode.

##### CDK / CloudFormation Parameters Changed

NA

#### Issue #, if available

NA

#### Description of how you validated changes
- Manual test
- E2E tests updated

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
