### PR TITLE
fix: 🐛 Handle APIGW path params in user group policies

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
@@ -91,7 +91,8 @@ export class AmplifyApigwResourceStack extends cdk.Stack implements AmplifyApigw
 
   // eslint-disable-next-line class-methods-use-this
   private _craftPolicyDocument(apiResourceName: string, pathName: string, supportedOperations: string[]) {
-    const paths = [pathName, appendToUrlPath(pathName, '*')];
+    const policyPathName = pathName.replace(/{[a-zA-Z0-9-]+}/g, '*');
+    const paths = [policyPathName, appendToUrlPath(policyPathName, '*')];
     const resources = paths.flatMap((path) =>
       supportedOperations.map((op) =>
         cdk.Fn.join('', [


### PR DESCRIPTION
Update the User Group Policy generation to substitute path parameters with wildcards

✅ Closes: #1680

#### Description of changes

Updates the User Group Policy generation to substitute path parameters with wildcards.

##### CDK / CloudFormation Parameters Changed

None

#### Issue #, if available

#1680

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
