### PR TITLE
chore: clean require cache before executing overrides

### DIFF
--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -73,98 +73,96 @@ batch:
           CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
-    - identifier: predictions_migration_api_10_function_10_rds_v2
+    - identifier: predictions_migration_api_10_function_10_schema_predictions
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/transformer-migrations/predictions-migration.test.ts|src/__tests__/api_10.test.ts|src/__tests__/function_10.test.ts|src/__tests__/rds-v2.test.ts
+            src/__tests__/transformer-migrations/predictions-migration.test.ts|src/__tests__/api_10.test.ts|src/__tests__/function_10.test.ts|src/__tests__/schema-predictions.test.ts
           CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_predictions_api_7_http_migration_global_sandbox
+    - identifier: api_7_http_migration_global_sandbox_schema_function_2
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/schema-predictions.test.ts|src/__tests__/api_7.test.ts|src/__tests__/transformer-migrations/http-migration.test.ts|src/__tests__/global_sandbox.test.ts
+            src/__tests__/api_7.test.ts|src/__tests__/transformer-migrations/http-migration.test.ts|src/__tests__/global_sandbox.test.ts|src/__tests__/schema-function-2.test.ts
           CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: >-
-        schema_function_2_api_connection_migration_api_8_schema_iterative_update_3
+    - identifier: api_connection_migration_api_8_schema_iterative_update_3_auth_migration
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/schema-function-2.test.ts|src/__tests__/migration/api.connection.migration.test.ts|src/__tests__/api_8.test.ts|src/__tests__/schema-iterative-update-3.test.ts
-          CLI_REGION: ap-southeast-1
+            src/__tests__/migration/api.connection.migration.test.ts|src/__tests__/api_8.test.ts|src/__tests__/schema-iterative-update-3.test.ts|src/__tests__/transformer-migrations/auth-migration.test.ts
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        auth_migration_lambda_conflict_handler_schema_iterative_update_1_schema_iterative_update_locking
+        lambda_conflict_handler_schema_iterative_update_1_schema_iterative_update_locking_index_with_stack_mappings
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/transformer-migrations/auth-migration.test.ts|src/__tests__/graphql-v2/lambda-conflict-handler.test.ts|src/__tests__/schema-iterative-update-1.test.ts|src/__tests__/schema-iterative-update-locking.test.ts
-          CLI_REGION: us-west-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: >-
-        index_with_stack_mappings_api_4_custom_policies_container_schema_iterative_rollback_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_MEDIUM
-        variables:
-          TEST_SUITE: >-
-            src/__tests__/graphql-v2/index-with-stack-mappings.test.ts|src/__tests__/api_4.test.ts|src/__tests__/custom_policies_container.test.ts|src/__tests__/schema-iterative-rollback-1.test.ts
-          CLI_REGION: ap-southeast-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: >-
-        schema_iterative_update_2_api_connection_migration2_schema_iterative_rollback_2_api_5
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_MEDIUM
-        variables:
-          TEST_SUITE: >-
-            src/__tests__/schema-iterative-update-2.test.ts|src/__tests__/migration/api.connection.migration2.test.ts|src/__tests__/schema-iterative-rollback-2.test.ts|src/__tests__/api_5.test.ts
+            src/__tests__/graphql-v2/lambda-conflict-handler.test.ts|src/__tests__/schema-iterative-update-1.test.ts|src/__tests__/schema-iterative-update-locking.test.ts|src/__tests__/graphql-v2/index-with-stack-mappings.test.ts
           CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
-    - identifier: containers_api_secrets_schema_function_1_api_3_base_cdk
+    - identifier: >-
+        api_4_custom_policies_container_schema_iterative_rollback_1_schema_iterative_update_2
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/containers-api-secrets.test.ts|src/__tests__/schema-function-1.test.ts|src/__tests__/api_3.test.ts|src/__tests__/cdk/base-cdk.test.ts
+            src/__tests__/api_4.test.ts|src/__tests__/custom_policies_container.test.ts|src/__tests__/schema-iterative-rollback-1.test.ts|src/__tests__/schema-iterative-update-2.test.ts
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: api_1_resolvers_sync_query_datastore_api_6
+    - identifier: >-
+        api_connection_migration2_schema_iterative_rollback_2_api_5_containers_api_secrets
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts|src/__tests__/api_6.test.ts
-          CLI_REGION: ap-northeast-1
+            src/__tests__/migration/api.connection.migration2.test.ts|src/__tests__/schema-iterative-rollback-2.test.ts|src/__tests__/api_5.test.ts|src/__tests__/containers-api-secrets.test.ts
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: api_lambda_auth_api_9
+    - identifier: schema_function_1_api_3_base_cdk_api_1
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/graphql-v2/api_lambda_auth.test.ts|src/__tests__/api_9.test.ts
-          CLI_REGION: us-east-1
+            src/__tests__/schema-function-1.test.ts|src/__tests__/api_3.test.ts|src/__tests__/cdk/base-cdk.test.ts|src/__tests__/api_1.test.ts
+          CLI_REGION: ap-southeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: resolvers_sync_query_datastore_api_6_api_lambda_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts|src/__tests__/api_6.test.ts|src/__tests__/graphql-v2/api_lambda_auth.test.ts
+          CLI_REGION: eu-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_9
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: src/__tests__/api_9.test.ts
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: function_migration
@@ -192,7 +190,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/migration/api.key.migration5.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: ap-southeast-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -220,7 +218,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-10.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_2
@@ -229,7 +227,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-2.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_1
@@ -247,7 +245,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-12.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_13
@@ -256,7 +254,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-13.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_15
@@ -357,7 +355,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-model.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: apigw
@@ -366,7 +364,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/apigw.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: containers_api_2
@@ -384,7 +382,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-14.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_7
@@ -393,7 +391,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-7.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_9
@@ -402,7 +400,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-9.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_5
@@ -449,7 +447,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-6.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_connection
@@ -458,7 +456,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-connection.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_had_node_to_node
@@ -468,7 +466,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-had-node-to-node.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_no_node_to_node
@@ -478,7 +476,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-no-node-to-node.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: api_2

--- a/packages/amplify-category-api/src/graphql-transformer/override.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/override.ts
@@ -69,6 +69,13 @@ export function applyFileBasedOverride(stackManager: StackManager, overrideDirPa
     projectName,
   };
   try {
+    // TODO: Invoke `runOverride` from CLI core once core refactor is done, and
+    // this function can become async https://github.com/aws-amplify/amplify-cli/blob/7bc0b5654a585104a537c1a3f9615bd672435b58/packages/amplify-cli-core/src/overrides-manager/override-runner.ts#L4
+    // before importing the override file, we should clear the require cache to avoid
+    // importing an outdated version of the override file
+    // see: https://github.com/nodejs/modules/issues/307
+    // and https://stackoverflow.com/questions/9210542/node-js-require-cache-possible-to-invalidate
+    delete require.cache[require.resolve(overrideFilePath)];
     const overrideImport = require(overrideFilePath);
     if (overrideImport && overrideImport?.override && typeof overrideImport?.override === 'function') {
       overrideImport.override(appsyncResourceObj, projectInfo);

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-transform.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-transform.ts
@@ -208,7 +208,7 @@ export class ApigwStackTransform {
         // eslint-disable-next-line import/no-dynamic-require
         const overrideImport = require(overrideJSFilePath);
         if (overrideImport && overrideImport?.override && typeof overrideImport?.override === 'function') {
-          overrideImport.override(this.resourceTemplateObj as AmplifyApigwResourceStack, projectInfo);
+          await overrideImport.override(this.resourceTemplateObj as AmplifyApigwResourceStack, projectInfo);
         }
       } catch (err) {
         throw new AmplifyError(

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-transform.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-transform.ts
@@ -12,7 +12,6 @@ import {
   Template,
   writeCFNTemplate,
 } from '@aws-amplify/amplify-cli-core';
-import { formatter, printer } from '@aws-amplify/amplify-prompts';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { AmplifyApigwResourceStack, ApigwInputs, CrudOperation, Path } from '.';
@@ -183,7 +182,7 @@ export class ApigwStackTransform {
       : this.resourceTemplateObj.generateStackResources(this.resourceName);
   }
 
-  async applyOverrides() {
+  async applyOverrides(): Promise<void> {
     const backendDir = pathManager.getBackendDirPath();
     const overrideFilePath = pathManager.getResourceDirectoryPath(undefined, AmplifyCategories.API, this.resourceName);
     const overrideJSFilePath = path.join(overrideFilePath, 'build', 'override.js');
@@ -192,34 +191,35 @@ export class ApigwStackTransform {
 
     // skip if packageManager or override.ts not found
     if (isBuild) {
-      let override;
+      const { envName } = stateManager.getLocalEnvInfo();
+      const { projectName } = stateManager.getProjectConfig();
+      const projectInfo = {
+        envName,
+        projectName,
+      };
       try {
-        ({ override } = await import(overrideJSFilePath));
-      } catch {
-        formatter.list(['No override file found', `To override ${this.resourceName} run "amplify override api"`]);
-        override = undefined;
-      }
-
-      if (override && typeof override === 'function') {
-        const { envName } = stateManager.getLocalEnvInfo();
-        const { projectName } = stateManager.getProjectConfig();
-        const projectInfo = {
-          envName,
-          projectName,
-        };
-        try {
-          override(this.resourceTemplateObj as AmplifyApigwResourceStack, projectInfo);
-        } catch (err) {
-          throw new AmplifyError(
-            'InvalidOverrideError',
-            {
-              message: 'Executing overrides failed.',
-              details: err.message,
-              resolution: 'There may be runtime errors in your overrides file. If so, fix the errors and try again.',
-            },
-            err,
-          );
+        // TODO: Invoke `runOverride` from CLI core once core refactor is done, and
+        // this function can become async https://github.com/aws-amplify/amplify-cli/blob/7bc0b5654a585104a537c1a3f9615bd672435b58/packages/amplify-cli-core/src/overrides-manager/override-runner.ts#L4
+        // before importing the override file, we should clear the require cache to avoid
+        // importing an outdated version of the override file
+        // see: https://github.com/nodejs/modules/issues/307
+        // and https://stackoverflow.com/questions/9210542/node-js-require-cache-possible-to-invalidate
+        delete require.cache[require.resolve(overrideJSFilePath)];
+        // eslint-disable-next-line import/no-dynamic-require
+        const overrideImport = require(overrideJSFilePath);
+        if (overrideImport && overrideImport?.override && typeof overrideImport?.override === 'function') {
+          overrideImport.override(this.resourceTemplateObj as AmplifyApigwResourceStack, projectInfo);
         }
+      } catch (err) {
+        throw new AmplifyError(
+          'InvalidOverrideError',
+          {
+            message: 'Executing overrides failed.',
+            details: err.message,
+            resolution: 'There may be runtime errors in your overrides file. If so, fix the errors and try again.',
+          },
+          err,
+        );
       }
     }
   }


### PR DESCRIPTION
#### Description of changes
For API Category, ensure before we `require` a file for overrides, we clean the require cache. This caused some issues in CLI if a customer used the unbundled CLI, so addressing here as well until we can migrate to user their utility.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
Related to VM2 removal.

#### Description of how you validated changes
Manually verified via `setup-dev` that I could deploy an app, add overrides, and change the overrides (and changes took effect).

#### Checklist
- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
