### PR TITLE
feat: release alpha cdk construct

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -196,16 +196,11 @@ jobs:
             git config user.email not@used.com
             git config user.name "Doesnt Matter"
             setNpmTag
-            # publish private package to verdaccio for e2e tests
-            cat packages/amplify-graphql-api-construct/package.json > stash.json
-            jq 'del(.private)' packages/amplify-graphql-api-construct/package.json > tmp.json
-            mv tmp.json packages/amplify-graphql-api-construct/package.json
             if [ -z $NPM_TAG ]; then
               yarn publish-to-verdaccio
             else
               yarn lerna publish --exact --dist-tag=latest --preid=$NPM_TAG --conventional-commits --conventional-prerelease --no-verify-access --yes --no-commit-hooks --no-push --no-git-tag-version
             fi
-            mv stash.json packages/amplify-graphql-api-construct/package.json
             unsetNpmRegistryUrl
       - run:
           name: Generate unified changelog

--- a/packages/amplify-graphql-api-construct/package.json
+++ b/packages/amplify-graphql-api-construct/package.json
@@ -7,7 +7,6 @@
     "url": "https://github.com/aws-amplify/amplify-category-api.git",
     "directory": "packages/amplify-graphql-api-construct"
   },
-  "private": true,
   "author": "Amazon Web Services",
   "license": "Apache-2.0",
   "main": "lib/index.js",


### PR DESCRIPTION
#### Description of changes
* Remove `private` flag on `package.json` for the new CDK construct to publish in an alpha state.
* Revert manual changes in tests required to get private package publishing to verdaccio correctly.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit + E2E Tests, passing CDK test https://app.circleci.com/pipelines/github/aws-amplify/amplify-category-api/7943/workflows/463edcdb-ede6-43c8-9167-8cb3fdd9ce70/jobs/162669

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
