### PR TITLE
feat: testing out approach for standalone import command

### DIFF
--- a/packages/amplify-graphql-api-commands/.npmignore
+++ b/packages/amplify-graphql-api-commands/.npmignore
@@ -1,0 +1,5 @@
+**/__mocks__/**
+**/__tests__/**
+./src
+tsconfig.json
+tsconfig.tsbuildinfo

--- a/packages/amplify-graphql-api-commands/package.json
+++ b/packages/amplify-graphql-api-commands/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@aws-amplify/graphql-commands-alpha",
+  "version": "0.1.0",
+  "description": "AppSync GraphQL Api Utilities to interact with a GraphQL Transform Construct.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws-amplify/amplify-category-api.git",
+    "directory": "packages/amplify-graphql-api-commands"
+  },
+  "author": "Amazon Web Services",
+  "license": "Apache-2.0",
+  "bin": "lib/import.js",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "clean": "rimraf lib tsconfig.tsbuildinfo node_modules",
+    "test": "jest",
+    "extract-api": "ts-node ../../scripts/extract-api.ts"
+  },
+  "keywords": [
+    "graphql",
+    "aws",
+    "amplify",
+    "api",
+    "appsync"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@aws-amplify/graphql-transformer-core": "1.3.7",
+    "@aws-amplify/graphql-transformer-interfaces": "2.2.4",
+    "@aws-amplify/graphql-schema-generator": "0.1.7",
+    "fs-extra": "^8.1.0"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^8.0.1",
+    "@types/node": "^12.12.6",
+    "rimraf": "^3.0.0",
+    "ts-jest": "^26.4.4"
+  },
+  "jest": {
+    "testURL": "http://localhost",
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testRegex": "((\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ],
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80
+      }
+    }
+  }
+}

--- a/packages/amplify-graphql-api-commands/src/__tests__/import.test.ts
+++ b/packages/amplify-graphql-api-commands/src/__tests__/import.test.ts
@@ -1,0 +1,5 @@
+describe('import', () => {
+  it('does something', () => {
+    // TK
+  });
+});

--- a/packages/amplify-graphql-api-commands/src/import.ts
+++ b/packages/amplify-graphql-api-commands/src/import.ts
@@ -1,0 +1,23 @@
+import * as fs from 'fs';
+import { generateRDSSchema } from '@aws-amplify/graphql-schema-generator';
+import { RDSConnectionSecrets, ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+
+const generateSecretValuesFromSecretStore = async (secretStorePrefix: string): Promise<RDSConnectionSecrets> => {
+  return {
+    host: 'localhost',
+    port: 3306,
+    database: 'test',
+    username: 'XXXX',
+    password: 'XXXX',
+    secretStoreArn: secretStorePrefix,
+  };
+};
+
+export const importRDSSchema = async (secretStorePrefix: string, outPath: string): Promise<void> => {
+  const secretValues = await generateSecretValuesFromSecretStore(secretStorePrefix);
+  const generatedSchema = await generateRDSSchema({
+    engine: ImportedRDSType.MYSQL,
+    ...secretValues,
+  });
+  fs.writeFileSync(outPath, generatedSchema);
+};

--- a/packages/amplify-graphql-api-commands/src/index.ts
+++ b/packages/amplify-graphql-api-commands/src/index.ts
@@ -1,0 +1,1 @@
+export * from './index';

--- a/packages/amplify-graphql-api-commands/tsconfig.json
+++ b/packages/amplify-graphql-api-commands/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+    "strict": true,
+    "allowJs": false,
+    "removeComments": false
+  },
+  "exclude": ["coverage", "lib", "src/__tests__"]
+}

--- a/packages/amplify-graphql-schema-generator/package.json
+++ b/packages/amplify-graphql-schema-generator/package.json
@@ -30,9 +30,6 @@
     "knex": "~2.4.0",
     "mysql2": "~2.3.3"
   },
-  "peerDependencies": {
-    "@aws-amplify/amplify-prompts": "^2.6.8"
-  },
   "jest": {
     "transform": {
       "^.+\\.tsx?$": "ts-jest"

--- a/packages/amplify-graphql-schema-generator/src/datasource-adapter/mysql-datasource-adapter.ts
+++ b/packages/amplify-graphql-schema-generator/src/datasource-adapter/mysql-datasource-adapter.ts
@@ -1,7 +1,6 @@
 import { EnumType, Field, FieldDataType, FieldType, Index } from '../schema-representation';
 import { DataSourceAdapter } from './datasource-adapter';
 import { knex } from 'knex';
-import { printer } from '@aws-amplify/amplify-prompts';
 
 export interface MySQLDataSourceConfig {
   host: string;
@@ -73,7 +72,7 @@ export class MySQLDataSourceAdapter extends DataSourceAdapter {
         debug: false,
       });
     } catch (err) {
-      printer.info(err);
+      console.info(err);
       throw err;
     }
   }

--- a/packages/amplify-graphql-schema-generator/src/schema-generator/index.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-generator/index.ts
@@ -1,1 +1,2 @@
 export * from './generate-schema';
+export * from './top-level-invocation';

--- a/packages/amplify-graphql-schema-generator/src/schema-generator/top-level-invocation.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-generator/top-level-invocation.ts
@@ -1,0 +1,80 @@
+import * as os from 'os';
+import { ImportedRDSType, ImportedDataSourceConfig } from '@aws-amplify/graphql-transformer-core';
+import { DataSourceAdapter, MySQLDataSourceAdapter, MySQLDataSourceConfig } from '../datasource-adapter';
+import { Engine, Schema } from '../schema-representation';
+import { generateGraphQLSchema } from './generate-schema';
+
+type AmplifyInputEntry = {
+  name: string;
+  type: string;
+  default: string | number;
+  comment?: string | undefined;
+};
+
+export const generateRDSSchema = async (databaseConfig: ImportedDataSourceConfig): Promise<string> => {
+  // Establish the connection
+  let adapter: DataSourceAdapter;
+  let schema: Schema;
+  switch (databaseConfig.engine) {
+    case ImportedRDSType.MYSQL:
+      adapter = new MySQLDataSourceAdapter(databaseConfig as MySQLDataSourceConfig);
+      schema = new Schema(new Engine('MySQL'));
+      break;
+    default:
+      console.error('Only MySQL Data Source is supported.');
+  }
+
+  try {
+    await adapter.initialize();
+  } catch (error) {
+    console.error(
+      'Failed to connect to the specified RDS Data Source. Check the connection details in the schema and re-try. Use "amplify api update-secrets" to update the user credentials.',
+    );
+    throw error;
+  }
+
+  const models = await adapter.getModels();
+  adapter.cleanup();
+  models.forEach((m) => schema.addModel(m));
+
+  const schemaString =
+    (await constructDefaultGlobalAmplifyInput(databaseConfig.engine, false)) + os.EOL + os.EOL + generateGraphQLSchema(schema);
+  return schemaString;
+};
+
+const getGlobalAmplifyInputEntries = async (
+  dataSourceType = ImportedRDSType.MYSQL,
+  includeAuthRule = true,
+): Promise<AmplifyInputEntry[]> => {
+  const inputs: AmplifyInputEntry[] = [
+    {
+      name: 'engine',
+      type: 'String',
+      default: dataSourceType,
+    },
+  ];
+
+  if (includeAuthRule) {
+    inputs.push({
+      name: 'globalAuthRule',
+      type: 'AuthRule',
+      default: '{ allow: public }',
+      comment: `This "input" configures a global authorization rule to enable public access to all models in this schema.
+    Learn more about authorization rules here: https://docs.amplify.aws/lib/graphql/auth-rules/`,
+    });
+  }
+  return inputs;
+};
+
+const constructDefaultGlobalAmplifyInput = async (dataSourceType: ImportedRDSType, includeAuthRule: boolean): Promise<string> => {
+  const inputs = await getGlobalAmplifyInputEntries(dataSourceType, includeAuthRule);
+  const inputsString = inputs.reduce(
+    (acc: string, input): string =>
+      acc +
+      ` ${input.name}: ${input.type} = ${input.type === 'String' ? '"' + input.default + '"' : input.default} ${
+        input.comment ? '# ' + input.comment : ''
+      } \n`,
+    '',
+  );
+  return `input Amplify {\n${inputsString}}\n`;
+};


### PR DESCRIPTION
#### Description of changes
Getting a feel for the changes required to support RDS db import outside of the Amplify CLI, this PR does not yet have the API category refactored to use the same refactoed out utility.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
N/A

#### Checklist
- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
