### PR TITLE
chore: use peer deps for cdk and constructs, and update in amplify packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "parse-path": "^5.0.0",
     "parse-url": "^8.1.0",
     "moment-timezone": "^0.5.35",
-    "**/aws-cdk-lib": "~2.68.0",
+    "**/aws-cdk-lib": "~2.80.0",
     "**/@aws-amplify/amplify-cli-core": "4.0.4",
     "ejs": "^3.1.7",
     "json5": "^2.2.3",

--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -35,7 +35,7 @@
     "@aws-amplify/graphql-transformer-core": "1.3.3",
     "@aws-amplify/graphql-transformer-interfaces": "2.2.2",
     "@aws-amplify/graphql-transformer-migrator": "2.1.7",
-    "@aws-cdk/aws-apigatewayv2-alpha": "~2.68.0-alpha.0",
+    "@aws-cdk/aws-apigatewayv2-alpha": "~2.80.0-alpha.0",
     "@graphql-tools/merge": "^6.0.18",
     "@octokit/rest": "^18.0.9",
     "aws-cdk-lib": "~2.80.0",

--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -38,7 +38,7 @@
     "@aws-cdk/aws-apigatewayv2-alpha": "~2.68.0-alpha.0",
     "@graphql-tools/merge": "^6.0.18",
     "@octokit/rest": "^18.0.9",
-    "aws-cdk-lib": "~2.68.0",
+    "aws-cdk-lib": "~2.80.0",
     "aws-sdk": "^2.1113.0",
     "chalk": "^4.1.1",
     "cloudform-types": "^4.2.0",

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -527,7 +527,7 @@ export function initCDKProject(cwd: string, templatePath: string): Promise<strin
       });
   })).then(() => new Promise<void>((resolve, reject) => {
     // override dep version from cdk init
-    spawn('npm', ['install', '--save', 'aws-cdk-lib@2.68.0'], { cwd, stripColors: true })
+    spawn('npm', ['install', '--save', 'aws-cdk-lib@2.80.0'], { cwd, stripColors: true })
       .run((err: Error) => {
         if (!err) {
           resolve();

--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -33,8 +33,6 @@
     "@aws-amplify/graphql-relational-transformer": "1.2.3",
     "@aws-amplify/graphql-transformer-core": "1.3.3",
     "@aws-amplify/graphql-transformer-interfaces": "2.2.2",
-    "aws-cdk-lib": "~2.68.0",
-    "constructs": "^10.0.5",
     "graphql": "^15.5.0",
     "graphql-mapping-template": "4.20.8",
     "graphql-transformer-common": "4.24.6",
@@ -45,6 +43,10 @@
     "@aws-amplify/graphql-index-transformer": "1.2.3",
     "@aws-amplify/graphql-searchable-transformer": "1.2.5",
     "@types/node": "^12.12.6"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "^2.68.0",
+    "constructs": "^10.0.5"
   },
   "jest": {
     "testURL": "http://localhost",

--- a/packages/amplify-graphql-function-transformer/package.json
+++ b/packages/amplify-graphql-function-transformer/package.json
@@ -30,11 +30,13 @@
   "dependencies": {
     "@aws-amplify/graphql-transformer-core": "1.3.3",
     "@aws-amplify/graphql-transformer-interfaces": "2.2.2",
-    "aws-cdk-lib": "~2.68.0",
-    "constructs": "^10.0.5",
     "graphql": "^15.5.0",
     "graphql-mapping-template": "4.20.8",
     "graphql-transformer-common": "4.24.6"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "^2.68.0",
+    "constructs": "^10.0.5"
   },
   "jest": {
     "transform": {

--- a/packages/amplify-graphql-http-transformer/package.json
+++ b/packages/amplify-graphql-http-transformer/package.json
@@ -30,11 +30,13 @@
   "dependencies": {
     "@aws-amplify/graphql-transformer-core": "1.3.3",
     "@aws-amplify/graphql-transformer-interfaces": "2.2.2",
-    "aws-cdk-lib": "~2.68.0",
-    "constructs": "^10.0.5",
     "graphql": "^15.5.0",
     "graphql-mapping-template": "4.20.8",
     "graphql-transformer-common": "4.24.6"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "^2.68.0",
+    "constructs": "^10.0.5"
   },
   "jest": {
     "transform": {

--- a/packages/amplify-graphql-index-transformer/package.json
+++ b/packages/amplify-graphql-index-transformer/package.json
@@ -31,12 +31,13 @@
     "@aws-amplify/graphql-model-transformer": "1.3.3",
     "@aws-amplify/graphql-transformer-core": "1.3.3",
     "@aws-amplify/graphql-transformer-interfaces": "2.2.2",
-    "@aws-cdk/assert": "~2.68.0",
-    "aws-cdk-lib": "~2.68.0",
-    "constructs": "^10.0.5",
     "graphql": "^15.5.0",
     "graphql-mapping-template": "4.20.8",
     "graphql-transformer-common": "4.24.6"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "^2.68.0",
+    "constructs": "^10.0.5"
   },
   "jest": {
     "transform": {

--- a/packages/amplify-graphql-maps-to-transformer/package.json
+++ b/packages/amplify-graphql-maps-to-transformer/package.json
@@ -32,10 +32,12 @@
   "dependencies": {
     "@aws-amplify/graphql-transformer-core": "1.3.3",
     "@aws-amplify/graphql-transformer-interfaces": "2.2.2",
-    "aws-cdk-lib": "~2.68.0",
-    "constructs": "^10.0.5",
     "graphql-mapping-template": "4.20.8",
     "graphql-transformer-common": "4.24.6"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "^2.68.0",
+    "constructs": "^10.0.5"
   },
   "devDependencies": {
     "@aws-amplify/graphql-index-transformer": "1.2.3",

--- a/packages/amplify-graphql-migration-tests/package.json
+++ b/packages/amplify-graphql-migration-tests/package.json
@@ -48,7 +48,7 @@
     "@aws-amplify/graphql-transformer-interfaces": "2.2.2",
     "@aws-amplify/graphql-transformer-migrator": "2.1.7",
     "@aws-cdk/cloudformation-diff": "~2.68.0",
-    "aws-cdk-lib": "~2.68.0",
+    "aws-cdk-lib": "~2.80.0",
     "fs-extra": "^8.1.0",
     "graphql-auth-transformer": "7.2.57",
     "graphql-connection-transformer": "5.2.56",

--- a/packages/amplify-graphql-migration-tests/package.json
+++ b/packages/amplify-graphql-migration-tests/package.json
@@ -47,7 +47,7 @@
     "@aws-amplify/graphql-transformer-core": "1.3.3",
     "@aws-amplify/graphql-transformer-interfaces": "2.2.2",
     "@aws-amplify/graphql-transformer-migrator": "2.1.7",
-    "@aws-cdk/cloudformation-diff": "~2.68.0",
+    "@aws-cdk/cloudformation-diff": "~2.80.0",
     "aws-cdk-lib": "~2.80.0",
     "fs-extra": "^8.1.0",
     "graphql-auth-transformer": "7.2.57",

--- a/packages/amplify-graphql-model-transformer/package.json
+++ b/packages/amplify-graphql-model-transformer/package.json
@@ -31,11 +31,13 @@
   "dependencies": {
     "@aws-amplify/graphql-transformer-core": "1.3.3",
     "@aws-amplify/graphql-transformer-interfaces": "2.2.2",
-    "aws-cdk-lib": "~2.68.0",
-    "constructs": "^10.0.5",
     "graphql": "^15.5.0",
     "graphql-mapping-template": "4.20.8",
     "graphql-transformer-common": "4.24.6"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "^2.68.0",
+    "constructs": "^10.0.5"
   },
   "devDependencies": {
     "@types/node": "^12.12.6"

--- a/packages/amplify-graphql-predictions-transformer/package.json
+++ b/packages/amplify-graphql-predictions-transformer/package.json
@@ -30,11 +30,13 @@
   "dependencies": {
     "@aws-amplify/graphql-transformer-core": "1.3.3",
     "@aws-amplify/graphql-transformer-interfaces": "2.2.2",
-    "aws-cdk-lib": "~2.68.0",
-    "constructs": "^10.0.5",
     "graphql": "^15.5.0",
     "graphql-mapping-template": "4.20.8",
     "graphql-transformer-common": "4.24.6"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "^2.68.0",
+    "constructs": "^10.0.5"
   },
   "devDependencies": {
     "bestzip": "^2.1.5"

--- a/packages/amplify-graphql-relational-transformer/package.json
+++ b/packages/amplify-graphql-relational-transformer/package.json
@@ -32,12 +32,14 @@
     "@aws-amplify/graphql-model-transformer": "1.3.3",
     "@aws-amplify/graphql-transformer-core": "1.3.3",
     "@aws-amplify/graphql-transformer-interfaces": "2.2.2",
-    "aws-cdk-lib": "~2.68.0",
-    "constructs": "^10.0.5",
     "graphql": "^15.5.0",
     "graphql-mapping-template": "4.20.8",
     "graphql-transformer-common": "4.24.6",
     "immer": "^9.0.12"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "^2.68.0",
+    "constructs": "^10.0.5"
   },
   "jest": {
     "transform": {

--- a/packages/amplify-graphql-searchable-transformer/package.json
+++ b/packages/amplify-graphql-searchable-transformer/package.json
@@ -31,11 +31,13 @@
     "@aws-amplify/graphql-model-transformer": "1.3.3",
     "@aws-amplify/graphql-transformer-core": "1.3.3",
     "@aws-amplify/graphql-transformer-interfaces": "2.2.2",
-    "aws-cdk-lib": "~2.68.0",
-    "constructs": "^10.0.5",
     "graphql": "^15.5.0",
     "graphql-mapping-template": "4.20.8",
     "graphql-transformer-common": "4.24.6"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "^2.68.0",
+    "constructs": "^10.0.5"
   },
   "devDependencies": {
     "@types/node": "^12.12.6"

--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -29,8 +29,6 @@
   },
   "dependencies": {
     "@aws-amplify/graphql-transformer-interfaces": "2.2.2",
-    "aws-cdk-lib": "~2.68.0",
-    "constructs": "^10.0.5",
     "fs-extra": "^8.1.0",
     "graphql": "^15.5.0",
     "graphql-transformer-common": "4.24.6",
@@ -39,6 +37,10 @@
     "md5": "^2.3.0",
     "object-hash": "^3.0.0",
     "ts-dedent": "^2.0.0"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "^2.68.0",
+    "constructs": "^10.0.5"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.1",

--- a/packages/amplify-graphql-transformer-interfaces/package.json
+++ b/packages/amplify-graphql-transformer-interfaces/package.json
@@ -27,9 +27,11 @@
     "extract-api": "ts-node ../../scripts/extract-api.ts"
   },
   "dependencies": {
-    "aws-cdk-lib": "~2.68.0",
-    "constructs": "^10.0.5",
     "graphql": "^15.5.0"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "^2.68.0",
+    "constructs": "^10.0.5"
   },
   "jest": {
     "transform": {

--- a/packages/amplify-migration-tests/package.json
+++ b/packages/amplify-migration-tests/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@aws-amplify/amplify-cli-core": "4.0.4",
-    "@aws-cdk/cloudformation-diff": "~2.68.0",
+    "@aws-cdk/cloudformation-diff": "~2.80.0",
     "amplify-category-api-e2e-core": "4.1.5",
     "aws-cdk-lib": "~2.80.0",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-migration-tests/package.json
+++ b/packages/amplify-migration-tests/package.json
@@ -27,7 +27,7 @@
     "@aws-amplify/amplify-cli-core": "4.0.4",
     "@aws-cdk/cloudformation-diff": "~2.68.0",
     "amplify-category-api-e2e-core": "4.1.5",
-    "aws-cdk-lib": "~2.68.0",
+    "aws-cdk-lib": "~2.80.0",
     "fs-extra": "^8.1.0",
     "graphql-transformer-core": "8.1.3",
     "lodash": "^4.17.21",

--- a/packages/graphql-transformers-e2e-tests/resources/jsonServer/package.json
+++ b/packages/graphql-transformers-e2e-tests/resources/jsonServer/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "devDependencies": {
-    "aws-cdk": "~2.68.0",
+    "aws-cdk": "~2.80.0",
     "@types/node": "^12.12.6",
     "typescript": "^3.8.3"
   },

--- a/packages/graphql-transformers-e2e-tests/resources/jsonServer/package.json
+++ b/packages/graphql-transformers-e2e-tests/resources/jsonServer/package.json
@@ -8,7 +8,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "~2.68.0",
+    "aws-cdk-lib": "~2.80.0",
     "constructs": "^10.0.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -535,25 +535,25 @@
   resolved "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.165.tgz#c169599d83beceea7e638082ef9833997f04c85d"
   integrity sha512-bsyLQD/vqXQcc9RDmlM1XqiFNO/yewgVFXmkMcQkndJbmE/jgYkzewwYGrBlfL725hGLQipXq19+jwWwdsXQqg==
 
-"@aws-cdk/aws-apigatewayv2-alpha@~2.68.0-alpha.0":
-  version "2.68.0-alpha.0"
-  resolved "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.68.0-alpha.0.tgz#f9cfe135eedbd60aacc48735b63323ea7961c5db"
-  integrity sha512-UZ1GBt7DfxKLfs49Fg1Y33/RRVoD1NZDd0V+e9Tj/dkSm9d0JEiuMU8TRtandsd38kl7n1fSLEVsXu3/WAYAPg==
+"@aws-cdk/aws-apigatewayv2-alpha@~2.80.0-alpha.0":
+  version "2.80.0-alpha.0"
+  resolved "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.80.0-alpha.0.tgz#37a1c2ef166aea24bcf58b3efa776511c6b8569a"
+  integrity sha512-XBvDiay46ThYP5hoPcwVfzE9egPiwHMGUpVepg6qJ+HQwCmLesbArwurmG2TXcfRbO06uXrAWmWpAqQmh7nstw==
 
-"@aws-cdk/cfnspec@2.68.0":
-  version "2.68.0"
-  resolved "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-2.68.0.tgz#e678c62d92ca76f8513a23c3c78f00ae49a7ab2e"
-  integrity sha512-g062ljKOvMaeEgp2GR2ewoF3BzeGYpu+AA7UvN/SN+2S0detSwU+qHlxSFeTe0DLyCFaMttNEh81VmYCfiHtpg==
+"@aws-cdk/cfnspec@2.80.0-alpha.0":
+  version "2.80.0-alpha.0"
+  resolved "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-2.80.0-alpha.0.tgz#bb83ddadbb62d1905f6be17b0ec18eba22c9314d"
+  integrity sha512-5lDAtKK68x2rb+JP0LjH7q6Doc8oFqiNqKtAwYtHj56QbfpEFI//KxtTwvEliwArof2+fPLQgazaABcTki8k2g==
   dependencies:
     fs-extra "^9.1.0"
     md5 "^2.3.0"
 
-"@aws-cdk/cloudformation-diff@~2.68.0":
-  version "2.68.0"
-  resolved "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-2.68.0.tgz#e5c69c9419472e3dd56bde418b3fabbca85d4005"
-  integrity sha512-JnX0sygxNHWU3aKdzSus25B1TuKYWDwnNL2tw3svZvfHcw3Nwz857JTOn/yNOJxT7cZbCbOqNPrOT6Xv+LrxTQ==
+"@aws-cdk/cloudformation-diff@~2.80.0":
+  version "2.80.0"
+  resolved "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-2.80.0.tgz#bdb413822782fbb55a0a63f9dc3607f10de6a282"
+  integrity sha512-EB0MpDJkLbpheVlgZxjWKLX8IvhzoOrHjMR3R+4+ceV3KPJfsqIkvkY6I/YxtlNxSsF7mDTKwu0YZtcUQA4NCQ==
   dependencies:
-    "@aws-cdk/cfnspec" "2.68.0"
+    "@aws-cdk/cfnspec" "2.80.0-alpha.0"
     chalk "^4"
     diff "^5.1.0"
     fast-deep-equal "^3.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -520,27 +520,20 @@
   dependencies:
     "@aws-amplify/core" "4.7.15"
 
-"@aws-cdk/assert@~2.68.0":
-  version "2.68.0"
-  resolved "https://registry.npmjs.org/@aws-cdk/assert/-/assert-2.68.0.tgz#d83b44ba278d3e3a32c13f372c697f26c6061b64"
-  integrity sha512-bEztvoYdVp17I/ClYRGZa4wlEP/qNNq4Q+Z7EKwRL0cLDmvq4EI1m1N8LhUPAH7B6YXp5d1164gC6Nr0lV8bbA==
-  dependencies:
-    "@aws-cdk/cloudformation-diff" "2.68.0"
-
-"@aws-cdk/asset-awscli-v1@^2.2.97":
-  version "2.2.177"
-  resolved "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.177.tgz#c2e29a97b06c9c4a15a56ea228799ad12aac5097"
-  integrity sha512-jNskqpWyDbTeWnIsyMwrtanz/MltBm1gMHOHiFS/4CBBHYfDT3h7Go5uruNSW32W1gWDej58PGJ+26E4g1gLhA==
+"@aws-cdk/asset-awscli-v1@^2.2.177":
+  version "2.2.198"
+  resolved "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.198.tgz#7a7cddbbc33c6f42b4e6457296dc40c5926d27c3"
+  integrity sha512-RfOMXFMyZ5Ca8ytB3/vs6srFH5HVV4M2JS9Wsb/uXPEpSblEmuf31iGVfN6Q+xRoNPm8icsquCRQ79JBqH4yjA==
 
 "@aws-cdk/asset-kubectl-v20@^2.1.1":
   version "2.1.1"
   resolved "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz#d01c1efb867fb7f2cfd8c8b230b8eae16447e156"
   integrity sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw==
 
-"@aws-cdk/asset-node-proxy-agent-v5@^2.0.77":
-  version "2.0.148"
-  resolved "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.148.tgz#b6ac2f6c9a725db14dc7592d449675c13eb0d86e"
-  integrity sha512-WnBr+sA5MCPyRuiL9u2CH0Vnn6Peq0TYEXlk0FCqdViVFUCz4/hplEn0mcFV5/iqOkx2OFXOktSRsc8grRZCLw==
+"@aws-cdk/asset-node-proxy-agent-v5@^2.0.148":
+  version "2.0.165"
+  resolved "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.165.tgz#c169599d83beceea7e638082ef9833997f04c85d"
+  integrity sha512-bsyLQD/vqXQcc9RDmlM1XqiFNO/yewgVFXmkMcQkndJbmE/jgYkzewwYGrBlfL725hGLQipXq19+jwWwdsXQqg==
 
 "@aws-cdk/aws-apigatewayv2-alpha@~2.68.0-alpha.0":
   version "2.68.0-alpha.0"
@@ -555,7 +548,7 @@
     fs-extra "^9.1.0"
     md5 "^2.3.0"
 
-"@aws-cdk/cloudformation-diff@2.68.0", "@aws-cdk/cloudformation-diff@~2.68.0":
+"@aws-cdk/cloudformation-diff@~2.68.0":
   version "2.68.0"
   resolved "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-2.68.0.tgz#e5c69c9419472e3dd56bde418b3fabbca85d4005"
   integrity sha512-JnX0sygxNHWU3aKdzSus25B1TuKYWDwnNL2tw3svZvfHcw3Nwz857JTOn/yNOJxT7cZbCbOqNPrOT6Xv+LrxTQ==
@@ -8129,22 +8122,23 @@ aws-appsync@^4.1.1, aws-appsync@^4.1.9:
     url "^0.11.0"
     uuid "3.x"
 
-aws-cdk-lib@~2.68.0:
-  version "2.68.0"
-  resolved "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.68.0.tgz#5448dfff733a88551e3df61df5c5b646a7b6ee75"
-  integrity sha512-roN3xwzv/GleGG3CaJrf+thdzr9WBzJU4LotumEOs+0cGfeXSta8Pm/cGAeY4kplr5r10QWUovH0fv/bi6Vrbw==
+aws-cdk-lib@~2.68.0, aws-cdk-lib@~2.80.0:
+  version "2.80.0"
+  resolved "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.80.0.tgz#1118860637d33fab8f646551c29a75728404b64e"
+  integrity sha512-PoqD3Yms5I0ajuTi071nTW/hpkH3XsdyZzn5gYsPv0qD7mqP3h6Qr+6RiGx+yQ1KcVFyxWdX15uK+DsC0KwvcQ==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "^2.2.97"
+    "@aws-cdk/asset-awscli-v1" "^2.2.177"
     "@aws-cdk/asset-kubectl-v20" "^2.1.1"
-    "@aws-cdk/asset-node-proxy-agent-v5" "^2.0.77"
+    "@aws-cdk/asset-node-proxy-agent-v5" "^2.0.148"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
-    fs-extra "^9.1.0"
+    fs-extra "^11.1.1"
     ignore "^5.2.4"
     jsonschema "^1.4.1"
     minimatch "^3.1.2"
     punycode "^2.3.0"
-    semver "^7.3.8"
+    semver "^7.5.1"
+    table "^6.8.1"
     yaml "1.10.2"
 
 aws-sdk-mock@^5.6.2:
@@ -11372,7 +11366,7 @@ fs-extra@^10.0.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^11.1.0:
+fs-extra@^11.1.0, fs-extra@^11.1.1:
   version "11.1.1"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
   integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
@@ -17671,6 +17665,13 @@ semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.5.1:
+  version "7.5.3"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
+  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@~7.3.0:
   version "7.3.8"


### PR DESCRIPTION
#### Description of changes
Using peer deps for transformer CDK version, and bumping amplify plugin and library versions to use 2.80. This will need to be run through e2e tests to verify behavior.

##### CDK / CloudFormation Parameters Changed
Using a new CDK version, but no CDK code or config has changed.

This takes us through the following CDK releases:
* https://github.com/aws/aws-cdk/releases/tag/v2.80.0
* https://github.com/aws/aws-cdk/releases/tag/v2.79.1
* https://github.com/aws/aws-cdk/releases/tag/v2.79.0
* https://github.com/aws/aws-cdk/releases/tag/v2.78.0
* https://github.com/aws/aws-cdk/releases/tag/v2.77.0
* https://github.com/aws/aws-cdk/releases/tag/v2.76.0
* https://github.com/aws/aws-cdk/releases/tag/v2.75.1
* https://github.com/aws/aws-cdk/releases/tag/v2.75.0
* https://github.com/aws/aws-cdk/releases/tag/v2.74.0
* https://github.com/aws/aws-cdk/releases/tag/v2.73.0
* https://github.com/aws/aws-cdk/releases/tag/v2.72.1
* https://github.com/aws/aws-cdk/releases/tag/v2.72.0
* https://github.com/aws/aws-cdk/releases/tag/v2.71.0
* https://github.com/aws/aws-cdk/releases/tag/v2.70.0
* https://github.com/aws/aws-cdk/releases/tag/v2.69.0

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit Tests + E2E Tests

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
