### PR TITLE
fix(graphql-schema-validation): relationship names not unique

### DIFF
--- a/packages/amplify-schema-validator/package.json
+++ b/packages/amplify-schema-validator/package.json
@@ -33,7 +33,7 @@
   "size-limit": [
     {
       "path": "./dist/index.js",
-      "limit": "5 KB",
+      "limit": "6 KB",
       "ignore": [
         "graphql"
       ]

--- a/packages/amplify-schema-validator/src/__tests__/schemas/invalid-unique-field-names-with-relation.graphql
+++ b/packages/amplify-schema-validator/src/__tests__/schemas/invalid-unique-field-names-with-relation.graphql
@@ -1,0 +1,17 @@
+type Contact @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  users: [User] @manyToMany(relationName: "UserContact")
+  Users: User @hasOne
+}
+
+type User @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  name: String
+  image: String
+  status: String
+  email: AWSEmail
+  sub: String
+  createdOn: AWSTimestamp
+  Contacts: [Contact] @manyToMany(relationName: "UserContact")
+  contactID: ID! @index(name: "byContact")
+}

--- a/packages/amplify-schema-validator/src/__tests__/schemas/invalid-unique-field-names-with-relation.graphql
+++ b/packages/amplify-schema-validator/src/__tests__/schemas/invalid-unique-field-names-with-relation.graphql
@@ -1,10 +1,10 @@
-type Contact @model @auth(rules: [{allow: public}]) {
+type Contact @model @auth(rules: [{ allow: public }]) {
   id: ID!
   users: [User] @manyToMany(relationName: "UserContact")
   Users: User @hasOne
 }
 
-type User @model @auth(rules: [{allow: public}]) {
+type User @model @auth(rules: [{ allow: public }]) {
   id: ID!
   name: String
   image: String

--- a/packages/amplify-schema-validator/src/__tests__/schemas/valid-unique-field-names-with-relation.graphql
+++ b/packages/amplify-schema-validator/src/__tests__/schemas/valid-unique-field-names-with-relation.graphql
@@ -1,10 +1,10 @@
-type Contact @model @auth(rules: [{allow: public}]) {
+type Contact @model @auth(rules: [{ allow: public }]) {
   id: ID!
   users: [User] @manyToMany(relationName: "UserContact")
   Users: String
 }
 
-type User @model @auth(rules: [{allow: public}]) {
+type User @model @auth(rules: [{ allow: public }]) {
   id: ID!
   name: String
   image: String

--- a/packages/amplify-schema-validator/src/__tests__/schemas/valid-unique-field-names-with-relation.graphql
+++ b/packages/amplify-schema-validator/src/__tests__/schemas/valid-unique-field-names-with-relation.graphql
@@ -1,0 +1,17 @@
+type Contact @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  users: [User] @manyToMany(relationName: "UserContact")
+  Users: String
+}
+
+type User @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  name: String
+  image: String
+  status: String
+  email: AWSEmail
+  sub: String
+  createdOn: AWSTimestamp
+  Contacts: [Contact] @manyToMany(relationName: "UserContact")
+  contactID: ID! @index(name: "byContact")
+}

--- a/packages/amplify-schema-validator/src/__tests__/validates-unique-field-names-with-relation.test.ts
+++ b/packages/amplify-schema-validator/src/__tests__/validates-unique-field-names-with-relation.test.ts
@@ -1,0 +1,15 @@
+import { validateSchema } from '..';
+import { readSchema } from './helpers/readSchema';
+
+describe('Validate Schema', () => {
+  it('fails validation if relationship fields are not unique', () => {
+    const schema = readSchema('invalid-unique-field-names-with-relation.graphql');
+    const errorRegex = 'There are two or more relationship fields with the same name';
+    expect(() => validateSchema(schema)).toThrow(errorRegex);
+  });
+
+  it('passes validation if relationship names are unique', () => {
+    const schema = readSchema('valid-unique-field-names-with-relation.graphql');
+    expect(() => validateSchema(schema)).not.toThrow();
+  });
+});

--- a/packages/amplify-schema-validator/src/index.ts
+++ b/packages/amplify-schema-validator/src/index.ts
@@ -24,6 +24,7 @@ import { validateBelongsToIsUsedWhenDatastoreInUse } from './validators/use-belo
 import { validateDirectivesFromOlderTransformerVersionAreNotUsed } from './validators/use-directives-from-older-transformer-version';
 import { validateDirectivesFromNewerTransformerVersionAreNotUsed } from './validators/use-directives-from-newer-transformer-version';
 import { ValidateSchemaProps } from './helpers/schema-validator-props';
+import { validateFieldNamesAreUniqueWithRelationsPresent } from './validators/unique-field-names-with-relation';
 
 const allValidators = [
   validateIndexScalarTypes,
@@ -43,6 +44,7 @@ const allValidators = [
   validateIndexExistsInRelatedModel,
   validateEnumIsDefinedOnce,
   validateKeyExistsInRelatedModel,
+  validateFieldNamesAreUniqueWithRelationsPresent,
 ];
 
 const allValidatorsWithContext = [

--- a/packages/amplify-schema-validator/src/index.ts
+++ b/packages/amplify-schema-validator/src/index.ts
@@ -62,7 +62,7 @@ const allValidatorsWithContext = [
  */
 export const validateSchema = (schemaString: string): void => {
   const schema = parse(schemaString);
-  const validationErrors = allValidators.flatMap((validate) => validate(schema));
+  const validationErrors = allValidators.flatMap(validate => validate(schema));
   if (validationErrors.length > 0) {
     const allErrorMessages = validationErrors.map((error: Error) => `${error.name} - ${error.message}`);
     throw new ValidationError(allErrorMessages.join('\n'));
@@ -79,7 +79,7 @@ export const validateSchema = (schemaString: string): void => {
  */
 export const validateSchemaWithContext = (schemaString: string, props: ValidateSchemaProps): void => {
   const schema = parse(schemaString);
-  const validationErrors = allValidatorsWithContext.flatMap((validate) => validate(schema, props));
+  const validationErrors = allValidatorsWithContext.flatMap(validate => validate(schema, props));
   if (validationErrors.length > 0) {
     const allErrorMessages = validationErrors.map((error: Error) => `${error.name} - ${error.message}`);
     throw new ValidationError(allErrorMessages.join('\n'));

--- a/packages/amplify-schema-validator/src/index.ts
+++ b/packages/amplify-schema-validator/src/index.ts
@@ -62,7 +62,7 @@ const allValidatorsWithContext = [
  */
 export const validateSchema = (schemaString: string): void => {
   const schema = parse(schemaString);
-  const validationErrors = allValidators.flatMap(validate => validate(schema));
+  const validationErrors = allValidators.flatMap((validate) => validate(schema));
   if (validationErrors.length > 0) {
     const allErrorMessages = validationErrors.map((error: Error) => `${error.name} - ${error.message}`);
     throw new ValidationError(allErrorMessages.join('\n'));
@@ -79,7 +79,7 @@ export const validateSchema = (schemaString: string): void => {
  */
 export const validateSchemaWithContext = (schemaString: string, props: ValidateSchemaProps): void => {
   const schema = parse(schemaString);
-  const validationErrors = allValidatorsWithContext.flatMap(validate => validate(schema, props));
+  const validationErrors = allValidatorsWithContext.flatMap((validate) => validate(schema, props));
   if (validationErrors.length > 0) {
     const allErrorMessages = validationErrors.map((error: Error) => `${error.name} - ${error.message}`);
     throw new ValidationError(allErrorMessages.join('\n'));

--- a/packages/amplify-schema-validator/src/validators/unique-field-names-with-relation.ts
+++ b/packages/amplify-schema-validator/src/validators/unique-field-names-with-relation.ts
@@ -1,6 +1,4 @@
-import { DocumentNode, Kind, ObjectTypeDefinitionNode, StringValueNode } from 'graphql';
-import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
-import { getGraphqlName, toUpper } from '../helpers/util';
+import { DocumentNode, Kind, ObjectTypeDefinitionNode } from 'graphql';
 import { ValidationError } from '../exceptions/validation-error';
 
 /**

--- a/packages/amplify-schema-validator/src/validators/unique-field-names-with-relation.ts
+++ b/packages/amplify-schema-validator/src/validators/unique-field-names-with-relation.ts
@@ -11,26 +11,26 @@ import { ValidationError } from '../exceptions/validation-error';
  */
 
 export const validateFieldNamesAreUniqueWithRelationsPresent = (schema: DocumentNode): Error[] => {
-    const errors: Error[] = [];
-    const objectTypeDefinitions = schema.definitions.filter(
-        (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,
-    ) as ObjectTypeDefinitionNode[];
-    objectTypeDefinitions.forEach((objectTypeDefinition) => {
-        const directiveFields = objectTypeDefinition.fields?.filter((objectField) =>
-            objectField.directives?.some((directive) =>
-                directive.name.value === 'manyToMany' || directive.name.value === 'hasMany' || directive.name.value === 'hasOne'
-            )
-        );
+  const errors: Error[] = [];
+  const objectTypeDefinitions = schema.definitions.filter(
+    defintion => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,
+  ) as ObjectTypeDefinitionNode[];
+  objectTypeDefinitions.forEach(objectTypeDefinition => {
+    const directiveFields = objectTypeDefinition.fields?.filter(objectField =>
+      objectField.directives?.some(
+        directive => directive.name.value === 'manyToMany' || directive.name.value === 'hasMany' || directive.name.value === 'hasOne',
+      ),
+    );
 
-        const uniquefields = new Set();
-        directiveFields?.forEach((field) => {
-            const val = field.name.value;
-            if (!uniquefields.has(val.toLowerCase())) {
-                uniquefields.add(val.toLowerCase());
-            } else {
-                errors.push(new ValidationError(`There are two or more relationship fields with the same name`));
-            }
-        });
+    const uniquefields = new Set();
+    directiveFields?.forEach(field => {
+      const val = field.name.value;
+      if (!uniquefields.has(val.toLowerCase())) {
+        uniquefields.add(val.toLowerCase());
+      } else {
+        errors.push(new ValidationError(`There are two or more relationship fields with the same name`));
+      }
     });
-    return errors;
+  });
+  return errors;
 };

--- a/packages/amplify-schema-validator/src/validators/unique-field-names-with-relation.ts
+++ b/packages/amplify-schema-validator/src/validators/unique-field-names-with-relation.ts
@@ -1,0 +1,36 @@
+import { DocumentNode, Kind, ObjectTypeDefinitionNode, StringValueNode } from 'graphql';
+import { InvalidDirectiveError } from '../exceptions/invalid-directive-error';
+import { getGraphqlName, toUpper } from '../helpers/util';
+import { ValidationError } from '../exceptions/validation-error';
+
+/**
+ * Validates that two or more relationship fields with the same name does not exist
+ *
+ * @param schema graphql schema
+ * @returns true if relationship fields are unique
+ */
+
+export const validateFieldNamesAreUniqueWithRelationsPresent = (schema: DocumentNode): Error[] => {
+    const errors: Error[] = [];
+    const objectTypeDefinitions = schema.definitions.filter(
+        (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,
+    ) as ObjectTypeDefinitionNode[];
+    objectTypeDefinitions.forEach((objectTypeDefinition) => {
+        const directiveFields = objectTypeDefinition.fields?.filter((objectField) =>
+            objectField.directives?.some((directive) =>
+                directive.name.value === 'manyToMany' || directive.name.value === 'hasMany' || directive.name.value === 'hasOne'
+            )
+        );
+
+        const uniquefields = new Set();
+        directiveFields?.forEach((field) => {
+            const val = field.name.value;
+            if (!uniquefields.has(val.toLowerCase())) {
+                uniquefields.add(val.toLowerCase());
+            } else {
+                errors.push(new ValidationError(`There are two or more relationship fields with the same name`));
+            }
+        });
+    });
+    return errors;
+};

--- a/packages/amplify-schema-validator/src/validators/unique-field-names-with-relation.ts
+++ b/packages/amplify-schema-validator/src/validators/unique-field-names-with-relation.ts
@@ -11,17 +11,17 @@ import { ValidationError } from '../exceptions/validation-error';
 export const validateFieldNamesAreUniqueWithRelationsPresent = (schema: DocumentNode): Error[] => {
   const errors: Error[] = [];
   const objectTypeDefinitions = schema.definitions.filter(
-    defintion => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,
+    (defintion) => defintion.kind === Kind.OBJECT_TYPE_DEFINITION,
   ) as ObjectTypeDefinitionNode[];
-  objectTypeDefinitions.forEach(objectTypeDefinition => {
-    const directiveFields = objectTypeDefinition.fields?.filter(objectField =>
+  objectTypeDefinitions.forEach((objectTypeDefinition) => {
+    const directiveFields = objectTypeDefinition.fields?.filter((objectField) =>
       objectField.directives?.some(
-        directive => directive.name.value === 'manyToMany' || directive.name.value === 'hasMany' || directive.name.value === 'hasOne',
+        (directive) => directive.name.value === 'manyToMany' || directive.name.value === 'hasMany' || directive.name.value === 'hasOne',
       ),
     );
 
     const uniquefields = new Set();
-    directiveFields?.forEach(field => {
+    directiveFields?.forEach((field) => {
       const val = field.name.value;
       if (!uniquefields.has(val.toLowerCase())) {
         uniquefields.add(val.toLowerCase());


### PR DESCRIPTION
#### Description of changes
This PR adds schema validation for relationship fields with the same name

##### CDK / CloudFormation Parameters Changed
None

#### Description of how you validated changes

#### Issue #, if available
N/A

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
