### PR TITLE
fix: use tagged release for e2e tests for codebuild

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -167,7 +167,7 @@ function _installCLIFromLocalRegistry {
     startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
     setNpmRegistryUrlToLocal
     changeNpmGlobalPath
-    npm install -g @aws-amplify/cli-internal
+    npm install -g @aws-amplify/cli-internal@12.2.0-aws-cdk-lib-2-28.0
     echo "using Amplify CLI version: "$(amplify --version)
     npm list -g --depth=1 | grep -e '@aws-amplify/amplify-category-api' -e 'amplify-codegen'
     unsetNpmRegistryUrl


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Synchronizing Codebuild config w/ CircleCI config

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
E2E tests on codebuild are failing

#### Description of how you validated changes
https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:382a21c7-ff3d-4c9f-94c3-5523095f243a?region=us-east-1

#### Checklist
- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
