### PR TITLE
chore: use peer deps for api category for cdk and constructs

### DIFF
--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -38,11 +38,9 @@
     "@aws-cdk/aws-apigatewayv2-alpha": "~2.80.0-alpha.0",
     "@graphql-tools/merge": "^6.0.18",
     "@octokit/rest": "^18.0.9",
-    "aws-cdk-lib": "~2.80.0",
     "aws-sdk": "^2.1113.0",
     "chalk": "^4.1.1",
     "cloudform-types": "^4.2.0",
-    "constructs": "^10.0.5",
     "fs-extra": "^8.1.0",
     "graphql": "^15.5.0",
     "graphql-auth-transformer": "7.2.61",
@@ -73,7 +71,9 @@
     "@aws-amplify/amplify-prompts": "^2.6.8",
     "@aws-amplify/amplify-provider-awscloudformation": "^8.1.0",
     "amplify-headless-interface": "^1.17.3",
-    "amplify-util-headless-input": "^1.9.12"
+    "amplify-util-headless-input": "^1.9.12",
+    "aws-cdk-lib": "^2.80.0",
+    "constructs": "^10.0.5"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.0",

--- a/scripts/cloud-utils.sh
+++ b/scripts/cloud-utils.sh
@@ -28,7 +28,7 @@ function triggerProjectBatch {
     echo AWS Account: $account_number
     echo Project: $project_name 
     echo Target Branch: $target_branch
-    RESULT=$(aws codebuild start-build-batch --profile="${profile_name}" --project-name $project_name --source-version=$target_branch \
+    RESULT=$(aws codebuild start-build-batch --region=$REGION --profile="${profile_name}" --project-name $project_name --source-version=$target_branch \
      --environment-variables-override name=BRANCH_NAME,value=$target_branch,type=PLAINTEXT \
      --query 'buildBatch.id' --output text)
     echo "https://$REGION.console.aws.amazon.com/codesuite/codebuild/$account_number/projects/$project_name/batch/$RESULT?region=$REGION"


### PR DESCRIPTION
#### Description of changes
Use Peer dep for api category to ensure we're more easily aligned w/ the CLI moving forward. Related PR in CLI https://github.com/aws-amplify/amplify-cli/pull/12937

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit + E2E tests

#### Checklist
- [x] PR description included
- [ ] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
