### PR TITLE
fix: don't perform sub if bucketName is an unresolved token

### DIFF
--- a/packages/amplify-graphql-api-construct/src/__tests__/__functional__/__snapshots__/predictions.test.ts.snap
+++ b/packages/amplify-graphql-api-construct/src/__tests__/__functional__/__snapshots__/predictions.test.ts.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`predictions category generates a resolver and iam policy without fn::sub when a real bucket is passed in 1`] = `
+"{
+  \\"Fn::Join\\": [
+    \\"\\\\n\\",
+    [
+      {
+        \\"Fn::Join\\": [
+          \\"\\",
+          [
+            \\"$util.qr($ctx.stash.put(\\\\\\"s3Bucket\\\\\\", \\\\\\"\\",
+            {
+              \\"Ref\\": \\"referencetoPredictionsBucket6CDC1F68Ref\\"
+            },
+            \\"\\\\\\"))\\"
+          ]
+        ]
+      },
+      \\"$util.qr($ctx.stash.put(\\\\\\"isList\\\\\\", false))\\\\n{}\\"
+    ]
+  ]
+}"
+`;
+
+exports[`predictions category generates a resolver and iam policy without fn::sub when a real bucket is passed in 2`] = `
+"{
+  \\"Type\\": \\"AWS::IAM::Policy\\",
+  \\"Properties\\": {
+    \\"PolicyDocument\\": {
+      \\"Statement\\": [
+        {
+          \\"Action\\": \\"s3:GetObject\\",
+          \\"Effect\\": \\"Allow\\",
+          \\"Resource\\": {
+            \\"Fn::Join\\": [
+              \\"\\",
+              [
+                \\"arn:aws:s3:::\\",
+                {
+                  \\"Ref\\": \\"referencetoPredictionsBucket6CDC1F68Ref\\"
+                },
+                \\"/public/*\\"
+              ]
+            ]
+          }
+        }
+      ],
+      \\"Version\\": \\"2012-10-17\\"
+    },
+    \\"PolicyName\\": \\"PredictionsStorageAccess68CD5140\\",
+    \\"Roles\\": [
+      {
+        \\"Ref\\": \\"predictionsIAMRole5BB74A99\\"
+      }
+    ]
+  }
+}"
+`;

--- a/packages/amplify-graphql-api-construct/src/__tests__/__functional__/predictions.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/__functional__/predictions.test.ts
@@ -1,6 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import * as s3 from 'aws-cdk-lib/aws-s3';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Template, Match } from 'aws-cdk-lib/assertions';
 import { AmplifyGraphqlApi } from '../../amplify-graphql-api';
 
 /**
@@ -47,5 +47,49 @@ describe('predictions category', () => {
     expect(api.resources.nestedStacks.PredictionsDirectiveStack).toBeDefined();
     const predictionsTemplate = Template.fromStack(api.resources.nestedStacks.PredictionsDirectiveStack);
     expect(predictionsTemplate).toBeDefined();
+  });
+
+  it('generates a resolver and iam policy without fn::sub when a real bucket is passed in', () => {
+    const stack = new cdk.Stack();
+    const api = new AmplifyGraphqlApi(stack, 'TestApi', {
+      schema: /* GraphQL */ `
+        type Query {
+          recognizeTextFromImage: String @predictions(actions: [identifyText])
+        }
+      `,
+      authorizationConfig: {
+        apiKeyConfig: { expires: cdk.Duration.days(7) },
+      },
+      predictionsBucket: new s3.Bucket(stack, 'PredictionsBucket'),
+    });
+
+    expect(api.resources.nestedStacks.PredictionsDirectiveStack).toBeDefined();
+    const predictionsTemplate = Template.fromStack(api.resources.nestedStacks.PredictionsDirectiveStack);
+    expect(predictionsTemplate).toBeDefined();
+
+    predictionsTemplate.resourceCountIs('AWS::AppSync::Resolver', 1);
+
+    const resolver = predictionsTemplate.findResources('AWS::AppSync::Resolver').QueryrecognizeTextFromImageResolver;
+    const requestMappingTemplate = JSON.stringify(resolver.Properties.RequestMappingTemplate, null, 2);
+    expect(requestMappingTemplate).toMatchSnapshot();
+    expect(requestMappingTemplate).not.toMatch(/Fn::Sub/);
+
+    predictionsTemplate.resourcePropertiesCountIs(
+      'AWS::IAM::Policy',
+      {
+        PolicyDocument: {
+          Statement: Match.arrayWith([Match.objectLike({ Action: 's3:GetObject' })]),
+        },
+      },
+      1,
+    );
+
+    const policies = predictionsTemplate.findResources('AWS::IAM::Policy');
+
+    const storageAccessPolicyId = Object.keys(policies).filter((policyId) => policyId.match(/PredictionsStorageAccess/))[0];
+    const storageAccessPolicy = JSON.stringify(policies[storageAccessPolicyId], null, 2);
+
+    expect(storageAccessPolicy).toMatchSnapshot();
+    expect(storageAccessPolicy).not.toMatch(/Fn::Sub/);
   });
 });


### PR DESCRIPTION
#### Description of changes
If a token is passed in for the predictions bucket name, then don't perform substitution, since conceivably this is already a token to a final value.

This gets predictions working for the CDK construct.

##### CDK / CloudFormation Parameters Changed
Rework how table access is referenced if a token is provided for the bucket name.

#### Issue #, if available
N/A

#### Description of how you validated changes
Updated function tests for CDK construct, and validated manually that I can deploy and successfully use predictions.

Also running e2e suite to verify not regressions to existing functionality.

Validated with the following shape

```typescript
new AmplifyGraphqlApi(stack, 'MyApi', {
  schema: /* GraphQL */ `
    type Query {
      recognizeTextFromImage: String @predictions(actions: [identifyText])
    }
  `,
  predictionsBucket: new s3.Bucket(stack, 'PredictionsBucket'),
  authorizationConfig: { apiKeyConfig: { expires: cdk.Duration.days(30) } },
});
```

And uploading a file to the generated bucket:

<img width="1355" alt="Screenshot 2023-08-22 at 5 27 19 PM" src="https://github.com/aws-amplify/amplify-category-api/assets/91494052/61814f01-b486-44c0-ab67-fa8b8c7a3564">

Allows to retrieve the text:

<img width="1608" alt="Screenshot 2023-08-22 at 5 27 10 PM" src="https://github.com/aws-amplify/amplify-category-api/assets/91494052/e4800446-ef36-4055-b3b6-be7b73c0aba0">

For the following image:
<img width="517" alt="sign" src="https://github.com/aws-amplify/amplify-category-api/assets/91494052/0dbd5d38-f042-4be9-b09c-37f603cf8bc9">

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
