### PR TITLE
chore: remove env suffix from API name for graphql construct

### DIFF
--- a/packages/amplify-graphql-api-construct/src/__tests__/__functional__/basic.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/__functional__/basic.test.ts
@@ -25,7 +25,7 @@ describe('basic functionality', () => {
 
     template.resourceCountIs('AWS::AppSync::GraphQLApi', 1);
     template.hasResourceProperties('AWS::AppSync::GraphQLApi', {
-      Name: 'MyApi-NONE',
+      Name: 'MyApi',
     });
 
     template.resourceCountIs('AWS::AppSync::DataSource', 1);
@@ -104,7 +104,7 @@ describe('basic functionality', () => {
 
     template.resourceCountIs('AWS::AppSync::GraphQLApi', 1);
     template.hasResourceProperties('AWS::AppSync::GraphQLApi', {
-      Name: 'TestApi-NONE',
+      Name: 'TestApi',
     });
   });
 });

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -333,8 +333,12 @@ export class GraphQLTransform {
     const authorizationConfig = adoptAuthModes(stackManager, synthParameters, this.authConfig);
     const apiName = synthParameters.apiName;
     const env = synthParameters.amplifyEnvironmentName;
+    // N.B. changing the GraphqlApi Name is a 'No Interruptions' action,
+    // so theoretically this optional env suffix behavior should be safe to apply retroactively to CLI users.
+    // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-graphqlapi.html#aws-resource-appsync-graphqlapi-properties
+    const name = env === 'NONE' ? apiName : `${apiName}-${env}`;
     const api = new GraphQLApi(scope, 'GraphQLAPI', {
-      name: `${apiName}-${env}`,
+      name,
       authorizationConfig,
       host: this.options.host,
       sandboxModeEnabled: this.transformParameters.sandboxModeEnabled,


### PR DESCRIPTION
#### Description of changes
No longer adding the `env` variable to the end of the graphql api name if it the default value `NONE`. Because this is a `No Interruptions` action in CFN, it should be safe to apply this to users who have deployed these cfn stacks manually without an ENV set, they'll just have the API name update in the cloudformation console/sdk results.

##### CDK / CloudFormation Parameters Changed
* CfnGraphqlApi.Name property has been changed, which is a No Interruptions style update. [Reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-graphqlapi.html#aws-resource-appsync-graphqlapi-properties)

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit Test

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
