### PR TITLE
chore: increase test coverage for api construct, and fix slot overrides bug

### DIFF
--- a/packages/amplify-graphql-api-construct/package.json
+++ b/packages/amplify-graphql-api-construct/package.json
@@ -62,7 +62,7 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "branches": 50,
+        "branches": 80,
         "functions": 80,
         "lines": 80
       }

--- a/packages/amplify-graphql-api-construct/src/__tests__/internal/authorization-modes.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/internal/authorization-modes.test.ts
@@ -1,6 +1,7 @@
 import { IUserPool } from 'aws-cdk-lib/aws-cognito';
 import { convertAuthorizationModesToTransformerAuthConfig } from '../../internal/authorization-modes';
 import { IRole } from 'aws-cdk-lib/aws-iam';
+import { Duration } from 'aws-cdk-lib';
 
 describe('convertAuthorizationModesToTransformerAuthConfig', () => {
   it('generates userPool auth parameters', () => {
@@ -25,5 +26,22 @@ describe('convertAuthorizationModesToTransformerAuthConfig', () => {
     expect(cfnIncludeParameters.authRoleName).toEqual('testAuthRole');
     expect('unauthRoleName' in cfnIncludeParameters).toEqual(true);
     expect(cfnIncludeParameters.unauthRoleName).toEqual('testUnauthRole');
+  });
+
+  it('generates for multiple auth modes', () => {
+    const authenticatedUserRole = { roleName: 'testAuthRole' } as IRole;
+    const unauthenticatedUserRole = { roleName: 'testUnauthRole' } as IRole;
+    const { authConfig } = convertAuthorizationModesToTransformerAuthConfig({
+      defaultAuthMode: 'API_KEY',
+      apiKeyConfig: {
+        expires: { toDays: () => 7 } as Duration,
+      },
+      iamConfig: {
+        authenticatedUserRole,
+        unauthenticatedUserRole,
+      },
+    });
+    expect(authConfig).toBeDefined();
+    expect(authConfig?.additionalAuthenticationProviders.length).toEqual(1);
   });
 });

--- a/packages/amplify-graphql-api-construct/src/__tests__/internal/user-defined-slots.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/internal/user-defined-slots.test.ts
@@ -1,8 +1,79 @@
-import { MappingTemplate } from 'aws-cdk-lib/aws-appsync';
-import { getSlotName, parseUserDefinedSlots } from '../../internal/user-defined-slots';
+import { Code, FunctionRuntime, MappingTemplate } from 'aws-cdk-lib/aws-appsync';
+import { getSlotName, parseUserDefinedSlots, validateFunctionSlots, separateSlots } from '../../internal/user-defined-slots';
 import { FunctionSlot } from '../../types';
 
 describe('user-defined-slots', () => {
+  describe('validateFunctionSlots', () => {
+    it('throws on unexpected property', () => {
+      expect(() => {
+        validateFunctionSlots([{
+          typeName: 'Mutation',
+          fieldName: 'createTodo',
+          slotName: 'postUpdate',
+          slotIndex: 1,
+          function: {
+            code: Code.fromInline('Hi there'),
+            runtime: FunctionRuntime.JS_1_0_0,
+          },
+        }]);
+      }).toThrowErrorMatchingInlineSnapshot('"Unexpected property found on function slot, only requestMappingTemplate and responseMappingTemplate supported"');
+    });
+
+    it('throws on missing properties', () => {
+      expect(() => {
+        validateFunctionSlots([{
+          typeName: 'Mutation',
+          fieldName: 'createTodo',
+          slotName: 'postUpdate',
+          slotIndex: 1,
+          function: {},
+        }]);
+      }).toThrowErrorMatchingInlineSnapshot('"Expected at least one of either requestMappingTemplate or responseMappingTemplate"');
+    });
+  });
+
+  describe('separateSlots', () => {
+    it('splits a slot into if both request and response mapping are defined', () => {
+      const potentiallySeparatedSlots = separateSlots([{
+        typeName: 'Mutation',
+        fieldName: 'createTodo',
+        slotName: 'postUpdate',
+        slotIndex: 1,
+        function: {
+          requestMappingTemplate: MappingTemplate.fromString('Request Template'),
+          responseMappingTemplate: MappingTemplate.fromString('Response Template'),
+        },
+      }]);
+      expect(potentiallySeparatedSlots.length).toEqual(2);
+    });
+
+    it('does not split on just request mapping template', () => {
+      const potentiallySeparatedSlots = separateSlots([{
+        typeName: 'Mutation',
+        fieldName: 'createTodo',
+        slotName: 'postUpdate',
+        slotIndex: 1,
+        function: {
+          requestMappingTemplate: MappingTemplate.fromString('Request Template'),
+        },
+      }]);
+      expect(potentiallySeparatedSlots.length).toEqual(1);
+    });
+
+    it('does not split on just response mapping template', () => {
+      const potentiallySeparatedSlots = separateSlots([{
+        typeName: 'Mutation',
+        fieldName: 'createTodo',
+        slotName: 'postUpdate',
+        slotIndex: 1,
+        function: {
+          responseMappingTemplate: MappingTemplate.fromString('Response Template'),
+        },
+      }]);
+      expect(potentiallySeparatedSlots.length).toEqual(1);
+    });
+  });
+
   describe('getSlotName', () => {
     it('generates given the input params for a mutation slot', () => {
       expect(getSlotName({
@@ -63,5 +134,67 @@ describe('user-defined-slots', () => {
         }
       });
     });
+  });
+
+  it('support response mapping template', () => {
+    const vtl = '$utils.toJson({})';
+    const functionSlot: FunctionSlot = {
+      typeName: 'Mutation',
+      fieldName: 'createTodo',
+      slotName: 'preAuth',
+      slotIndex: 1,
+      function: {
+        responseMappingTemplate: MappingTemplate.fromString(vtl),
+      },
+    };
+    const parsedSlots = parseUserDefinedSlots([functionSlot]);
+    expect(Object.keys(parsedSlots).length).toEqual(1);
+    expect(parsedSlots['Mutation.createTodo'].length).toEqual(1);
+    expect(parsedSlots['Mutation.createTodo'][0]).toMatchObject({
+      responseResolver: {
+        fileName: 'Mutation.createTodo.preAuth.1.res.vtl',
+        template: vtl,
+      }
+    });
+  });
+
+  it('supports multiple slots on the same resolver', () => {
+    const vtl1 = '$utils.toJson({})';
+    const vtl2 = '$utils.toJson({ hi: "there" })';
+    const functionSlot: FunctionSlot = {
+      typeName: 'Mutation',
+      fieldName: 'createTodo',
+      slotName: 'preAuth',
+      slotIndex: 1,
+      function: {
+        responseMappingTemplate: MappingTemplate.fromString(vtl1),
+      },
+    };
+    const functionSlot2: FunctionSlot = {
+      typeName: 'Mutation',
+      fieldName: 'createTodo',
+      slotName: 'preAuth',
+      slotIndex: 2,
+      function: {
+        responseMappingTemplate: MappingTemplate.fromString(vtl2),
+      },
+    };
+    const parsedSlots = parseUserDefinedSlots([functionSlot, functionSlot2]);
+    expect(Object.keys(parsedSlots).length).toEqual(1);
+    expect(parsedSlots['Mutation.createTodo'].length).toEqual(2);
+    expect(parsedSlots['Mutation.createTodo']).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        responseResolver: {
+          fileName: 'Mutation.createTodo.preAuth.1.res.vtl',
+          template: vtl1,
+        }
+      }),
+      expect.objectContaining({
+        responseResolver: {
+          fileName: 'Mutation.createTodo.preAuth.2.res.vtl',
+          template: vtl2,
+        }
+      }),
+    ]));
   });
 });

--- a/packages/amplify-graphql-api-construct/src/internal/user-defined-slots.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/user-defined-slots.ts
@@ -32,30 +32,27 @@ export const validateFunctionSlots = (functionSlots: FunctionSlot[]): void => {
  * @param functionSlots the possibly consolidated slots.
  * @returns no longer consolidated slots.
  */
-export const separateSlots = (functionSlots: FunctionSlot[]): FunctionSlot[] => {
-  const separatedSlots: FunctionSlot[] = [];
-  functionSlots.forEach((slot) => {
-    if (slot.function.requestMappingTemplate && slot.function.responseMappingTemplate) {
-      separatedSlots.push(
-        {
-          ...slot,
-          function: {
-            requestMappingTemplate: slot.function.requestMappingTemplate,
-          },
+export const separateSlots = (functionSlots: FunctionSlot[]): FunctionSlot[] => functionSlots.flatMap((slot) => {
+  if (slot.function.requestMappingTemplate && slot.function.responseMappingTemplate) {
+    return [
+      {
+        ...slot,
+        function: {
+          requestMappingTemplate: slot.function.requestMappingTemplate,
         },
-        {
-          ...slot,
-          function: {
-            responseMappingTemplate: slot.function.responseMappingTemplate,
-          },
+      },
+      {
+        ...slot,
+        function: {
+          responseMappingTemplate: slot.function.responseMappingTemplate,
         },
-      );
-    } else {
-      separatedSlots.push(slot);
-    }
-  });
-  return functionSlots;
-};
+      },
+    ];
+  }
+  return [
+    slot,
+  ];
+});
 
 /**
  * Given a set of strongly typed input params, generate a valid transformer slot name.


### PR DESCRIPTION
#### Description of changes
Getting unit test coverage for line/branch/function up to 80, and enforce in `package.json`.
Fix a bug where multiple slot overrides weren't being split appropriately (current workaround for shimmed alpha state).

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit tests pass.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
