### PR TITLE
chore: update lint rules, and catch up transform so it passes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -139,7 +139,7 @@ module.exports = {
     'no-var': 'error',
     'strict': 'error',
     'spaced-comment': ['error', 'always'],
-    'no-new': 'error',
+    'no-new': 'off',
     'no-underscore-dangle': 'error',
     'no-template-curly-in-string': 'error',
     'no-plusplus': 'off',

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
@@ -1,5 +1,4 @@
 /* eslint-disable jsdoc/require-param-description */
-/* eslint-disable no-new */
 /* eslint-disable no-use-before-define */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable no-underscore-dangle */

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -1213,12 +1213,10 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
         authPolicyDocuments.forEach((authPolicyDocument, i) => {
           const paddedIndex = `${i + 1}`.padStart(2, '0');
           const resourceName = `${ResourceConstants.RESOURCES.AuthRolePolicy}${paddedIndex}`;
-          /* eslint-disable no-new */
           new iam.ManagedPolicy(rootStack, resourceName, {
             document: iam.PolicyDocument.fromJson(authPolicyDocument),
             roles: [iamAuthRoleArn],
           });
-          /* eslint-enable */
         });
       }
     }
@@ -1238,12 +1236,10 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
       unauthPolicyDocuments.forEach((unauthPolicyDocument, i) => {
         const paddedIndex = `${i + 1}`.padStart(2, '0');
         const resourceName = `${ResourceConstants.RESOURCES.UnauthRolePolicy}${paddedIndex}`;
-        /* eslint-disable no-new */
         new iam.ManagedPolicy(ctx.stackManager.rootStack, resourceName, {
           document: iam.PolicyDocument.fromJson(unauthPolicyDocument),
           roles: [iamUnauthRoleArn],
         });
-        /* eslint-enable */
       });
     }
   }

--- a/packages/amplify-graphql-default-value-transformer/src/validators.ts
+++ b/packages/amplify-graphql-default-value-transformer/src/validators.ts
@@ -88,7 +88,6 @@ const validateAwsEmail = (x: string): boolean => EMAIL_ADDRESS_REGEX.test(x);
 
 const validateAwsUrl = (x: string): boolean => {
   try {
-    // eslint-disable-next-line no-new
     new URL(x);
     return true;
   } catch (e) {

--- a/packages/amplify-graphql-model-transformer/src/resources/dynamo-model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/dynamo-model-resource-generator.ts
@@ -128,7 +128,6 @@ export class DynamoModelResourceGenerator extends ModelResourceGenerator {
     );
 
     // Add conditions.
-    // eslint-disable-next-line no-new
     new cdk.CfnCondition(stack, ResourceConstants.CONDITIONS.HasEnvironmentParameter, {
       expression: cdk.Fn.conditionNot(cdk.Fn.conditionEquals(env, ResourceConstants.NONE)),
     });
@@ -173,7 +172,6 @@ export class DynamoModelResourceGenerator extends ModelResourceGenerator {
     };
 
     const streamArnOutputId = `GetAtt${ModelResourceIDs.ModelTableStreamArn(def!.name.value)}`;
-    // eslint-disable-next-line no-new
     new cdk.CfnOutput(stack, streamArnOutputId, {
       value: cdk.Fn.getAtt(tableLogicalName, 'StreamArn').toString(),
       description: 'Your DynamoDB table StreamArn.',
@@ -181,7 +179,6 @@ export class DynamoModelResourceGenerator extends ModelResourceGenerator {
     });
 
     const tableNameOutputId = `GetAtt${tableLogicalName}Name`;
-    // eslint-disable-next-line no-new
     new cdk.CfnOutput(stack, tableNameOutputId, {
       value: cdk.Fn.ref(tableLogicalName),
       description: 'Your DynamoDB table name.',
@@ -224,7 +221,6 @@ export class DynamoModelResourceGenerator extends ModelResourceGenerator {
     }
 
     const datasourceOutputId = `GetAtt${datasourceRoleLogicalID}Name`;
-    // eslint-disable-next-line no-new
     new cdk.CfnOutput(stack, datasourceOutputId, {
       value: dataSource.ds.attrName,
       description: 'Your model DataSource name.',

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-cfnOutput.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-cfnOutput.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import { CfnOutput, Fn } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { ResourceConstants } from 'graphql-transformer-common';

--- a/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
@@ -297,7 +297,6 @@ export class SearchableModelTransformer extends TransformerPluginBase {
 
     const envParam = context.stackManager.getParameter(Env) as CfnParameter;
 
-    // eslint-disable-next-line no-new
     new CfnCondition(stack, HasEnvironmentParameter, {
       expression: Fn.conditionNot(Fn.conditionEquals(envParam, ResourceConstants.NONE)),
     });

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transformation/transform.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transformation/transform.test.ts
@@ -29,7 +29,6 @@ const mockTransformer: TransformerPluginProvider = {
 describe('GraphQLTransform', () => {
   it('throws on construction with no transformers', () => {
     expect(() => {
-      // eslint-disable-next-line no-new
       new GraphQLTransform({
         transformers: [],
       });

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transformation/utils.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transformation/utils.test.ts
@@ -1,0 +1,43 @@
+import { removeAmplifyInputDefinition } from '../../transformation/utils';
+
+describe('removeAmplifyInputDefinition', () => {
+  it('strips input Amplify objects', () => {
+    const input = /* GraphQL */ `
+      input Amplify { globalAuthRule: AuthRule = { allow: public } }
+    
+      type Todo {
+        id: ID!
+        content: String!
+      }
+    `;
+    const expectedOutput = /* GraphQL */ `type Todo {
+  id: ID!
+  content: String!
+}
+`;
+    expect(removeAmplifyInputDefinition(input)).toEqual(expectedOutput);
+  });
+
+  it('does not strip Amplify type objects', () => {
+    const input = /* GraphQL */ `
+      type Amplify {
+        id: ID!
+      }
+    
+      type Todo {
+        id: ID!
+        content: String!
+      }
+    `;
+    const expectedOutput = /* GraphQL */ `type Amplify {
+  id: ID!
+}
+
+type Todo {
+  id: ID!
+  content: String!
+}
+`;
+    expect(removeAmplifyInputDefinition(input)).toEqual(expectedOutput);
+  });
+});

--- a/packages/amplify-graphql-transformer-core/src/transformation/sync-utils.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/sync-utils.ts
@@ -22,7 +22,6 @@ type DeltaSyncConfig = {
 export function createSyncTable(context: TransformerContext) {
   const stack = context.stackManager.getStackFor(SyncResourceIDs.syncTableName);
   const tableName = context.resourceHelper.generateTableName(SyncResourceIDs.syncTableName);
-  // eslint-disable-next-line no-new
   new Table(stack, SyncResourceIDs.syncDataSourceID, {
     tableName,
     partitionKey: {

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -26,10 +26,9 @@ import {
   TypeDefinitionNode,
   TypeExtensionNode,
   UnionTypeDefinitionNode,
-  print,
 } from 'graphql';
 import _ from 'lodash';
-import { DefinitionNode, DocumentNode } from 'graphql/language';
+import { DocumentNode } from 'graphql/language';
 import { ResolverConfig } from '../config/transformer-config';
 import { InvalidTransformerError, SchemaValidationError, UnknownDirectiveError } from '../errors';
 import { GraphQLApi } from '../graphql-api';
@@ -47,6 +46,7 @@ import {
   matchEnumValueDirective,
   matchFieldDirective,
   matchInputFieldDirective,
+  removeAmplifyInputDefinition,
   sortTransformerPlugins,
 } from './utils';
 import { validateAuthModes, validateModelSchema } from './validation';
@@ -755,20 +755,3 @@ export class GraphQLTransform {
     return this.logs;
   }
 }
-
-const removeAmplifyInputDefinition = (schema: string): string => {
-  if (_.isEmpty(schema)) {
-    return schema;
-  }
-
-  const parsedSchema: any = parse(schema);
-
-  parsedSchema.definitions = parsedSchema.definitions.filter((definition: DefinitionNode) => !(
-    definition.kind === 'InputObjectTypeDefinition'
-    && definition.name
-    && definition.name.value === 'Amplify'
-  ));
-
-  const sanitizedSchema = print(parsedSchema);
-  return sanitizedSchema;
-};

--- a/packages/amplify-graphql-transformer-core/src/transformation/utils.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/utils.ts
@@ -7,8 +7,12 @@ import {
   DirectiveDefinitionNode,
   TypeSystemDefinitionNode,
   Kind,
+  parse,
+  print,
+  DefinitionNode,
 } from 'graphql';
 import { TransformerPluginProvider, TransformerPluginType } from '@aws-amplify/graphql-transformer-interfaces';
+import _ from 'lodash';
 
 export function makeSeenTransformationKey(
   directive: DirectiveNode,
@@ -179,3 +183,23 @@ export function sortTransformerPlugins(plugins: TransformerPluginProvider[]): Tr
     return aIdx - bIdx;
   });
 }
+
+/**
+ * Return the input schema with the `Amplify` input node stripped.
+ * @param schema the input schema to scrub
+ * @returns the input shema without the `Amplify` input node
+ */
+export const removeAmplifyInputDefinition = (schema: string): string => {
+  if (_.isEmpty(schema)) {
+    return schema;
+  }
+
+  const { definitions, ...rest } = parse(schema);
+
+  const isAmplifyInputNode = (definition: DefinitionNode): boolean => definition.kind === 'InputObjectTypeDefinition' && definition.name.value === 'Amplify';
+
+  return print({
+    definitions: definitions.filter((definition: DefinitionNode) => !isAmplifyInputNode(definition)),
+    ...rest,
+  });
+};


### PR DESCRIPTION
#### Description of changes
Turning off `no-new` eslint rule, since our CDK usage will cause this to break all over. Also ensuring the core `transformer` file passes all eslint rules to make it easier to work on over the next few changes.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit tests

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
