### PR TITLE
fix: publish issue with webhook trigger

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -83,6 +83,8 @@ function _setShell {
 function _buildLinux {
   _setShell
   echo "Linux Build"
+  echo $CODEBUILD_WEBHOOK_TRIGGER
+  echo $CODEBUILD_WEBHOOK_BASE_REF
   yarn run production-build
   yarn build-tests
   storeCacheForBuildJob
@@ -123,11 +125,17 @@ function _publishToLocalRegistry {
     echo "Publish To Local Registry"
     loadCacheFromBuildJob
     if [ -z "$BRANCH_NAME" ]; then
-      export BRANCH_NAME="$(git symbolic-ref HEAD --short 2>/dev/null)"
-      if [ "$BRANCH_NAME" = "" ] ; then
-        BRANCH_NAME="$(git rev-parse HEAD | xargs git name-rev | cut -d' ' -f2 | sed 's/remotes\/origin\///g')";
+      if [ -z "$CODEBUILD_WEBHOOK_TRIGGER" ]; then
+        export BRANCH_NAME="$(git symbolic-ref HEAD --short 2>/dev/null)"
+        if [ "$BRANCH_NAME" = "" ] ; then
+          BRANCH_NAME="$(git rev-parse HEAD | xargs git name-rev | cut -d' ' -f2 | sed 's/remotes\/origin\///g')";
+        fi
+      elif [[ "$CODEBUILD_WEBHOOK_TRIGGER" == "pr/"* ]]; then
+        echo $CODEBUILD_WEBHOOK_BASE_REF
+        export BRANCH_NAME=$CODEBUILD_WEBHOOK_BASE_REF
       fi
     fi
+    echo $BRANCH_NAME
     git checkout $BRANCH_NAME
   
     # Fetching git tags from upstream

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -83,10 +83,6 @@ function _setShell {
 function _buildLinux {
   _setShell
   echo "Linux Build"
-  echo $CODEBUILD_WEBHOOK_TRIGGER
-  echo $CODEBUILD_WEBHOOK_BASE_REF
-  TEST_BRANCH=${CODEBUILD_WEBHOOK_BASE_REF##*/}
-  echo $TEST_BRANCH
   yarn run production-build
   yarn build-tests
   storeCacheForBuildJob
@@ -133,7 +129,6 @@ function _publishToLocalRegistry {
           BRANCH_NAME="$(git rev-parse HEAD | xargs git name-rev | cut -d' ' -f2 | sed 's/remotes\/origin\///g')";
         fi
       elif [[ "$CODEBUILD_WEBHOOK_TRIGGER" == "pr/"* ]]; then
-        echo $CODEBUILD_WEBHOOK_BASE_REF
         export BRANCH_NAME=${CODEBUILD_WEBHOOK_BASE_REF##*/}
       fi
     fi

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -85,6 +85,8 @@ function _buildLinux {
   echo "Linux Build"
   echo $CODEBUILD_WEBHOOK_TRIGGER
   echo $CODEBUILD_WEBHOOK_BASE_REF
+  TEST_BRANCH=${CODEBUILD_WEBHOOK_BASE_REF##*/}
+  echo $TEST_BRANCH
   yarn run production-build
   yarn build-tests
   storeCacheForBuildJob
@@ -132,7 +134,7 @@ function _publishToLocalRegistry {
         fi
       elif [[ "$CODEBUILD_WEBHOOK_TRIGGER" == "pr/"* ]]; then
         echo $CODEBUILD_WEBHOOK_BASE_REF
-        export BRANCH_NAME=$CODEBUILD_WEBHOOK_BASE_REF
+        export BRANCH_NAME=${CODEBUILD_WEBHOOK_BASE_REF##*/}
       fi
     fi
     echo $BRANCH_NAME


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Fixed the issue of the branch not being checkout in the `publishToLocalRegistry` when the build is triggered with webhook
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
