### PR TITLE
chore: pass constructs around instead of stacks

### DIFF
--- a/packages/amplify-category-api/src/graphql-transformer/override.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/override.ts
@@ -24,14 +24,14 @@ export function applyFileBasedOverride(stackManager: StackManager, overrideDirPa
 
   const stacks: string[] = [];
   const amplifyApiObj: any = {};
-  stackManager.rootStack.node.findAll().forEach((node) => {
+  stackManager.scope.node.findAll().forEach((node) => {
     const resource = node as CfnResource;
     if (resource.cfnResourceType === 'AWS::CloudFormation::Stack') {
       stacks.push(node.node.id.split('.')[0]);
     }
   });
 
-  stackManager.rootStack.node.findAll().forEach((node) => {
+  stackManager.scope.node.findAll().forEach((node) => {
     const resource = node as CfnResource;
     let pathArr;
     if (node.node.id === 'Resource') {

--- a/packages/amplify-graphql-auth-transformer/src/utils/index.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/index.ts
@@ -13,6 +13,7 @@ import {
   RoleDefinition,
   RolesByProvider,
 } from './definitions';
+import { Construct } from 'constructs';
 
 export * from './constants';
 export * from './definitions';
@@ -116,12 +117,12 @@ export const getAuthDirectiveRules = (authDir: DirectiveWrapper, options?: GetAu
 /**
  * gets stack name if the field is paired with function, predictions, or by itself
  */
-export const getStackForField = (
+export const getScopeForField = (
   ctx: TransformerContextProvider,
   obj: ObjectTypeDefinitionNode,
   fieldName: string,
   hasModelDirective: boolean,
-): Stack => {
+): Construct => {
   const fieldNode = obj.fields.find((f) => f.name.value === fieldName);
   const fieldDirectives = fieldNode.directives.map((d) => d.name.value);
   if (fieldDirectives.includes('function')) {
@@ -133,7 +134,7 @@ export const getStackForField = (
   if (hasModelDirective) {
     return ctx.stackManager.getStack(obj.name.value);
   }
-  return ctx.stackManager.rootStack;
+  return ctx.stackManager.scope;
 };
 
 /**

--- a/packages/amplify-graphql-http-transformer/src/graphql-http-transformer.ts
+++ b/packages/amplify-graphql-http-transformer/src/graphql-http-transformer.ts
@@ -295,12 +295,12 @@ function createResolver(stack: cdk.Stack, dataSourceId: string, context: Transfo
     requestTemplate.push(
       qref(
         `$ctx.stash.put("authRole", "arn:aws:sts::${
-          cdk.Stack.of(context.stackManager.rootStack).account
+          cdk.Stack.of(context.stackManager.scope).account
         }:assumed-role/${authRoleParameter}/CognitoIdentityCredentials")`,
       ),
       qref(
         `$ctx.stash.put("unauthRole", "arn:aws:sts::${
-          cdk.Stack.of(context.stackManager.rootStack).account
+          cdk.Stack.of(context.stackManager.scope).account
         }:assumed-role/${unauthRoleParameter}/CognitoIdentityCredentials")`,
       ),
     );

--- a/packages/amplify-graphql-index-transformer/src/resolvers/resolvers.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers/resolvers.ts
@@ -530,7 +530,7 @@ function makeQueryResolver(config: IndexDirectiveConfiguration, ctx: Transformer
     ),
   );
 
-  resolver.mapToStack(ctx.stackManager.getStackFor(resolverResourceId, stackId));
+  resolver.setScope(ctx.stackManager.getScopeFor(resolverResourceId, stackId));
   ctx.resolvers.addResolver(object.name.value, queryField, resolver);
 }
 

--- a/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
@@ -10,19 +10,12 @@ import {
   qref,
   ifElse,
   compoundExpression,
-  iff,
   toJson,
   printBlock,
-  and,
-  not,
-  equals,
-  int,
-  nul,
   set,
   list,
 } from 'graphql-mapping-template';
 import { ResourceConstants } from 'graphql-transformer-common';
-import { Stack } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Effect, IRole, Policy, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { IFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
@@ -34,7 +27,7 @@ export type OPERATIONS = 'CREATE' | 'UPDATE' | 'DELETE' | 'GET' | 'LIST' | 'SYNC
 const OPERATION_KEY = '__operation';
 
 export const createRdsLambda = (
-  stack: Stack,
+  scope: Construct,
   apiGraphql: GraphQLAPIProvider,
   lambdaRole: IRole,
   environment?: { [key: string]: string },
@@ -51,7 +44,7 @@ export const createRdsLambda = (
     lambdaRole,
     environment,
     undefined,
-    stack,
+    scope,
   );
 };
 

--- a/packages/amplify-graphql-model-transformer/src/resources/model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/model-resource-generator.ts
@@ -132,7 +132,7 @@ export abstract class ModelResourceGenerator {
             `${query.typeName}.${query.fieldName}.{slotName}.{slotIndex}.req.vtl`,
           ),
         );
-        resolver.mapToStack(context.stackManager.getStackFor(query.resolverLogicalId, def!.name.value));
+        resolver.setScope(context.stackManager.getScopeFor(query.resolverLogicalId, def!.name.value));
         context.resolvers.addResolver(query.typeName, query.fieldName, resolver);
       });
 
@@ -166,7 +166,7 @@ export abstract class ModelResourceGenerator {
             `${mutation.typeName}.${mutation.fieldName}.{slotName}.{slotIndex}.req.vtl`,
           ),
         );
-        resolver.mapToStack(context.stackManager.getStackFor(mutation.resolverLogicalId, def!.name.value));
+        resolver.setScope(context.stackManager.getScopeFor(mutation.resolverLogicalId, def!.name.value));
         context.resolvers.addResolver(mutation.typeName, mutation.fieldName, resolver);
       });
 
@@ -213,7 +213,7 @@ export abstract class ModelResourceGenerator {
               ),
             );
           }
-          resolver.mapToStack(context.stackManager.getStackFor(subscription.resolverLogicalId, def!.name.value));
+          resolver.setScope(context.stackManager.getScopeFor(subscription.resolverLogicalId, def!.name.value));
           context.resolvers.addResolver(subscription.typeName, subscription.fieldName, resolver);
         });
       }

--- a/packages/amplify-graphql-model-transformer/src/resources/rds-model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/rds-model-resource-generator.ts
@@ -18,14 +18,14 @@ export class RdsModelResourceGenerator extends ModelResourceGenerator {
     if (this.isEnabled()) {
       const secretEntry = context.datasourceSecretParameterLocations.get(MYSQL_DB_TYPE);
       const { RDSLambdaIAMRoleLogicalID, RDSLambdaLogicalID, RDSLambdaDataSourceLogicalID } = ResourceConstants.RESOURCES;
-      const lambdaRoleStack = context.stackManager.getStackFor(RDSLambdaIAMRoleLogicalID, RDS_STACK_NAME);
-      const lambdaStack = context.stackManager.getStackFor(RDSLambdaLogicalID, RDS_STACK_NAME);
+      const lambdaRoleScope = context.stackManager.getScopeFor(RDSLambdaIAMRoleLogicalID, RDS_STACK_NAME);
+      const lambdaScope = context.stackManager.getScopeFor(RDSLambdaLogicalID, RDS_STACK_NAME);
       const role = createRdsLambdaRole(
         context.resourceHelper.generateIAMRoleName(RDSLambdaIAMRoleLogicalID),
-        lambdaRoleStack,
+        lambdaRoleScope,
         secretEntry as RDSConnectionSecrets,
       );
-      const lambda = createRdsLambda(lambdaStack, context.api, role, {
+      const lambda = createRdsLambda(lambdaScope, context.api, role, {
         username: secretEntry?.username ?? '',
         password: secretEntry?.password ?? '',
         host: secretEntry?.host ?? '',
@@ -33,8 +33,8 @@ export class RdsModelResourceGenerator extends ModelResourceGenerator {
         database: secretEntry?.database ?? '',
       });
 
-      const lambdaDataSourceStack = context.stackManager.getStackFor(RDSLambdaDataSourceLogicalID, RDS_STACK_NAME);
-      const rdsDatasource = context.api.host.addLambdaDataSource(`${RDSLambdaDataSourceLogicalID}`, lambda, {}, lambdaDataSourceStack);
+      const lambdaDataSourceScope = context.stackManager.getScopeFor(RDSLambdaDataSourceLogicalID, RDS_STACK_NAME);
+      const rdsDatasource = context.api.host.addLambdaDataSource(`${RDSLambdaDataSourceLogicalID}`, lambda, {}, lambdaDataSourceScope);
       this.models.forEach((model) => {
         context.dataSources.add(model, rdsDatasource);
         this.datasourceMap[model.name.value] = rdsDatasource;

--- a/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
+++ b/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
@@ -353,10 +353,10 @@ function createResolver(
     const unauthRoleParameter = (context.stackManager.getParameter(IAM_UNAUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
     requestTemplate.push(
       `$util.qr($ctx.stash.put("authRole", "arn:aws:sts::${
-        cdk.Stack.of(context.stackManager.rootStack).account
+        cdk.Stack.of(context.stackManager.scope).account
       }:assumed-role/${authRoleParameter}/CognitoIdentityCredentials"))`,
       `$util.qr($ctx.stash.put("unauthRole", "arn:aws:sts::${
-        cdk.Stack.of(context.stackManager.rootStack).account
+        cdk.Stack.of(context.stackManager.scope).account
       }:assumed-role/${unauthRoleParameter}/CognitoIdentityCredentials"))`,
     );
   }

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -176,7 +176,7 @@ export function makeGetItemConnectionWithKeyResolver(config: HasOneDirectiveConf
     ),
   );
 
-  resolver.mapToStack(ctx.stackManager.getStackFor(resolverResourceId, CONNECTION_STACK));
+  resolver.setScope(ctx.stackManager.getScopeFor(resolverResourceId, CONNECTION_STACK));
   ctx.resolvers.addResolver(object.name.value, field.name.value, resolver);
 }
 
@@ -308,7 +308,7 @@ export function makeQueryConnectionWithKeyResolver(config: HasManyDirectiveConfi
     ),
   );
 
-  resolver.mapToStack(ctx.stackManager.getStackFor(resolverResourceId, CONNECTION_STACK));
+  resolver.setScope(ctx.stackManager.getScopeFor(resolverResourceId, CONNECTION_STACK));
   ctx.resolvers.addResolver(object.name.value, field.name.value, resolver);
 }
 

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-cfnParameters.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-cfnParameters.ts
@@ -1,8 +1,9 @@
 import { ResourceConstants } from 'graphql-transformer-common';
-import { CfnParameter, Stack } from 'aws-cdk-lib';
+import { CfnParameter } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import { ALLOWABLE_SEARCHABLE_INSTANCE_TYPES } from '../constants';
 
-export const createParametersStack = (stack: Stack): Map<string, CfnParameter> => {
+export const createParametersStack = (scope: Construct): Map<string, CfnParameter> => {
   const {
     OpenSearchAccessIAMRoleName,
     OpenSearchStreamingLambdaHandlerName,
@@ -20,7 +21,7 @@ export const createParametersStack = (stack: Stack): Map<string, CfnParameter> =
   return new Map<string, CfnParameter>([
     [
       OpenSearchAccessIAMRoleName,
-      new CfnParameter(stack, OpenSearchAccessIAMRoleName, {
+      new CfnParameter(scope, OpenSearchAccessIAMRoleName, {
         description: 'The name of the IAM role assumed by AppSync for OpenSearch.',
         default: 'AppSyncOpenSearchRole',
       }),
@@ -28,7 +29,7 @@ export const createParametersStack = (stack: Stack): Map<string, CfnParameter> =
 
     [
       OpenSearchStreamingLambdaHandlerName,
-      new CfnParameter(stack, OpenSearchStreamingLambdaHandlerName, {
+      new CfnParameter(scope, OpenSearchStreamingLambdaHandlerName, {
         description: 'The name of the lambda handler.',
         default: 'python_streaming_function.lambda_handler',
       }),
@@ -36,7 +37,7 @@ export const createParametersStack = (stack: Stack): Map<string, CfnParameter> =
 
     [
       OpenSearchStreamingLambdaRuntime,
-      new CfnParameter(stack, OpenSearchStreamingLambdaRuntime, {
+      new CfnParameter(scope, OpenSearchStreamingLambdaRuntime, {
         // eslint-disable-next-line no-multi-str
         description:
           'The lambda runtime \
@@ -47,7 +48,7 @@ export const createParametersStack = (stack: Stack): Map<string, CfnParameter> =
 
     [
       OpenSearchStreamingFunctionName,
-      new CfnParameter(stack, OpenSearchStreamingFunctionName, {
+      new CfnParameter(scope, OpenSearchStreamingFunctionName, {
         description: 'The name of the streaming lambda function.',
         default: 'DdbToEsFn',
       }),
@@ -55,7 +56,7 @@ export const createParametersStack = (stack: Stack): Map<string, CfnParameter> =
 
     [
       OpenSearchStreamBatchSize,
-      new CfnParameter(stack, OpenSearchStreamBatchSize, {
+      new CfnParameter(scope, OpenSearchStreamBatchSize, {
         description: 'The maximum number of records to stream to OpenSearch per batch.',
         type: 'Number',
         default: 100,
@@ -64,7 +65,7 @@ export const createParametersStack = (stack: Stack): Map<string, CfnParameter> =
 
     [
       OpenSearchStreamMaximumBatchingWindowInSeconds,
-      new CfnParameter(stack, OpenSearchStreamMaximumBatchingWindowInSeconds, {
+      new CfnParameter(scope, OpenSearchStreamMaximumBatchingWindowInSeconds, {
         description: 'The maximum amount of time in seconds to wait for DynamoDB stream records before sending to streaming lambda.',
         type: 'Number',
         default: 1,
@@ -73,7 +74,7 @@ export const createParametersStack = (stack: Stack): Map<string, CfnParameter> =
 
     [
       OpenSearchAccessIAMRoleName,
-      new CfnParameter(stack, OpenSearchStreamingIAMRoleName, {
+      new CfnParameter(scope, OpenSearchStreamingIAMRoleName, {
         description: 'The name of the streaming lambda function IAM role.',
         default: 'SearchLambdaIAMRole',
       }),
@@ -81,7 +82,7 @@ export const createParametersStack = (stack: Stack): Map<string, CfnParameter> =
 
     [
       OpenSearchDebugStreamingLambda,
-      new CfnParameter(stack, OpenSearchDebugStreamingLambda, {
+      new CfnParameter(scope, OpenSearchDebugStreamingLambda, {
         description: 'Enable debug logs for the Dynamo -> OpenSearch streaming lambda.',
         default: 0,
         type: 'Number',
@@ -91,7 +92,7 @@ export const createParametersStack = (stack: Stack): Map<string, CfnParameter> =
 
     [
       OpenSearchInstanceCount,
-      new CfnParameter(stack, OpenSearchInstanceCount, {
+      new CfnParameter(scope, OpenSearchInstanceCount, {
         description: 'The number of instances to launch into the OpenSearch domain.',
         default: 1,
         type: 'Number',
@@ -100,7 +101,7 @@ export const createParametersStack = (stack: Stack): Map<string, CfnParameter> =
 
     [
       OpenSearchInstanceType,
-      new CfnParameter(stack, OpenSearchInstanceType, {
+      new CfnParameter(scope, OpenSearchInstanceType, {
         description: 'The type of instance to launch into the OpenSearch domain.',
         default: 't2.small.elasticsearch',
         allowedValues: ALLOWABLE_SEARCHABLE_INSTANCE_TYPES,
@@ -109,7 +110,7 @@ export const createParametersStack = (stack: Stack): Map<string, CfnParameter> =
 
     [
       OpenSearchEBSVolumeGB,
-      new CfnParameter(stack, OpenSearchEBSVolumeGB, {
+      new CfnParameter(scope, OpenSearchEBSVolumeGB, {
         description: 'The size in GB of the EBS volumes that contain our data.',
         default: 10,
         type: 'Number',

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-datasource.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-datasource.ts
@@ -2,10 +2,10 @@ import { GraphQLAPIProvider } from '@aws-amplify/graphql-transformer-interfaces'
 import { BaseDataSource } from 'aws-cdk-lib/aws-appsync';
 import { IRole } from 'aws-cdk-lib/aws-iam';
 import { ResourceConstants } from 'graphql-transformer-common';
-import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 
 export const createSearchableDataSource = (
-  stack: Stack,
+  scope: Construct,
   graphqlApiProvider: GraphQLAPIProvider,
   domainEndpoint: string,
   role: IRole,
@@ -21,6 +21,6 @@ export const createSearchableDataSource = (
       serviceRole: role,
       name: OpenSearchDataSourceLogicalID,
     },
-    stack,
+    scope,
   );
 };

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-streaming-lambda.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-streaming-lambda.ts
@@ -1,13 +1,13 @@
 import * as path from 'path';
 import { GraphQLAPIProvider, TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { EventSourceMapping, IFunction, LayerVersion, Runtime, StartingPosition } from 'aws-cdk-lib/aws-lambda';
-import { CfnParameter, Fn, Stack, Duration } from 'aws-cdk-lib';
+import { CfnParameter, Fn, Duration } from 'aws-cdk-lib';
 import { Effect, IRole, Policy, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 import { ResourceConstants, SearchableResourceIDs } from 'graphql-transformer-common';
 
 export const createLambda = (
-  stack: Stack,
+  scope: Construct,
   apiGraphql: GraphQLAPIProvider,
   parameterMap: Map<string, CfnParameter>,
   lambdaRole: IRole,
@@ -32,7 +32,7 @@ export const createLambda = (
     Runtime.PYTHON_3_8,
     [
       LayerVersion.fromLayerVersionArn(
-        stack,
+        scope,
         'LambdaLayerVersion',
         Fn.findInMap('LayerResourceMapping', Fn.ref('AWS::Region'), 'layerRegion'),
       ),
@@ -40,7 +40,7 @@ export const createLambda = (
     lambdaRole,
     enviroment,
     undefined,
-    stack,
+    scope,
   );
 };
 

--- a/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
@@ -308,7 +308,7 @@ export class SearchableModelTransformer extends TransformerPluginBase {
     stack.templateOptions.description = 'An auto-generated nested stack for searchable.';
     stack.templateOptions.templateFormatVersion = '2010-09-09';
 
-    const parameterMap = createParametersInStack(context.stackManager.rootStack);
+    const parameterMap = createParametersInStack(context.stackManager.scope);
 
     const domain = createSearchableDomain(
       stack,
@@ -388,7 +388,7 @@ export class SearchableModelTransformer extends TransformerPluginBase {
         ),
       );
 
-      resolver.mapToStack(stack);
+      resolver.setScope(stack);
       context.resolvers.addResolver(typeName, def.fieldName, resolver);
     }
 

--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -13,7 +13,6 @@ import { AppSyncDataSourceType } from '@aws-amplify/graphql-transformer-interfac
 import { AppSyncFunctionConfigurationProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { AuthorizationConfig } from 'aws-cdk-lib/aws-appsync';
 import { AuthorizationType } from 'aws-cdk-lib/aws-appsync';
-import * as cdk from 'aws-cdk-lib';
 import { CfnApiKey } from 'aws-cdk-lib/aws-appsync';
 import { CfnElement } from 'aws-cdk-lib';
 import { CfnGraphQLSchema } from 'aws-cdk-lib/aws-appsync';
@@ -114,7 +113,7 @@ export const enum ConflictHandlerType {
 }
 
 // @public (undocumented)
-function createSyncLambdaIAMPolicy(context: TransformerContextProvider, stack: cdk.Stack, name: string, region?: string): iam.Policy;
+function createSyncLambdaIAMPolicy(context: TransformerContextProvider, scope: Construct, name: string, region?: string): iam.Policy;
 
 // Warning: (ae-forgotten-export) The symbol "TransformerContext" needs to be exported by the entry point index.d.ts
 //
@@ -434,15 +433,13 @@ export class StackManager implements StackManagerProvider {
     // (undocumented)
     getParameter: (name: string) => CfnParameter | void;
     // (undocumented)
+    getScopeFor: (resourceId: string, defaultStackName?: string) => Construct;
+    // (undocumented)
     getStack: (stackName: string) => Stack;
     // (undocumented)
-    getStackFor: (resourceId: string, defaultStackName?: string) => Stack;
-    // (undocumented)
     hasStack: (stackName: string) => boolean;
-    // Warning: (ae-forgotten-export) The symbol "TransformerRootStack" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
-    readonly rootStack: TransformerRootStack;
+    readonly scope: Construct;
 }
 
 // @public (undocumented)
@@ -576,6 +573,8 @@ export abstract class TransformerModelEnhancerBase extends TransformerModelBase 
     constructor(name: string, doc: DocumentNode_2 | string, type?: TransformerPluginType);
 }
 
+// Warning: (ae-forgotten-export) The symbol "TransformerRootStack" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export class TransformerNestedStack extends TransformerRootStack {
     // Warning: (ae-forgotten-export) The symbol "TransformerNestedStackProps" needs to be exported by the entry point index.d.ts
@@ -645,13 +644,13 @@ export class TransformerResolver implements TransformerResolverProvider {
     // (undocumented)
     findSlot: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider) => Slot | undefined;
     // (undocumented)
-    mapToStack: (stack: Stack) => void;
+    setScope: (scope: Construct) => void;
     // (undocumented)
     slotExists: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider) => boolean;
     // (undocumented)
     synthesize: (context: TransformerContextProvider, api: GraphQLAPIProvider) => void;
     // (undocumented)
-    synthesizeResolvers: (stack: Stack, api: GraphQLAPIProvider, slotsNames: string[]) => AppSyncFunctionConfigurationProvider[];
+    synthesizeResolvers: (scope: Construct, api: GraphQLAPIProvider, slotsNames: string[]) => AppSyncFunctionConfigurationProvider[];
     // (undocumented)
     updateSlot: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider) => void;
 }

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transformation/transform.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transformation/transform.test.ts
@@ -56,9 +56,9 @@ describe('GraphQLTransform', () => {
       } as unknown as TransformerOutput;
       transform.testGenerateGraphQlApi(stackManager, transformerOutput);
       if (isAPIKeyExpected) {
-        expect(stackManager.rootStack.node.tryFindChild('GraphQLAPIKeyOutput')).toBeDefined();
+        expect(stackManager.scope.node.tryFindChild('GraphQLAPIKeyOutput')).toBeDefined();
       } else {
-        expect(stackManager.rootStack.node.tryFindChild('GraphQLAPIKeyOutput')).toBeUndefined();
+        expect(stackManager.scope.node.tryFindChild('GraphQLAPIKeyOutput')).toBeUndefined();
       }
     };
 

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -317,7 +317,7 @@ export class GraphQLTransform {
     // Todo: Move this to its own transformer plugin to support modifying the API
     // Like setting the auth mode and enabling logging and such
 
-    const { rootStack } = stackManager;
+    const { scope } = stackManager;
     const authorizationConfig = adoptAuthModes(stackManager, this.authConfig);
     const apiName = stackManager.addParameter('AppSyncApiName', {
       default: 'AppSyncSimpleTransform',
@@ -327,7 +327,7 @@ export class GraphQLTransform {
     if (!envName) {
       throw new Error('Parameter `env` not configured properly.');
     }
-    const api = new GraphQLApi(rootStack, 'GraphQLAPI', {
+    const api = new GraphQLApi(scope, 'GraphQLAPI', {
       name: `${apiName}-${envName.valueAsString}`,
       authorizationConfig,
       host: this.options.host,
@@ -352,7 +352,7 @@ export class GraphQLTransform {
         expires: apiKeyExpirationDays,
       });
 
-      new CfnOutput(rootStack, 'GraphQLAPIKeyOutput', {
+      new CfnOutput(scope, 'GraphQLAPIKeyOutput', {
         value: apiKey.attrApiKey,
         description: 'Your GraphQL API ID.',
         exportName: Fn.join(':', [Aws.STACK_NAME, 'GraphQLApiKey']),
@@ -364,13 +364,13 @@ export class GraphQLTransform {
       stackManager.addParameter(IAM_UNAUTH_ROLE_PARAMETER, { type: 'String' });
     }
 
-    new CfnOutput(rootStack, 'GraphQLAPIIdOutput', {
+    new CfnOutput(scope, 'GraphQLAPIIdOutput', {
       value: api.apiId,
       description: 'Your GraphQL API ID.',
       exportName: Fn.join(':', [Aws.STACK_NAME, 'GraphQLApiId']),
     });
 
-    new CfnOutput(rootStack, 'GraphQLAPIEndpointOutput', {
+    new CfnOutput(scope, 'GraphQLAPIEndpointOutput', {
       value: api.graphqlUrl,
       description: 'Your GraphQL API endpoint.',
       exportName: Fn.join(':', [Aws.STACK_NAME, 'GraphQLApiEndpoint']),

--- a/packages/amplify-graphql-transformer-core/src/utils/authType.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/authType.ts
@@ -39,11 +39,11 @@ export function adoptAuthMode(stackManager: StackManager, entry: AppSyncAuthConf
       const userPoolId = stackManager.addParameter('AuthCognitoUserPoolId', {
         type: 'String',
       }).valueAsString;
-      const rootStack = stackManager.rootStack;
+      const scope = stackManager.scope;
       return {
         authorizationType: authType,
         userPoolConfig: {
-          userPool: UserPool.fromUserPoolId(rootStack, 'transformer-user-pool', userPoolId),
+          userPool: UserPool.fromUserPoolId(scope, 'transformer-user-pool', userPoolId),
         },
       };
     case AuthorizationType.IAM:

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -385,13 +385,13 @@ export interface StackManagerProvider {
     // (undocumented)
     getParameter: (name: string) => CfnParameter | void;
     // (undocumented)
-    getStack: (stackName: string) => Stack;
+    getScopeFor: (resourceId: string, defaultStackName?: string) => Construct;
     // (undocumented)
-    getStackFor: (resourceId: string, defaultStackName?: string) => Stack;
+    getStack: (stackName: string) => Stack;
     // (undocumented)
     hasStack: (stackName: string) => boolean;
     // (undocumented)
-    readonly rootStack: Stack;
+    readonly scope: Construct;
 }
 
 // @public (undocumented)
@@ -719,7 +719,7 @@ export interface TransformerResolverProvider {
     // (undocumented)
     addToSlot: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider, dataSource?: DataSourceProvider) => void;
     // (undocumented)
-    mapToStack: (stack: Stack) => void;
+    setScope: (scope: Construct) => void;
     // (undocumented)
     synthesize: (context: TransformerContextProvider, api: GraphQLAPIProvider) => void;
 }
@@ -793,23 +793,23 @@ export type TransformerValidationStepContextProvider = Pick<TransformerContextPr
 // @public (undocumented)
 export interface TransformHostProvider {
     // (undocumented)
-    addAppSyncFunction: (name: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider, dataSourceName: string, stack?: Stack) => AppSyncFunctionConfigurationProvider;
+    addAppSyncFunction: (name: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider, dataSourceName: string, scope?: Construct) => AppSyncFunctionConfigurationProvider;
     // (undocumented)
-    addDynamoDbDataSource(name: string, table: ITable, options?: DynamoDbDataSourceOptions, stack?: Stack): DynamoDbDataSource;
+    addDynamoDbDataSource(name: string, table: ITable, options?: DynamoDbDataSourceOptions, scope?: Construct): DynamoDbDataSource;
     // (undocumented)
-    addHttpDataSource(name: string, endpoint: string, options?: DataSourceOptions, stack?: Stack): HttpDataSource;
+    addHttpDataSource(name: string, endpoint: string, options?: DataSourceOptions, scope?: Construct): HttpDataSource;
     // (undocumented)
-    addLambdaDataSource(name: string, lambdaFunction: IFunction, options?: DataSourceOptions, stack?: Stack): LambdaDataSource;
+    addLambdaDataSource(name: string, lambdaFunction: IFunction, options?: DataSourceOptions, scope?: Construct): LambdaDataSource;
     // (undocumented)
     addLambdaFunction: (functionName: string, functionKey: string, handlerName: string, filePath: string, runtime: Runtime, layers?: ILayerVersion[], role?: IRole, environment?: {
         [key: string]: string;
-    }, timeout?: Duration, stack?: Stack) => IFunction;
+    }, timeout?: Duration, scope?: Construct) => IFunction;
     // (undocumented)
-    addNoneDataSource(name: string, options?: DataSourceOptions, stack?: Stack): NoneDataSource;
+    addNoneDataSource(name: string, options?: DataSourceOptions, scope?: Construct): NoneDataSource;
     // (undocumented)
-    addResolver: (typeName: string, fieldName: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider, resolverLogicalId?: string, dataSourceName?: string, pipelineConfig?: string[], stack?: Stack) => CfnResolver;
+    addResolver: (typeName: string, fieldName: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider, resolverLogicalId?: string, dataSourceName?: string, pipelineConfig?: string[], scope?: Construct) => CfnResolver;
     // (undocumented)
-    addSearchableDataSource(name: string, endpoint: string, region: string, options?: SearchableDataSourceOptions, stack?: Stack): BaseDataSource;
+    addSearchableDataSource(name: string, endpoint: string, region: string, options?: SearchableDataSourceOptions, scope?: Construct): BaseDataSource;
     // (undocumented)
     getDataSource: (name: string) => BaseDataSource | void;
     // (undocumented)

--- a/packages/amplify-graphql-transformer-interfaces/src/transform-host-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transform-host-provider.ts
@@ -1,4 +1,4 @@
-import { Duration, Stack } from 'aws-cdk-lib';
+import { Duration } from 'aws-cdk-lib';
 import {
   BaseDataSource,
   DynamoDbDataSource,
@@ -11,6 +11,7 @@ import { CfnResolver } from 'aws-cdk-lib/aws-appsync';
 import { ITable } from 'aws-cdk-lib/aws-dynamodb';
 import { IFunction, ILayerVersion, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { IRole } from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
 import {
   AppSyncFunctionConfigurationProvider,
   DataSourceOptions,
@@ -28,16 +29,16 @@ export interface DynamoDbDataSourceOptions extends DataSourceOptions {
 export interface TransformHostProvider {
   setAPI(api: GraphqlApiBase): void;
 
-  addHttpDataSource(name: string, endpoint: string, options?: DataSourceOptions, stack?: Stack): HttpDataSource;
-  addDynamoDbDataSource(name: string, table: ITable, options?: DynamoDbDataSourceOptions, stack?: Stack): DynamoDbDataSource;
-  addNoneDataSource(name: string, options?: DataSourceOptions, stack?: Stack): NoneDataSource;
-  addLambdaDataSource(name: string, lambdaFunction: IFunction, options?: DataSourceOptions, stack?: Stack): LambdaDataSource;
+  addHttpDataSource(name: string, endpoint: string, options?: DataSourceOptions, scope?: Construct): HttpDataSource;
+  addDynamoDbDataSource(name: string, table: ITable, options?: DynamoDbDataSourceOptions, scope?: Construct): DynamoDbDataSource;
+  addNoneDataSource(name: string, options?: DataSourceOptions, scope?: Construct): NoneDataSource;
+  addLambdaDataSource(name: string, lambdaFunction: IFunction, options?: DataSourceOptions, scope?: Construct): LambdaDataSource;
   addSearchableDataSource(
     name: string,
     endpoint: string,
     region: string,
     options?: SearchableDataSourceOptions,
-    stack?: Stack,
+    scope?: Construct,
   ): BaseDataSource;
 
   addAppSyncFunction: (
@@ -45,7 +46,7 @@ export interface TransformHostProvider {
     requestMappingTemplate: MappingTemplateProvider,
     responseMappingTemplate: MappingTemplateProvider,
     dataSourceName: string,
-    stack?: Stack,
+    scope?: Construct,
   ) => AppSyncFunctionConfigurationProvider;
 
   addResolver: (
@@ -56,7 +57,7 @@ export interface TransformHostProvider {
     resolverLogicalId?: string,
     dataSourceName?: string,
     pipelineConfig?: string[],
-    stack?: Stack,
+    scope?: Construct,
   ) => CfnResolver;
 
   addLambdaFunction: (
@@ -69,7 +70,7 @@ export interface TransformHostProvider {
     role?: IRole,
     environment?: { [key: string]: string },
     timeout?: Duration,
-    stack?: Stack,
+    scope?: Construct,
   ) => IFunction;
 
   getDataSource: (name: string) => BaseDataSource | void;

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/stack-manager-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/stack-manager-provider.ts
@@ -1,11 +1,12 @@
 import { CfnParameter, CfnParameterProps, Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 
 export interface StackManagerProvider {
-  readonly rootStack: Stack;
+  readonly scope: Construct;
   getStack: (stackName: string) => Stack;
   createStack: (stackName: string) => Stack;
   hasStack: (stackName: string) => boolean;
-  getStackFor: (resourceId: string, defaultStackName?: string) => Stack;
+  getScopeFor: (resourceId: string, defaultStackName?: string) => Construct;
   addParameter: (name: string, props: CfnParameterProps) => CfnParameter;
   getParameter: (name: string) => CfnParameter | void;
 }

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-resolver-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-resolver-provider.ts
@@ -1,4 +1,4 @@
-import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import { GraphQLAPIProvider, MappingTemplateProvider } from '../graphql-api-provider';
 import { DataSourceProvider } from './transformer-datasource-provider';
 import { TransformerContextProvider } from './transformer-context-provider';
@@ -11,7 +11,7 @@ export interface TransformerResolverProvider {
     dataSource?: DataSourceProvider,
   ) => void;
   synthesize: (context: TransformerContextProvider, api: GraphQLAPIProvider) => void;
-  mapToStack: (stack: Stack) => void;
+  setScope: (scope: Construct) => void;
 }
 
 export interface TransformerResolversManagerProvider {


### PR DESCRIPTION
#### Description of changes
This change is a precursor to a refactor of the internal stack manager, where we'll no longer always pass stacks around, but instead could deal w/ arbitrary scopes.

This is to decouple and shrink the changes in a PR such as this https://github.com/aws-amplify/amplify-category-api/pull/1699

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit + E2E Tests

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
