### PR TITLE
build: add vpc-db-lambda/lib and rds-patching-lambda/lib to prettier ignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,5 @@ packages/amplify-category-api/src/__tests__/commands/api/mock-data/invalid_schem
 packages/amplify-migration-tests/amplify-migration-reports
 packages/amplify-category-api/resources/
 packages/amplify-graphql-model-transformer/rds-lambda/
+packages/amplify-graphql-model-transformer/publish-notification-lambda/lib/
+packages/amplify-graphql-schema-generator/vpc-db-lambda/lib/

--- a/.prettierignore
+++ b/.prettierignore
@@ -15,3 +15,4 @@ packages/amplify-category-api/resources/
 packages/amplify-graphql-model-transformer/rds-lambda/
 packages/amplify-graphql-model-transformer/publish-notification-lambda/lib/
 packages/amplify-graphql-schema-generator/vpc-db-lambda/lib/
+packages/amplify-graphql-model-transformer/rds-patching-lambda/lib/


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* add vpc-db-lambda/lib and rds-patching-lambda/lib to prettier ignore

Some lib dirs are missing from the prettier ignore causing lint step to fail on CB.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

N/A

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

`yarn prettier-check`.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
