### PR TITLE
fix(api): make id optional if not a string type

### DIFF
--- a/packages/amplify-category-api/amplify-plugin.json
+++ b/packages/amplify-category-api/amplify-plugin.json
@@ -12,7 +12,10 @@
     "rebuild",
     "remove",
     "update",
-    "help"
+    "help",
+    "import",
+    "generate-schema",
+    "update-secrets"
   ],
   "commandAliases": {
     "configure": "update"

--- a/packages/amplify-category-api/src/commands/api.ts
+++ b/packages/amplify-category-api/src/commands/api.ts
@@ -56,6 +56,18 @@ export const run = async (context: $TSContext) => {
       name: 'override',
       description: 'Generates overrides file to apply custom modifications to CloudFormation',
     },
+    {
+      name: 'import',
+      description: 'Imports existing datasource to GraphQL API',
+    },
+    {
+      name: 'generate-schema',
+      description: 'Generates the GraphQL schema from the Data Source',
+    },
+    {
+      name: 'update-secrets',
+      description: 'Updates the API plugin related secrets',
+    },
   ];
 
   context.amplify.showHelp(header, commands);

--- a/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
@@ -1,0 +1,244 @@
+import {
+  addApiWithoutSchema, 
+  amplifyPush, 
+  apiGqlCompile, 
+  createNewProjectDir, 
+  createRDSInstance, 
+  deleteDBInstance, 
+  deleteProject, 
+  deleteProjectDir, 
+  getAppSyncApi, 
+  getProjectMeta, 
+  importRDSDatabase, 
+  initJSProjectWithProfile,
+  updateSchema, 
+} from 'amplify-category-api-e2e-core';
+import { existsSync, readFileSync } from 'fs-extra';
+import generator from 'generate-password';
+import { ObjectTypeDefinitionNode, parse } from 'graphql';
+import gql from 'graphql-tag';
+import path from 'path';
+import { print } from 'graphql';
+import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+const CDK_FUNCTION_TYPE = 'AWS::Lambda::Function';
+const CDK_SUBSCRIPTION_TYPE = 'AWS::SNS::Subscription';
+const APPSYNC_DATA_SOURCE_TYPE = 'AWS::AppSync::DataSource';
+
+const SNS_TOPIC_REGION = 'us-east-1';
+const SNS_TOPIC_ARN = 'arn:aws:sns:us-east-1:582037449441:AmplifyRDSLayerNotification';
+
+describe("RDS Tests", () => {
+  const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
+  
+  // Generate settings for RDS instance
+  const username = db_user;
+  const password = db_password;
+  let port = 3306;
+  let region = 'us-east-1';
+  const database = 'default_db';
+  let host = 'localhost';
+  const identifier = `integtest${db_identifier}`;
+  const projName = 'rdsimportapi';
+  let projRoot;
+
+  beforeAll(async () => {
+  });
+
+  afterAll(async () => {
+    await cleanupDatabase();
+  });
+
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir('rdsimportapi');
+  });
+
+  afterEach(async () => {
+    const metaFilePath = path.join(projRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
+    if (existsSync(metaFilePath)) {
+      await deleteProject(projRoot);
+    }
+    deleteProjectDir(projRoot);
+  });
+
+  const setupDatabase = async () => {
+    const db = await createRDSInstance({
+      identifier,
+      engine: 'mysql',
+      dbname: database,
+      username,
+      password,
+      region,
+      publiclyAccessible: false,
+    });
+    port = db.port;
+    host = db.endpoint;
+  };
+
+  const cleanupDatabase = async () => {
+    await deleteDBInstance(identifier, region);
+  };
+
+  it("import workflow of mysql relational database within vpc with no public access", async () => {
+    const apiName = 'rdsapivpc';
+    await initJSProjectWithProfile(projRoot, {
+      disableAmplifyAppCreation: false,
+      name: projName,
+    });
+    
+    const metaAfterInit = getProjectMeta(projRoot);
+    region = metaAfterInit.providers.awscloudformation.Region;
+    await setupDatabase();
+  
+    const rdsSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.rds.graphql');
+
+    await addApiWithoutSchema(projRoot, { transformerVersion: 2, apiName });
+    
+    // This only verifies the prompt for VPC access. Does not verify the actual import.
+    await importRDSDatabase(projRoot, {
+      database: 'mysql', // Import the default 'mysql' database
+      host,
+      port,
+      username,
+      password,
+      useVpc: true,
+      apiExists: true,
+    });
+
+    const schemaContent = readFileSync(rdsSchemaFilePath, 'utf8');
+    const schema = parse(schemaContent);
+
+    // Generated schema should contain the types with model directive
+    // db is one of the default table in mysql database
+    const dbObjectType = schema.definitions.find(d => d.kind === 'ObjectTypeDefinition' && d.name.value === 'db') as ObjectTypeDefinitionNode;
+    expect(dbObjectType).toBeDefined();
+    expect(dbObjectType.directives.find(d => d.name.value === 'model')).toBeDefined();
+
+    const updatedSchema = gql`
+      input AMPLIFY {
+        engine: String = "mysql"
+        globalAuthRule: AuthRule = {allow: public}
+      }
+
+      type component @model {
+        component_id: Int! @primaryKey
+        component_group_id: Int!
+        component_urn: String!
+      }
+    `;
+    updateSchema(projRoot, apiName, print(updatedSchema), 'schema.rds.graphql');
+    await apiGqlCompile(projRoot);
+
+    // Validate the generated resources in the CloudFormation template
+    const apisDirectory = path.join(projRoot, 'amplify', 'backend', 'api');
+    const apiDirectory = path.join(apisDirectory, apiName);
+    const cfnRDSTemplateFile = path.join(apiDirectory, 'build', 'stacks', `RdsApiStack.json`);
+    const cfnTemplate = JSON.parse(readFileSync(cfnRDSTemplateFile, 'utf8'));
+    expect(cfnTemplate.Resources).toBeDefined();
+    const resources = cfnTemplate.Resources;
+
+    // Validate if the SQL lambda function has VPC configuration
+    const rdsLambdaFunction = getResource(resources, 'RDSLambdaLogicalID', CDK_FUNCTION_TYPE);
+    expect(rdsLambdaFunction).toBeDefined();
+    expect(rdsLambdaFunction.Properties).toBeDefined();
+    expect(rdsLambdaFunction.Properties.VpcConfig).toBeDefined();
+    expect(rdsLambdaFunction.Properties.VpcConfig.SubnetIds).toBeDefined();
+    expect(rdsLambdaFunction.Properties.VpcConfig.SubnetIds.length).toBeGreaterThan(0);
+    expect(rdsLambdaFunction.Properties.VpcConfig.SecurityGroupIds).toBeDefined();
+    expect(rdsLambdaFunction.Properties.VpcConfig.SecurityGroupIds.length).toBeGreaterThan(0);
+
+    // Validate patching lambda and subscription
+    const rdsPatchingLambdaFunction = getResource(resources, 'RDSPatchingLambdaLogicalID', CDK_FUNCTION_TYPE);
+    expect(rdsPatchingLambdaFunction).toBeDefined();
+    expect(rdsPatchingLambdaFunction.Properties).toBeDefined();
+    expect(rdsPatchingLambdaFunction.Properties.Environment).toBeDefined();
+    expect(rdsPatchingLambdaFunction.Properties.Environment.Variables).toBeDefined();
+    expect(rdsPatchingLambdaFunction.Properties.Environment.Variables.LAMBDA_FUNCTION_ARN).toBeDefined();
+    const rdsDataSourceLambda = getResource(resources, 'RDSLambdaDataSource', APPSYNC_DATA_SOURCE_TYPE);
+    expect(rdsPatchingLambdaFunction.Properties.Environment.Variables.LAMBDA_FUNCTION_ARN).toEqual(rdsDataSourceLambda.Properties.LambdaConfig.LambdaFunctionArn);
+
+    // Validate subscription
+    const rdsPatchingSubscription = getResource(resources, 'RDSPatchingLambdaLogicalID', CDK_SUBSCRIPTION_TYPE);
+    expect(rdsPatchingSubscription).toBeDefined();
+    expect(rdsPatchingSubscription.Properties).toBeDefined();
+    expect(rdsPatchingSubscription.Properties.Protocol).toBeDefined();
+    expect(rdsPatchingSubscription.Properties.Protocol).toEqual('lambda');
+    expect(rdsPatchingSubscription.Properties.Endpoint).toBeDefined();
+    expect(rdsPatchingSubscription.Properties.TopicArn).toBeDefined();
+    expect(rdsPatchingSubscription.Properties.TopicArn).toEqual(SNS_TOPIC_ARN);
+    expect(rdsPatchingSubscription.Properties.Region).toEqual(SNS_TOPIC_REGION);
+    expect(rdsPatchingSubscription.Properties.FilterPolicy).toBeDefined();
+    expect(rdsPatchingSubscription.Properties.FilterPolicy.Region).toBeDefined();
+
+    await amplifyPush(projRoot);
+
+    // Get the AppSync API details after deployment
+    const meta = getProjectMeta(projRoot);
+    const { output } = meta.api.rdsapivpc;
+    const { GraphQLAPIIdOutput, GraphQLAPIEndpointOutput, GraphQLAPIKeyOutput } = output;
+    const { graphqlApi } = await getAppSyncApi(GraphQLAPIIdOutput, region);
+
+    expect(GraphQLAPIIdOutput).toBeDefined();
+    expect(GraphQLAPIEndpointOutput).toBeDefined();
+    expect(GraphQLAPIKeyOutput).toBeDefined();
+
+    expect(graphqlApi).toBeDefined();
+    expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
+
+    const apiEndPoint = GraphQLAPIEndpointOutput as string;
+    const apiKey = GraphQLAPIKeyOutput as string;
+
+    const appSyncClient = new AWSAppSyncClient({
+      url: apiEndPoint,
+      region,
+      disableOffline: true,
+      auth: {
+        type: AUTH_TYPE.API_KEY,
+        apiKey,
+      },
+    });
+
+    // VPC will not have VPC endpoints for SSM defined and the security group's inbound rule for port 443 is not defined.
+    // Expect the listComponents query to fail with an error.
+    expect(appSyncClient).toBeDefined();
+    try {
+      await listComponents(appSyncClient);
+      throw new Error('Expected listComponents to fail.');
+    } catch (err) {
+      expect(err.message).toEqual('GraphQL error: Unable to get the database credentials. Check the logs for more details.');
+    }
+  });
+}); 
+
+const getResource = (resources: Map<string, any>, resourcePrefix: string, resourceType: string): any => {
+  const keys = Array.from(Object.keys(resources)).filter(key => key.startsWith(resourcePrefix));
+  for (const key of keys) {
+    const resource = resources[key];
+    if (resource.Type === resourceType) {
+      return resource;
+    }
+  }
+};
+
+const listComponents = async (client) => {
+  const listComponents = /* GraphQL */ `
+      query listComponents {
+        listComponents {
+          items {
+            component_group_id
+            component_id
+            component_urn
+          }
+        }
+      }
+    `;
+  const listResult: any = await client.query({
+    query: gql(listComponents),
+    fetchPolicy: 'no-cache',
+  });
+
+  return listResult;
+};

--- a/packages/amplify-e2e-tests/src/__tests__/rds-model-v2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-model-v2.test.ts
@@ -1,0 +1,578 @@
+import {
+  RDSTestDataProvider, 
+  addApiWithoutSchema, 
+  addRDSPortInboundRule, 
+  amplifyPush, 
+  createNewProjectDir, 
+  createRDSInstance, 
+  deleteDBInstance, 
+  deleteProject, 
+  deleteProjectDir, 
+  getAppSyncApi, 
+  getProjectMeta, 
+  importRDSDatabase, 
+  initJSProjectWithProfile, 
+  removeRDSPortInboundRule, 
+} from 'amplify-category-api-e2e-core';
+import axios from 'axios';
+import { existsSync, readFileSync } from 'fs-extra';
+import generator from 'generate-password';
+import { ObjectTypeDefinitionNode, parse } from 'graphql';
+import path from 'path';
+import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
+import gql from 'graphql-tag';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+describe("RDS Model Directive", () => {
+  const publicIpCidr = "0.0.0.0/0";
+  const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
+  
+  // Generate settings for RDS instance
+  const username = db_user;
+  const password = db_password;
+  const region = 'us-east-1';
+  let port = 3306;
+  const database = 'default_db';
+  let host = 'localhost';
+  const identifier = `integtest${db_identifier}`;
+  const projName = 'rdsmodelapitest';
+
+  let projRoot;
+  let appSyncClient;
+
+  beforeAll(async () => {
+    projRoot = await createNewProjectDir('rdsmodelapi');
+    await setupDatabase();
+    await initProjectAndImportSchema();
+    await amplifyPush(projRoot);
+
+    const meta = getProjectMeta(projRoot);
+    const region = meta.providers.awscloudformation.Region;
+    const { output } = meta.api.rdsapi;
+    const { GraphQLAPIIdOutput, GraphQLAPIEndpointOutput, GraphQLAPIKeyOutput } = output;
+    const { graphqlApi } = await getAppSyncApi(GraphQLAPIIdOutput, region);
+
+    expect(GraphQLAPIIdOutput).toBeDefined();
+    expect(GraphQLAPIEndpointOutput).toBeDefined();
+    expect(GraphQLAPIKeyOutput).toBeDefined();
+
+    expect(graphqlApi).toBeDefined();
+    expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
+
+    const apiEndPoint = GraphQLAPIEndpointOutput as string;
+    const apiKey = GraphQLAPIKeyOutput as string;
+
+    appSyncClient = new AWSAppSyncClient({
+      url: apiEndPoint,
+      region,
+      disableOffline: true,
+      auth: {
+        type: AUTH_TYPE.API_KEY,
+        apiKey,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    const metaFilePath = path.join(projRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
+    if (existsSync(metaFilePath)) {
+      await deleteProject(projRoot);
+    }
+    deleteProjectDir(projRoot);
+    await cleanupDatabase();
+  });
+
+  beforeEach(async () => {
+  });
+
+  afterEach(async () => {
+  });
+
+  const setupDatabase = async () => {
+    // This test performs the below
+    // 1. Create a RDS Instance
+    // 2. Add the external IP address of the current machine to security group inbound rule to allow public access
+    // 3. Connect to the database and execute DDL
+
+    const db = await createRDSInstance({
+      identifier,
+      engine: 'mysql',
+      dbname: database,
+      username,
+      password,
+      region,
+    });
+    port = db.port;
+    host = db.endpoint;
+    await addRDSPortInboundRule({
+      region,
+      port: db.port,
+      cidrIp: publicIpCidr,
+    });
+
+    const dbAdapter = new RDSTestDataProvider({
+      host: db.endpoint,
+      port: db.port,
+      username,
+      password,
+      database: db.dbName,
+    });
+
+    await dbAdapter.runQuery([
+      "CREATE TABLE Contact (id VARCHAR(40) PRIMARY KEY, FirstName VARCHAR(20), LastName VARCHAR(50))",
+      "CREATE TABLE Person (personId INT PRIMARY KEY, FirstName VARCHAR(20), LastName VARCHAR(50))",
+      "CREATE TABLE Employee (ID INT PRIMARY KEY, FirstName VARCHAR(20), LastName VARCHAR(50))",
+      "CREATE TABLE Student (studentId INT NOT NULL, classId CHAR(1) NOT NULL, FirstName VARCHAR(20), LastName VARCHAR(50), PRIMARY KEY (studentId, classId))",
+    ]);
+    dbAdapter.cleanup();
+  };
+
+  const cleanupDatabase = async () => {
+    // 1. Remove the IP address from the security group
+    // 2. Delete the RDS instance
+    await removeRDSPortInboundRule({
+      region,
+      port: port,
+      cidrIp: publicIpCidr,
+    });
+    await deleteDBInstance(identifier, region);
+  };
+
+  const initProjectAndImportSchema = async () => {
+    const apiName = 'rdsapi';
+    await initJSProjectWithProfile(projRoot, {
+      disableAmplifyAppCreation: false,
+      name: projName,
+    });
+    const rdsSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.rds.graphql');
+
+    await addApiWithoutSchema(projRoot, { transformerVersion: 2, apiName });
+    
+    await importRDSDatabase(projRoot, {
+      database,
+      host,
+      port,
+      username,
+      password,
+      useVpc: false,
+      apiExists: true,
+    });
+
+    const schemaContent = readFileSync(rdsSchemaFilePath, 'utf8');
+    const schema = parse(schemaContent);
+
+    // Generated schema should contains the types and fields from the database
+    const contactObjectType = schema.definitions.find(d => d.kind === 'ObjectTypeDefinition' && d.name.value === 'Contact') as ObjectTypeDefinitionNode;
+    const personObjectType = schema.definitions.find(d => d.kind === 'ObjectTypeDefinition' && d.name.value === 'Person');
+    const employeeObjectType = schema.definitions.find(d => d.kind === 'ObjectTypeDefinition' && d.name.value === 'Employee');
+
+    expect(contactObjectType).toBeDefined();
+    expect(personObjectType).toBeDefined();
+    expect(employeeObjectType).toBeDefined();
+
+    // Verify the fields in the generated schema on type 'Contacts'
+    const contactsIdFieldType = contactObjectType.fields.find(f => f.name.value === 'id');
+    const contactsFirstNameFieldType = contactObjectType.fields.find(f => f.name.value === 'FirstName');
+    const contactsLastNameFieldType = contactObjectType.fields.find(f => f.name.value === 'LastName');
+
+    expect(contactsIdFieldType).toBeDefined();
+    expect(contactsFirstNameFieldType).toBeDefined();
+    expect(contactsLastNameFieldType).toBeDefined();
+
+    // PrimaryKey directive must be defined on Id field.
+    expect(contactsIdFieldType.directives.find(d => d.name.value === 'primaryKey')).toBeDefined();
+  };
+
+  test('check CRUDL on contact table with default primary key', async () => {
+    const contact1 = await createContact('David', 'Smith');
+    const contact2 = await createContact('Chris', 'Sundersingh');
+
+    expect(contact1.data.createContact.id).toBeDefined();
+    expect(contact1.data.createContact.FirstName).toEqual('David');
+    expect(contact1.data.createContact.LastName).toEqual('Smith');
+
+    expect(contact2.data.createContact.id).toBeDefined();
+    expect(contact2.data.createContact.FirstName).toEqual('Chris');
+    expect(contact2.data.createContact.LastName).toEqual('Sundersingh');
+
+    const getContact1 = await getContact(contact1.data.createContact.id);
+    expect(getContact1.data.getContact.id).toEqual(contact1.data.createContact.id);
+    expect(getContact1.data.getContact.FirstName).toEqual('David');
+    expect(getContact1.data.getContact.LastName).toEqual('Smith');
+
+    const contact1Updated = await updateContact(contact1.data.createContact.id, 'David', 'Jones');
+    expect(contact1Updated.data.updateContact.id).toEqual(contact1.data.createContact.id);
+    expect(contact1Updated.data.updateContact.FirstName).toEqual('David');
+    expect(contact1Updated.data.updateContact.LastName).toEqual('Jones');
+
+    const getContact1Updated = await getContact(contact1.data.createContact.id);
+    expect(getContact1Updated.data.getContact.id).toEqual(contact1.data.createContact.id);
+    expect(getContact1Updated.data.getContact.FirstName).toEqual('David');
+    expect(getContact1Updated.data.getContact.LastName).toEqual('Jones');
+
+    const listContactsResult = await listContacts();
+    expect(listContactsResult.data.listContacts.items.length).toEqual(2);
+    expect(listContactsResult.data.listContacts.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: contact1.data.createContact.id, FirstName: 'David', LastName: 'Jones' }),
+      expect.objectContaining({ id: contact2.data.createContact.id, FirstName: 'Chris', LastName: 'Sundersingh' }),
+    ]));
+
+    const deleteContact1 = await deleteContact(contact1.data.createContact.id);
+    expect(deleteContact1.data.deleteContact.id).toEqual(contact1.data.createContact.id);
+    expect(deleteContact1.data.deleteContact.FirstName).toEqual('David');
+    expect(deleteContact1.data.deleteContact.LastName).toEqual('Jones');
+
+    const listContactsResultAfterDelete = await listContacts();
+    expect(listContactsResultAfterDelete.data.listContacts.items.length).toEqual(1);
+    expect(listContactsResultAfterDelete.data.listContacts.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: contact2.data.createContact.id, FirstName: 'Chris', LastName: 'Sundersingh' }),
+    ]));
+  });
+
+  test('check CRUDL, filter, limit and nextToken on student table with composite key', async () => {
+    const student1A = await createStudent(1, 'A', 'David', 'Smith');
+    const student1B = await createStudent(1, 'B', 'Chris', 'Sundersingh');
+    const student2A = await createStudent(2, 'A', 'John', 'Doe');
+    const student2B = await createStudent(2, 'B', 'Jane', 'Doe');
+
+    expect(student1A.data.createStudent.studentId).toEqual(1);
+    expect(student1A.data.createStudent.classId).toEqual('A');
+    expect(student1A.data.createStudent.FirstName).toEqual('David');
+    expect(student1A.data.createStudent.LastName).toEqual('Smith');
+
+    expect(student1B.data.createStudent.studentId).toEqual(1);
+    expect(student1B.data.createStudent.classId).toEqual('B');
+    expect(student1B.data.createStudent.FirstName).toEqual('Chris');
+    expect(student1B.data.createStudent.LastName).toEqual('Sundersingh');
+
+    expect(student2A.data.createStudent.studentId).toEqual(2);
+    expect(student2A.data.createStudent.classId).toEqual('A');
+    expect(student2A.data.createStudent.FirstName).toEqual('John');
+    expect(student2A.data.createStudent.LastName).toEqual('Doe');
+
+    expect(student2B.data.createStudent.studentId).toEqual(2);
+    expect(student2B.data.createStudent.classId).toEqual('B');
+    expect(student2B.data.createStudent.FirstName).toEqual('Jane');
+    expect(student2B.data.createStudent.LastName).toEqual('Doe');
+
+    const student1AUpdated = await updateStudent(1, 'A', 'David', 'Jones');
+    const student2AUpdated = await updateStudent(2, 'A', 'John', 'Smith');
+
+    expect(student1AUpdated.data.updateStudent.studentId).toEqual(1);
+    expect(student1AUpdated.data.updateStudent.classId).toEqual('A');
+    expect(student1AUpdated.data.updateStudent.FirstName).toEqual('David');
+    expect(student1AUpdated.data.updateStudent.LastName).toEqual('Jones');
+
+    expect(student2AUpdated.data.updateStudent.studentId).toEqual(2);
+    expect(student2AUpdated.data.updateStudent.classId).toEqual('A');
+    expect(student2AUpdated.data.updateStudent.FirstName).toEqual('John');
+    expect(student2AUpdated.data.updateStudent.LastName).toEqual('Smith');
+
+    const student1ADeleted = await deleteStudent(1, 'A');
+
+    expect(student1ADeleted.data.deleteStudent.studentId).toEqual(1);
+    expect(student1ADeleted.data.deleteStudent.classId).toEqual('A');
+    expect(student1ADeleted.data.deleteStudent.FirstName).toEqual('David');
+    expect(student1ADeleted.data.deleteStudent.LastName).toEqual('Jones');
+
+    const getStudent1B = await getStudent(1, 'B');
+
+    expect(getStudent1B.data.getStudent.studentId).toEqual(1);
+    expect(getStudent1B.data.getStudent.classId).toEqual('B');
+    expect(getStudent1B.data.getStudent.FirstName).toEqual('Chris');
+    expect(getStudent1B.data.getStudent.LastName).toEqual('Sundersingh');
+
+    const listStudentsResult = await listStudents();
+    expect(listStudentsResult.data.listStudents.items.length).toEqual(3);
+    expect(listStudentsResult.data.listStudents.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ studentId: 1, classId: 'B', FirstName: 'Chris', LastName: 'Sundersingh' }),
+      expect.objectContaining({ studentId: 2, classId: 'A', FirstName: 'John', LastName: 'Smith' }),
+      expect.objectContaining({ studentId: 2, classId: 'B', FirstName: 'Jane', LastName: 'Doe' }),
+    ]));
+
+    // Validate limit and nextToken
+    const listStudentsResultWithLimit = await listStudents(2);
+    expect(listStudentsResultWithLimit.data.listStudents.items.length).toEqual(2);
+    expect(listStudentsResultWithLimit.data.listStudents.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ studentId: 1, classId: 'B', FirstName: 'Chris', LastName: 'Sundersingh' }),
+      expect.objectContaining({ studentId: 2, classId: 'A', FirstName: 'John', LastName: 'Smith' }),
+    ]));
+    expect(listStudentsResultWithLimit.data.listStudents.nextToken).toBeDefined();
+
+    const listStudentsResultWithNextToken = await listStudents(2, listStudentsResultWithLimit.data.listStudents.nextToken);
+    expect(listStudentsResultWithNextToken.data.listStudents.items.length).toEqual(1);
+    expect(listStudentsResultWithNextToken.data.listStudents.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ studentId: 2, classId: 'B', FirstName: 'Jane', LastName: 'Doe' }),
+    ]));
+    expect(listStudentsResultWithNextToken.data.listStudents.nextToken).toBeNull();
+
+    // Validate filter
+    const listStudentsResultWithFilter = await listStudents(10, null, { and: [{ FirstName: { eq: 'John' } }, { LastName: { eq: 'Smith' } }] });
+    expect(listStudentsResultWithFilter.data.listStudents.items.length).toEqual(1);
+    expect(listStudentsResultWithFilter.data.listStudents.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ studentId: 2, classId: 'A', FirstName: 'John', LastName: 'Smith' }),
+    ]));
+    expect(listStudentsResultWithFilter.data.listStudents.nextToken).toBeNull();
+
+    const listStudentsResultWithFilter2 = await listStudents(10, null, { FirstName: { size: { eq: 4 } } });
+    expect(listStudentsResultWithFilter2.data.listStudents.items.length).toEqual(2);
+    expect(listStudentsResultWithFilter2.data.listStudents.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ studentId: 2, classId: 'A', FirstName: 'John', LastName: 'Smith' }),
+      expect.objectContaining({ studentId: 2, classId: 'A', FirstName: 'John', LastName: 'Smith' }),
+    ]));
+  });
+
+  // CURDL on Contact table helpers
+  const createContact = async (firstName: string, lastName: string) => {
+    const createMutation = /* GraphQL */ `
+        mutation CreateContact($input: CreateContactInput!, $condition: ModelContactConditionInput) {
+          createContact(input: $input, condition: $condition) {
+            id
+            FirstName
+            LastName
+          }
+        }
+      `;
+    const createInput = {
+      input: {
+        FirstName: firstName,
+        LastName: lastName,
+      },
+    };
+    const createResult: any = await appSyncClient.mutate({
+      mutation: gql(createMutation),
+      fetchPolicy: 'no-cache',
+      variables: createInput,
+    });
+
+    return createResult;
+  };
+
+  const updateContact = async (id: string, firstName: string, lastName: string) => {
+    const updateMutation = /* GraphQL */ `
+        mutation UpdateContact($input: UpdateContactInput!, $condition: ModelContactConditionInput) {
+          updateContact(input: $input, condition: $condition) {
+            id
+            FirstName
+            LastName
+          }
+        }
+      `;
+    const updateInput = {
+      input: {
+        id,
+        FirstName: firstName,
+        LastName: lastName,
+      },
+    };
+    const updateResult: any = await appSyncClient.mutate({
+      mutation: gql(updateMutation),
+      fetchPolicy: 'no-cache',
+      variables: updateInput,
+    });
+
+    return updateResult;
+  };
+
+  const deleteContact = async (id: string) => {
+    const deleteMutation = /* GraphQL */ `
+        mutation DeleteContact($input: DeleteContactInput!, $condition: ModelContactConditionInput) {
+          deleteContact(input: $input, condition: $condition) {
+            id
+            FirstName
+            LastName
+          }
+        }
+      `;
+    const deleteInput = {
+      input: {
+        id,
+      },
+    };
+    const deleteResult: any = await appSyncClient.mutate({
+      mutation: gql(deleteMutation),
+      fetchPolicy: 'no-cache',
+      variables: deleteInput,
+    });
+
+    return deleteResult;
+  };
+
+  const getContact = async (id: string) => {
+    const getQuery = /* GraphQL */ `
+        query GetContact($id: String!) {
+          getContact(id: $id) {
+            id
+            FirstName
+            LastName
+          }
+        }
+      `;
+    const getInput = {
+      id,
+    };
+    const getResult: any = await appSyncClient.query({
+      query: gql(getQuery),
+      fetchPolicy: 'no-cache',
+      variables: getInput,
+    });
+
+    return getResult;
+  };
+
+  const listContacts = async () => {
+    const listQuery = /* GraphQL */ `
+        query ListContact {
+          listContacts {
+            items {
+              id
+              FirstName
+              LastName
+            }
+          }
+        }
+      `;
+    const listResult: any = await appSyncClient.query({
+      query: gql(listQuery),
+      fetchPolicy: 'no-cache',
+    });
+
+    return listResult;
+  };
+
+  // CURDL on Student table helpers
+  const createStudent = async (studentId: number, classId: string, firstName: string, lastName: string) => {
+    const createMutation = /* GraphQL */ `
+        mutation CreateStuden($input: CreateStudentInput!, $condition: ModelStudentConditionInput) {
+          createStudent(input: $input, condition: $condition) {
+            studentId
+            classId
+            FirstName
+            LastName
+          }
+        }
+      `;
+    const createInput = {
+      input: {
+        studentId,
+        classId,
+        FirstName: firstName,
+        LastName: lastName,
+      },
+    };
+    const createResult: any = await appSyncClient.mutate({
+      mutation: gql(createMutation),
+      fetchPolicy: 'no-cache',
+      variables: createInput,
+    });
+
+    return createResult;
+  };
+
+  const updateStudent = async (studentId: number, classId: string, firstName: string, lastName: string) => {
+    const updateMutation = /* GraphQL */ `
+        mutation UpdateStudent($input: UpdateStudentInput!, $condition: ModelStudentConditionInput) {
+          updateStudent(input: $input, condition: $condition) {
+            studentId,
+            classId,
+            FirstName
+            LastName
+          }
+        }
+      `;
+    const updateInput = {
+      input: {
+        studentId,
+        classId,
+        FirstName: firstName,
+        LastName: lastName,
+      },
+    };
+    const updateResult: any = await appSyncClient.mutate({
+      mutation: gql(updateMutation),
+      fetchPolicy: 'no-cache',
+      variables: updateInput,
+    });
+
+    return updateResult;
+  };
+
+  const deleteStudent = async (studentId: number, classId: string) => {
+    const deleteMutation = /* GraphQL */ `
+        mutation DeleteStudent($input: DeleteStudentInput!, $condition: ModelStudentConditionInput) {
+          deleteStudent(input: $input, condition: $condition) {
+            studentId
+            classId
+            FirstName
+            LastName
+          }
+        }
+      `;
+    const deleteInput = {
+      input: {
+        studentId,
+        classId,
+      },
+    };
+    const deleteResult: any = await appSyncClient.mutate({
+      mutation: gql(deleteMutation),
+      fetchPolicy: 'no-cache',
+      variables: deleteInput,
+    });
+
+    return deleteResult;
+  };
+
+  const getStudent = async (studentId: number, classId: string) => {
+    const getQuery = /* GraphQL */ `
+        query GetStudent($studentId: Int!, $classId: String!) {
+          getStudent(studentId: $studentId, classId: $classId) {
+            studentId
+            classId
+            FirstName
+            LastName
+          }
+        }
+      `;
+    const getInput = {
+      studentId,
+      classId,
+    };
+    const getResult: any = await appSyncClient.query({
+      query: gql(getQuery),
+      fetchPolicy: 'no-cache',
+      variables: getInput,
+    });
+
+    return getResult;
+  };
+
+  const listStudents = async (limit: number = 100, nextToken: string | null = null, filter: any = null) => {
+    const listQuery = /* GraphQL */ `
+        query ListStudents($limit: Int, $nextToken: String, $filter: ModelStudentFilterInput) {
+          listStudents(limit: $limit, nextToken: $nextToken, filter: $filter) {
+            items {
+              studentId
+              classId
+              FirstName
+              LastName
+            }
+            nextToken
+          }
+        }
+      `;
+    const listResult: any = await appSyncClient.query({
+      query: gql(listQuery),
+      fetchPolicy: 'no-cache',
+      variables: {
+        limit,
+        nextToken,
+        filter,
+      },
+    });
+
+    return listResult;
+  };
+}); 

--- a/packages/amplify-e2e-tests/src/__tests__/rds-v2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-v2.test.ts
@@ -1,0 +1,217 @@
+import {
+  RDSTestDataProvider, 
+  addApiWithoutSchema, 
+  addRDSPortInboundRule, 
+  createNewProjectDir, 
+  createRDSInstance, 
+  deleteDBInstance, 
+  deleteProject, 
+  deleteProjectDir, 
+  importRDSDatabase, 
+  initJSProjectWithProfile, 
+  removeRDSPortInboundRule, 
+} from 'amplify-category-api-e2e-core';
+import axios from 'axios';
+import { existsSync, readFileSync } from 'fs-extra';
+import generator from 'generate-password';
+import { ObjectTypeDefinitionNode, parse } from 'graphql';
+import path from 'path';
+
+describe("RDS Tests", () => {
+  let publicIpCidr = "0.0.0.0/0";
+  const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
+  const RDS_MAPPING_FILE = 'https://amplify-rds-layer-resources.s3.amazonaws.com/rds-layer-mapping.json';
+
+  // Generate settings for RDS instance
+  const username = db_user;
+  const password = db_password;
+  const region = 'us-east-1';
+  let port = 3306;
+  const database = 'default_db';
+  let host = 'localhost';
+  const identifier = `integtest${db_identifier}`;
+
+  let projRoot;
+
+  beforeAll(async () => {
+    // Get the public IP of the machine running the test
+    const url = "http://api.ipify.org/";
+    const response = await axios(url);
+    publicIpCidr = `${response.data.trim()}/32`;
+    await setupDatabase();
+  });
+
+  afterAll(async () => {
+    await cleanupDatabase();
+  });
+
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir('rdsimportapi');
+  });
+
+  afterEach(async () => {
+    const metaFilePath = path.join(projRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
+    if (existsSync(metaFilePath)) {
+      await deleteProject(projRoot);
+    }
+    deleteProjectDir(projRoot);
+  });
+
+  const setupDatabase = async () => {
+    // This test performs the below
+    // 1. Create a RDS Instance
+    // 2. Add the external IP address of the current machine to security group inbound rule to allow public access
+    // 3. Connect to the database and execute DDL
+
+    const db = await createRDSInstance({
+      identifier,
+      engine: 'mysql',
+      dbname: database,
+      username,
+      password,
+      region,
+    });
+    port = db.port;
+    host = db.endpoint;
+    await addRDSPortInboundRule({
+      region,
+      port: db.port,
+      cidrIp: publicIpCidr,
+    });
+
+    const dbAdapter = new RDSTestDataProvider({
+      host: db.endpoint,
+      port: db.port,
+      username,
+      password,
+      database: db.dbName,
+    });
+    await dbAdapter.runQuery([
+      "CREATE TABLE Contacts (ID INT PRIMARY KEY, FirstName VARCHAR(20), LastName VARCHAR(50))",
+      "CREATE TABLE Person (ID INT PRIMARY KEY, FirstName VARCHAR(20), LastName VARCHAR(50))",
+      "CREATE TABLE Employee (ID INT PRIMARY KEY, FirstName VARCHAR(20), LastName VARCHAR(50))",
+    ]);
+    dbAdapter.cleanup();
+  };
+
+  const cleanupDatabase = async () => {
+    // 1. Remove the IP address from the security group
+    // 2. Delete the RDS instance
+    await removeRDSPortInboundRule({
+      region,
+      port: port,
+      cidrIp: publicIpCidr,
+    });
+    await deleteDBInstance(identifier, region);
+  };
+
+  it("import workflow of mysql relational database with public access", async () => {
+    const apiName = 'rdsapi';
+    await initJSProjectWithProfile(projRoot, {
+      disableAmplifyAppCreation: false,
+    });
+    const rdsSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.rds.graphql');
+
+    await addApiWithoutSchema(projRoot, { transformerVersion: 2, apiName });
+    
+    await importRDSDatabase(projRoot, {
+      database,
+      host,
+      port,
+      username,
+      password,
+      useVpc: false,
+      apiExists: true,
+    });
+
+    const schemaContent = readFileSync(rdsSchemaFilePath, 'utf8');
+    const schema = parse(schemaContent);
+
+    // Generated schema should contains the types and fields from the database
+    const contactsObjectType = schema.definitions.find(d => d.kind === 'ObjectTypeDefinition' && d.name.value === 'Contacts') as ObjectTypeDefinitionNode;
+    const personObjectType = schema.definitions.find(d => d.kind === 'ObjectTypeDefinition' && d.name.value === 'Person');
+    const employeeObjectType = schema.definitions.find(d => d.kind === 'ObjectTypeDefinition' && d.name.value === 'Employee');
+
+    expect(contactsObjectType).toBeDefined();
+    expect(personObjectType).toBeDefined();
+    expect(employeeObjectType).toBeDefined();
+
+    // Verify the fields in the generated schema on type 'Contacts'
+    const contactsIdFieldType = contactsObjectType.fields.find(f => f.name.value === 'ID');
+    const contactsFirstNameFieldType = contactsObjectType.fields.find(f => f.name.value === 'FirstName');
+    const contactsLastNameFieldType = contactsObjectType.fields.find(f => f.name.value === 'LastName');
+
+    expect(contactsIdFieldType).toBeDefined();
+    expect(contactsFirstNameFieldType).toBeDefined();
+    expect(contactsLastNameFieldType).toBeDefined();
+
+    // PrimaryKey directive must be defined on Id field.
+    expect(contactsIdFieldType.directives.find(d => d.name.value === 'primaryKey')).toBeDefined();
+  });
+
+  // This test must be updated if the rds layer mapping file is updated
+  test("check the rds layer mapping file on the service account is available", async () => {
+    const rdsMappingFile = await axios.get(RDS_MAPPING_FILE);
+    expect(rdsMappingFile).toBeDefined();
+    expect(rdsMappingFile.data).toBeDefined();
+    expect(rdsMappingFile.data).toMatchObject({
+      "ap-northeast-1": {
+        "layerRegion": "arn:aws:lambda:ap-northeast-1:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "us-east-1": {
+        "layerRegion": "arn:aws:lambda:us-east-1:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "ap-southeast-1": {
+        "layerRegion": "arn:aws:lambda:ap-southeast-1:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "eu-west-1": {
+        "layerRegion": "arn:aws:lambda:eu-west-1:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "us-west-1": {
+        "layerRegion": "arn:aws:lambda:us-west-1:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "ap-east-1": {
+        "layerRegion": "arn:aws:lambda:ap-east-1:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "ap-northeast-2": {
+        "layerRegion": "arn:aws:lambda:ap-northeast-2:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "ap-northeast-3": {
+        "layerRegion": "arn:aws:lambda:ap-northeast-3:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "ap-south-1": {
+        "layerRegion": "arn:aws:lambda:ap-south-1:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "ap-southeast-2": {
+        "layerRegion": "arn:aws:lambda:ap-southeast-2:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "ca-central-1": {
+        "layerRegion": "arn:aws:lambda:ca-central-1:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "eu-central-1": {
+        "layerRegion": "arn:aws:lambda:eu-central-1:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "eu-north-1": {
+        "layerRegion": "arn:aws:lambda:eu-north-1:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "eu-west-2": {
+        "layerRegion": "arn:aws:lambda:eu-west-2:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "eu-west-3": {
+        "layerRegion": "arn:aws:lambda:eu-west-3:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "sa-east-1": {
+        "layerRegion": "arn:aws:lambda:sa-east-1:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "us-east-2": {
+        "layerRegion": "arn:aws:lambda:us-east-2:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "us-west-2": {
+        "layerRegion": "arn:aws:lambda:us-west-2:582037449441:layer:AmplifyRDSLayer:5"
+      },
+      "me-south-1": {
+        "layerRegion": "arn:aws:lambda:me-south-1:582037449441:layer:AmplifyRDSLayer:5"
+      }
+    });
+  });
+}); 

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -1,5 +1,224 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ModelTransformer:  id with non string type should require the field on create mutation 1`] = `
+"type Task {
+  id: Int!
+  title: String!
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelTaskConnection {
+  items: [Task]!
+  nextToken: String
+}
+
+input ModelTaskFilterInput {
+  id: ModelIntInput
+  title: ModelStringInput
+  and: [ModelTaskFilterInput]
+  or: [ModelTaskFilterInput]
+  not: ModelTaskFilterInput
+}
+
+type Query {
+  getTask(id: ID!): Task
+  listTasks(filter: ModelTaskFilterInput, limit: Int, nextToken: String): ModelTaskConnection
+}
+
+input ModelTaskConditionInput {
+  id: ModelIntInput
+  title: ModelStringInput
+  and: [ModelTaskConditionInput]
+  or: [ModelTaskConditionInput]
+  not: ModelTaskConditionInput
+}
+
+input CreateTaskInput {
+  id: Int!
+  title: String!
+}
+
+input UpdateTaskInput {
+  id: Int!
+  title: String
+}
+
+input DeleteTaskInput {
+  id: ID!
+}
+
+type Mutation {
+  createTask(input: CreateTaskInput!, condition: ModelTaskConditionInput): Task
+  updateTask(input: UpdateTaskInput!, condition: ModelTaskConditionInput): Task
+  deleteTask(input: DeleteTaskInput!, condition: ModelTaskConditionInput): Task
+}
+
+input ModelSubscriptionTaskFilterInput {
+  id: ModelSubscriptionIntInput
+  title: ModelSubscriptionStringInput
+  and: [ModelSubscriptionTaskFilterInput]
+  or: [ModelSubscriptionTaskFilterInput]
+}
+
+type Subscription {
+  onCreateTask(filter: ModelSubscriptionTaskFilterInput): Task @aws_subscribe(mutations: [\\"createTask\\"])
+  onUpdateTask(filter: ModelSubscriptionTaskFilterInput): Task @aws_subscribe(mutations: [\\"updateTask\\"])
+  onDeleteTask(filter: ModelSubscriptionTaskFilterInput): Task @aws_subscribe(mutations: [\\"deleteTask\\"])
+}
+"
+`;
+
 exports[`ModelTransformer:  should filter known input types from create and update input fields 1`] = `
 "type Test {
   id: ID!

--- a/packages/amplify-graphql-transformer-core/src/wrappers/object-definition-wrapper.ts
+++ b/packages/amplify-graphql-transformer-core/src/wrappers/object-definition-wrapper.ts
@@ -27,7 +27,7 @@ import {
 import { DirectiveWrapper } from '../utils/directive-wrapper';
 
 export class GenericFieldWrapper {
-  protected type: TypeNode;
+  public type: TypeNode;
 
   public readonly directives: DirectiveWrapper[];
 


### PR DESCRIPTION
#### Description of changes

Currently, if a model has primary key field 'id' of type 'Int', amplify generates the CreateModelInput type with optional id field which results in assigning autogenerated uuid (string) to an integer field. This results in error in DDB and id field evaluate to MAX_INT value in RDS. To avoid the problem, making the field as mandatory if the type is not ID/String.

This PR also adds back the RDS commands and RDS E2E tests back.

##### CDK / CloudFormation Parameters Changed
NA
<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Manual test
- Unit test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
