### PR TITLE
chore: refactor remaining bool config into transormParameters

### DIFF
--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/transformer-options-v2.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/transformer-options-v2.test.ts
@@ -1,19 +1,19 @@
-import { legacyApiKeyEnabledFromParameters } from '../../graphql-transformer/transformer-options-v2';
+import { suppressApiKeyGeneration } from '../../graphql-transformer/transformer-options-v2';
 
-describe('legacyApiKeyEnabledFromParameters', () => {
-  it('returns undefined if not defined in params', () => {
-    expect(legacyApiKeyEnabledFromParameters({})).toBeUndefined();
+describe('suppressApiKeyGeneration', () => {
+  it('returns false if not defined in params', () => {
+    expect(suppressApiKeyGeneration({})).toEqual(false);
   });
 
   it('returns true if value is set to 1', () => {
-    expect(legacyApiKeyEnabledFromParameters({ CreateAPIKey: 1 })).toEqual(true);
+    expect(suppressApiKeyGeneration({ CreateAPIKey: 1 })).toEqual(false);
   });
 
   it('returns false if value is set to 0', () => {
-    expect(legacyApiKeyEnabledFromParameters({ CreateAPIKey: 0 })).toEqual(false);
+    expect(suppressApiKeyGeneration({ CreateAPIKey: 0 })).toEqual(true);
   });
 
   it('returns false if value is set to -1', () => {
-    expect(legacyApiKeyEnabledFromParameters({ CreateAPIKey: -1 })).toEqual(false);
+    expect(suppressApiKeyGeneration({ CreateAPIKey: -1 })).toEqual(true);
   });
 });

--- a/packages/amplify-category-api/src/graphql-transformer/transformer-options-types.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transformer-options-types.ts
@@ -36,12 +36,9 @@ export type TransformerProjectOptions = {
   dryRun?: boolean;
   authConfig?: AppSyncAuthConfiguration;
   stacks: Record<string, Template>;
-  sandboxModeEnabled?: boolean;
   sanityCheckRules: SanityCheckRules;
   overrideConfig: OverrideConfig;
   userDefinedSlots: Record<string, UserDefinedSlot[]>;
-  legacyApiKeyEnabled?: boolean;
-  disableResolverDeduping?: boolean;
   stackMapping: Record<string, string>;
   transformParameters: TransformParameters;
 };

--- a/packages/amplify-graphql-api-construct/API.md
+++ b/packages/amplify-graphql-api-construct/API.md
@@ -168,11 +168,15 @@ export type SubscriptionFunctionSlot = FunctionSlotBase & {
 // @public
 export type TransformParameters = {
     shouldDeepMergeDirectiveConfigDefaults: boolean;
+    disableResolverDeduping: boolean;
+    sandboxModeEnabled: boolean;
     useSubUsernameForDefaultIdentityClaim: boolean;
     populateOwnerFieldForStaticGroupAuth: boolean;
+    suppressApiKeyGeneration: boolean;
     secondaryKeyAsGSI: boolean;
     enableAutoIndexQueryNames: boolean;
     respectPrimaryKeyAttributesOnConnectionField: boolean;
+    enableSearchNodeToNodeEncryption: boolean;
 };
 
 // @public

--- a/packages/amplify-graphql-api-construct/src/internal/default-parameters.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/default-parameters.ts
@@ -1,38 +1,17 @@
-import { TransformParameters } from '@aws-amplify/graphql-transformer-interfaces';
+import { TransformParameters } from '../types';
 
 /**
  * Defaults which will be used by the transformer if overrides are not provided in the construct parameters.
  */
 export const defaultTransformParameters: TransformParameters = {
-  /**
-   * Restore parity w/ GQLv1 @model parameter behavior, where setting a single field doesn't implicitly set the other fields to null.
-   */
   shouldDeepMergeDirectiveConfigDefaults: true,
-
-  /**
-   * Ensure that oidc and userPool auth use the `sub` field in the for the username field, which disallows new users with the same
-   * id to access data from a deleted user in the pool.
-   */
+  disableResolverDeduping: false,
+  sandboxModeEnabled: false,
   useSubUsernameForDefaultIdentityClaim: true,
-
-  /**
-   * Ensure that the owner field is still populated even if a static iam or group authorization applies.
-   */
   populateOwnerFieldForStaticGroupAuth: true,
-
-  /**
-   * If disabled, generated @index as an LSI instead of a GSI.
-   */
+  suppressApiKeyGeneration: false,
   secondaryKeyAsGSI: true,
-
-  /**
-   * Automate generation of query names, and as a result attaching all indexes as queries to the generated API.
-   * If enabled, @index can be provided a null name field to disable the generation of the query on the api.
-   */
   enableAutoIndexQueryNames: true,
-
-  /**
-   * Enable custom primary key support, there's no good reason to disable this unless trying not to update a legacy app.
-   */
   respectPrimaryKeyAttributesOnConnectionField: true,
+  enableSearchNodeToNodeEncryption: false,
 };

--- a/packages/amplify-graphql-api-construct/src/types.ts
+++ b/packages/amplify-graphql-api-construct/src/types.ts
@@ -221,19 +221,62 @@ export type FunctionSlot =
  * have different default behaviors.
  */
 export type TransformParameters = {
-  // General Model Params
+  /**
+   * Restore parity w/ GQLv1 @model parameter behavior, where setting a single field doesn't implicitly set the other fields to null.
+   */
   shouldDeepMergeDirectiveConfigDefaults: boolean;
 
-  // Auth Params
+  /**
+   * Disable resolver deduping, this can sometimes cause problems because dedupe ordering isn't stable today, which can
+   * lead to circular dependencies across stacks if models are reordered.
+   */
+  disableResolverDeduping: boolean;
+
+  /**
+   * Enabling sandbox mode will enable api key auth on all models in the transformed schema.
+   */
+  sandboxModeEnabled: boolean;
+
+  /**
+   * Ensure that oidc and userPool auth use the `sub` field in the for the username field, which disallows new users with the same
+   * id to access data from a deleted user in the pool.
+   */
   useSubUsernameForDefaultIdentityClaim: boolean;
+
+  /**
+   * Ensure that the owner field is still populated even if a static iam or group authorization applies.
+   */
   populateOwnerFieldForStaticGroupAuth: boolean;
 
-  // Index Params
+  /**
+   * If enabled, disable api key resource generation even if specified as an auth rule on the construct.
+   * This is a legacy parameter from the GraphQL Transformer existing in Amplify CLI, not recommended to change.
+   */
+  suppressApiKeyGeneration: boolean;
+
+  /**
+   * If disabled, generated @index as an LSI instead of a GSI.
+   */
   secondaryKeyAsGSI: boolean;
+
+  /**
+   * Automate generation of query names, and as a result attaching all indexes as queries to the generated API.
+   * If enabled, @index can be provided a null name field to disable the generation of the query on the api.
+   */
   enableAutoIndexQueryNames: boolean;
 
-  // Relational Params
+  /**
+   * Enable custom primary key support, there's no good reason to disable this unless trying not to update a legacy app.
+   */
   respectPrimaryKeyAttributesOnConnectionField: boolean;
+
+  /**
+   * If enabled, set nodeToNodeEncryption on the searchable domain (if one exists). Not recommended for use, prefer
+   * to use `Object.values(resources.additionalResources['AWS::Elasticsearch::Domain']).forEach((domain: CfnDomain) => {
+   *   domain.NodeToNodeEncryptionOptions = { Enabled: True };
+   * });
+   */
+  enableSearchNodeToNodeEncryption: boolean;
 };
 
 /**

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -679,7 +679,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
       );
     } else {
       // if the related @model does not have auth we need to add a sandbox mode expression
-      relatedAuthExpression = generateSandboxExpressionForField(ctx.sandboxModeEnabled);
+      relatedAuthExpression = generateSandboxExpressionForField(ctx.transformParameters.sandboxModeEnabled);
     }
     // if there is field auth on the relational query then we need to add field auth read rules first
     // in the request we then add the rules of the related type

--- a/packages/amplify-graphql-index-transformer/src/resolvers/resolvers.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers/resolvers.ts
@@ -528,7 +528,7 @@ function makeQueryResolver(config: IndexDirectiveConfiguration, ctx: Transformer
   resolver.addToSlot(
     'postAuth',
     MappingTemplate.s3MappingTemplateFromString(
-      generateAuthExpressionForSandboxMode(ctx.sandboxModeEnabled),
+      generateAuthExpressionForSandboxMode(ctx.transformParameters.sandboxModeEnabled),
       `${queryTypeName}.${queryField}.{slotName}.{slotIndex}.res.vtl`,
     ),
   );

--- a/packages/amplify-graphql-index-transformer/src/schema.ts
+++ b/packages/amplify-graphql-index-transformer/src/schema.ts
@@ -333,7 +333,7 @@ export function ensureQueryField(config: IndexDirectiveConfiguration, ctx: Trans
   }
 
   args.push(makeInputValueDefinition('sortDirection', makeNamedType('ModelSortDirection')));
-  if (!hasAuth && ctx.sandboxModeEnabled && ctx.authConfig.defaultAuthentication.authenticationType !== 'API_KEY') {
+  if (!hasAuth && ctx.transformParameters.sandboxModeEnabled && ctx.authConfig.defaultAuthentication.authenticationType !== 'API_KEY') {
     directives.push(makeDirective('aws_api_key', []));
   }
   const queryFieldObj = makeConnectionField(queryField, object.name.value, args, directives);

--- a/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-has-many.test.ts
+++ b/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-has-many.test.ts
@@ -19,7 +19,9 @@ const mappedHasMany = /* GraphQL */ `
 const transformSchema = (schema: string) => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new HasManyTransformer(), new BelongsToTransformer(), new MapsToTransformer()],
-    sandboxModeEnabled: true,
+    transformParameters: {
+      sandboxModeEnabled: true,
+    },
   });
   return transformer.transform(schema);
 };

--- a/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-has-one.test.ts
+++ b/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-has-one.test.ts
@@ -45,7 +45,9 @@ const biDiHasOneMapped = /* GraphQL */ `
 const transformSchema = (schema: string) => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new HasOneTransformer(), new BelongsToTransformer(), new MapsToTransformer()],
-    sandboxModeEnabled: true,
+    transformParameters: {
+      sandboxModeEnabled: true,
+    },
   });
   return transformer.transform(schema);
 };

--- a/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-many-to-many.test.ts
+++ b/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-many-to-many.test.ts
@@ -38,8 +38,8 @@ const transformSchema = (schema: string): DeploymentResources => {
     ],
     transformParameters: {
       respectPrimaryKeyAttributesOnConnectionField: false,
+      sandboxModeEnabled: true,
     },
-    sandboxModeEnabled: true,
   });
   return transformer.transform(schema);
 };

--- a/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-model.test.ts
+++ b/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-model.test.ts
@@ -12,7 +12,9 @@ describe('@mapsTo directive on model type', () => {
     `;
     const transformer = new GraphQLTransform({
       transformers: [new ModelTransformer(), new MapsToTransformer()],
-      sandboxModeEnabled: true,
+      transformParameters: {
+        sandboxModeEnabled: true,
+      },
     });
     const out = transformer.transform(basicSchema);
     expect(out.stacks.Task.Resources!.TaskTable!.Properties.TableName).toMatchInlineSnapshot(`

--- a/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-multiple-renames.test.ts
+++ b/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-multiple-renames.test.ts
@@ -61,7 +61,9 @@ const transformSchema = (schema: string, enableDataStore = false) => {
       new BelongsToTransformer(),
       new MapsToTransformer(),
     ],
-    sandboxModeEnabled: true,
+    transformParameters: {
+      sandboxModeEnabled: true,
+    },
     resolverConfig: enableDataStore
       ? {
         project: {

--- a/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-searchable.test.ts
+++ b/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-searchable.test.ts
@@ -31,7 +31,9 @@ const mappedHasManyAndSearchableSchema = /* GraphQL */ `
 const transformSchema = (schema: string) => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new HasManyTransformer(), new SearchableModelTransformer(), new MapsToTransformer()],
-    sandboxModeEnabled: true,
+    transformParameters: {
+      sandboxModeEnabled: true,
+    },
   });
   return transformer.transform(schema);
 };

--- a/packages/amplify-graphql-migration-tests/src/v2-transformer-provider.ts
+++ b/packages/amplify-graphql-migration-tests/src/v2-transformer-provider.ts
@@ -18,7 +18,9 @@ export const v2transformerProvider = (config: Partial<V2TransformerTestConfig> =
   const transform = new GraphQLTransform({
     transformers: config.transformers ?? getDefaultTransformers(),
     authConfig: defaultAuthConfig,
-    sandboxModeEnabled: true,
+    transformParameters: {
+      sandboxModeEnabled: true,
+    },
   });
 
   return transform;

--- a/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
@@ -1159,8 +1159,10 @@ describe('ModelTransformer: ', () => {
           ConflictHandler: ConflictHandlerType.AUTOMERGE,
         },
       },
-      sandboxModeEnabled: true,
       transformers: [new ModelTransformer()],
+      transformParameters: {
+        sandboxModeEnabled: true,
+      },
     });
     const out = transformer.transform(validSchema);
     expect(out).toBeDefined();
@@ -1250,8 +1252,10 @@ describe('ModelTransformer: ', () => {
           }
         }
       },
-      sandboxModeEnabled: true,
-      transformers: [new ModelTransformer()]
+      transformers: [new ModelTransformer()],
+      transformParameters: {
+        sandboxModeEnabled: true,
+      },
     });
     const out = transformer.transform(validSchema);
     expect(out).toBeDefined();
@@ -1337,8 +1341,10 @@ describe('ModelTransformer: ', () => {
       name: String
     }`;
     const transformer = new GraphQLTransform({
-      sandboxModeEnabled: true,
       transformers: [new ModelTransformer()],
+      transformParameters: {
+        sandboxModeEnabled: true,
+      },
     });
     const out = transformer.transform(validSchema);
 
@@ -1374,8 +1380,10 @@ describe('ModelTransformer: ', () => {
           },
         ],
       },
-      sandboxModeEnabled: true,
       transformers: [new ModelTransformer()],
+      transformParameters: {
+        sandboxModeEnabled: true,
+      }
     });
     const out = transformer.transform(validSchema);
     expect(out).toBeDefined();

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -291,7 +291,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
         }
       }
       // global auth check
-      if (!hasAuth && ctx.sandboxModeEnabled && ctx.authConfig.defaultAuthentication.authenticationType !== 'API_KEY') {
+      if (!hasAuth && ctx.transformParameters.sandboxModeEnabled && ctx.authConfig.defaultAuthentication.authenticationType !== 'API_KEY') {
         const apiKeyDirArray = [makeDirective(API_KEY_DIRECTIVE, [])];
         extendTypeWithDirectives(ctx, def.name.value, apiKeyDirArray);
         propagateApiKeyToNestedTypes(ctx as TransformerContextProvider, def, new Set<string>());

--- a/packages/amplify-graphql-model-transformer/src/resources/model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/model-resource-generator.ts
@@ -125,7 +125,7 @@ export abstract class ModelResourceGenerator {
         resolver.addToSlot(
           'postAuth',
           MappingTemplate.s3MappingTemplateFromString(
-            generateAuthExpressionForSandboxMode(context.sandboxModeEnabled),
+            generateAuthExpressionForSandboxMode(context.transformParameters.sandboxModeEnabled),
             `${query.typeName}.${query.fieldName}.{slotName}.{slotIndex}.req.vtl`,
           ),
         );
@@ -159,7 +159,7 @@ export abstract class ModelResourceGenerator {
         resolver.addToSlot(
           'postAuth',
           MappingTemplate.s3MappingTemplateFromString(
-            generateAuthExpressionForSandboxMode(context.sandboxModeEnabled),
+            generateAuthExpressionForSandboxMode(context.transformParameters.sandboxModeEnabled),
             `${mutation.typeName}.${mutation.fieldName}.{slotName}.{slotIndex}.req.vtl`,
           ),
         );
@@ -205,7 +205,7 @@ export abstract class ModelResourceGenerator {
             resolver.addToSlot(
               'postAuth',
               MappingTemplate.s3MappingTemplateFromString(
-                generateAuthExpressionForSandboxMode(context.sandboxModeEnabled),
+                generateAuthExpressionForSandboxMode(context.transformParameters.sandboxModeEnabled),
                 `${subscription.typeName}.${subscription.fieldName}.{slotName}.{slotIndex}.req.vtl`,
               ),
             );

--- a/packages/amplify-graphql-searchable-transformer/API.md
+++ b/packages/amplify-graphql-searchable-transformer/API.md
@@ -14,8 +14,7 @@ import { TransformerTransformSchemaStepContextProvider } from '@aws-amplify/grap
 
 // @public (undocumented)
 export class SearchableModelTransformer extends TransformerPluginBase {
-    // Warning: (ae-forgotten-export) The symbol "SearchableModelTransformerOptions" needs to be exported by the entry point index.d.ts
-    constructor(options?: SearchableModelTransformerOptions);
+    constructor();
     // (undocumented)
     generateResolvers: (context: TransformerContextProvider) => void;
     // (undocumented)

--- a/packages/amplify-graphql-searchable-transformer/package.json
+++ b/packages/amplify-graphql-searchable-transformer/package.json
@@ -57,7 +57,7 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "branches": 58,
+        "branches": 57,
         "functions": 80,
         "lines": 80
       }

--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -232,17 +232,11 @@ export interface GraphQLTransformOptions {
     // (undocumented)
     readonly authConfig?: AppSyncAuthConfiguration;
     // (undocumented)
-    readonly disableResolverDeduping?: boolean;
-    // (undocumented)
     readonly host?: TransformHostProvider;
-    // (undocumented)
-    readonly legacyApiKeyEnabled?: boolean;
     // (undocumented)
     readonly overrideConfig?: OverrideConfig;
     // (undocumented)
     readonly resolverConfig?: ResolverConfig;
-    // (undocumented)
-    readonly sandboxModeEnabled?: boolean;
     // Warning: (ae-forgotten-export) The symbol "StackMapping" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transformation/transform.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transformation/transform.test.ts
@@ -97,28 +97,24 @@ describe('GraphQLTransform', () => {
       invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: false });
     });
 
-    it('creates an api key for apps with API_KEY authorization if legacyApiKeyEnabled is set to true', () => {
+    it('creates an api key for apps with API_KEY authorization if suppressApiKeyGeneration is set to false', () => {
       const transform = new TestGraphQLTransform({
         transformers: [mockTransformer],
         authConfig: apiKeyAuthConfig,
-        legacyApiKeyEnabled: true,
+        transformParameters: {
+          suppressApiKeyGeneration: false,
+        }
       });
       invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: true });
     });
 
-    it('does not create an api key for apps with API_KEY authorization if legacyApiKeyEnabled is undefined', () => {
+    it('does not create an api key for apps with API_KEY authorization if suppressApiKeyGeneration is set to true', () => {
       const transform = new TestGraphQLTransform({
         transformers: [mockTransformer],
         authConfig: apiKeyAuthConfig,
-      });
-      invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: true });
-    });
-
-    it('does not create an api key for apps with API_KEY authorization if legacyApiKeyEnabled is set to false', () => {
-      const transform = new TestGraphQLTransform({
-        transformers: [mockTransformer],
-        authConfig: apiKeyAuthConfig,
-        legacyApiKeyEnabled: false,
+        transformParameters: {
+          suppressApiKeyGeneration: true,
+        },
       });
       invokeAndVerifyIfAPIKeyIsDefined({ transform, isAPIKeyExpected: false });
     });

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -30,6 +30,7 @@ import {
   print,
 } from 'graphql';
 import _ from 'lodash';
+import { DocumentNode } from 'graphql/language';
 import { ResolverConfig } from '../config/transformer-config';
 import { InvalidTransformerError, SchemaValidationError, UnknownDirectiveError } from '../errors';
 import { GraphQLApi } from '../graphql-api';
@@ -39,7 +40,6 @@ import { StackManager } from '../transformer-context/stack-manager';
 import { adoptAuthModes, IAM_AUTH_ROLE_PARAMETER, IAM_UNAUTH_ROLE_PARAMETER } from '../utils/authType';
 import * as SyncUtils from './sync-utils';
 import { MappingTemplate } from '../cdk-compat';
-
 import { UserDefinedSlot, OverrideConfig, DatasourceTransformationConfig } from './types';
 import {
   makeSeenTransformationKey,
@@ -51,7 +51,6 @@ import {
   sortTransformerPlugins,
 } from './utils';
 import { validateAuthModes, validateModelSchema } from './validation';
-import { DocumentNode } from 'graphql/language';
 import { TransformerPreProcessContext } from '../transformer-context/pre-process-context';
 import { DatasourceType } from '../config/project-config';
 import { defaultTransformParameters } from '../transformer-context/transform-parameters';
@@ -80,12 +79,9 @@ export interface GraphQLTransformOptions {
   readonly stacks?: Record<string, Template>;
   readonly transformParameters?: Partial<TransformParameters>;
   readonly host?: TransformHostProvider;
-  readonly sandboxModeEnabled?: boolean;
-  readonly disableResolverDeduping?: boolean;
   readonly userDefinedSlots?: Record<string, UserDefinedSlot[]>;
   readonly resolverConfig?: ResolverConfig;
   readonly overrideConfig?: OverrideConfig;
-  readonly legacyApiKeyEnabled?: boolean;
 }
 export type StackMapping = { [resourceId: string]: string };
 export class GraphQLTransform {
@@ -96,8 +92,6 @@ export class GraphQLTransform {
   private readonly resolverConfig?: ResolverConfig;
   private readonly userDefinedSlots: Record<string, UserDefinedSlot[]>;
   private readonly overrideConfig?: OverrideConfig;
-  private readonly disableResolverDeduping?: boolean;
-  private readonly legacyApiKeyEnabled?: boolean;
   private readonly transformParameters: TransformParameters;
 
   // A map from `${directive}.${typename}.${fieldName?}`: true
@@ -131,8 +125,6 @@ export class GraphQLTransform {
     this.userDefinedSlots = options.userDefinedSlots || ({} as Record<string, UserDefinedSlot[]>);
     this.overrideConfig = options.overrideConfig;
     this.resolverConfig = options.resolverConfig || {};
-    this.legacyApiKeyEnabled = options.legacyApiKeyEnabled;
-    this.disableResolverDeduping = options.disableResolverDeduping;
     this.transformParameters = {
       ...defaultTransformParameters,
       ...(options.transformParameters ?? {}),
@@ -190,7 +182,6 @@ export class GraphQLTransform {
       this.stackMappingOverrides,
       this.authConfig,
       this.transformParameters,
-      this.options.sandboxModeEnabled,
       this.resolverConfig,
       datasourceConfig?.datasourceSecretParameterLocations,
     );
@@ -337,15 +328,15 @@ export class GraphQLTransform {
       name: `${apiName}-${envName.valueAsString}`,
       authorizationConfig,
       host: this.options.host,
-      sandboxModeEnabled: this.options.sandboxModeEnabled,
+      sandboxModeEnabled: this.transformParameters.sandboxModeEnabled,
       environmentName: envName.valueAsString,
-      disableResolverDeduping: this.disableResolverDeduping,
+      disableResolverDeduping: this.transformParameters.disableResolverDeduping,
     });
     const authModes = [authorizationConfig.defaultAuthorization, ...(authorizationConfig.additionalAuthorizationModes || [])].map(
       mode => mode?.authorizationType,
     );
 
-    if (authModes.includes(AuthorizationType.API_KEY) && this.legacyApiKeyEnabled !== false) {
+    if (authModes.includes(AuthorizationType.API_KEY) && !this.transformParameters.suppressApiKeyGeneration) {
       const apiKeyConfig: AuthorizationMode | undefined = [
         authorizationConfig.defaultAuthorization,
         ...(authorizationConfig.additionalAuthorizationModes || []),

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
@@ -52,7 +52,6 @@ export class TransformerContext implements TransformerContextProvider {
   public readonly transformParameters: TransformParameters;
   public _api?: GraphQLAPIProvider;
   public readonly authConfig: AppSyncAuthConfiguration;
-  public readonly sandboxModeEnabled: boolean;
   private resolverConfig: ResolverConfig | undefined;
   public readonly modelToDatasourceMap: Map<string, DatasourceType>;
   public readonly datasourceSecretParameterLocations: Map<string, RDSConnectionSecrets>;
@@ -65,7 +64,6 @@ export class TransformerContext implements TransformerContextProvider {
     stackMapping: Record<string, string>,
     authConfig: AppSyncAuthConfiguration,
     transformParameters: TransformParameters,
-    sandboxModeEnabled?: boolean,
     resolverConfig?: ResolverConfig,
     datasourceSecretParameterLocations?: Map<string, RDSConnectionSecrets>,
   ) {
@@ -76,7 +74,6 @@ export class TransformerContext implements TransformerContextProvider {
     const stackManager = new StackManager(app, stackMapping);
     this.stackManager = stackManager;
     this.authConfig = authConfig;
-    this.sandboxModeEnabled = sandboxModeEnabled ?? false;
     this.resourceHelper = new TransformerResourceHelper(stackManager);
     this.transformParameters = transformParameters;
     this.resolverConfig = resolverConfig;

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/transform-parameters.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/transform-parameters.ts
@@ -3,10 +3,13 @@ import type { TransformParameters } from '@aws-amplify/graphql-transformer-inter
 export const defaultTransformParameters: TransformParameters = {
   // General Model Params
   shouldDeepMergeDirectiveConfigDefaults: true,
+  disableResolverDeduping: false,
+  sandboxModeEnabled: false,
 
   // Auth Params
   useSubUsernameForDefaultIdentityClaim: true,
   populateOwnerFieldForStaticGroupAuth: true,
+  suppressApiKeyGeneration: false,
 
   // Index Params
   secondaryKeyAsGSI: true,
@@ -14,4 +17,7 @@ export const defaultTransformParameters: TransformParameters = {
 
   // Relational Params
   respectPrimaryKeyAttributesOnConnectionField: true,
+
+  // Search Params
+  enableSearchNodeToNodeEncryption: false,
 };

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -440,7 +440,7 @@ export interface Template {
 export type TransformerAuthProvider = TransformerPluginProvider;
 
 // @public (undocumented)
-export type TransformerBeforeStepContextProvider = Pick<TransformerContextProvider, 'inputDocument' | 'modelToDatasourceMap' | 'transformParameters' | 'isProjectUsingDataStore' | 'getResolverConfig' | 'authConfig' | 'stackManager' | 'sandboxModeEnabled'>;
+export type TransformerBeforeStepContextProvider = Pick<TransformerContextProvider, 'inputDocument' | 'modelToDatasourceMap' | 'transformParameters' | 'isProjectUsingDataStore' | 'getResolverConfig' | 'authConfig' | 'stackManager'>;
 
 // @public (undocumented)
 export interface TransformerContextOutputProvider {
@@ -532,8 +532,6 @@ export interface TransformerContextProvider {
     resolvers: TransformerResolversManagerProvider;
     // (undocumented)
     resourceHelper: TransformerResourceHelperProvider;
-    // (undocumented)
-    sandboxModeEnabled: boolean;
     // (undocumented)
     stackManager: StackManagerProvider;
     // (undocumented)
@@ -779,7 +777,7 @@ export interface TransformerSchemaHelperProvider {
 }
 
 // @public (undocumented)
-export type TransformerSchemaVisitStepContextProvider = Pick<TransformerContextProvider, 'inputDocument' | 'modelToDatasourceMap' | 'output' | 'providerRegistry' | 'transformParameters' | 'isProjectUsingDataStore' | 'getResolverConfig' | 'metadata' | 'authConfig' | 'resourceHelper' | 'sandboxModeEnabled'>;
+export type TransformerSchemaVisitStepContextProvider = Pick<TransformerContextProvider, 'inputDocument' | 'modelToDatasourceMap' | 'output' | 'providerRegistry' | 'transformParameters' | 'isProjectUsingDataStore' | 'getResolverConfig' | 'metadata' | 'authConfig' | 'resourceHelper'>;
 
 // @public (undocumented)
 export type TransformerSecrets = {
@@ -790,7 +788,7 @@ export type TransformerSecrets = {
 export type TransformerTransformSchemaStepContextProvider = TransformerValidationStepContextProvider;
 
 // @public (undocumented)
-export type TransformerValidationStepContextProvider = Pick<TransformerContextProvider, 'inputDocument' | 'modelToDatasourceMap' | 'output' | 'providerRegistry' | 'dataSources' | 'transformParameters' | 'isProjectUsingDataStore' | 'getResolverConfig' | 'metadata' | 'authConfig' | 'sandboxModeEnabled' | 'resourceHelper' | 'resolvers' | 'stackManager'>;
+export type TransformerValidationStepContextProvider = Pick<TransformerContextProvider, 'inputDocument' | 'modelToDatasourceMap' | 'output' | 'providerRegistry' | 'dataSources' | 'transformParameters' | 'isProjectUsingDataStore' | 'getResolverConfig' | 'metadata' | 'authConfig' | 'resourceHelper' | 'resolvers' | 'stackManager'>;
 
 // @public (undocumented)
 export interface TransformHostProvider {
@@ -827,11 +825,15 @@ export interface TransformHostProvider {
 // @public (undocumented)
 export type TransformParameters = {
     shouldDeepMergeDirectiveConfigDefaults: boolean;
+    disableResolverDeduping: boolean;
+    sandboxModeEnabled: boolean;
     useSubUsernameForDefaultIdentityClaim: boolean;
     populateOwnerFieldForStaticGroupAuth: boolean;
+    suppressApiKeyGeneration: boolean;
     secondaryKeyAsGSI: boolean;
     enableAutoIndexQueryNames: boolean;
     respectPrimaryKeyAttributesOnConnectionField: boolean;
+    enableSearchNodeToNodeEncryption: boolean;
 };
 
 // @public (undocumented)

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transform-parameters.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transform-parameters.ts
@@ -7,10 +7,13 @@
 export type TransformParameters = {
   // General Model Params
   shouldDeepMergeDirectiveConfigDefaults: boolean;
+  disableResolverDeduping: boolean;
+  sandboxModeEnabled: boolean;
 
   // Auth Params
   useSubUsernameForDefaultIdentityClaim: boolean;
   populateOwnerFieldForStaticGroupAuth: boolean;
+  suppressApiKeyGeneration: boolean;
 
   // Index Params
   secondaryKeyAsGSI: boolean;
@@ -18,4 +21,7 @@ export type TransformParameters = {
 
   // Relational Params
   respectPrimaryKeyAttributesOnConnectionField: boolean;
+
+  // Search Params
+  enableSearchNodeToNodeEncryption: boolean;
 };

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
@@ -30,7 +30,6 @@ export interface TransformerContextProvider {
   api: GraphQLAPIProvider;
   resourceHelper: TransformerResourceHelperProvider;
   authConfig: AppSyncAuthConfiguration;
-  sandboxModeEnabled: boolean;
   transformParameters: TransformParameters;
 
   isProjectUsingDataStore(): boolean;
@@ -46,7 +45,6 @@ export type TransformerBeforeStepContextProvider = Pick<
   | 'getResolverConfig'
   | 'authConfig'
   | 'stackManager'
-  | 'sandboxModeEnabled'
 >;
 
 export type TransformerSchemaVisitStepContextProvider = Pick<
@@ -61,7 +59,6 @@ export type TransformerSchemaVisitStepContextProvider = Pick<
   | 'metadata'
   | 'authConfig'
   | 'resourceHelper'
-  | 'sandboxModeEnabled'
 >;
 
 export type TransformerValidationStepContextProvider = Pick<
@@ -76,7 +73,6 @@ export type TransformerValidationStepContextProvider = Pick<
   | 'getResolverConfig'
   | 'metadata'
   | 'authConfig'
-  | 'sandboxModeEnabled'
   | 'resourceHelper'
   | 'resolvers'
   | 'stackManager'

--- a/packages/amplify-graphql-transformer/API.md
+++ b/packages/amplify-graphql-transformer/API.md
@@ -36,13 +36,10 @@ export type ExecuteTransformConfig = TransformConfig & {
 
 // @public (undocumented)
 export type TransformConfig = {
-    legacyApiKeyEnabled?: boolean;
-    disableResolverDeduping?: boolean;
     transformersFactoryArgs: TransformerFactoryArgs;
     resolverConfig?: ResolverConfig;
     authConfig?: AppSyncAuthConfiguration;
     stacks?: Record<string, Template>;
-    sandboxModeEnabled?: boolean;
     overrideConfig?: OverrideConfig;
     userDefinedSlots?: Record<string, UserDefinedSlot[]>;
     stackMapping?: Record<string, string>;
@@ -55,13 +52,8 @@ export type TransformerFactoryArgs = {
     storageConfig?: any;
     adminRoles?: Array<string>;
     identityPoolId?: string;
-    searchConfig?: TransformerSearchConfig;
     customTransformers?: TransformerPluginProvider[];
 };
-
-// Warnings were encountered during analysis:
-//
-// src/graphql-transformer.ts:47:3 - (ae-forgotten-export) The symbol "TransformerSearchConfig" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/amplify-graphql-transformer/package.json
+++ b/packages/amplify-graphql-transformer/package.json
@@ -63,7 +63,7 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "branches": 73,
+        "branches": 69,
         "functions": 25,
         "lines": 52
       }

--- a/packages/amplify-graphql-transformer/src/graphql-transformer.ts
+++ b/packages/amplify-graphql-transformer/src/graphql-transformer.ts
@@ -31,10 +31,6 @@ import {
   UserDefinedSlot,
 } from '@aws-amplify/graphql-transformer-core';
 
-export type TransformerSearchConfig = {
-  enableNodeToNodeEncryption?: boolean;
-};
-
 /**
  * Arguments passed into a TransformerFactory
  * Used to determine how to create a new GraphQLTransform
@@ -44,7 +40,6 @@ export type TransformerFactoryArgs = {
   storageConfig?: any;
   adminRoles?: Array<string>;
   identityPoolId?: string;
-  searchConfig?: TransformerSearchConfig;
   customTransformers?: TransformerPluginProvider[];
 };
 
@@ -52,13 +47,10 @@ export type TransformerFactoryArgs = {
  * Transformer Options used to create a GraphQL Transform and compile a GQL API
  */
 export type TransformConfig = {
-  legacyApiKeyEnabled?: boolean;
-  disableResolverDeduping?: boolean;
   transformersFactoryArgs: TransformerFactoryArgs;
   resolverConfig?: ResolverConfig;
   authConfig?: AppSyncAuthConfiguration;
   stacks?: Record<string, Template>;
-  sandboxModeEnabled?: boolean;
   overrideConfig?: OverrideConfig;
   userDefinedSlots?: Record<string, UserDefinedSlot[]>;
   stackMapping?: Record<string, string>;
@@ -90,7 +82,7 @@ export const constructTransformerChain = (
     new DefaultValueTransformer(),
     authTransformer,
     new MapsToTransformer(),
-    new SearchableModelTransformer({ enableNodeToNodeEncryption: options?.searchConfig?.enableNodeToNodeEncryption }),
+    new SearchableModelTransformer(),
     ...(options?.customTransformers ?? []),
   ];
 };
@@ -104,12 +96,9 @@ export const constructTransform = (config: TransformConfig): GraphQLTransform =>
   const {
     transformersFactoryArgs,
     authConfig,
-    sandboxModeEnabled,
     resolverConfig,
     overrideConfig,
     userDefinedSlots,
-    legacyApiKeyEnabled,
-    disableResolverDeduping,
     stacks,
     stackMapping,
     transformParameters,
@@ -123,12 +112,9 @@ export const constructTransform = (config: TransformConfig): GraphQLTransform =>
     authConfig,
     stacks,
     transformParameters,
-    sandboxModeEnabled,
     userDefinedSlots,
     resolverConfig,
     overrideConfig,
-    legacyApiKeyEnabled,
-    disableResolverDeduping,
   });
 };
 

--- a/packages/amplify-util-mock/src/__e2e_v2__/searchable-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e_v2__/searchable-transformer.e2e.test.ts
@@ -22,7 +22,9 @@ describe('@searchable transformer', () => {
     try {
       const transformer = new GraphQLTransform({
         transformers: [new ModelTransformer(), new SearchableModelTransformer()],
-        sandboxModeEnabled: true,
+        transformParameters: {
+          sandboxModeEnabled: true,
+        },
       });
       const out = await transformer.transform(validSchema);
       let ddbClient;

--- a/packages/amplify-util-mock/src/__e2e_v2__/util-method.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e_v2__/util-method.e2e.test.ts
@@ -14,7 +14,9 @@ jest.setTimeout(2000000);
 const runTransformer = async (validSchema: string) => {
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer()],
-    sandboxModeEnabled: true,
+    transformParameters: {
+      sandboxModeEnabled: true,
+    },
   });
   const out = await transformer.transform(validSchema);
   return out;

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/BelongsToTransformerV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/BelongsToTransformerV2.e2e.test.ts
@@ -11,9 +11,9 @@ describe('@belongsTo transformer', () => {
   const transformerFactory = () => new GraphQLTransform({
     transformParameters: {
       respectPrimaryKeyAttributesOnConnectionField: false,
+      sandboxModeEnabled: true,
     },
     transformers: [new ModelTransformer(), new BelongsToTransformer(), new HasManyTransformer(), new HasOneTransformer()],
-    sandboxModeEnabled: true,
   });
   const validSchema = /* GraphQL */ `
     type Blog @model {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/DefaultValueTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/DefaultValueTransformer.e2e.test.ts
@@ -68,7 +68,9 @@ beforeAll(async () => {
 
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new DefaultValueTransformer()],
-    sandboxModeEnabled: true,
+    transformParameters: {
+      sandboxModeEnabled: true,
+    }
   });
   const out = transformer.transform(validSchema);
   const finishedStack = await deploy(

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/HttpTransformerV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/HttpTransformerV2.e2e.test.ts
@@ -102,7 +102,9 @@ beforeAll(async () => {
 
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new HttpTransformer()],
-    sandboxModeEnabled: true,
+    transformParameters: {
+      sandboxModeEnabled: true,
+    },
   });
 
   const out = transformer.transform(validSchema);

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/IndexTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/IndexTransformer.e2e.test.ts
@@ -110,7 +110,9 @@ beforeAll(async () => {
 
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
-    sandboxModeEnabled: true,
+    transformParameters: {
+      sandboxModeEnabled: true,
+    },
   });
   const out = transformer.transform(validSchema);
   const finishedStack = await deploy(

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/IndexWithAutoQueryField.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/IndexWithAutoQueryField.e2e.test.ts
@@ -105,7 +105,9 @@ beforeAll(async () => {
 
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer()],
-    sandboxModeEnabled: true,
+    transformParameters: {
+      sandboxModeEnabled: true,
+    },
   });
   const out = transformer.transform(validSchema);
   const finishedStack = await deploy(

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MapsToTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MapsToTransformer.e2e.test.ts
@@ -10,9 +10,9 @@ describe('@mapsTo transformer', () => {
     new GraphQLTransform({
       transformParameters: {
         respectPrimaryKeyAttributesOnConnectionField: false,
+        sandboxModeEnabled: true,
       },
       transformers: [new ModelTransformer(), new HasManyTransformer(), new BelongsToTransformer(), new MapsToTransformer()],
-      sandboxModeEnabled: true,
     });
 
   const initialSchema = /* GraphQL */ `

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/ModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/ModelTransformer.e2e.test.ts
@@ -88,7 +88,9 @@ beforeAll(async () => {
   `;
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer()],
-    sandboxModeEnabled: true,
+    transformParameters: {
+      sandboxModeEnabled: true,
+    },
   });
   const out = transformer.transform(validSchema);
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PredictionsTransformerV2Tests.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PredictionsTransformerV2Tests.e2e.test.ts
@@ -52,7 +52,9 @@ beforeAll(async () => {
   }
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new PredictionsTransformer({ bucketName: BUCKET_NAME })],
-    sandboxModeEnabled: true,
+    transformParameters: {
+      sandboxModeEnabled: true,
+    },
   });
   const out = transformer.transform(validSchema);
   const finishedStack = await deploy(

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalTransformers.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalTransformers.e2e.test.ts
@@ -159,12 +159,12 @@ type ModelB @model {
         new ManyToManyTransformer(modelTransformer, indexTransformer, hasOneTransformer, authTransformer),
         authTransformer,
       ],
-      sandboxModeEnabled: true,
       transformParameters: {
         shouldDeepMergeDirectiveConfigDefaults: false,
         populateOwnerFieldForStaticGroupAuth: false,
         useSubUsernameForDefaultIdentityClaim: false,
-        respectPrimaryKeyAttributesOnConnectionField: false
+        respectPrimaryKeyAttributesOnConnectionField: false,
+        sandboxModeEnabled: true,
       }
     });
     out = transformer.transform(validSchema);

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformerV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformerV2.e2e.test.ts
@@ -84,7 +84,9 @@ beforeAll(async () => {
     `;
   const transformer = new GraphQLTransform({
     transformers: [new ModelTransformer(), new SearchableModelTransformer()],
-    sandboxModeEnabled: true,
+    transformParameters: {
+      sandboxModeEnabled: true,
+    },
   });
   try {
     await awsS3Client.createBucket({ Bucket: BUCKET_NAME }).promise();


### PR DESCRIPTION
#### Description of changes
Refactor the following pieces of config and state into the `transformParameters` in order to collect config flags into a single location.

* `suppressApiKeyGeneration` - this turns the current tri-state for `legacyApiKeyEnabled` into a straightforward non-optional boolean.
* `enableSearchNodeToNodeEncryption`
* `disableResolverDeduping`
* `sandboxModeEnabled`

__N.B. This will require the mock util tests to be updated again in CLI when we release, since they're reaching inside the transformer to run those tests.__

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit + E2E Tests

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
