### PR TITLE
chore: bump up unit test coverage for graphql-transformer package

### DIFF
--- a/packages/amplify-graphql-transformer/package.json
+++ b/packages/amplify-graphql-transformer/package.json
@@ -63,9 +63,9 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "branches": 69,
-        "functions": 25,
-        "lines": 52
+        "branches": 80,
+        "functions": 80,
+        "lines": 80
       }
     }
   }

--- a/packages/amplify-graphql-transformer/src/__tests__/graphql-transformer.test.ts
+++ b/packages/amplify-graphql-transformer/src/__tests__/graphql-transformer.test.ts
@@ -1,16 +1,131 @@
-import { TransformerPluginProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { constructTransformerChain } from '../graphql-transformer';
+import { AppSyncAuthConfiguration, TransformerLogLevel, TransformerPluginProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { constructTransformerChain, constructTransform, executeTransform, TransformConfig, defaultPrintTransformerLog } from '../graphql-transformer';
+import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
+import { TransformerLog } from '@aws-amplify/graphql-transformer-interfaces/src';
 
 describe('constructTransformerChain', () => {
   it('returns 14 transformers when no custom transformers are provided', () => {
     expect(constructTransformerChain().length).toEqual(14);
   });
 
-
   it('returns 16 transformers when 2 custom transformers are provided', () => {
     expect(constructTransformerChain({ customTransformers: [
       {} as unknown as TransformerPluginProvider,
       {} as unknown as TransformerPluginProvider,
     ] }).length).toEqual(16);
+  });
+
+  it('succeeds on admin roles', () => {
+    expect(constructTransformerChain({
+      adminRoles: ['testRole'],
+    }).length).toEqual(14);
+  });
+});
+
+const defaultTransformConfig: TransformConfig = {
+  transformersFactoryArgs: {},
+  transformParameters: {
+    shouldDeepMergeDirectiveConfigDefaults: false,
+    disableResolverDeduping: false,
+    sandboxModeEnabled: false,
+    useSubUsernameForDefaultIdentityClaim: false,
+    populateOwnerFieldForStaticGroupAuth: false,
+    suppressApiKeyGeneration: false,
+    secondaryKeyAsGSI: false,
+    enableAutoIndexQueryNames: false,
+    respectPrimaryKeyAttributesOnConnectionField: false,
+    enableSearchNodeToNodeEncryption: false,
+  },
+};
+
+describe('constructTransform', () => {
+  it('returns a graphql transform', () => {
+    const transform = constructTransform(defaultTransformConfig);
+    expect(transform).toBeDefined();
+    expect(transform).toBeInstanceOf(GraphQLTransform);
+  });
+});
+
+describe('executeTransform', () => {
+  it('executes a transform', () => {
+    expect(executeTransform({
+      ...defaultTransformConfig,
+      schema: /* GraphQL */ `
+        type Todo @model {
+          content: String!
+        }
+      `,
+    })).toBeDefined();
+  });
+
+  it('writes logs to provided printer', () => {
+    const userPoolAuthConfig: AppSyncAuthConfiguration = {
+      defaultAuthentication: {
+        authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+        userPoolConfig: {
+          userPoolId: 'myUserPool',
+        },
+      },
+      additionalAuthenticationProviders: [],
+    };
+    let didLog = false;
+    executeTransform({
+      ...defaultTransformConfig,
+      schema: /* GraphQL */ `
+        type Todo @model @auth(rules: [{ allow: owner }]) {
+          content: String!
+        }
+      `,
+      transformersFactoryArgs: { authConfig: userPoolAuthConfig },
+      authConfig: userPoolAuthConfig,
+      printTransformerLog: (): void => { didLog = true },
+    });
+    expect(didLog).toEqual(true);
+  });
+
+  it('does not log warnings on simple schema', () => {
+    executeTransform({
+      ...defaultTransformConfig,
+      schema: /* GraphQL */ `
+        type Todo @model {
+          content: String!
+        }
+      `,
+      printTransformerLog: ({ message }: TransformerLog): void => {
+        throw new Error(`Transformer logging not expected, received ${message}`);
+      },
+    });
+  });
+});
+
+describe('defaultPrintTransformerLog', () => {
+  it('writes error messages', () => {
+    const error = jest.spyOn(console, 'error')
+    defaultPrintTransformerLog({ message: 'test error message', level: TransformerLogLevel.ERROR });
+    expect(error).toHaveBeenCalledWith('test error message');
+  });
+
+  it('writes warning messages', () => {
+    const warn = jest.spyOn(console, 'warn')
+    defaultPrintTransformerLog({ message: 'test warn message', level: TransformerLogLevel.WARN });
+    expect(warn).toHaveBeenCalledWith('test warn message');
+  });
+
+  it('writes info messages', () => {
+    const info = jest.spyOn(console, 'info')
+    defaultPrintTransformerLog({ message: 'test info message', level: TransformerLogLevel.INFO });
+    expect(info).toHaveBeenCalledWith('test info message');
+  });
+
+  it('writes debug message', () => {
+    const debug = jest.spyOn(console, 'debug')
+    defaultPrintTransformerLog({ message: 'test debug message', level: TransformerLogLevel.DEBUG });
+    expect(debug).toHaveBeenCalledWith('test debug message');
+  });
+
+  it('writes unexpected log levels to error', () => {
+    const error = jest.spyOn(console, 'error')
+    defaultPrintTransformerLog({ message: 'unexpected message', level: 'bad' as TransformerLogLevel });
+    expect(error).toHaveBeenCalledWith('unexpected message');
   });
 });

--- a/packages/amplify-graphql-transformer/src/graphql-transformer.ts
+++ b/packages/amplify-graphql-transformer/src/graphql-transformer.ts
@@ -129,7 +129,7 @@ export type ExecuteTransformConfig = TransformConfig & {
  * By default, rely on console to print out the transformer logs.
  * @param log the log to print.
  */
-const defaultPrintTransformerLog = (log: TransformerLog): void => {
+export const defaultPrintTransformerLog = (log: TransformerLog): void => {
   switch (log.level) {
     case TransformerLogLevel.ERROR:
       console.error(log.message);


### PR DESCRIPTION
#### Description of changes
Getting unit test coverage for line/branch/function up to 80, and enforce in `package.json`.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit tests pass.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
