### PR TITLE
Check for directives not supported in RDS yet

### DIFF
--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/rds-utils.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/rds-utils.test.ts
@@ -1,0 +1,98 @@
+import { checkForUnsupportedDirectives } from '../../../../provider-utils/awscloudformation/utils/rds-resources/utils';
+
+describe('check for unsupported RDS directives', () => {
+  const modelToDatasourceMap = new Map();
+  modelToDatasourceMap.set('Post', { dbType: 'MySQL' });
+
+  it('should throw error if auth directive is present on a model', () => {
+    const schema = `
+            type Post @model @auth(rules: [{allow: owner}]) {
+                id: ID!
+                title: String!
+            }
+        `;
+    expect(() => checkForUnsupportedDirectives(schema, modelToDatasourceMap)).toThrowError();
+  });
+
+  it('should throw error if auth directive is present on a field', () => {
+    const schema = `
+            type Post @model {
+                id: ID!
+                title: String! @auth(rules: [{allow: owner}])
+            }
+        `;
+    expect(() => checkForUnsupportedDirectives(schema, modelToDatasourceMap)).toThrowError();
+  });
+
+  it('should throw error if searchable directive is present on a model', () => {
+    const schema = `
+            type Post @model @searchable {
+                id: ID!
+                title: String!
+            }
+        `;
+    expect(() => checkForUnsupportedDirectives(schema, modelToDatasourceMap)).toThrowError();
+  });
+
+  it('should throw error if predictions directive is present on a query type field', () => {
+    const schema = `
+            type Query {
+                recognizeTextFromImage: String @predictions(actions: [identifyText])
+            }
+        `;
+    expect(() => checkForUnsupportedDirectives(schema, modelToDatasourceMap)).toThrowError();
+  });
+
+  it('should throw error if function directive is present on a field', () => {
+    const schema = `
+            type Query {
+                echo(msg: String): String @function(name: "echofunction")
+            }
+        `;
+    expect(() => checkForUnsupportedDirectives(schema, modelToDatasourceMap)).toThrowError();
+  });
+
+  it('should throw error if manyToMany directive is present on a field', () => {
+    const schema = `
+            type Post @model {
+                id: ID!
+                title: String!
+                content: String
+                tags: [Tag] @manyToMany(relationName: "PostTags")
+            }
+            
+            type Tag @model {
+                id: ID!
+                label: String!
+                posts: [Post] @manyToMany(relationName: "PostTags")
+            }
+        `;
+    expect(() => checkForUnsupportedDirectives(schema, modelToDatasourceMap)).toThrowError();
+  });
+
+  it('should throw error if http directive is present on a field', () => {
+    const schema = `
+            type Post {
+                id: ID!
+                title: String
+                description: String
+                views: Int
+            }
+            
+            type Query {
+                listPosts: [Post] @http(url: "https://www.example.com/posts")
+            }
+        `;
+    expect(() => checkForUnsupportedDirectives(schema, modelToDatasourceMap)).toThrowError();
+  });
+
+  it('should throw error if mapsTo directive is present on a model', () => {
+    const schema = `
+            type Post @model @mapsTo(name: "Article") {
+                id: ID!
+                title: String!
+            }
+        `;
+    expect(() => checkForUnsupportedDirectives(schema, modelToDatasourceMap)).toThrowError();
+  });
+});

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/rds-utils.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/rds-utils.test.ts
@@ -13,7 +13,7 @@ describe('check for unsupported RDS directives', () => {
             }
         `;
     expect(() => checkForUnsupportedDirectives(schema, modelToDatasourceMap)).toThrowErrorMatchingInlineSnapshot(
-      `"Directive @auth  belonging to a type Post is not supported on RDS datasource backed types. Following directives are not supported on RDS datasource backed types: auth, searchable, predictions, function, manyToMany, http, mapsTo"`,
+      `"@auth directive on type \\"Post\\"  is not supported on RDS datasource. Following directives are not supported on RDS datasource: auth, searchable, predictions, function, manyToMany, http, mapsTo"`,
     );
   });
 
@@ -25,7 +25,7 @@ describe('check for unsupported RDS directives', () => {
             }
         `;
     expect(() => checkForUnsupportedDirectives(schema, modelToDatasourceMap)).toThrowErrorMatchingInlineSnapshot(
-      `"Directive @auth on field title belonging to a type Post is not supported on RDS datasource backed types. Following directives are not supported on RDS datasource backed types: auth, searchable, predictions, function, manyToMany, http, mapsTo"`,
+      `"@auth directive on type \\"Post\\" and field \\"title\\" is not supported on RDS datasource. Following directives are not supported on RDS datasource: auth, searchable, predictions, function, manyToMany, http, mapsTo"`,
     );
   });
 
@@ -37,7 +37,7 @@ describe('check for unsupported RDS directives', () => {
             }
         `;
     expect(() => checkForUnsupportedDirectives(schema, modelToDatasourceMap)).toThrowErrorMatchingInlineSnapshot(
-      `"Directive @searchable  belonging to a type Post is not supported on RDS datasource backed types. Following directives are not supported on RDS datasource backed types: auth, searchable, predictions, function, manyToMany, http, mapsTo"`,
+      `"@searchable directive on type \\"Post\\"  is not supported on RDS datasource. Following directives are not supported on RDS datasource: auth, searchable, predictions, function, manyToMany, http, mapsTo"`,
     );
   });
 
@@ -48,7 +48,7 @@ describe('check for unsupported RDS directives', () => {
             }
         `;
     expect(() => checkForUnsupportedDirectives(schema, modelToDatasourceMap)).toThrowErrorMatchingInlineSnapshot(
-      `"Directive @predictions on field recognizeTextFromImage belonging to a type Query is not supported on RDS datasource backed types. Following directives are not supported on RDS datasource backed types: auth, searchable, predictions, function, manyToMany, http, mapsTo"`,
+      `"@predictions directive on type \\"Query\\" and field \\"recognizeTextFromImage\\" is not supported on RDS datasource. Following directives are not supported on RDS datasource: auth, searchable, predictions, function, manyToMany, http, mapsTo"`,
     );
   });
 
@@ -59,7 +59,7 @@ describe('check for unsupported RDS directives', () => {
             }
         `;
     expect(() => checkForUnsupportedDirectives(schema, modelToDatasourceMap)).toThrowErrorMatchingInlineSnapshot(
-      `"Directive @function on field echo belonging to a type Query is not supported on RDS datasource backed types. Following directives are not supported on RDS datasource backed types: auth, searchable, predictions, function, manyToMany, http, mapsTo"`,
+      `"@function directive on type \\"Query\\" and field \\"echo\\" is not supported on RDS datasource. Following directives are not supported on RDS datasource: auth, searchable, predictions, function, manyToMany, http, mapsTo"`,
     );
   });
 
@@ -79,7 +79,7 @@ describe('check for unsupported RDS directives', () => {
             }
         `;
     expect(() => checkForUnsupportedDirectives(schema, modelToDatasourceMap)).toThrowErrorMatchingInlineSnapshot(
-      `"Directive @manyToMany on field tags belonging to a type Post is not supported on RDS datasource backed types. Following directives are not supported on RDS datasource backed types: auth, searchable, predictions, function, manyToMany, http, mapsTo"`,
+      `"@manyToMany directive on type \\"Post\\" and field \\"tags\\" is not supported on RDS datasource. Following directives are not supported on RDS datasource: auth, searchable, predictions, function, manyToMany, http, mapsTo"`,
     );
   });
 
@@ -97,7 +97,7 @@ describe('check for unsupported RDS directives', () => {
             }
         `;
     expect(() => checkForUnsupportedDirectives(schema, modelToDatasourceMap)).toThrowErrorMatchingInlineSnapshot(
-      `"Directive @http on field listPosts belonging to a type Query is not supported on RDS datasource backed types. Following directives are not supported on RDS datasource backed types: auth, searchable, predictions, function, manyToMany, http, mapsTo"`,
+      `"@http directive on type \\"Query\\" and field \\"listPosts\\" is not supported on RDS datasource. Following directives are not supported on RDS datasource: auth, searchable, predictions, function, manyToMany, http, mapsTo"`,
     );
   });
 
@@ -109,7 +109,7 @@ describe('check for unsupported RDS directives', () => {
             }
         `;
     expect(() => checkForUnsupportedDirectives(schema, modelToDatasourceMap)).toThrowErrorMatchingInlineSnapshot(
-      `"Directive @mapsTo  belonging to a type Post is not supported on RDS datasource backed types. Following directives are not supported on RDS datasource backed types: auth, searchable, predictions, function, manyToMany, http, mapsTo"`,
+      `"@mapsTo directive on type \\"Post\\"  is not supported on RDS datasource. Following directives are not supported on RDS datasource: auth, searchable, predictions, function, manyToMany, http, mapsTo"`,
     );
   });
 

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -17,6 +17,7 @@ import { mergeUserConfigWithTransformOutput, writeDeploymentToDisk } from './uti
 import { generateTransformerOptions } from './transformer-options-v2';
 import { TransformerProjectOptions } from './transformer-options-types';
 import { getAppSyncAPIName } from '../provider-utils/awscloudformation/utils/amplify-meta-utils';
+import { checkForUnsupportedDirectives } from '../provider-utils/awscloudformation/utils/rds-resources/utils';
 import { executeTransform } from '@aws-amplify/graphql-transformer';
 import {
   getConnectionSecrets,
@@ -183,6 +184,8 @@ const buildAPIProject = async (context: $TSContext, opts: TransformerProjectOpti
   if (!schema) {
     return undefined;
   }
+
+  checkForUnsupportedDirectives(schema, opts.projectConfig.modelToDatasourceMap);
 
   const { modelToDatasourceMap } = opts.projectConfig;
   const datasourceSecretMap = await getDatasourceSecretMap(context);

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
@@ -1,0 +1,66 @@
+import { parse, FieldDefinitionNode, ObjectTypeDefinitionNode, visit } from 'graphql';
+import _ from 'lodash';
+import { DatasourceType } from '@aws-amplify/graphql-transformer-core';
+
+export const checkForUnsupportedDirectives = (schema: string, modelToDatasourceMap: Map<string, DatasourceType>): void => {
+  const unsupportedRDSDirectives = ['auth', 'searchable', 'predictions', 'function', 'manyToMany', 'http', 'mapsTo'];
+  if (_.isEmpty(schema)) {
+    return;
+  }
+  // get all the models in the modelToDatasourceMap that are backed by RDS whose value is present in the db_type property inside the map
+  const rdsModels = Array.from(modelToDatasourceMap?.entries())
+    .filter(([key, value]) => value?.dbType === 'MySQL')
+    .map(([key, value]) => key);
+  const document = parse(schema);
+  const schemaVisitor = {
+    FieldDefinition: {
+      enter(node: FieldDefinitionNode, key, parent, path, ancestors): any {
+        const parentName = getParentName(ancestors);
+        if (!(parentName === 'Query') && !rdsModels.includes(parentName)) {
+          return;
+        }
+        node?.directives?.map((directive) => {
+          if (unsupportedRDSDirectives.includes(directive?.name?.value)) {
+            throw unsupportedDirectiveError(directive?.name?.value, node?.name?.value, parentName, unsupportedRDSDirectives);
+          }
+        });
+      },
+    },
+    ObjectTypeDefinition: {
+      enter(node: ObjectTypeDefinitionNode): any {
+        const typeName = node?.name?.value;
+        if (!(typeName === 'Query') && !rdsModels.includes(typeName)) {
+          return;
+        }
+        node?.directives?.map((directive) => {
+          if (unsupportedRDSDirectives.includes(directive?.name?.value)) {
+            throw unsupportedDirectiveError(directive?.name?.value, undefined, node?.name?.value, unsupportedRDSDirectives);
+          }
+        });
+      },
+    },
+  };
+
+  visit(document, schemaVisitor);
+};
+
+const unsupportedDirectiveError = (
+  directiveName: string,
+  fieldName: string | undefined,
+  typeName: string,
+  unsupportedDirectives: string[],
+): Error => {
+  return new Error(
+    `Directive @${directiveName} ${
+      fieldName ? `on field ${fieldName}` : ''
+    } belonging to a type ${typeName} is not supported on RDS datasource backed types. Following directives are not supported on RDS datasource backed types: ${unsupportedDirectives.join(
+      ', ',
+    )}`,
+  );
+};
+
+const getParentName = (ancestors: any[]): string | undefined => {
+  if (ancestors && ancestors?.length > 0) {
+    return (ancestors[ancestors.length - 1] as ObjectTypeDefinitionNode)?.name?.value;
+  }
+};

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
@@ -1,15 +1,16 @@
 import { parse, FieldDefinitionNode, ObjectTypeDefinitionNode, visit } from 'graphql';
 import _ from 'lodash';
-import { DatasourceType } from '@aws-amplify/graphql-transformer-core';
+import { DatasourceType, MYSQL_DB_TYPE } from '@aws-amplify/graphql-transformer-core';
 
 export const checkForUnsupportedDirectives = (schema: string, modelToDatasourceMap: Map<string, DatasourceType>): void => {
   const unsupportedRDSDirectives = ['auth', 'searchable', 'predictions', 'function', 'manyToMany', 'http', 'mapsTo'];
-  if (_.isEmpty(schema)) {
+  if (_.isEmpty(schema) || _.isEmpty(modelToDatasourceMap)) {
     return;
   }
+
   // get all the models in the modelToDatasourceMap that are backed by RDS whose value is present in the db_type property inside the map
   const rdsModels = Array.from(modelToDatasourceMap?.entries())
-    .filter(([key, value]) => value?.dbType === 'MySQL')
+    .filter(([key, value]) => value?.dbType === MYSQL_DB_TYPE)
     .map(([key, value]) => key);
   const document = parse(schema);
   const schemaVisitor = {

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
@@ -57,11 +57,9 @@ const unsupportedDirectiveError = (
   unsupportedDirectives: string[],
 ): Error => {
   return new Error(
-    `Directive @${directiveName} ${
-      fieldName ? `on field ${fieldName}` : ''
-    } belonging to a type ${typeName} is not supported on RDS datasource backed types. Following directives are not supported on RDS datasource backed types: ${unsupportedDirectives.join(
-      ', ',
-    )}`,
+    `@${directiveName} directive on type "${typeName}" ${
+      fieldName ? `and field "${fieldName}"` : ''
+    } is not supported on RDS datasource. Following directives are not supported on RDS datasource: ${unsupportedDirectives.join(', ')}`,
   );
 };
 

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
@@ -12,12 +12,17 @@ export const checkForUnsupportedDirectives = (schema: string, modelToDatasourceM
   const rdsModels = Array.from(modelToDatasourceMap?.entries())
     .filter(([key, value]) => value?.dbType === MYSQL_DB_TYPE)
     .map(([key, value]) => key);
+
+  if (_.isEmpty(rdsModels)) {
+    return;
+  }
+
   const document = parse(schema);
   const schemaVisitor = {
     FieldDefinition: {
       enter(node: FieldDefinitionNode, key, parent, path, ancestors): any {
         const parentName = getParentName(ancestors);
-        if (!(parentName === 'Query') && !rdsModels.includes(parentName)) {
+        if (!(parentName === 'Query') && !rdsModels?.includes(parentName)) {
           return;
         }
         node?.directives?.map((directive) => {
@@ -30,7 +35,7 @@ export const checkForUnsupportedDirectives = (schema: string, modelToDatasourceM
     ObjectTypeDefinition: {
       enter(node: ObjectTypeDefinitionNode): any {
         const typeName = node?.name?.value;
-        if (!(typeName === 'Query') && !rdsModels.includes(typeName)) {
+        if (!(typeName === 'Query') && !rdsModels?.includes(typeName)) {
           return;
         }
         node?.directives?.map((directive) => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Some of the directives like `auth, searchable` etc. are not yet supported for RDS datasource backed models.
We check for these and throw a useful error message so that customers can remove them from their schema before they re-compile again.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Added unit tests, tested in a CLI project.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
