### PR TITLE
fix: modelgen test promise issue

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/datastore-modelgen.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/datastore-modelgen.test.ts
@@ -7,6 +7,15 @@ import {
   deleteProjectDir
 } from 'amplify-category-api-e2e-core';
 
+// This is to fix the issue of error not rejected in the codebuild,
+async function testModelsWithUnknownType(projRoot: string): Promise<void> {
+  if (process.env.CIRCLECI) {
+    await expect(generateModels(projRoot)).rejects.toThrowError();
+  } else if(process.env.CODEBUILD) {
+    await generateModelsWithUnknownTypeError(projRoot);
+  }
+};
+
 describe('data store modelgen tests', () => {
   let projRoot: string;
   const schemaWithAppSyncScalars = 'modelgen/model_gen_schema_with_aws_scalars.graphql';
@@ -30,7 +39,7 @@ describe('data store modelgen tests', () => {
 
     await expect(generateModels(projRoot)).resolves.not.toThrow();
     updateApiSchema(projRoot, projName, schemaWithError);
-    await generateModelsWithUnknownTypeError(projRoot);
+    await testModelsWithUnknownType(projRoot);
   });
 
   it('should generate models for iOS project', async () => {
@@ -42,7 +51,7 @@ describe('data store modelgen tests', () => {
 
     await expect(generateModels(projRoot)).resolves.not.toThrow();
     updateApiSchema(projRoot, projName, schemaWithError);
-    await generateModelsWithUnknownTypeError(projRoot);
+    await testModelsWithUnknownType(projRoot);
   });
 
   it('should generate models for angular project', async () => {
@@ -54,7 +63,7 @@ describe('data store modelgen tests', () => {
 
     await expect(generateModels(projRoot)).resolves.not.toThrow();
     updateApiSchema(projRoot, projName, schemaWithError);
-    await generateModelsWithUnknownTypeError(projRoot);
+    await testModelsWithUnknownType(projRoot);
   });
 
   it('should generate models for react project', async () => {
@@ -66,6 +75,6 @@ describe('data store modelgen tests', () => {
 
     await expect(generateModels(projRoot)).resolves.not.toThrow();
     updateApiSchema(projRoot, projName, schemaWithError);
-    await generateModelsWithUnknownTypeError(projRoot);
+    await testModelsWithUnknownType(projRoot);
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
The error is not rejected in codebuild but in CircleCI in modelgen test. The PR is to fix this issue.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available
The `unknown type` error are both thrown if I check both the artifacts from CCI and CodeBuild. Also the error stack trace is same. However, the codebuild does not reject the promise.  The only difference is that the error of `amplify-meta.json` not existing is displayed in different colors(red in CCI and white in CodeBuild)

- In CCI:
The output is too quick to get a screenshot. Attach the link for reference
https://output.circle-artifacts.com/output/job/1e954839-8ff8-44f8-a7ec-7a5830836d2b/artifacts/0/packages/amplify-e2e-tests/amplify-e2e-reports/index.html
- In CodeBuild:
<img width="914" alt="image" src="https://github.com/aws-amplify/amplify-category-api/assets/20614187/7c714246-634b-45f3-b68a-39698a5a9504">

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
