### PR TITLE
chore: add check for reserved tag names

### DIFF
--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -131,33 +131,34 @@ batch:
           CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
-    - identifier: containers_api_secrets_schema_function_1_api_3_api_1
+    - identifier: containers_api_secrets_schema_function_1_api_3_base_cdk
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/containers-api-secrets.test.ts|src/__tests__/schema-function-1.test.ts|src/__tests__/api_3.test.ts|src/__tests__/api_1.test.ts
+            src/__tests__/containers-api-secrets.test.ts|src/__tests__/schema-function-1.test.ts|src/__tests__/api_3.test.ts|src/__tests__/cdk/base-cdk.test.ts
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: resolvers_sync_query_datastore_api_6_api_lambda_auth
+    - identifier: api_1_resolvers_sync_query_datastore_api_6
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts|src/__tests__/api_6.test.ts|src/__tests__/graphql-v2/api_lambda_auth.test.ts
-          CLI_REGION: eu-west-2
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts|src/__tests__/api_6.test.ts
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: api_9
+    - identifier: api_lambda_auth_api_9
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
-          TEST_SUITE: src/__tests__/api_9.test.ts
-          CLI_REGION: eu-central-1
+          TEST_SUITE: >-
+            src/__tests__/graphql-v2/api_lambda_auth.test.ts|src/__tests__/api_9.test.ts
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: function_migration
@@ -350,7 +351,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-model.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: apigw
@@ -359,7 +360,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/apigw.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: containers_api_2
@@ -377,7 +378,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-14.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_7
@@ -386,7 +387,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-7.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_9
@@ -395,7 +396,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-9.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_5
@@ -442,7 +443,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-6.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_connection
@@ -451,7 +452,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-connection.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_had_node_to_node
@@ -461,7 +462,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-had-node-to-node.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_no_node_to_node
@@ -471,7 +472,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-no-node-to-node.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: api_2

--- a/codebuild_specs/scripts/publish.sh
+++ b/codebuild_specs/scripts/publish.sh
@@ -23,20 +23,27 @@ else
   git config --global user.name $GITHUB_USER
 fi
 
+RESERVED_TAGS=(alpha beta dev latest main)
+
 if [[ "$BRANCH_NAME" =~ ^cb-tagged-release ]]; then
   if [[ "$BRANCH_NAME" =~ ^cb-tagged-release-without-e2e-tests\/.* ]]; then
       # Remove tagged-release-without-e2e-tests/
-    export NPM_TAG="${BRANCH_NAME/cb-tagged-release-without-e2e-tests\//}"
+    NPM_TAG="${BRANCH_NAME/cb-tagged-release-without-e2e-tests\//}"
   elif [[ "$BRANCH_NAME" =~ ^cb-tagged-release\/.* ]]; then
     # Remove tagged-release/
-    export NPM_TAG="${BRANCH_NAME/cb-tagged-release\//}"
+    NPM_TAG="${BRANCH_NAME/cb-tagged-release\//}"
   fi
   if [ -z "$NPM_TAG" ]; then
     echo "Tag name is missing. Name your branch with either cb-tagged-release/<tag-name> or cb-tagged-release-without-e2e-tests/<tag-name>"
     exit 1
   fi
-  echo "Publishing to NPM with tag $NPM_TAG"
-  yarn publish:tag
+  if [[ " ${RESERVED_TAGS[*]} " =~ " ${NPM_TAG} " ]]; then
+    echo "The $NPM_TAG tag is reserved. Use alternate tag name"
+  else
+    echo "Publishing to NPM with tag $NPM_TAG"
+    export NPM_TAG="$NPM_TAG"
+    yarn publish:tag
+  fi
 else
   yarn publish:$BRANCH_NAME
 fi


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Do not allow reserved tag names for custom tag releases.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Ran script locally with BRANCH_NAME set as "cb-tagged-release/latest" and verified that it prints the error.
Ran script locally with BRANCH_NAME set as "cb-tagged-release/myvalidtag" and verified that it sets tag as "myvalidtag".

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
