### PR TITLE
fix: use addDependency instead of addDependsOn

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/resources/dynamo-model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/dynamo-model-resource-generator.ts
@@ -210,7 +210,7 @@ export class DynamoModelResourceGenerator extends ModelResourceGenerator {
     );
 
     const cfnDataSource = dataSource.node.defaultChild as CfnDataSource;
-    cfnDataSource.addDependsOn(role.node.defaultChild as CfnRole);
+    cfnDataSource.addDependency(role.node.defaultChild as CfnRole);
 
     if (context.isProjectUsingDataStore()) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
#### Description of changes
Replace usage of deprecated `addDependsOn` with `addDependency`.

##### CDK / CloudFormation Parameters Changed
This should not result in changing CDK, since it's a replacement method for addDependsOn.

#### Issue #, if available
N/A - getting build and test warnings.

#### Description of how you validated changes
Unit + E2E Tests

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
