### PR TITLE
feat: enable passing in generated functions to the graphql transform

### DIFF
--- a/packages/amplify-graphql-api-construct/src/__tests__/__functional__/functions.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/__functional__/functions.test.ts
@@ -1,0 +1,234 @@
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { AmplifyGraphqlApi } from '../../amplify-graphql-api';
+
+describe('function directive', () => {
+  it('references a function by name defined elsewhere', () => {
+    const stack = new cdk.Stack();
+    const api = new AmplifyGraphqlApi(stack, 'TestApi', {
+      apiName: 'MyApi',
+      schema: /* GraphQL */ `
+        type Query {
+          repeat(message: String!): String! @function(name: "repeat")
+        }
+      `,
+      authorizationConfig: {
+        apiKeyConfig: { expires: cdk.Duration.days(7) },
+      },
+    });
+
+    expect(api.resources.nestedStacks.FunctionDirectiveStack).toBeDefined();
+    const functionDirectiveTemplate = Template.fromStack(api.resources.nestedStacks.FunctionDirectiveStack);
+
+    functionDirectiveTemplate.resourceCountIs('AWS::AppSync::DataSource', 1);
+    functionDirectiveTemplate.hasResourceProperties('AWS::AppSync::DataSource', {
+      Type: 'AWS_LAMBDA',
+      Name: 'RepeatLambdaDataSource',
+      LambdaConfig: {
+        LambdaFunctionArn: {
+          'Fn::If': [
+            'HasEnvironmentParameter',
+            {
+              'Fn::Sub': [
+                // eslint-disable-next-line no-template-curly-in-string
+                'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:repeat',
+                {},
+              ],
+            },
+            {
+              // eslint-disable-next-line no-template-curly-in-string
+              'Fn::Sub': 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:repeat',
+            },
+          ],
+        },
+      },
+    });
+
+    functionDirectiveTemplate.resourceCountIs('AWS::IAM::Policy', 1);
+    functionDirectiveTemplate.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: [
+          {
+            Action: 'lambda:InvokeFunction',
+            Effect: 'Allow',
+            Resource: [
+              {
+                'Fn::If': [
+                  'HasEnvironmentParameter',
+                  {
+                    'Fn::Sub': [
+                      // eslint-disable-next-line no-template-curly-in-string
+                      'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:repeat',
+                      {},
+                    ],
+                  },
+                  {
+                    // eslint-disable-next-line no-template-curly-in-string
+                    'Fn::Sub': 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:repeat',
+                  },
+                ],
+              },
+              {
+                'Fn::Join': [
+                  '',
+                  [
+                    {
+                      'Fn::If': [
+                        'HasEnvironmentParameter',
+                        {
+                          'Fn::Sub': [
+                            // eslint-disable-next-line no-template-curly-in-string
+                            'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:repeat',
+                            {},
+                          ],
+                        },
+                        {
+                          // eslint-disable-next-line no-template-curly-in-string
+                          'Fn::Sub': 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:repeat',
+                        },
+                      ],
+                    },
+                    ':*',
+                  ],
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  it('throw an exception if function is imported by arn', () => {
+    const stack = new cdk.Stack();
+    const referencedFunction = lambda.Function.fromFunctionArn(stack, 'Imported', 'arn:aws:lambda:us-west-2:123456789100:function:dummyFn');
+
+    expect(
+      () =>
+        new AmplifyGraphqlApi(stack, 'TestApi', {
+          apiName: 'MyApi',
+          schema: /* GraphQL */ `
+            type Query {
+              repeat(message: String!): String! @function(name: "repeat")
+            }
+          `,
+          functionNameMap: {
+            repeat: referencedFunction,
+          },
+          authorizationConfig: {
+            apiKeyConfig: { expires: cdk.Duration.days(7) },
+          },
+        }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Cannot modify permission to lambda function. Function is either imported or $LATEST version.
+      If the function is imported from the same account use \`fromFunctionAttributes()\` API with the \`sameEnvironment\` flag.
+      If the function is imported from a different account and already has the correct permissions use \`fromFunctionAttributes()\` API with the \`skipPermissions\` flag."
+    `);
+  });
+
+  it('allows importing by attribute with sameEnvironment flag', () => {
+    const stack = new cdk.Stack();
+    const referencedFunction = lambda.Function.fromFunctionAttributes(stack, 'Imported', {
+      functionArn: 'arn:aws:lambda:us-west-2:123456789100:function:dummyFn',
+      sameEnvironment: true,
+    });
+
+    const api = new AmplifyGraphqlApi(stack, 'TestApi', {
+      apiName: 'MyApi',
+      schema: /* GraphQL */ `
+        type Query {
+          repeat(message: String!): String! @function(name: "repeat")
+        }
+      `,
+      functionNameMap: {
+        repeat: referencedFunction,
+      },
+      authorizationConfig: {
+        apiKeyConfig: { expires: cdk.Duration.days(7) },
+      },
+    });
+
+    expect(api.resources.nestedStacks.FunctionDirectiveStack).toBeDefined();
+    const functionDirectiveTemplate = Template.fromStack(api.resources.nestedStacks.FunctionDirectiveStack);
+
+    functionDirectiveTemplate.resourceCountIs('AWS::AppSync::DataSource', 1);
+    functionDirectiveTemplate.hasResourceProperties('AWS::AppSync::DataSource', {
+      Type: 'AWS_LAMBDA',
+      Name: 'RepeatLambdaDataSource',
+      LambdaConfig: {
+        LambdaFunctionArn: 'arn:aws:lambda:us-west-2:123456789100:function:dummyFn',
+      },
+    });
+
+    functionDirectiveTemplate.resourceCountIs('AWS::IAM::Policy', 1);
+    functionDirectiveTemplate.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: [
+          {
+            Action: 'lambda:InvokeFunction',
+            Effect: 'Allow',
+            Resource: [
+              'arn:aws:lambda:us-west-2:123456789100:function:dummyFn',
+              'arn:aws:lambda:us-west-2:123456789100:function:dummyFn:*',
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  it('supports passing in a function defined in-stack', () => {
+    const stack = new cdk.Stack();
+    const referencedFunction = new lambda.Function(stack, 'Createdfunction', {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      code: lambda.Code.fromInline('I am code'),
+      handler: 'index.main',
+    });
+
+    const api = new AmplifyGraphqlApi(stack, 'TestApi', {
+      apiName: 'MyApi',
+      schema: /* GraphQL */ `
+        type Query {
+          repeat(message: String!): String! @function(name: "repeat")
+        }
+      `,
+      functionNameMap: {
+        repeat: referencedFunction,
+      },
+      authorizationConfig: {
+        apiKeyConfig: { expires: cdk.Duration.days(7) },
+      },
+    });
+
+    expect(api.resources.nestedStacks.FunctionDirectiveStack).toBeDefined();
+    const functionDirectiveTemplate = Template.fromStack(api.resources.nestedStacks.FunctionDirectiveStack);
+
+    functionDirectiveTemplate.resourceCountIs('AWS::AppSync::DataSource', 1);
+    functionDirectiveTemplate.hasResourceProperties('AWS::AppSync::DataSource', {
+      Type: 'AWS_LAMBDA',
+      Name: 'RepeatLambdaDataSource',
+      LambdaConfig: {
+        LambdaFunctionArn: { Ref: Match.stringLikeRegexp('referencetoCreatedfunction.*Arn') },
+      },
+    });
+
+    functionDirectiveTemplate.resourceCountIs('AWS::IAM::Policy', 1);
+    functionDirectiveTemplate.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: [
+          {
+            Action: 'lambda:InvokeFunction',
+            Effect: 'Allow',
+            Resource: [
+              { Ref: Match.stringLikeRegexp('referencetoCreatedfunction.*Arn') },
+              {
+                'Fn::Join': ['', [{ Ref: Match.stringLikeRegexp('referencetoCreatedfunction.*Arn') }, ':*']],
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+});

--- a/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
+++ b/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
@@ -72,11 +72,6 @@ export class AmplifyGraphqlApi<SchemaType = AmplifyGraphqlApiResources> extends 
 
     const { processedSchema, processedFunctionSlots } = preprocessSchema(unprocessedSchema, schemaPreprocessor);
 
-    // TODO: Wire referenced functions into the transform.
-    if (functionNameMap && Object.keys(functionNameMap).length > 0) {
-      throw new Error('functionNameMap not yet supported in this revision.');
-    }
-
     validateFunctionSlots(functionSlots ?? []);
     const separatedFunctionSlots = separateSlots([...(functionSlots ?? []), ...(processedFunctionSlots ?? [])]);
 
@@ -112,6 +107,7 @@ export class AmplifyGraphqlApi<SchemaType = AmplifyGraphqlApiResources> extends 
         adminRoles,
         customTransformers: transformers ?? [],
         ...(predictionsBucket ? { storageConfig: { bucketName: predictionsBucket.bucketName } } : {}),
+        functionNameMap,
       },
       authConfig,
       stackMapping: stackMappings ?? {},

--- a/packages/amplify-graphql-function-transformer/API.md
+++ b/packages/amplify-graphql-function-transformer/API.md
@@ -7,6 +7,7 @@
 import { DirectiveNode } from 'graphql';
 import { FieldDefinitionNode } from 'graphql';
 import { InterfaceTypeDefinitionNode } from 'graphql';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { ObjectTypeDefinitionNode } from 'graphql';
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { TransformerPluginBase } from '@aws-amplify/graphql-transformer-core';
@@ -14,7 +15,7 @@ import { TransformerSchemaVisitStepContextProvider } from '@aws-amplify/graphql-
 
 // @public (undocumented)
 export class FunctionTransformer extends TransformerPluginBase {
-    constructor();
+    constructor(functionNameMap?: Record<string, lambda.IFunction> | undefined);
     // (undocumented)
     field: (parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode, definition: FieldDefinitionNode, directive: DirectiveNode, acc: TransformerSchemaVisitStepContextProvider) => void;
     // (undocumented)

--- a/packages/amplify-graphql-function-transformer/package.json
+++ b/packages/amplify-graphql-function-transformer/package.json
@@ -57,7 +57,7 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "branches": 70,
+        "branches": 66,
         "functions": 80,
         "lines": 80
       }

--- a/packages/amplify-graphql-transformer/API.md
+++ b/packages/amplify-graphql-transformer/API.md
@@ -9,6 +9,7 @@ import { AssetProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { Construct } from 'constructs';
 import { DatasourceType } from '@aws-amplify/graphql-transformer-core';
 import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
+import { IFunction } from 'aws-cdk-lib/aws-lambda';
 import { NestedStackProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { RDSConnectionSecrets } from '@aws-amplify/graphql-transformer-core';
 import { RDSLayerMapping } from '@aws-amplify/graphql-transformer-interfaces';
@@ -62,6 +63,7 @@ export type TransformerFactoryArgs = {
     adminRoles?: Array<string>;
     identityPoolId?: string;
     customTransformers?: TransformerPluginProvider[];
+    functionNameMap?: Record<string, IFunction>;
 };
 
 // (No @packageDocumentation comment for this package)

--- a/packages/amplify-graphql-transformer/src/graphql-transformer.ts
+++ b/packages/amplify-graphql-transformer/src/graphql-transformer.ts
@@ -33,6 +33,7 @@ import {
   UserDefinedSlot,
 } from '@aws-amplify/graphql-transformer-core';
 import { Construct } from 'constructs';
+import { IFunction } from 'aws-cdk-lib/aws-lambda';
 
 /**
  * Arguments passed into a TransformerFactory
@@ -44,6 +45,7 @@ export type TransformerFactoryArgs = {
   adminRoles?: Array<string>;
   identityPoolId?: string;
   customTransformers?: TransformerPluginProvider[];
+  functionNameMap?: Record<string, IFunction>;
 };
 
 /**
@@ -71,7 +73,7 @@ export const constructTransformerChain = (options?: TransformerFactoryArgs): Tra
 
   return [
     modelTransformer,
-    new FunctionTransformer(),
+    new FunctionTransformer(options?.functionNameMap),
     new HttpTransformer(),
     new PredictionsTransformer(options?.storageConfig),
     new PrimaryKeyTransformer(),


### PR DESCRIPTION
#### Description of changes
Allow for passing in functions defined in-stack be used by the `@function` directive rather than relying on reference by name, or name +region, etc.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit tests, I didn't add a unit test to the function transformer package due to difficulty in generating a function in a different stack, and passing it through, so instead just testing in the construct itself.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
