### PR TITLE
fix: re-enable userOverriddenSlot response from api category transformation, to support mock

### DIFF
--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/transform-graphql-schema-v2.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/transform-graphql-schema-v2.test.ts
@@ -2,7 +2,7 @@ import { $TSContext, pathManager } from '@aws-amplify/amplify-cli-core';
 import { printer } from '@aws-amplify/amplify-prompts';
 import { ApiCategoryFacade } from '@aws-amplify/amplify-cli-core';
 import { constructTransformerChain } from '@aws-amplify/graphql-transformer';
-import { transformGraphQLSchemaV2 } from '../../graphql-transformer/transform-graphql-schema-v2';
+import { getUserOverridenSlots, transformGraphQLSchemaV2 } from '../../graphql-transformer/transform-graphql-schema-v2';
 import { generateTransformerOptions } from '../../graphql-transformer/transformer-options-v2';
 import { getAppSyncAPIName } from '../../provider-utils/awscloudformation/utils/amplify-meta-utils';
 import { AmplifyCLIFeatureFlagAdapter } from '../../graphql-transformer/amplify-cli-feature-flag-adapter';
@@ -90,5 +90,135 @@ describe('transformGraphQLSchemaV2', () => {
     expect(printerMock.warn).toBeCalledWith(
       'WARNING: owners may reassign ownership for the following model(s) and role(s): Todo: [owner]. If this is not intentional, you may want to apply field-level authorization rules to these fields. To read more: https://docs.amplify.aws/cli/graphql/authorization-rules/#per-user--owner-based-data-access.',
     );
+  });
+});
+
+describe('getUserOverridenSlots', () => {
+  it('returns for empty request', () => {
+    expect(getUserOverridenSlots({})).toEqual([]);
+  });
+
+  it('returns for request mapping template', () => {
+    expect(
+      getUserOverridenSlots({
+        'Query.getTodo': [
+          {
+            resolverTypeName: 'Query',
+            resolverFieldName: 'getTodo',
+            slotName: 'preAuth',
+            requestResolver: {
+              fileName: 'Query.getTodo.preAuth.1.req.vtl',
+              template: '$util.unauthorized()',
+            },
+          },
+        ],
+      }),
+    ).toEqual(['Query.getTodo.preAuth.1.req.vtl']);
+  });
+
+  it('returns for response mapping template', () => {
+    expect(
+      getUserOverridenSlots({
+        'Query.getTodo': [
+          {
+            resolverTypeName: 'Query',
+            resolverFieldName: 'getTodo',
+            slotName: 'preAuth',
+            requestResolver: {
+              fileName: 'Query.getTodo.preAuth.1.res.vtl',
+              template: '$util.unauthorized()',
+            },
+          },
+        ],
+      }),
+    ).toEqual(['Query.getTodo.preAuth.1.res.vtl']);
+  });
+
+  it('returns for both requets and response mapping template', () => {
+    expect(
+      getUserOverridenSlots({
+        'Query.getTodo': [
+          {
+            resolverTypeName: 'Query',
+            resolverFieldName: 'getTodo',
+            slotName: 'preAuth',
+            requestResolver: {
+              fileName: 'Query.getTodo.preAuth.1.req.vtl',
+              template: '$util.unauthorized()',
+            },
+          },
+          {
+            resolverTypeName: 'Query',
+            resolverFieldName: 'getTodo',
+            slotName: 'preAuth',
+            responseResolver: {
+              fileName: 'Query.getTodo.preAuth.1.res.vtl',
+              template: '$util.unauthorized()',
+            },
+          },
+        ],
+      }),
+    ).toEqual(['Query.getTodo.preAuth.1.req.vtl', 'Query.getTodo.preAuth.1.res.vtl']);
+  });
+
+  it('returns for multiple overridden resolvers', () => {
+    expect(
+      getUserOverridenSlots({
+        'Query.getTodo': [
+          {
+            resolverTypeName: 'Query',
+            resolverFieldName: 'getTodo',
+            slotName: 'preAuth',
+            requestResolver: {
+              fileName: 'Query.getTodo.preAuth.1.req.vtl',
+              template: '$util.unauthorized()',
+            },
+          },
+          {
+            resolverTypeName: 'Query',
+            resolverFieldName: 'getTodo',
+            slotName: 'preAuth',
+            responseResolver: {
+              fileName: 'Query.getTodo.preAuth.1.res.vtl',
+              template: '$util.unauthorized()',
+            },
+          },
+        ],
+        'Query.listTodos': [
+          {
+            resolverTypeName: 'Query',
+            resolverFieldName: 'listTodos',
+            slotName: 'postDataLoad',
+            requestResolver: {
+              fileName: 'Query.listTodos.postDataLoad.1.req.vtl',
+              template: '$util.unauthorized()',
+            },
+          },
+        ],
+      }),
+    ).toEqual(['Query.getTodo.preAuth.1.req.vtl', 'Query.getTodo.preAuth.1.res.vtl', 'Query.listTodos.postDataLoad.1.req.vtl']);
+  });
+
+  // This doesn't seem to be what the system does, but type allows, so testing it.
+  it('returns when set on the same object', () => {
+    expect(
+      getUserOverridenSlots({
+        'Query.getTodo': [
+          {
+            resolverTypeName: 'Query',
+            resolverFieldName: 'getTodo',
+            slotName: 'preAuth',
+            requestResolver: {
+              fileName: 'Query.getTodo.preAuth.1.req.vtl',
+              template: '$util.unauthorized()',
+            },
+            responseResolver: {
+              fileName: 'Query.getTodo.preAuth.1.res.vtl',
+              template: '$util.unauthorized()',
+            },
+          },
+        ],
+      }),
+    ).toEqual(['Query.getTodo.preAuth.1.req.vtl', 'Query.getTodo.preAuth.1.res.vtl']);
   });
 });

--- a/packages/amplify-category-api/src/graphql-transformer/cdk-compat/transform-manager.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/cdk-compat/transform-manager.ts
@@ -78,7 +78,7 @@ export class TransformManager {
     return synthParameters;
   }
 
-  generateDeploymentResources(): DeploymentResources {
+  generateDeploymentResources(): Omit<DeploymentResources, 'userOverriddenSlots'> {
     if (this.overrideConfig?.overrideFlag) {
       this.overrideConfig.applyOverride(this.rootStack);
     }
@@ -117,7 +117,6 @@ export class TransformManager {
       stacks: childStacks,
       rootStack: rootStackTemplate!,
       stackMapping: {},
-      userOverriddenSlots: [],
     };
   }
 


### PR DESCRIPTION
#### Description of changes
Apparently userOverriddenSlots was used in mock, so re-enabling in the output.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A,  getting e2e tests to pass on https://github.com/aws-amplify/amplify-category-api/pull/1751

#### Description of how you validated changes
Added unit tests after using debugger to inspect passed through state.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
