### PR TITLE
chore: add back in backwards compatibility apis to core transformer

### DIFF
--- a/packages/amplify-category-api/src/graphql-transformer/cdk-compat/transform-manager.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/cdk-compat/transform-manager.ts
@@ -1,6 +1,13 @@
 import { App, CfnParameter, Stack } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import type { AssetProvider, NestedStackProvider, S3Asset, AssetProps, SynthParameters } from '@aws-amplify/graphql-transformer-interfaces';
+import type {
+  AssetProvider,
+  NestedStackProvider,
+  S3Asset,
+  AssetProps,
+  SynthParameters,
+  TransformParameterProvider,
+} from '@aws-amplify/graphql-transformer-interfaces';
 import { DeploymentResources, Template } from './deployment-resources';
 import { TransformerStackSythesizer } from './stack-synthesizer';
 import { TransformerNestedStack } from './nested-stack';
@@ -22,11 +29,15 @@ export class TransformManager {
   public readonly rootStack: TransformerRootStack;
   private readonly stackSynthesizer = new TransformerStackSythesizer();
   private readonly childStackSynthesizers: Map<string, TransformerStackSythesizer> = new Map();
+  private synthParameters: SynthParameters;
+  private paramMap: Map<string, CfnParameter>;
 
-  constructor(private readonly overrideConfig?: OverrideConfig) {
+  constructor(private readonly overrideConfig: OverrideConfig | undefined, hasIamAuth: boolean, hasUserPoolAuth: boolean) {
     this.rootStack = new TransformerRootStack(this.app, 'transformer-root-stack', {
       synthesizer: this.stackSynthesizer,
     });
+
+    this.generateParameters(hasIamAuth, hasUserPoolAuth);
   }
 
   getTransformScope(): Construct {
@@ -55,27 +66,45 @@ export class TransformManager {
     };
   }
 
-  getSynthParameters(hasIamAuth: boolean, hasUserPoolAuth: boolean): SynthParameters {
+  private generateParameters(hasIamAuth: boolean, hasUserPoolAuth: boolean): void {
+    this.paramMap = new Map();
     const envParameter = new CfnParameter(this.rootStack, 'env', {
       default: 'NONE',
       type: 'String',
     });
+    this.paramMap.set('env', envParameter);
     const apiNameParameter = new CfnParameter(this.rootStack, 'AppSyncApiName', {
       default: 'AppSyncSimpleTransform',
       type: 'String',
     });
-    const synthParameters: SynthParameters = {
+    this.paramMap.set('AppSyncApiName', apiNameParameter);
+    this.synthParameters = {
       amplifyEnvironmentName: envParameter.valueAsString,
       apiName: apiNameParameter.valueAsString,
     };
     if (hasIamAuth) {
-      synthParameters.authenticatedUserRoleName = new CfnParameter(this.rootStack, 'authRoleName', { type: 'String' }).valueAsString;
-      synthParameters.unauthenticatedUserRoleName = new CfnParameter(this.rootStack, 'unauthRoleName', { type: 'String' }).valueAsString;
+      const authenticatedUserRoleNameParameter = new CfnParameter(this.rootStack, 'authRoleName', { type: 'String' });
+      this.synthParameters.authenticatedUserRoleName = authenticatedUserRoleNameParameter.valueAsString;
+      this.paramMap.set('authRoleName', authenticatedUserRoleNameParameter);
+      const unauthenticatedUserRoleNameParameter = new CfnParameter(this.rootStack, 'unauthRoleName', { type: 'String' });
+      this.synthParameters.unauthenticatedUserRoleName = unauthenticatedUserRoleNameParameter.valueAsString;
+      this.paramMap.set('unauthRoleName', unauthenticatedUserRoleNameParameter);
     }
     if (hasUserPoolAuth) {
-      synthParameters.userPoolId = new CfnParameter(this.rootStack, 'AuthCognitoUserPoolId', { type: 'String' }).valueAsString;
+      const userPoolIdParameter = new CfnParameter(this.rootStack, 'AuthCognitoUserPoolId', { type: 'String' });
+      this.synthParameters.userPoolId = userPoolIdParameter.valueAsString;
+      this.paramMap.set('AuthCognitoUserPoolId', userPoolIdParameter);
     }
-    return synthParameters;
+  }
+
+  getParameterProvider(): TransformParameterProvider {
+    return {
+      provide: (name: string): CfnParameter | void => this.paramMap.get(name),
+    };
+  }
+
+  getSynthParameters(): SynthParameters {
+    return this.synthParameters;
   }
 
   generateDeploymentResources(): Omit<DeploymentResources, 'userOverriddenSlots'> {

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -210,14 +210,15 @@ const buildAPIProject = async (context: $TSContext, opts: TransformerProjectOpti
   }
   const rdsLayerMapping = await getRDSLayerMapping();
 
-  const transformManager = new TransformManager(opts.overrideConfig);
+  const transformManager = new TransformManager(opts.overrideConfig, hasIamAuth(opts.authConfig), hasUserPoolAuth(opts.authConfig));
 
   executeTransform({
     ...opts,
     scope: transformManager.rootStack,
     nestedStackProvider: transformManager.getNestedStackProvider(),
     assetProvider: transformManager.getAssetProvider(),
-    synthParameters: transformManager.getSynthParameters(hasIamAuth(opts.authConfig), hasUserPoolAuth(opts.authConfig)),
+    parameterProvider: transformManager.getParameterProvider(),
+    synthParameters: transformManager.getSynthParameters(),
     schema,
     modelToDatasourceMap: opts.projectConfig.modelToDatasourceMap,
     datasourceSecretParameterLocations: datasourceSecretMap,

--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -14,6 +14,7 @@ import { AuthorizationConfig } from 'aws-cdk-lib/aws-appsync';
 import { AuthorizationType } from 'aws-cdk-lib/aws-appsync';
 import { CfnApiKey } from 'aws-cdk-lib/aws-appsync';
 import { CfnGraphQLSchema } from 'aws-cdk-lib/aws-appsync';
+import { CfnParameter } from 'aws-cdk-lib';
 import { CfnResource } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { DataSourceInstance } from '@aws-amplify/graphql-transformer-interfaces';
@@ -74,6 +75,7 @@ import { TransformerSchemaVisitStepContextProvider } from '@aws-amplify/graphql-
 import { TransformerSecrets } from '@aws-amplify/graphql-transformer-interfaces';
 import { TransformerTransformSchemaStepContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { TransformHostProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { TransformParameterProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import type { TransformParameters } from '@aws-amplify/graphql-transformer-interfaces';
 import { TypeDefinitionNode } from 'graphql';
 import { TypeNode } from 'graphql';
@@ -221,7 +223,7 @@ export class GraphQLTransform {
     // Warning: (ae-forgotten-export) The symbol "TransformOption" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    transform({ scope, nestedStackProvider, assetProvider, synthParameters, schema, datasourceConfig }: TransformOption): void;
+    transform({ scope, nestedStackProvider, parameterProvider, assetProvider, synthParameters, schema, datasourceConfig, }: TransformOption): void;
 }
 
 // @public (undocumented)
@@ -416,13 +418,17 @@ export type SetResourceNameProps = {
 // @public (undocumented)
 export class StackManager implements StackManagerProvider {
     // Warning: (ae-forgotten-export) The symbol "ResourceToStackMap" needs to be exported by the entry point index.d.ts
-    constructor(scope: Construct, nestedStackProvider: NestedStackProvider, resourceMapping: ResourceToStackMap);
+    constructor(scope: Construct, nestedStackProvider: NestedStackProvider, parameterProvider: TransformParameterProvider | undefined, resourceMapping: ResourceToStackMap);
     // (undocumented)
     createStack: (stackName: string) => Stack;
+    // (undocumented)
+    getParameter: (name: string) => CfnParameter | void;
     // (undocumented)
     getScopeFor: (resourceId: string, defaultStackName?: string) => Construct;
     // (undocumented)
     getStack: (stackName: string) => Stack;
+    // (undocumented)
+    getStackFor: (resourceId: string, defaultStackName?: string) => Construct;
     // (undocumented)
     hasStack: (stackName: string) => boolean;
     // (undocumented)
@@ -592,6 +598,8 @@ export class TransformerResolver implements TransformerResolverProvider {
     //
     // (undocumented)
     findSlot: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider) => Slot | undefined;
+    // (undocumented)
+    mapToStack: (stack: Stack) => void;
     // (undocumented)
     setScope: (scope: Construct) => void;
     // (undocumented)

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transformation/transform.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transformation/transform.test.ts
@@ -69,7 +69,7 @@ describe('GraphQLTransform', () => {
     }): void => {
       const app = new App();
       const stack = new Stack(app, 'TestStack');
-      const stackManager = new StackManager(stack, testNestedStackProvider, {});
+      const stackManager = new StackManager(stack, testNestedStackProvider, undefined, {});
       const transformerOutput = {
         buildSchema: jest.fn(() => ''),
       } as unknown as TransformerOutput;
@@ -98,7 +98,7 @@ describe('GraphQLTransform', () => {
       const transform = new TestGraphQLTransform({ transformers: [mockTransformer] });
       const app = new App();
       const stack = new Stack(app, 'TestStack');
-      const stackManager = new StackManager(stack, testNestedStackProvider, {});
+      const stackManager = new StackManager(stack, testNestedStackProvider, undefined, {});
       const transformerOutput = {
         buildSchema: jest.fn(() => ''),
       } as unknown as TransformerOutput;

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -9,7 +9,12 @@ import {
   RDSLayerMapping,
   SynthParameters,
 } from '@aws-amplify/graphql-transformer-interfaces';
-import type { AssetProvider, StackManagerProvider, TransformParameters } from '@aws-amplify/graphql-transformer-interfaces';
+import type {
+  AssetProvider,
+  StackManagerProvider,
+  TransformParameterProvider,
+  TransformParameters,
+} from '@aws-amplify/graphql-transformer-interfaces';
 import { AuthorizationMode, AuthorizationType } from 'aws-cdk-lib/aws-appsync';
 import { Aws, CfnOutput, Fn, Stack } from 'aws-cdk-lib';
 import {
@@ -88,6 +93,7 @@ export interface GraphQLTransformOptions {
 export type TransformOption = {
   scope: Construct;
   nestedStackProvider: NestedStackProvider;
+  parameterProvider?: TransformParameterProvider;
   assetProvider: AssetProvider;
   synthParameters: SynthParameters;
   schema: string;
@@ -185,12 +191,21 @@ export class GraphQLTransform {
    * on to the next transformer. At the end of the transformation a
    * cloudformation template is returned.
    */
-  public transform({ scope, nestedStackProvider, assetProvider, synthParameters, schema, datasourceConfig }: TransformOption): void {
+  public transform({
+    scope,
+    nestedStackProvider,
+    parameterProvider,
+    assetProvider,
+    synthParameters,
+    schema,
+    datasourceConfig,
+  }: TransformOption): void {
     this.seenTransformations = {};
     const parsedDocument = parse(schema);
     const context = new TransformerContext(
       scope,
       nestedStackProvider,
+      parameterProvider,
       assetProvider,
       synthParameters,
       parsedDocument,

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
@@ -10,7 +10,12 @@ import {
   RDSLayerMapping,
   SynthParameters,
 } from '@aws-amplify/graphql-transformer-interfaces';
-import type { AssetProvider, NestedStackProvider, TransformParameters } from '@aws-amplify/graphql-transformer-interfaces';
+import type {
+  AssetProvider,
+  NestedStackProvider,
+  TransformParameterProvider,
+  TransformParameters,
+} from '@aws-amplify/graphql-transformer-interfaces';
 import { TransformerContextMetadataProvider } from '@aws-amplify/graphql-transformer-interfaces/src/transformer-context/transformer-context-provider';
 import { DocumentNode } from 'graphql';
 import { Construct } from 'constructs';
@@ -78,6 +83,7 @@ export class TransformerContext implements TransformerContextProvider {
   constructor(
     scope: Construct,
     nestedStackProvider: NestedStackProvider,
+    parameterProvider: TransformParameterProvider | undefined,
     assetProvider: AssetProvider,
     public readonly synthParameters: SynthParameters,
     public readonly inputDocument: DocumentNode,
@@ -95,7 +101,7 @@ export class TransformerContext implements TransformerContextProvider {
     this.resolvers = new ResolverManager();
     this.dataSources = new TransformerDataSourceManager();
     this.providerRegistry = new TransformerContextProviderRegistry();
-    this.stackManager = new StackManager(scope, nestedStackProvider, stackMapping);
+    this.stackManager = new StackManager(scope, nestedStackProvider, parameterProvider, stackMapping);
     this.authConfig = authConfig;
     this.resourceHelper = new TransformerResourceHelper(this.synthParameters);
     this.transformParameters = transformParameters;

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -162,6 +162,15 @@ export class TransformerResolver implements TransformerResolverProvider {
     this.slotNames = new Set([...requestSlots, ...responseSlots]);
   }
 
+  /**
+   * Map a resolver to a given stack.
+   * @deprecated, use setScope instead.
+   * @param stack the stack you are mapping to
+   */
+  mapToStack = (stack: Stack): void => {
+    this.scope = stack;
+  };
+
   setScope = (scope: Construct): void => {
     this.scope = scope;
   };

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/stack-manager.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/stack-manager.ts
@@ -1,5 +1,5 @@
-import { StackManagerProvider, NestedStackProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { Stack } from 'aws-cdk-lib';
+import { StackManagerProvider, NestedStackProvider, TransformParameterProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { CfnParameter, Stack } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
 export type ResourceToStackMap = Record<string, string>;
@@ -15,6 +15,7 @@ export class StackManager implements StackManagerProvider {
   constructor(
     public readonly scope: Construct,
     private readonly nestedStackProvider: NestedStackProvider,
+    private readonly parameterProvider: TransformParameterProvider | undefined,
     resourceMapping: ResourceToStackMap,
   ) {
     this.resourceToStackMap = new Map(Object.entries(resourceMapping));
@@ -38,6 +39,23 @@ export class StackManager implements StackManagerProvider {
     }
     return this.createStack(stackName);
   };
+
+  /**
+   * Alias for `getScopeFor` to maintain some backwards compatibility for 3p plugins.
+   * @deprecated - use `getScopeFor` instead.
+   * @param resourceId the resourceId to search for
+   * @param defaultStackName the default stack name to retrieve.
+   * @returns the stack, or a new one if not yet defined.
+   */
+  getStackFor = (resourceId: string, defaultStackName?: string): Construct => this.getScopeFor(resourceId, defaultStackName);
+
+  /**
+   * Retrieve a parameter used for synth.
+   * @deprecated - use `context.synthParameters.amplifyEnvironmentName` (e.g. for `env`) to retrieve known parameters.
+   * @param name the param name to retrieve.
+   * @returns the parameter, or none if not defined.
+   */
+  getParameter = (name: string): CfnParameter | void => this.parameterProvider && this.parameterProvider.provide(name);
 
   getStack = (stackName: string): Stack => {
     if (this.stacks.has(stackName)) {

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -7,6 +7,7 @@
 import { BackedDataSource } from 'aws-cdk-lib/aws-appsync';
 import { BaseDataSource } from 'aws-cdk-lib/aws-appsync';
 import { CfnDomain } from 'aws-cdk-lib/aws-elasticsearch';
+import { CfnParameter } from 'aws-cdk-lib';
 import { CfnResolver } from 'aws-cdk-lib/aws-appsync';
 import { CfnResource } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
@@ -297,9 +298,13 @@ export interface StackManagerProvider {
     // (undocumented)
     createStack: (stackName: string) => Stack;
     // (undocumented)
+    getParameter: (name: string) => CfnParameter | void;
+    // (undocumented)
     getScopeFor: (resourceId: string, defaultStackName?: string) => Construct;
     // (undocumented)
     getStack: (stackName: string) => Stack;
+    // (undocumented)
+    getStackFor: (resourceId: string, defaultStackName?: string) => Construct;
     // (undocumented)
     hasStack: (stackName: string) => boolean;
     // (undocumented)
@@ -614,6 +619,8 @@ export interface TransformerResolverProvider {
     // (undocumented)
     addToSlot: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider, dataSource?: DataSourceProvider) => void;
     // (undocumented)
+    mapToStack: (stack: Stack) => void;
+    // (undocumented)
     setScope: (scope: Construct) => void;
     // (undocumented)
     synthesize: (context: TransformerContextProvider, api: GraphQLAPIProvider) => void;
@@ -715,6 +722,12 @@ export interface TransformHostProvider {
     hasResolver: (typeName: string, fieldName: string) => boolean;
     // (undocumented)
     setAPI(api: GraphqlApiBase): void;
+}
+
+// @public (undocumented)
+export interface TransformParameterProvider {
+    // (undocumented)
+    provide: (name: string) => CfnParameter | void;
 }
 
 // @public (undocumented)

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/index.ts
@@ -21,3 +21,4 @@ export { TransformerSchemaHelperProvider } from './schema-helper-provider';
 export { TransformerPreProcessContextProvider } from './transformer-preprocess-context-provider';
 export { StackManagerProvider } from './stack-manager-provider';
 export { SynthParameters } from './synth-parameters';
+export { TransformParameterProvider } from './transform-parameter-provider';

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/stack-manager-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/stack-manager-provider.ts
@@ -1,4 +1,4 @@
-import { Stack } from 'aws-cdk-lib';
+import { CfnParameter, Stack } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
 export interface StackManagerProvider {
@@ -7,4 +7,16 @@ export interface StackManagerProvider {
   createStack: (stackName: string) => Stack;
   hasStack: (stackName: string) => boolean;
   getScopeFor: (resourceId: string, defaultStackName?: string) => Construct;
+
+  /**
+   * Retrieve the given scope for a stack name.
+   * @deprecated use getScopeFor instead.
+   */
+  getStackFor: (resourceId: string, defaultStackName?: string) => Construct;
+
+  /**
+   * Try and retrieve a parameter for the given name.
+   * @deprecated use context.synthParameters instead.
+   */
+  getParameter: (name: string) => CfnParameter | void;
 }

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transform-parameter-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transform-parameter-provider.ts
@@ -1,0 +1,8 @@
+import { CfnParameter } from 'aws-cdk-lib';
+
+/**
+ * Provider in order to facilitate existing 3p transformers which may depend on `env` parameters, for example.
+ */
+export interface TransformParameterProvider {
+  provide: (name: string) => CfnParameter | void;
+}

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-resolver-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-resolver-provider.ts
@@ -1,4 +1,5 @@
 import { Construct } from 'constructs';
+import { Stack } from 'aws-cdk-lib';
 import { GraphQLAPIProvider, MappingTemplateProvider } from '../graphql-api-provider';
 import { DataSourceProvider } from './transformer-datasource-provider';
 import { TransformerContextProvider } from './transformer-context-provider';
@@ -12,6 +13,12 @@ export interface TransformerResolverProvider {
   ) => void;
   synthesize: (context: TransformerContextProvider, api: GraphQLAPIProvider) => void;
   setScope: (scope: Construct) => void;
+
+  /**
+   * Map the given resolver to a stack.
+   * @deprecated use setScope instead.
+   */
+  mapToStack: (stack: Stack) => void;
 }
 
 export interface TransformerResolversManagerProvider {

--- a/packages/amplify-graphql-transformer/API.md
+++ b/packages/amplify-graphql-transformer/API.md
@@ -17,6 +17,7 @@ import { ResolverConfig } from '@aws-amplify/graphql-transformer-core';
 import { SynthParameters } from '@aws-amplify/graphql-transformer-interfaces';
 import { TransformerLog } from '@aws-amplify/graphql-transformer-interfaces';
 import { TransformerPluginProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { TransformParameterProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import type { TransformParameters } from '@aws-amplify/graphql-transformer-interfaces/src';
 import { UserDefinedSlot } from '@aws-amplify/graphql-transformer-core';
 import { VpcConfig } from '@aws-amplify/graphql-transformer-interfaces';
@@ -40,6 +41,7 @@ export type ExecuteTransformConfig = TransformConfig & {
     rdsLayerMapping?: RDSLayerMapping;
     scope: Construct;
     nestedStackProvider: NestedStackProvider;
+    parameterProvider?: TransformParameterProvider;
     assetProvider: AssetProvider;
     synthParameters: SynthParameters;
 };

--- a/packages/amplify-graphql-transformer/src/graphql-transformer.ts
+++ b/packages/amplify-graphql-transformer/src/graphql-transformer.ts
@@ -23,6 +23,7 @@ import {
   NestedStackProvider,
   AssetProvider,
   SynthParameters,
+  TransformParameterProvider,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import type { TransformParameters } from '@aws-amplify/graphql-transformer-interfaces/src';
 import {
@@ -130,6 +131,7 @@ export type ExecuteTransformConfig = TransformConfig & {
   rdsLayerMapping?: RDSLayerMapping;
   scope: Construct;
   nestedStackProvider: NestedStackProvider;
+  parameterProvider?: TransformParameterProvider;
   assetProvider: AssetProvider;
   synthParameters: SynthParameters;
 };
@@ -173,6 +175,7 @@ export const executeTransform = (config: ExecuteTransformConfig): void => {
     nestedStackProvider,
     assetProvider,
     synthParameters,
+    parameterProvider,
   } = config;
 
   const printLog = printTransformerLog ?? defaultPrintTransformerLog;
@@ -182,6 +185,7 @@ export const executeTransform = (config: ExecuteTransformConfig): void => {
     transform.transform({
       scope,
       nestedStackProvider,
+      parameterProvider,
       assetProvider,
       synthParameters,
       schema,


### PR DESCRIPTION
#### Description of changes
Adding back in alias methods to keep from breaking 3p transformers.

This pr reintroduces the following APIs in core:
* `resolver.mapToStack`
* `context.stackManager.getParameter`
* `context.stackManager.getStackFor`

##### CDK / CloudFormation Parameters Changed
N/A, exposing paramMap for existing plugin use-cases.

#### Issue #, if available
N/A

#### Description of how you validated changes
Running unit + e2e tests.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
