### PR TITLE
fix: reading admin role names

### DIFF
--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/utils.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/utils.test.ts
@@ -1,8 +1,8 @@
 import * as path from 'path';
 import { DatasourceType } from '@aws-amplify/graphql-transformer-core';
 import * as fs from 'fs-extra';
-import { $TSContext, CloudformationProviderFacade } from '@aws-amplify/amplify-cli-core';
-import { mergeUserConfigWithTransformOutput, writeDeploymentToDisk } from '../../graphql-transformer/utils';
+import { $TSContext, CloudformationProviderFacade, pathManager, JSONUtilities } from '@aws-amplify/amplify-cli-core';
+import { mergeUserConfigWithTransformOutput, writeDeploymentToDisk, getAdminRoles } from '../../graphql-transformer/utils';
 import { TransformerProjectConfig } from '../../graphql-transformer/cdk-compat/project-config';
 import { DeploymentResources } from '../../graphql-transformer/cdk-compat/deployment-resources';
 
@@ -280,6 +280,60 @@ describe('graphql transformer utils', () => {
           },
         });
       });
+    });
+  });
+
+  describe('read Admin role names from custom-roles.json', () => {
+    const pathManagerMock = pathManager as jest.Mocked<typeof pathManager>;
+    pathManagerMock.getResourceDirectoryPath.mockReturnValue('mockdir');
+    const mockContext = {
+      amplify: {
+        getEnvInfo: () => ({
+          envName: 'test',
+        }),
+        getResourceStatus: () => ({
+          allResources: [],
+          resourcesToBeDeleted: [],
+        }),
+      },
+    } as unknown as $TSContext;
+
+    it('should return empty array if custom-roles.json does not exist', async () => {
+      fs_mock.existsSync.mockReturnValueOnce(false);
+      const adminRoles = await getAdminRoles(mockContext, 'test');
+      expect(adminRoles).toEqual([]);
+    });
+
+    it('should return empty array if custom-roles.json does not contain admin roles', async () => {
+      const JSONUtilitiesMock = JSONUtilities as jest.Mocked<typeof JSONUtilities>;
+      JSONUtilitiesMock.readJson.mockReturnValueOnce({
+        adminRoleNames: [],
+      });
+      fs_mock.existsSync.mockReturnValueOnce(true);
+      const adminRoles = await getAdminRoles(mockContext, 'test');
+      expect(adminRoles).toEqual([]);
+    });
+
+    it('should return admin roles if present as array in custom-roles.json', async () => {
+      const JSONUtilitiesMock = JSONUtilities as jest.Mocked<typeof JSONUtilities>;
+      const testRole = 'my-custom-role';
+      JSONUtilitiesMock.readJson.mockReturnValueOnce({
+        adminRoleNames: [testRole],
+      });
+      fs_mock.existsSync.mockReturnValueOnce(true);
+      const adminRoles = await getAdminRoles(mockContext, 'test');
+      expect(adminRoles).toEqual([testRole]);
+    });
+
+    it('should return admin roles if present as string in custom-roles.json', async () => {
+      const JSONUtilitiesMock = JSONUtilities as jest.Mocked<typeof JSONUtilities>;
+      const testRole = 'my-custom-role';
+      JSONUtilitiesMock.readJson.mockReturnValueOnce({
+        adminRoleNames: testRole,
+      });
+      fs_mock.existsSync.mockReturnValueOnce(true);
+      const adminRoles = await getAdminRoles(mockContext, 'test');
+      expect(adminRoles).toEqual([testRole]);
     });
   });
 });

--- a/packages/amplify-category-api/src/graphql-transformer/utils.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/utils.ts
@@ -23,7 +23,7 @@ const AMPLIFY_MANAGE_ROLE = '_Manage-only/CognitoIdentityCredentials';
 const PROVIDER_NAME = 'awscloudformation';
 
 interface CustomRolesConfig {
-  adminRoleNames?: Array<string>;
+  adminRoleNames?: Array<string> | string;
 }
 
 export const getIdentityPoolId = async (ctx: $TSContext): Promise<string | undefined> => {
@@ -73,7 +73,10 @@ export const getAdminRoles = async (ctx: $TSContext, apiResourceName: string | u
     if (fs.existsSync(customRoleFile)) {
       const customRoleConfig = JSONUtilities.readJson<CustomRolesConfig>(customRoleFile);
       if (customRoleConfig && customRoleConfig.adminRoleNames) {
-        const adminRoleNames = customRoleConfig.adminRoleNames
+        const customAdminRoles = Array.isArray(customRoleConfig.adminRoleNames)
+          ? customRoleConfig.adminRoleNames
+          : [customRoleConfig.adminRoleNames];
+        const adminRoleNames = customAdminRoles
           // eslint-disable-next-line no-template-curly-in-string
           .map((r) => (r.includes('${env}') ? r.replace('${env}', currentEnv) : r));
         adminRoles.push(...adminRoleNames);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
 In CLI `11.1.1`, specifying the admin role names as a string in the `custom-roles.json` file as shown below is supported.
```
{
"adminRoleNames": "amplify-123456-unauthRole"
}
```
While in the latest version `12.3.0`, we fail with error message `customRoleConfig.adminRoleNames.map is not a function`.
This PR fixes this regression and restores the original behavior.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Added unit tests,
Tested in a JS app that a single string input for admin role names compiles.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
