### PR TITLE
chore: add minimum unit test threshold

### DIFF
--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -95,6 +95,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 27,
+        "functions": 36,
+        "lines": 44
+      }
+    }
   }
 }

--- a/packages/amplify-graphql-api-construct/package.json
+++ b/packages/amplify-graphql-api-construct/package.json
@@ -59,6 +59,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 73,
+        "functions": 69,
+        "lines": 74
+      }
+    }
   }
 }

--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -60,6 +60,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80
+      }
+    }
   }
 }

--- a/packages/amplify-graphql-default-value-transformer/package.json
+++ b/packages/amplify-graphql-default-value-transformer/package.json
@@ -53,6 +53,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 54,
+        "functions": 80,
+        "lines": 80
+      }
+    }
   }
 }

--- a/packages/amplify-graphql-function-transformer/package.json
+++ b/packages/amplify-graphql-function-transformer/package.json
@@ -50,6 +50,13 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 70,
+        "functions": 80,
+        "lines": 80
+      }
+    },
     "modulePathIgnorePatterns": [
       "overrides"
     ]

--- a/packages/amplify-graphql-http-transformer/package.json
+++ b/packages/amplify-graphql-http-transformer/package.json
@@ -50,6 +50,13 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80
+      }
+    },
     "modulePathIgnorePatterns": [
       "overrides"
     ]

--- a/packages/amplify-graphql-index-transformer/package.json
+++ b/packages/amplify-graphql-index-transformer/package.json
@@ -51,6 +51,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80
+      }
+    }
   }
 }

--- a/packages/amplify-graphql-maps-to-transformer/package.json
+++ b/packages/amplify-graphql-maps-to-transformer/package.json
@@ -58,6 +58,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 58,
+        "functions": 80,
+        "lines": 80
+      }
+    }
   }
 }

--- a/packages/amplify-graphql-model-transformer/package.json
+++ b/packages/amplify-graphql-model-transformer/package.json
@@ -54,6 +54,13 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 61,
+        "functions": 74,
+        "lines": 80
+      }
+    },
     "modulePathIgnorePatterns": [
       "overrides"
     ]

--- a/packages/amplify-graphql-predictions-transformer/package.json
+++ b/packages/amplify-graphql-predictions-transformer/package.json
@@ -53,6 +53,13 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80
+      }
+    },
     "modulePathIgnorePatterns": [
       "overrides"
     ]

--- a/packages/amplify-graphql-relational-transformer/package.json
+++ b/packages/amplify-graphql-relational-transformer/package.json
@@ -52,6 +52,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 39,
+        "functions": 50,
+        "lines": 55
+      }
+    }
   }
 }

--- a/packages/amplify-graphql-schema-generator/package.json
+++ b/packages/amplify-graphql-schema-generator/package.json
@@ -47,6 +47,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 54,
+        "functions": 59,
+        "lines": 70
+      }
+    }
   }
 }

--- a/packages/amplify-graphql-searchable-transformer/package.json
+++ b/packages/amplify-graphql-searchable-transformer/package.json
@@ -55,6 +55,13 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 58,
+        "functions": 80,
+        "lines": 80
+      }
+    },
     "modulePathIgnorePatterns": [
       "overrides"
     ]

--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -62,6 +62,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 14,
+        "functions": 22,
+        "lines": 29
+      }
+    }
   }
 }

--- a/packages/amplify-graphql-transformer-migrator/package.json
+++ b/packages/amplify-graphql-transformer-migrator/package.json
@@ -57,6 +57,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 77,
+        "functions": 80,
+        "lines": 80
+      }
+    }
   }
 }

--- a/packages/amplify-graphql-transformer/package.json
+++ b/packages/amplify-graphql-transformer/package.json
@@ -60,6 +60,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 73,
+        "functions": 25,
+        "lines": 52
+      }
+    }
   }
 }

--- a/packages/graphql-auth-transformer/package.json
+++ b/packages/graphql-auth-transformer/package.json
@@ -52,6 +52,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80
+      }
+    }
   }
 }

--- a/packages/graphql-connection-transformer/package.json
+++ b/packages/graphql-connection-transformer/package.json
@@ -45,6 +45,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80
+      }
+    }
   }
 }

--- a/packages/graphql-dynamodb-transformer/package.json
+++ b/packages/graphql-dynamodb-transformer/package.json
@@ -50,6 +50,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 75,
+        "functions": 80,
+        "lines": 80
+      }
+    }
   }
 }

--- a/packages/graphql-elasticsearch-transformer/package.json
+++ b/packages/graphql-elasticsearch-transformer/package.json
@@ -49,6 +49,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 76,
+        "functions": 80,
+        "lines": 80
+      }
+    }
   }
 }

--- a/packages/graphql-function-transformer/package.json
+++ b/packages/graphql-function-transformer/package.json
@@ -44,6 +44,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80
+      }
+    }
   }
 }

--- a/packages/graphql-http-transformer/package.json
+++ b/packages/graphql-http-transformer/package.json
@@ -43,6 +43,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80
+      }
+    }
   }
 }

--- a/packages/graphql-key-transformer/package.json
+++ b/packages/graphql-key-transformer/package.json
@@ -45,6 +45,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80
+      }
+    }
   }
 }

--- a/packages/graphql-mapping-template/package.json
+++ b/packages/graphql-mapping-template/package.json
@@ -38,6 +38,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 27,
+        "functions": 34,
+        "lines": 47
+      }
+    }
   }
 }

--- a/packages/graphql-predictions-transformer/package.json
+++ b/packages/graphql-predictions-transformer/package.json
@@ -47,6 +47,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 77,
+        "functions": 80,
+        "lines": 80
+      }
+    }
   }
 }

--- a/packages/graphql-relational-schema-transformer/package.json
+++ b/packages/graphql-relational-schema-transformer/package.json
@@ -36,6 +36,13 @@
   },
   "jest": {
     "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80
+      }
+    },
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/packages/graphql-transformer-common/package.json
+++ b/packages/graphql-transformer-common/package.json
@@ -34,6 +34,13 @@
   },
   "jest": {
     "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80
+      }
+    },
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/packages/graphql-transformer-core/package.json
+++ b/packages/graphql-transformer-core/package.json
@@ -53,6 +53,13 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 20,
+        "functions": 32,
+        "lines": 35
+      }
+    }
   }
 }

--- a/packages/graphql-versioned-transformer/package.json
+++ b/packages/graphql-versioned-transformer/package.json
@@ -44,6 +44,14 @@
       "jsx",
       "json",
       "node"
-    ]
+    ],
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80
+      }
+    }
   }
 }


### PR DESCRIPTION
#### Description of changes
Add unit test coverage thresholds (currently set to `min(curr_val, 80)`) to prevent reduction in unit test coverage.

Info on the coverage configuration can be found here https://jestjs.io/docs/27.x/configuration#coveragethreshold-object

Line coverage refers to what % of lines are covered in the given package (in average across all files, since we're using global)
Branch coverage refers to what % of code paths are covered in the given package (in average across all files, since we're using global)
Function coverage refers to what % of functions are covered in the given package (in average across all files, since we're using global)

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit tests

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
