### PR TITLE
param store refactor

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -1243,7 +1243,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
           throw new TransformerContractError('AuthRole policies should be generated, but no resources were added.');
         }
       } else {
-        const authRoleParameter = (ctx.stackManager.getParameter(IAM_AUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
+        const authRoleParameter = (ctx.parameterManager.getParameter(IAM_AUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
         const authPolicyDocuments = createPolicyDocumentForManagedPolicy(this.authPolicyResources);
         const { scope } = ctx.stackManager;
         // we need to add the arn path as this is something cdk is looking for when using imported roles in policies
@@ -1267,7 +1267,7 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
       if (this.unauthPolicyResources.size === 0) {
         throw new TransformerContractError('UnauthRole policies should be generated, but no resources were added');
       }
-      const unauthRoleParameter = (ctx.stackManager.getParameter(IAM_UNAUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
+      const unauthRoleParameter = (ctx.parameterManager.getParameter(IAM_UNAUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
       const unauthPolicyDocuments = createPolicyDocumentForManagedPolicy(this.unauthPolicyResources);
       const { scope } = ctx.stackManager;
       const iamUnauthRoleArn = iam.Role.fromRoleArn(

--- a/packages/amplify-graphql-function-transformer/src/graphql-function-transformer.ts
+++ b/packages/amplify-graphql-function-transformer/src/graphql-function-transformer.ts
@@ -65,7 +65,7 @@ export class FunctionTransformer extends TransformerPluginBase {
 
     const stack: cdk.Stack = context.stackManager.createStack(FUNCTION_DIRECTIVE_STACK);
     const createdResources = new Map<string, any>();
-    const env = context.stackManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
+    const env = context.parameterManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
 
     stack.templateOptions.templateFormatVersion = '2010-09-09';
     stack.templateOptions.description = 'An auto-generated nested stack for the @function directive.';
@@ -146,8 +146,8 @@ export class FunctionTransformer extends TransformerPluginBase {
           (mode) => mode?.authenticationType,
         );
         if (authModes.includes(AuthorizationType.IAM)) {
-          const authRoleParameter = (context.stackManager.getParameter(IAM_AUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
-          const unauthRoleParameter = (context.stackManager.getParameter(IAM_UNAUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
+          const authRoleParameter = (context.parameterManager.getParameter(IAM_AUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
+          const unauthRoleParameter = (context.parameterManager.getParameter(IAM_UNAUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
           requestTemplate.push(
             qref(
               `$ctx.stash.put("authRole", "arn:aws:sts::${

--- a/packages/amplify-graphql-http-transformer/src/graphql-http-transformer.ts
+++ b/packages/amplify-graphql-http-transformer/src/graphql-http-transformer.ts
@@ -203,7 +203,7 @@ export class HttpTransformer extends TransformerPluginBase {
     }
 
     const stack: cdk.Stack = context.stackManager.createStack(HTTP_DIRECTIVE_STACK);
-    const env = context.stackManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
+    const env = context.parameterManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
     const region = stack.region;
 
     stack.templateOptions.templateFormatVersion = '2010-09-09';
@@ -224,7 +224,7 @@ export class HttpTransformer extends TransformerPluginBase {
 }
 
 function createResolver(stack: cdk.Stack, dataSourceId: string, context: TransformerContextProvider, config: HttpDirectiveConfiguration) {
-  const env = context.stackManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
+  const env = context.parameterManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
   const region = stack.region;
 
   const { method, supportsBody } = config;
@@ -289,8 +289,8 @@ function createResolver(stack: cdk.Stack, dataSourceId: string, context: Transfo
   );
 
   if (authModes.includes(AuthorizationType.IAM)) {
-    const authRoleParameter = (context.stackManager.getParameter(IAM_AUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
-    const unauthRoleParameter = (context.stackManager.getParameter(IAM_UNAUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
+    const authRoleParameter = (context.parameterManager.getParameter(IAM_AUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
+    const unauthRoleParameter = (context.parameterManager.getParameter(IAM_UNAUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
 
     requestTemplate.push(
       qref(

--- a/packages/amplify-graphql-model-transformer/src/resources/dynamo-model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/dynamo-model-resource-generator.ts
@@ -25,28 +25,28 @@ export class DynamoModelResourceGenerator extends ModelResourceGenerator {
 
     if (this.isProvisioned()) {
       // add model related-parameters to the root stack
-      ctx.stackManager.addParameter(ResourceConstants.PARAMETERS.DynamoDBModelTableReadIOPS, {
+      ctx.parameterManager.addParameter(ResourceConstants.PARAMETERS.DynamoDBModelTableReadIOPS, {
         description: 'The number of read IOPS the table should support.',
         type: 'Number',
         default: 5,
       });
-      ctx.stackManager.addParameter(ResourceConstants.PARAMETERS.DynamoDBModelTableWriteIOPS, {
+      ctx.parameterManager.addParameter(ResourceConstants.PARAMETERS.DynamoDBModelTableWriteIOPS, {
         description: 'The number of write IOPS the table should support.',
         type: 'Number',
         default: 5,
       });
-      ctx.stackManager.addParameter(ResourceConstants.PARAMETERS.DynamoDBBillingMode, {
+      ctx.parameterManager.addParameter(ResourceConstants.PARAMETERS.DynamoDBBillingMode, {
         description: 'Configure @model types to create DynamoDB tables with PAY_PER_REQUEST or PROVISIONED billing modes.',
         default: 'PAY_PER_REQUEST',
         allowedValues: ['PAY_PER_REQUEST', 'PROVISIONED'],
       });
-      ctx.stackManager.addParameter(ResourceConstants.PARAMETERS.DynamoDBEnablePointInTimeRecovery, {
+      ctx.parameterManager.addParameter(ResourceConstants.PARAMETERS.DynamoDBEnablePointInTimeRecovery, {
         description: 'Whether to enable Point in Time Recovery on the table.',
         type: 'String',
         default: 'false',
         allowedValues: ['true', 'false'],
       });
-      ctx.stackManager.addParameter(ResourceConstants.PARAMETERS.DynamoDBEnableServerSideEncryption, {
+      ctx.parameterManager.addParameter(ResourceConstants.PARAMETERS.DynamoDBEnableServerSideEncryption, {
         description: 'Enable server side encryption powered by KMS.',
         type: 'String',
         default: 'true',
@@ -76,7 +76,7 @@ export class DynamoModelResourceGenerator extends ModelResourceGenerator {
     const tableName = context.resourceHelper.generateTableName(def!.name.value);
 
     // Add parameters.
-    const env = context.stackManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
+    const env = context.parameterManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
     const readIops = new cdk.CfnParameter(scope, ResourceConstants.PARAMETERS.DynamoDBModelTableReadIOPS, {
       description: 'The number of read IOPS the table should support.',
       type: 'Number',

--- a/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
+++ b/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
@@ -161,7 +161,7 @@ export class PredictionsTransformer extends TransformerPluginBase {
     }
 
     const stack: cdk.Stack = context.stackManager.createStack(PREDICTIONS_DIRECTIVE_STACK);
-    const env = context.stackManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
+    const env = context.parameterManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
     const createdResources = new Map<string, any>();
     const seenActions = new Set<string>();
     const role = new iam.Role(stack, PredictionsResourceIDs.iamRole, {
@@ -331,7 +331,7 @@ function createResolver(
   };
 
   if (referencesEnv(bucketName)) {
-    const env = context.stackManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
+    const env = context.parameterManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
     substitutions.env = env as unknown as string;
   }
   const requestTemplate = [
@@ -349,8 +349,8 @@ function createResolver(
     (mode) => mode?.authenticationType,
   );
   if (authModes.includes(AuthorizationType.IAM)) {
-    const authRoleParameter = (context.stackManager.getParameter(IAM_AUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
-    const unauthRoleParameter = (context.stackManager.getParameter(IAM_UNAUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
+    const authRoleParameter = (context.parameterManager.getParameter(IAM_AUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
+    const unauthRoleParameter = (context.parameterManager.getParameter(IAM_UNAUTH_ROLE_PARAMETER) as cdk.CfnParameter).valueAsString;
     requestTemplate.push(
       `$util.qr($ctx.stash.put("authRole", "arn:aws:sts::${
         cdk.Stack.of(context.stackManager.scope).account
@@ -437,7 +437,7 @@ function removeEnvReference(value: string): string {
 }
 
 function joinWithEnv(context: TransformerContextProvider, separator: string, listToJoin: any[]): string {
-  const env = context.stackManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
+  const env = context.parameterManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
   return cdk.Fn.conditionIf(
     ResourceConstants.CONDITIONS.HasEnvironmentParameter,
     cdk.Fn.join(separator, [...listToJoin, env]),
@@ -539,7 +539,7 @@ function getStorageArn(context: TransformerContextProvider, bucketName: string):
   };
 
   if (referencesEnv(bucketName)) {
-    const env = context.stackManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
+    const env = context.parameterManager.getParameter(ResourceConstants.PARAMETERS.Env) as cdk.CfnParameter;
     substitutions.env = env as unknown as string;
   }
 

--- a/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
@@ -297,7 +297,7 @@ export class SearchableModelTransformer extends TransformerPluginBase {
 
     setMappings(stack);
 
-    const envParam = context.stackManager.getParameter(Env) as CfnParameter;
+    const envParam = context.parameterManager.getParameter(Env) as CfnParameter;
 
     new CfnCondition(stack, HasEnvironmentParameter, {
       expression: Fn.conditionNot(Fn.conditionEquals(envParam, ResourceConstants.NONE)),

--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -14,8 +14,6 @@ import { AuthorizationConfig } from 'aws-cdk-lib/aws-appsync';
 import { AuthorizationType } from 'aws-cdk-lib/aws-appsync';
 import { CfnApiKey } from 'aws-cdk-lib/aws-appsync';
 import { CfnGraphQLSchema } from 'aws-cdk-lib/aws-appsync';
-import { CfnParameter } from 'aws-cdk-lib';
-import { CfnParameterProps } from 'aws-cdk-lib';
 import { CfnResource } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { DataSourceInstance } from '@aws-amplify/graphql-transformer-interfaces';
@@ -49,6 +47,7 @@ import { NamedTypeNode } from 'graphql';
 import { NestedStackProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { ObjectTypeDefinitionNode } from 'graphql';
 import { ObjectTypeExtensionNode } from 'graphql';
+import { ParameterManager } from '@aws-amplify/graphql-transformer-interfaces';
 import { QueryFieldType } from '@aws-amplify/graphql-transformer-interfaces';
 import { RDSLayerMapping } from '@aws-amplify/graphql-transformer-interfaces';
 import { S3MappingTemplateProvider } from '@aws-amplify/graphql-transformer-interfaces';
@@ -211,7 +210,7 @@ export class GraphQLTransform {
     // Warning: (ae-forgotten-export) The symbol "GraphQLApi" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    protected generateGraphQlApi(stackManager: StackManager, output: TransformerOutput): GraphQLApi;
+    protected generateGraphQlApi(stackManager: StackManagerProvider, parameterManager: ParameterManager, output: TransformerOutput): GraphQLApi;
     // (undocumented)
     getLogs(): TransformerLog[];
     // (undocumented)
@@ -219,7 +218,7 @@ export class GraphQLTransform {
     // Warning: (ae-forgotten-export) The symbol "TransformOption" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    transform({ scope, nestedStackProvider, assetProvider, schema, datasourceConfig }: TransformOption): void;
+    transform({ scope, nestedStackProvider, assetProvider, parameterManager, schema, datasourceConfig }: TransformOption): void;
 }
 
 // @public (undocumented)
@@ -415,11 +414,7 @@ export class StackManager implements StackManagerProvider {
     // Warning: (ae-forgotten-export) The symbol "ResourceToStackMap" needs to be exported by the entry point index.d.ts
     constructor(scope: Construct, nestedStackProvider: NestedStackProvider, resourceMapping: ResourceToStackMap);
     // (undocumented)
-    addParameter: (name: string, props: CfnParameterProps) => CfnParameter;
-    // (undocumented)
     createStack: (stackName: string) => Stack;
-    // (undocumented)
-    getParameter: (name: string) => CfnParameter | void;
     // (undocumented)
     getScopeFor: (resourceId: string, defaultStackName?: string) => Construct;
     // (undocumented)

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transformation/sync-utils.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transformation/sync-utils.test.ts
@@ -7,7 +7,7 @@ describe('getSyncConfig', () => {
   const createMockContext = (resolverConfig: ResolverConfig): TransformerTransformSchemaStepContextProvider =>
     ({
       getResolverConfig: () => resolverConfig,
-      stackManager: {
+      parameterManager: {
         getParameter: (_: string) => jest.fn() as unknown as CfnParameter,
       },
     } as unknown as TransformerTransformSchemaStepContextProvider);

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transformer-context/resource-helper.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transformer-context/resource-helper.test.ts
@@ -1,7 +1,6 @@
-import { GraphQLAPIProvider, TransformerResourceHelperProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { GraphQLAPIProvider, TransformerResourceHelperProvider, ParameterManager } from '@aws-amplify/graphql-transformer-interfaces';
 import { CfnParameter } from 'aws-cdk-lib';
 import { TransformerResourceHelper } from '../../transformer-context/resource-helper';
-import { StackManager } from '../../transformer-context/stack-manager';
 
 const testEnv = 'testenv';
 const testApiId = 'testtest123';
@@ -100,7 +99,7 @@ describe('getModelFieldMapKeys', () => {
 const getResourceHelper = (bindApi = true) => {
   const resourceHelper = new TransformerResourceHelper({
     getParameter: () => ({ valueAsString: testEnv } as CfnParameter),
-  } as unknown as StackManager);
+  } as unknown as ParameterManager);
   if (bindApi) {
     resourceHelper.bind({ apiId: testApiId } as GraphQLAPIProvider);
   }

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -370,8 +370,8 @@ export class TransformerResolver implements TransformerResolverProvider {
       (mode) => mode?.authenticationType === AuthorizationType.IAM,
     );
     if (hasIamAuth) {
-      const authRoleParameter = (context.stackManager.getParameter(IAM_AUTH_ROLE_PARAMETER) as CfnParameter).valueAsString;
-      const unauthRoleParameter = (context.stackManager.getParameter(IAM_UNAUTH_ROLE_PARAMETER) as CfnParameter).valueAsString;
+      const authRoleParameter = (context.parameterManager.getParameter(IAM_AUTH_ROLE_PARAMETER) as CfnParameter).valueAsString;
+      const unauthRoleParameter = (context.parameterManager.getParameter(IAM_UNAUTH_ROLE_PARAMETER) as CfnParameter).valueAsString;
       /* eslint-disable indent */
       initResolver += dedent`\n
       $util.qr($ctx.stash.put("authRole", "arn:aws:sts::${

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/stack-manager.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/stack-manager.ts
@@ -1,4 +1,4 @@
-import { StackManagerProvider, NestedStackProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { StackManagerProvider, NestedStackProvider, ParameterManager } from '@aws-amplify/graphql-transformer-interfaces';
 import { Stack, CfnParameter, CfnParameterProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
@@ -12,19 +12,12 @@ export class StackManager implements StackManagerProvider {
 
   private resourceToStackMap: Map<string, string>;
 
-  private paramMap: Map<string, CfnParameter> = new Map();
-
   constructor(
     public readonly scope: Construct,
     private readonly nestedStackProvider: NestedStackProvider,
     resourceMapping: ResourceToStackMap,
   ) {
-    // add Env Parameter to ensure to adhere to contract
     this.resourceToStackMap = new Map(Object.entries(resourceMapping));
-    this.addParameter('env', {
-      default: 'NONE',
-      type: 'String',
-    });
   }
 
   createStack = (stackName: string): Stack => {
@@ -52,12 +45,4 @@ export class StackManager implements StackManagerProvider {
     }
     throw new Error(`Stack ${stackName} is not created`);
   };
-
-  addParameter = (name: string, props: CfnParameterProps): CfnParameter => {
-    const param = new CfnParameter(this.scope, name, props);
-    this.paramMap.set(name, param);
-    return param;
-  };
-
-  getParameter = (name: string): CfnParameter | void => this.paramMap.get(name);
 }

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -234,6 +234,12 @@ export type NestedStackProvider = {
 };
 
 // @public (undocumented)
+export type ParameterManager = {
+    addParameter: (name: string, props: CfnParameterProps) => CfnParameter;
+    getParameter: (name: string) => CfnParameter | void;
+};
+
+// @public (undocumented)
 export enum QueryFieldType {
     // (undocumented)
     GET = "GET",
@@ -297,11 +303,7 @@ export interface SearchableDataSourceOptions extends DataSourceOptions {
 // @public (undocumented)
 export interface StackManagerProvider {
     // (undocumented)
-    addParameter: (name: string, props: CfnParameterProps) => CfnParameter;
-    // (undocumented)
     createStack: (stackName: string) => Stack;
-    // (undocumented)
-    getParameter: (name: string) => CfnParameter | void;
     // (undocumented)
     getScopeFor: (resourceId: string, defaultStackName?: string) => Construct;
     // (undocumented)
@@ -326,7 +328,7 @@ export enum SubscriptionFieldType {
 export type TransformerAuthProvider = TransformerPluginProvider;
 
 // @public (undocumented)
-export type TransformerBeforeStepContextProvider = Pick<TransformerContextProvider, 'inputDocument' | 'modelToDatasourceMap' | 'transformParameters' | 'isProjectUsingDataStore' | 'getResolverConfig' | 'authConfig' | 'stackManager'>;
+export type TransformerBeforeStepContextProvider = Pick<TransformerContextProvider, 'inputDocument' | 'modelToDatasourceMap' | 'transformParameters' | 'isProjectUsingDataStore' | 'getResolverConfig' | 'authConfig' | 'stackManager' | 'parameterManager'>;
 
 // @public (undocumented)
 export interface TransformerContextOutputProvider {
@@ -412,6 +414,8 @@ export interface TransformerContextProvider {
     modelToDatasourceMap: Map<string, DatasourceType>;
     // (undocumented)
     output: TransformerContextOutputProvider;
+    // (undocumented)
+    parameterManager: ParameterManager;
     // (undocumented)
     providerRegistry: TransformerProviderRegistry;
     // (undocumented)
@@ -678,7 +682,7 @@ export type TransformerSecrets = {
 export type TransformerTransformSchemaStepContextProvider = TransformerValidationStepContextProvider;
 
 // @public (undocumented)
-export type TransformerValidationStepContextProvider = Pick<TransformerContextProvider, 'inputDocument' | 'modelToDatasourceMap' | 'output' | 'providerRegistry' | 'dataSources' | 'transformParameters' | 'isProjectUsingDataStore' | 'getResolverConfig' | 'metadata' | 'authConfig' | 'resourceHelper' | 'resolvers' | 'stackManager'>;
+export type TransformerValidationStepContextProvider = Pick<TransformerContextProvider, 'inputDocument' | 'modelToDatasourceMap' | 'output' | 'providerRegistry' | 'dataSources' | 'transformParameters' | 'isProjectUsingDataStore' | 'getResolverConfig' | 'metadata' | 'authConfig' | 'resourceHelper' | 'resolvers' | 'stackManager' | 'parameterManager'>;
 
 // @public (undocumented)
 export interface TransformHostProvider {

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/index.ts
@@ -20,3 +20,4 @@ export {
 export { TransformerSchemaHelperProvider } from './schema-helper-provider';
 export { TransformerPreProcessContextProvider } from './transformer-preprocess-context-provider';
 export { StackManagerProvider } from './stack-manager-provider';
+export { ParameterManager } from './parameter-manager';

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/parameter-manager.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/parameter-manager.ts
@@ -1,0 +1,6 @@
+import { CfnParameter, CfnParameterProps } from 'aws-cdk-lib';
+
+export type ParameterManager = {
+  addParameter: (name: string, props: CfnParameterProps) => CfnParameter;
+  getParameter: (name: string) => CfnParameter | void;
+};

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/stack-manager-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/stack-manager-provider.ts
@@ -1,4 +1,4 @@
-import { CfnParameter, CfnParameterProps, Stack } from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
 export interface StackManagerProvider {
@@ -7,6 +7,4 @@ export interface StackManagerProvider {
   createStack: (stackName: string) => Stack;
   hasStack: (stackName: string) => boolean;
   getScopeFor: (resourceId: string, defaultStackName?: string) => Construct;
-  addParameter: (name: string, props: CfnParameterProps) => CfnParameter;
-  getParameter: (name: string) => CfnParameter | void;
 }

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
@@ -7,6 +7,7 @@ import { StackManagerProvider } from './stack-manager-provider';
 import { TransformerResourceHelperProvider } from './resource-resource-provider';
 import { TransformParameters } from './transform-parameters';
 import { TransformerResolversManagerProvider } from './transformer-resolver-provider';
+import { ParameterManager } from './parameter-manager';
 
 export interface TransformerContextMetadataProvider {
   set<T>(key: string, value: T): void;
@@ -27,6 +28,7 @@ export interface TransformerContextProvider {
   datasourceSecretParameterLocations: Map<string, TransformerSecrets>;
   output: TransformerContextOutputProvider;
   stackManager: StackManagerProvider;
+  parameterManager: ParameterManager;
   api: GraphQLAPIProvider;
   resourceHelper: TransformerResourceHelperProvider;
   authConfig: AppSyncAuthConfiguration;
@@ -47,6 +49,7 @@ export type TransformerBeforeStepContextProvider = Pick<
   | 'getResolverConfig'
   | 'authConfig'
   | 'stackManager'
+  | 'parameterManager'
 >;
 
 export type TransformerSchemaVisitStepContextProvider = Pick<
@@ -78,6 +81,7 @@ export type TransformerValidationStepContextProvider = Pick<
   | 'resourceHelper'
   | 'resolvers'
   | 'stackManager'
+  | 'parameterManager'
 >;
 
 export type TransformerPrepareStepContextProvider = TransformerValidationStepContextProvider;

--- a/packages/amplify-graphql-transformer-test-utils/src/test-transform.ts
+++ b/packages/amplify-graphql-transformer-test-utils/src/test-transform.ts
@@ -59,6 +59,7 @@ export const testTransform = (params: TestTransformParameters): DeploymentResour
     scope: transformManager.getTransformScope(),
     nestedStackProvider: transformManager.getNestedStackProvider(),
     assetProvider: transformManager.getAssetProvider(),
+    parameterManager: transformManager.getParameterManager(),
     schema,
     datasourceConfig: {
       modelToDatasourceMap,

--- a/packages/amplify-graphql-transformer/src/cdk-compat/transform-manager.ts
+++ b/packages/amplify-graphql-transformer/src/cdk-compat/transform-manager.ts
@@ -1,6 +1,12 @@
-import { App, Stack } from 'aws-cdk-lib';
+import { App, CfnParameter, CfnParameterProps, Stack } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import type { AssetProvider, NestedStackProvider, S3Asset, AssetProps } from '@aws-amplify/graphql-transformer-interfaces';
+import type {
+  AssetProvider,
+  NestedStackProvider,
+  S3Asset,
+  AssetProps,
+  ParameterManager,
+} from '@aws-amplify/graphql-transformer-interfaces';
 import { DeploymentResources, Template } from '../deployment-resources';
 import { TransformerStackSythesizer } from './stack-synthesizer';
 import { TransformerNestedStack } from './nested-stack';
@@ -18,13 +24,13 @@ export type OverrideConfig = {
  * and synthesizers, then provides mechanisms for synthesis.
  */
 export class TransformManager {
-  private readonly app: App;
+  private readonly app: App = new App();
   public readonly rootStack: TransformerRootStack;
   private readonly stackSynthesizer = new TransformerStackSythesizer();
   private readonly childStackSynthesizers: Map<string, TransformerStackSythesizer> = new Map();
+  private paramMap: Map<string, CfnParameter> = new Map();
 
   constructor(private readonly overrideConfig?: OverrideConfig) {
-    this.app = new App();
     this.rootStack = new TransformerRootStack(this.app, 'transformer-root-stack', {
       synthesizer: this.stackSynthesizer,
     });
@@ -53,6 +59,17 @@ export class TransformManager {
   getAssetProvider(): AssetProvider {
     return {
       provide: (scope: Construct, id: string, props: AssetProps): S3Asset => new AmplifyS3Asset(scope, id, props),
+    };
+  }
+
+  getParameterManager(): ParameterManager {
+    return {
+      addParameter: (name: string, props: CfnParameterProps): CfnParameter => {
+        const param = new CfnParameter(this.rootStack, name, props);
+        this.paramMap.set(name, param);
+        return param;
+      },
+      getParameter: (name: string): CfnParameter | void => this.paramMap.get(name),
     };
   }
 

--- a/packages/amplify-graphql-transformer/src/graphql-transformer.ts
+++ b/packages/amplify-graphql-transformer/src/graphql-transformer.ts
@@ -171,6 +171,7 @@ export const executeTransform = (config: ExecuteTransformConfig): DeploymentReso
       scope: transformManager.getTransformScope(),
       nestedStackProvider: transformManager.getNestedStackProvider(),
       assetProvider: transformManager.getAssetProvider(),
+      parameterManager: transformManager.getParameterManager(),
       schema,
       datasourceConfig: {
         modelToDatasourceMap,


### PR DESCRIPTION
#### Description of changes
Refactor the `parameterManager` into a standalone component, and out of the `stackManager` component. This is to facilitate creating code-based parameters for the CDK construct (since we don't want to actually invoke or add new parameters to the top-level CDK managed stack on customer behalf).

This does not add the new behavior yet, simply a refactor of the existing system.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit tests

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
