### PR TITLE
feat: store api id on stack output

### DIFF
--- a/packages/amplify-graphql-api-construct/API.md
+++ b/packages/amplify-graphql-api-construct/API.md
@@ -236,15 +236,18 @@ export const versionedGraphqlOutputSchema: z.ZodDiscriminatedUnion<"version", [z
         awsAppsyncApiEndpoint: z.ZodString;
         awsAppsyncAuthenticationType: z.ZodEnum<["API_KEY", "AWS_LAMBDA", "AWS_IAM", "OPENID_CONNECT", "AMAZON_COGNITO_USER_POOLS"]>;
         awsAppsyncApiKey: z.ZodOptional<z.ZodString>;
+        awsAppsyncApiId: z.ZodString;
     }, "strip", z.ZodTypeAny, {
         awsAppsyncRegion: string;
         awsAppsyncApiEndpoint: string;
         awsAppsyncAuthenticationType: "API_KEY" | "AMAZON_COGNITO_USER_POOLS" | "AWS_IAM" | "OPENID_CONNECT" | "AWS_LAMBDA";
+        awsAppsyncApiId: string;
         awsAppsyncApiKey?: string | undefined;
     }, {
         awsAppsyncRegion: string;
         awsAppsyncApiEndpoint: string;
         awsAppsyncAuthenticationType: "API_KEY" | "AMAZON_COGNITO_USER_POOLS" | "AWS_IAM" | "OPENID_CONNECT" | "AWS_LAMBDA";
+        awsAppsyncApiId: string;
         awsAppsyncApiKey?: string | undefined;
     }>;
 }, "strip", z.ZodTypeAny, {
@@ -253,6 +256,7 @@ export const versionedGraphqlOutputSchema: z.ZodDiscriminatedUnion<"version", [z
         awsAppsyncRegion: string;
         awsAppsyncApiEndpoint: string;
         awsAppsyncAuthenticationType: "API_KEY" | "AMAZON_COGNITO_USER_POOLS" | "AWS_IAM" | "OPENID_CONNECT" | "AWS_LAMBDA";
+        awsAppsyncApiId: string;
         awsAppsyncApiKey?: string | undefined;
     };
 }, {
@@ -261,6 +265,7 @@ export const versionedGraphqlOutputSchema: z.ZodDiscriminatedUnion<"version", [z
         awsAppsyncRegion: string;
         awsAppsyncApiEndpoint: string;
         awsAppsyncAuthenticationType: "API_KEY" | "AMAZON_COGNITO_USER_POOLS" | "AWS_IAM" | "OPENID_CONNECT" | "AWS_LAMBDA";
+        awsAppsyncApiId: string;
         awsAppsyncApiKey?: string | undefined;
     };
 }>]>;

--- a/packages/amplify-graphql-api-construct/src/__tests__/__functional__/outputs.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/__functional__/outputs.test.ts
@@ -23,6 +23,7 @@ describe('storeOutput', () => {
           "AWS::Amplify::Output": Object {
             "graphqlOutput": Object {
               "stackOutputs": Array [
+                "awsAppsyncApiId",
                 "awsAppsyncApiEndpoint",
                 "awsAppsyncAuthenticationType",
                 "awsAppsyncRegion",
@@ -101,6 +102,7 @@ describe('storeOutput', () => {
         version: '1',
         payload: {
           awsAppsyncApiEndpoint: expect.stringMatching(tokenRegex),
+          awsAppsyncApiId: expect.stringMatching(tokenRegex),
           awsAppsyncApiKey: expect.stringMatching(tokenRegex),
           awsAppsyncAuthenticationType: 'API_KEY',
           awsAppsyncRegion: expect.stringMatching(awsRegionTokenRegex),
@@ -133,6 +135,7 @@ describe('storeOutput', () => {
       expect(addBackendOutputEntry).toBeCalledWith('graphqlOutput', {
         version: '1',
         payload: {
+          awsAppsyncApiId: expect.stringMatching(tokenRegex),
           awsAppsyncApiEndpoint: expect.stringMatching(tokenRegex),
           awsAppsyncAuthenticationType: 'OPENID_CONNECT',
           awsAppsyncRegion: expect.stringMatching(awsRegionTokenRegex),

--- a/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
+++ b/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
@@ -142,6 +142,7 @@ export class AmplifyGraphqlApi<SchemaType = AmplifyGraphqlApiResources> extends 
     const output: GraphqlOutput = {
       version: '1',
       payload: {
+        awsAppsyncApiId: this.resources.cfnResources.cfnGraphqlApi.attrApiId,
         awsAppsyncApiEndpoint: this.resources.cfnResources.cfnGraphqlApi.attrGraphQlUrl,
         awsAppsyncAuthenticationType: this.resources.cfnResources.cfnGraphqlApi.authenticationType as AwsAppsyncAuthenticationType,
         awsAppsyncRegion: stack.region,

--- a/packages/amplify-graphql-api-construct/src/graphql-output.ts
+++ b/packages/amplify-graphql-api-construct/src/graphql-output.ts
@@ -13,6 +13,7 @@ export const graphqlOutputSchemaV1 = z.object({
     awsAppsyncApiEndpoint: z.string(),
     awsAppsyncAuthenticationType: AwsAppsyncAuthenticationType,
     awsAppsyncApiKey: z.string().optional(),
+    awsAppsyncApiId: z.string(),
   }),
 });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Stores the AppSync API ID in the CFN stack output. This ID is needed downstream to fetch the introspection schema from AppSync.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

aws_appsync_apiId added to CFN output.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
