### PR TITLE
feat(api): specify include or exclude tables option to generate schema

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/rds-relational-directives.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-relational-directives.test.ts
@@ -606,7 +606,7 @@ describe('RDS Relational Directives', () => {
     expect(noItemsResult.data.getCityByZip).toHaveLength(0);
   });
 
-  test('relational directives should be preserved on regenerate schema', async() => {
+  test('relational directives should be preserved on regenerate schema', async () => {
     await apiGenerateSchema(projRoot, {
       database,
       host,
@@ -621,7 +621,9 @@ describe('RDS Relational Directives', () => {
     const schema = parse(regeneratedSchema);
 
     // Check posts field on Blog type
-    const blogType = schema.definitions.find((def) => def.kind === 'ObjectTypeDefinition' && def.name.value === 'Blog') as ObjectTypeDefinitionNode;
+    const blogType = schema.definitions.find(
+      (def) => def.kind === 'ObjectTypeDefinition' && def.name.value === 'Blog',
+    ) as ObjectTypeDefinitionNode;
     expect(blogType).toBeDefined();
     const blogPostsField = blogType.fields.find((field) => field.name.value === 'posts');
     expect(blogPostsField).toBeDefined();
@@ -629,7 +631,9 @@ describe('RDS Relational Directives', () => {
     expect(blogsPostsDirective).toBeDefined();
 
     // Check posts field on Blog type
-    const postType = schema.definitions.find((def) => def.kind === 'ObjectTypeDefinition' && def.name.value === 'Post') as ObjectTypeDefinitionNode;
+    const postType = schema.definitions.find(
+      (def) => def.kind === 'ObjectTypeDefinition' && def.name.value === 'Post',
+    ) as ObjectTypeDefinitionNode;
     expect(postType).toBeDefined();
     const postBlogField = postType.fields.find((field) => field.name.value === 'blog');
     expect(postBlogField).toBeDefined();
@@ -637,7 +641,9 @@ describe('RDS Relational Directives', () => {
     expect(postBlogDirective).toBeDefined();
 
     // Check profile field on User type
-    const userType = schema.definitions.find((def) => def.kind === 'ObjectTypeDefinition' && def.name.value === 'User') as ObjectTypeDefinitionNode;
+    const userType = schema.definitions.find(
+      (def) => def.kind === 'ObjectTypeDefinition' && def.name.value === 'User',
+    ) as ObjectTypeDefinitionNode;
     expect(userType).toBeDefined();
     const userProfileField = userType.fields.find((field) => field.name.value === 'profile');
     expect(userProfileField).toBeDefined();
@@ -645,7 +651,9 @@ describe('RDS Relational Directives', () => {
     expect(userProfileDirective).toBeDefined();
 
     // Check profile field on User type
-    const profileType = schema.definitions.find((def) => def.kind === 'ObjectTypeDefinition' && def.name.value === 'Profile') as ObjectTypeDefinitionNode;
+    const profileType = schema.definitions.find(
+      (def) => def.kind === 'ObjectTypeDefinition' && def.name.value === 'Profile',
+    ) as ObjectTypeDefinitionNode;
     expect(profileType).toBeDefined();
     const profileUserField = profileType.fields.find((field) => field.name.value === 'user');
     expect(profileUserField).toBeDefined();

--- a/packages/amplify-e2e-tests/src/__tests__/rds-relational-directives.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-relational-directives.test.ts
@@ -3,6 +3,7 @@ import {
   addApiWithoutSchema,
   addRDSPortInboundRule,
   amplifyPush,
+  apiGenerateSchema,
   createNewProjectDir,
   createRDSInstance,
   deleteDBInstance,
@@ -14,12 +15,13 @@ import {
   initJSProjectWithProfile,
   removeRDSPortInboundRule,
 } from 'amplify-category-api-e2e-core';
-import { existsSync, writeFileSync, mkdirSync } from 'fs-extra';
+import { existsSync, writeFileSync, mkdirSync, readFileSync } from 'fs-extra';
 import generator from 'generate-password';
 import path from 'path';
 import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
 import { GQLQueryHelper } from '../query-utils/gql-helper';
 import { gql } from 'graphql-transformer-core';
+import { ObjectTypeDefinitionNode, parse } from 'graphql';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -602,6 +604,53 @@ describe('RDS Relational Directives', () => {
     expect(noItemsResult.data).toBeDefined();
     expect(noItemsResult.data.getCityByZip).toBeDefined();
     expect(noItemsResult.data.getCityByZip).toHaveLength(0);
+  });
+
+  test('relational directives should be preserved on regenerate schema', async() => {
+    await apiGenerateSchema(projRoot, {
+      database,
+      host,
+      port,
+      username,
+      password,
+      validCredentials: true,
+    });
+    const apiName = 'rdsrelationalapi';
+    const rdsSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.rds.graphql');
+    const regeneratedSchema = readFileSync(rdsSchemaFilePath, 'utf8');
+    const schema = parse(regeneratedSchema);
+
+    // Check posts field on Blog type
+    const blogType = schema.definitions.find((def) => def.kind === 'ObjectTypeDefinition' && def.name.value === 'Blog') as ObjectTypeDefinitionNode;
+    expect(blogType).toBeDefined();
+    const blogPostsField = blogType.fields.find((field) => field.name.value === 'posts');
+    expect(blogPostsField).toBeDefined();
+    const blogsPostsDirective = blogPostsField.directives.find((directive) => directive.name.value === 'hasMany');
+    expect(blogsPostsDirective).toBeDefined();
+
+    // Check posts field on Blog type
+    const postType = schema.definitions.find((def) => def.kind === 'ObjectTypeDefinition' && def.name.value === 'Post') as ObjectTypeDefinitionNode;
+    expect(postType).toBeDefined();
+    const postBlogField = postType.fields.find((field) => field.name.value === 'blog');
+    expect(postBlogField).toBeDefined();
+    const postBlogDirective = postBlogField.directives.find((directive) => directive.name.value === 'belongsTo');
+    expect(postBlogDirective).toBeDefined();
+
+    // Check profile field on User type
+    const userType = schema.definitions.find((def) => def.kind === 'ObjectTypeDefinition' && def.name.value === 'User') as ObjectTypeDefinitionNode;
+    expect(userType).toBeDefined();
+    const userProfileField = userType.fields.find((field) => field.name.value === 'profile');
+    expect(userProfileField).toBeDefined();
+    const userProfileDirective = userProfileField.directives.find((directive) => directive.name.value === 'hasOne');
+    expect(userProfileDirective).toBeDefined();
+
+    // Check profile field on User type
+    const profileType = schema.definitions.find((def) => def.kind === 'ObjectTypeDefinition' && def.name.value === 'Profile') as ObjectTypeDefinitionNode;
+    expect(profileType).toBeDefined();
+    const profileUserField = profileType.fields.find((field) => field.name.value === 'user');
+    expect(profileUserField).toBeDefined();
+    const profileUserDirective = profileUserField.directives.find((directive) => directive.name.value === 'belongsTo');
+    expect(profileUserDirective).toBeDefined();
   });
 
   const constructBlogHelper = (): GQLQueryHelper => {

--- a/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/mysql-datasource-adapter.test.ts.snap
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/mysql-datasource-adapter.test.ts.snap
@@ -1,5 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`testDataSourceAdapter exclude option should not import the given tables 1`] = `
+"type Capital @model {
+  id: Int! @primaryKey
+  name: String
+  countryId: Int @index(name: \\"countryId\\")
+}
+
+type Country @model {
+  id: Int! @primaryKey
+  name: String
+}
+"
+`;
+
+exports[`testDataSourceAdapter generate schema retains hasMany and belongsTo relationship 1`] = `
+"type Blog @model {
+  id: Int! @primaryKey
+  name: String
+  posts: [Post] @hasMany(references: [\\"userId\\"])
+}
+
+type Post @model {
+  id: Int! @primaryKey
+  content: String
+  blogId: Int!
+  blog: Blog @belongsTo(references: [\\"userId\\"])
+}
+"
+`;
+
+exports[`testDataSourceAdapter generate schema retains hasOne and belongsTo relationship 1`] = `
+"type User @model {
+  id: Int! @primaryKey
+  name: String
+  profile: Profile @hasOne(references: [\\"userId\\"])
+}
+
+type Profile @model {
+  id: Int! @primaryKey
+  content: String
+  userId: Int!
+  user: User @belongsTo(references: [\\"userId\\"])
+}
+"
+`;
+
 exports[`testDataSourceAdapter generates a default directive and optional types for fields with literal default values 1`] = `
 "type Account @model {
   id: Int! @primaryKey
@@ -24,6 +70,16 @@ exports[`testDataSourceAdapter generates primary key fields as required without 
   serialNumber: Int!
   ownerName: String
   amount: Float!
+}
+"
+`;
+
+exports[`testDataSourceAdapter include option should import only the given tables 1`] = `
+"type Tasks @model {
+  id: String! @primaryKey(sortKeyFields: [\\"title\\"])
+  title: String @index(name: \\"tasks_title\\") @index(name: \\"tasks_title_description\\", sortKeyFields: [\\"description\\"])
+  description: String
+  priority: String
 }
 "
 `;

--- a/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/mysql-datasource-adapter.test.ts.snap
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/mysql-datasource-adapter.test.ts.snap
@@ -30,7 +30,7 @@ type Post @model {
 "
 `;
 
-exports[`testDataSourceAdapter generate schema retains hasOne and belongsTo relationship 1`] = `
+exports[`testDataSourceAdapter generate schema retains hasOne and belongsTo relationship and removes the non-relational fields added manually 1`] = `
 "type User @model {
   id: Int! @primaryKey
   name: String

--- a/packages/amplify-graphql-schema-generator/src/__tests__/mysql-datasource-adapter.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/mysql-datasource-adapter.test.ts
@@ -1,6 +1,8 @@
 import { DataSourceAdapter, MySQLDataSourceAdapter } from '../datasource-adapter';
 import { Engine, Field, FieldType, Index, Model, Schema } from '../schema-representation';
 import { generateGraphQLSchema, isComputeExpression } from '../schema-generator';
+import { parse } from 'graphql';
+import { gql } from 'graphql-transformer-core';
 
 class TestDataSourceAdapter extends DataSourceAdapter {
   public async initialize(): Promise<void> {
@@ -125,10 +127,258 @@ describe('testDataSourceAdapter', () => {
     expect(graphqlSchema).toMatchSnapshot();
   });
 
+  it('include option should import only the given tables', () => {
+    const dbschema = new Schema(new Engine('MySQL'));
+
+    let model = new Model('Capital');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } }));
+    model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('countryId', { kind: 'Scalar', name: 'Int' }));
+    model.setPrimaryKey(['id']);
+    model.addIndex('countryId', ['countryId']);
+    dbschema.addModel(model);
+
+    model = new Model('Country');
+    const countryIdField = new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } });
+    countryIdField.default = { kind: 'DB_GENERATED', value: 'uuid()' };
+    model.addField(countryIdField);
+    model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
+    model.setPrimaryKey(['id']);
+    dbschema.addModel(model);
+
+    model = new Model('Tasks');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'String' } }));
+    model.addField(new Field('title', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('description', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('priority', { kind: 'Scalar', name: 'String' }));
+    model.setPrimaryKey(['id', 'title']);
+    model.addIndex('tasks_title', ['title']);
+    model.addIndex('tasks_title_description', ['title', 'description']);
+    dbschema.addModel(model);
+
+    const amplifyInputType = gql`
+      input AMPLIFY {
+        engine: String = "mysql"
+        globalAuthRule: AuthRule = {allow: public}
+        include: [String] = ["Tasks"]
+      }
+    `;
+
+    const graphqlSchema = generateGraphQLSchema(dbschema, amplifyInputType);
+    expect(graphqlSchema).toMatchSnapshot();
+  });
+
+  it('exclude option should not import the given tables', () => {
+    const dbschema = new Schema(new Engine('MySQL'));
+
+    let model = new Model('Capital');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } }));
+    model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('countryId', { kind: 'Scalar', name: 'Int' }));
+    model.setPrimaryKey(['id']);
+    model.addIndex('countryId', ['countryId']);
+    dbschema.addModel(model);
+
+    model = new Model('Country');
+    const countryIdField = new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } });
+    countryIdField.default = { kind: 'DB_GENERATED', value: 'uuid()' };
+    model.addField(countryIdField);
+    model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
+    model.setPrimaryKey(['id']);
+    dbschema.addModel(model);
+
+    model = new Model('Tasks');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'String' } }));
+    model.addField(new Field('title', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('description', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('priority', { kind: 'Scalar', name: 'String' }));
+    model.setPrimaryKey(['id', 'title']);
+    model.addIndex('tasks_title', ['title']);
+    model.addIndex('tasks_title_description', ['title', 'description']);
+    dbschema.addModel(model);
+
+    const amplifyInputType = gql`
+      input AMPLIFY {
+        engine: String = "mysql"
+        globalAuthRule: AuthRule = {allow: public}
+        exclude: [String] = ["Tasks"]
+      }
+    `;
+
+    const graphqlSchema = generateGraphQLSchema(dbschema, amplifyInputType);
+    expect(graphqlSchema).toMatchSnapshot();
+  });
+
+  it('providing both include and exclude option should throw an error', () => {
+    const dbschema = new Schema(new Engine('MySQL'));
+
+    let model = new Model('Capital');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } }));
+    model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('countryId', { kind: 'Scalar', name: 'Int' }));
+    model.setPrimaryKey(['id']);
+    model.addIndex('countryId', ['countryId']);
+    dbschema.addModel(model);
+
+    model = new Model('Country');
+    const countryIdField = new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } });
+    countryIdField.default = { kind: 'DB_GENERATED', value: 'uuid()' };
+    model.addField(countryIdField);
+    model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
+    model.setPrimaryKey(['id']);
+    dbschema.addModel(model);
+
+    model = new Model('Tasks');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'String' } }));
+    model.addField(new Field('title', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('description', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('priority', { kind: 'Scalar', name: 'String' }));
+    model.setPrimaryKey(['id', 'title']);
+    model.addIndex('tasks_title', ['title']);
+    model.addIndex('tasks_title_description', ['title', 'description']);
+    dbschema.addModel(model);
+
+    const amplifyInputType = gql`
+      input AMPLIFY {
+        engine: String = "mysql"
+        globalAuthRule: AuthRule = {allow: public}
+        include: [String] = ["Tasks"]
+        exclude: [String] = ["Tasks"]
+      }
+    `;
+    expect(() => generateGraphQLSchema(dbschema, amplifyInputType)).toThrowError('Cannot specify both include and exclude options. Please check your GraphQL schema.');
+  });
+
+  it('providing incorrect include and exclude datatype should throw an error', () => {
+    const dbschema = new Schema(new Engine('MySQL'));
+
+    let model = new Model('Capital');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } }));
+    model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('countryId', { kind: 'Scalar', name: 'Int' }));
+    model.setPrimaryKey(['id']);
+    model.addIndex('countryId', ['countryId']);
+    dbschema.addModel(model);
+
+    model = new Model('Country');
+    const countryIdField = new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } });
+    countryIdField.default = { kind: 'DB_GENERATED', value: 'uuid()' };
+    model.addField(countryIdField);
+    model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
+    model.setPrimaryKey(['id']);
+    dbschema.addModel(model);
+
+    model = new Model('Tasks');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'String' } }));
+    model.addField(new Field('title', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('description', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('priority', { kind: 'Scalar', name: 'String' }));
+    model.setPrimaryKey(['id', 'title']);
+    model.addIndex('tasks_title', ['title']);
+    model.addIndex('tasks_title_description', ['title', 'description']);
+    dbschema.addModel(model);
+
+    const amplifyInputTypeInclude = gql`
+      input AMPLIFY {
+        engine: String = "mysql"
+        globalAuthRule: AuthRule = {allow: public}
+        include: String = "Tasks"
+      }
+    `;
+    expect(() => generateGraphQLSchema(dbschema, amplifyInputTypeInclude)).toThrowError('Invalid value for include option. Please check your GraphQL schema.');
+
+    const amplifyInputTypeExclude = gql`
+      input AMPLIFY {
+        engine: String = "mysql"
+        globalAuthRule: AuthRule = {allow: public}
+        exclude: String = "Tasks"
+      }
+    `;
+    expect(() => generateGraphQLSchema(dbschema, amplifyInputTypeExclude)).toThrowError('Invalid value for include option. Please check your GraphQL schema.');
+  });
+
+  it('generate schema retains hasOne and belongsTo relationship', () => {
+    const dbschema = new Schema(new Engine('MySQL'));
+
+    let model = new Model('User');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } }));
+    model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
+    model.setPrimaryKey(['id']);
+    dbschema.addModel(model);
+
+    model = new Model('Profile');
+    const profileIdField = new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } });
+    model.addField(profileIdField);
+    model.addField(new Field('content', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('userId', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } }));
+    model.setPrimaryKey(['id']);
+    dbschema.addModel(model);
+
+    const existingSchema = gql`
+      input AMPLIFY {
+        engine: String = "mysql"
+        globalAuthRule: AuthRule = {allow: public}
+      }
+      type User @model {
+        id: Int!
+        name: String
+        profile: Profile @hasOne(references: ["userId"])
+      }
+      type Profile @model {
+        id: Int!
+        content: String
+        userId: Int!
+        user: User @belongsTo(references: ["userId"])
+      }
+    `;
+
+    const graphqlSchema = generateGraphQLSchema(dbschema, existingSchema);
+    expect(graphqlSchema).toMatchSnapshot();
+  });
+
+  it('generate schema retains hasMany and belongsTo relationship', () => {
+    const dbschema = new Schema(new Engine('MySQL'));
+
+    let model = new Model('Blog');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } }));
+    model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
+    model.setPrimaryKey(['id']);
+    dbschema.addModel(model);
+
+    model = new Model('Post');
+    const postIdField = new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } });
+    model.addField(postIdField);
+    model.addField(new Field('content', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('blogId', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } }));
+    model.setPrimaryKey(['id']);
+    dbschema.addModel(model);
+
+    const existingSchema = gql`
+      input AMPLIFY {
+        engine: String = "mysql"
+        globalAuthRule: AuthRule = {allow: public}
+      }
+      type Blog @model {
+        id: Int!
+        name: String
+        posts: [Post] @hasMany(references: ["userId"])
+      }
+      type Post @model {
+        id: Int!
+        content: String
+        blogId: Int!
+        blog: Blog @belongsTo(references: ["userId"])
+      }
+    `;
+
+    const graphqlSchema = generateGraphQLSchema(dbschema, existingSchema);
+    expect(graphqlSchema).toMatchSnapshot();
+  });
+
   it('generates a default directive and optional types for fields with literal default values', () => {
     const dbschema = new Schema(new Engine('MySQL'));
 
-    let model = new Model('Account');
+    const model = new Model('Account');
     model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } }));
     const serialNoField = new Field('serialNumber', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } });
     const ownerNameField = new Field('ownerName', { kind: 'NonNull', type: { kind: 'Scalar', name: 'String' } });
@@ -150,7 +400,7 @@ describe('testDataSourceAdapter', () => {
   it('generates optional type but no default directive for fields with computed default values', () => {
     const dbschema = new Schema(new Engine('MySQL'));
 
-    let model = new Model('Account');
+    const model = new Model('Account');
     model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } }));
     const computedField = new Field('computed', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Float' } });
 
@@ -185,7 +435,7 @@ describe('testDataSourceAdapter', () => {
   it('test generate graphql schema on model with enum field', () => {
     const dbschema = new Schema(new Engine('MySQL'));
 
-    let model = new Model('Profile');
+    const model = new Model('Profile');
     model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } }));
     model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
     model.addField(new Field('type', { kind: 'Enum', name: 'Profile_type', values: ['Manager', 'Employee'] }));
@@ -199,7 +449,7 @@ describe('testDataSourceAdapter', () => {
   it('generates primary key fields as required without the default directive added', () => {
     const dbschema = new Schema(new Engine('MySQL'));
 
-    let model = new Model('Account');
+    const model = new Model('Account');
     model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } }));
     const serialNoField = new Field('serialNumber', { kind: 'NonNull', type: { kind: 'Scalar', name: 'Int' } });
     const ownerNameField = new Field('ownerName', { kind: 'Scalar', name: 'String' });

--- a/packages/amplify-graphql-schema-generator/src/__tests__/mysql-datasource-adapter.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/mysql-datasource-adapter.test.ts
@@ -159,7 +159,7 @@ describe('testDataSourceAdapter', () => {
     const amplifyInputType = gql`
       input AMPLIFY {
         engine: String = "mysql"
-        globalAuthRule: AuthRule = {allow: public}
+        globalAuthRule: AuthRule = { allow: public }
         include: [String] = ["Tasks"]
       }
     `;
@@ -200,7 +200,7 @@ describe('testDataSourceAdapter', () => {
     const amplifyInputType = gql`
       input AMPLIFY {
         engine: String = "mysql"
-        globalAuthRule: AuthRule = {allow: public}
+        globalAuthRule: AuthRule = { allow: public }
         exclude: [String] = ["Tasks"]
       }
     `;
@@ -241,12 +241,14 @@ describe('testDataSourceAdapter', () => {
     const amplifyInputType = gql`
       input AMPLIFY {
         engine: String = "mysql"
-        globalAuthRule: AuthRule = {allow: public}
+        globalAuthRule: AuthRule = { allow: public }
         include: [String] = ["Tasks"]
         exclude: [String] = ["Tasks"]
       }
     `;
-    expect(() => generateGraphQLSchema(dbschema, amplifyInputType)).toThrowError('Cannot specify both include and exclude options. Please check your GraphQL schema.');
+    expect(() => generateGraphQLSchema(dbschema, amplifyInputType)).toThrowError(
+      'Cannot specify both include and exclude options. Please check your GraphQL schema.',
+    );
   });
 
   it('providing incorrect include and exclude datatype should throw an error', () => {
@@ -281,20 +283,24 @@ describe('testDataSourceAdapter', () => {
     const amplifyInputTypeInclude = gql`
       input AMPLIFY {
         engine: String = "mysql"
-        globalAuthRule: AuthRule = {allow: public}
+        globalAuthRule: AuthRule = { allow: public }
         include: String = "Tasks"
       }
     `;
-    expect(() => generateGraphQLSchema(dbschema, amplifyInputTypeInclude)).toThrowError('Invalid value for include option. Please check your GraphQL schema.');
+    expect(() => generateGraphQLSchema(dbschema, amplifyInputTypeInclude)).toThrowError(
+      'Invalid value for include option. Please check your GraphQL schema.',
+    );
 
     const amplifyInputTypeExclude = gql`
       input AMPLIFY {
         engine: String = "mysql"
-        globalAuthRule: AuthRule = {allow: public}
+        globalAuthRule: AuthRule = { allow: public }
         exclude: String = "Tasks"
       }
     `;
-    expect(() => generateGraphQLSchema(dbschema, amplifyInputTypeExclude)).toThrowError('Invalid value for include option. Please check your GraphQL schema.');
+    expect(() => generateGraphQLSchema(dbschema, amplifyInputTypeExclude)).toThrowError(
+      'Invalid value for include option. Please check your GraphQL schema.',
+    );
   });
 
   it('generate schema retains hasOne and belongsTo relationship', () => {
@@ -317,7 +323,7 @@ describe('testDataSourceAdapter', () => {
     const existingSchema = gql`
       input AMPLIFY {
         engine: String = "mysql"
-        globalAuthRule: AuthRule = {allow: public}
+        globalAuthRule: AuthRule = { allow: public }
       }
       type User @model {
         id: Int!
@@ -356,7 +362,7 @@ describe('testDataSourceAdapter', () => {
     const existingSchema = gql`
       input AMPLIFY {
         engine: String = "mysql"
-        globalAuthRule: AuthRule = {allow: public}
+        globalAuthRule: AuthRule = { allow: public }
       }
       type Blog @model {
         id: Int!

--- a/packages/amplify-graphql-schema-generator/src/__tests__/mysql-datasource-adapter.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/mysql-datasource-adapter.test.ts
@@ -303,7 +303,7 @@ describe('testDataSourceAdapter', () => {
     );
   });
 
-  it('generate schema retains hasOne and belongsTo relationship', () => {
+  it('generate schema retains hasOne and belongsTo relationship and removes the non-relational fields added manually', () => {
     const dbschema = new Schema(new Engine('MySQL'));
 
     let model = new Model('User');
@@ -328,11 +328,13 @@ describe('testDataSourceAdapter', () => {
       type User @model {
         id: Int!
         name: String
+        manuallyAddedField: String
         profile: Profile @hasOne(references: ["userId"])
       }
       type Profile @model {
         id: Int!
         content: String
+        manuallyAddedField: String
         userId: Int!
         user: User @belongsTo(references: ["userId"])
       }

--- a/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
@@ -1,5 +1,13 @@
 import { DirectiveWrapper, EnumWrapper, FieldWrapper, ObjectDefinitionWrapper } from '@aws-amplify/graphql-transformer-core';
-import { EnumValueDefinitionNode, Kind, print, parse, DocumentNode, InputObjectTypeDefinitionNode, ListValueNode, StringValueNode } from 'graphql';
+import {
+  EnumValueDefinitionNode,
+  Kind,
+  print,
+  DocumentNode,
+  InputObjectTypeDefinitionNode,
+  ListValueNode,
+  StringValueNode,
+} from 'graphql';
 import { EnumType, Field, Index, Model, Schema } from '../schema-representation';
 import { applySchemaOverrides } from './schema-overrides';
 
@@ -13,7 +21,6 @@ export const generateGraphQLSchema = (schema: Schema, existingSchemaDocument?: D
   const { includeTables, excludeTables } = getIncludeExcludeConfig(existingSchemaDocument);
 
   models.forEach((model) => {
-
     // Verify whether a table should be included or excluded
     if (includeTables.length > 0 && !includeTables.includes(model.getName())) {
       return;
@@ -268,7 +275,9 @@ const getIncludeExcludeConfig = (document: DocumentNode | undefined): IncludeExc
     return emptyConfig;
   }
 
-  const amplifyInputType = document.definitions.find((d) => d.kind === 'InputObjectTypeDefinition' && d.name.value === 'AMPLIFY') as InputObjectTypeDefinitionNode;
+  const amplifyInputType = document.definitions.find(
+    (d) => d.kind === 'InputObjectTypeDefinition' && d.name.value === 'AMPLIFY',
+  ) as InputObjectTypeDefinitionNode;
   if (!amplifyInputType) {
     return emptyConfig;
   }
@@ -286,19 +295,14 @@ const getIncludeExcludeConfig = (document: DocumentNode | undefined): IncludeExc
 
   const includeTables = (includeFieldNodeValue as ListValueNode)?.values.map((v: StringValueNode) => v.value);
   const excludeTables = (excludeFieldNodeValue as ListValueNode)?.values.map((v: StringValueNode) => v.value);
-  if (
-    includeTables &&
-    includeTables.length > 0 &&
-    excludeTables &&
-    excludeTables.length > 0
-  ) {
+  if (includeTables && includeTables.length > 0 && excludeTables && excludeTables.length > 0) {
     throw new Error('Cannot specify both include and exclude options. Please check your GraphQL schema.');
   }
 
   return {
     includeTables: includeTables || [],
     excludeTables: excludeTables || [],
-  }
+  };
 };
 
 /**

--- a/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
@@ -1,13 +1,5 @@
 import { DirectiveWrapper, EnumWrapper, FieldWrapper, ObjectDefinitionWrapper } from '@aws-amplify/graphql-transformer-core';
-import {
-  EnumValueDefinitionNode,
-  Kind,
-  print,
-  DocumentNode,
-  InputObjectTypeDefinitionNode,
-  ListValueNode,
-  StringValueNode,
-} from 'graphql';
+import { EnumValueDefinitionNode, Kind, print, DocumentNode, InputObjectTypeDefinitionNode, ListValueNode, StringValueNode } from 'graphql';
 import { EnumType, Field, Index, Model, Schema } from '../schema-representation';
 import { applySchemaOverrides } from './schema-overrides';
 

--- a/packages/amplify-graphql-schema-generator/src/schema-generator/schema-overrides.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-generator/schema-overrides.ts
@@ -37,9 +37,6 @@ const preserveRelationalDirectives = (document: DocumentNode, existingDocument: 
   const RELATIONAL_DIRECTIVES = ['hasOne', 'hasMany', 'belongsTo'];
   const documentWrapper = document as any;
 
-  if (!existingDocument) {
-    return document;
-  }
   existingDocument.definitions
     .filter((def) => def.kind === 'ObjectTypeDefinition' && def.directives.find((dir) => dir.name.value === MODEL_DIRECTIVE_NAME))
     .forEach((existingObject: ObjectTypeDefinitionNode) => {

--- a/packages/amplify-graphql-schema-generator/src/schema-generator/schema-overrides.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-generator/schema-overrides.ts
@@ -1,15 +1,17 @@
 import { DocumentNode, FieldDefinitionNode, ObjectTypeDefinitionNode, visit } from 'graphql';
 import { isArrayOrObject, findMatchingField, getNonModelTypes, isOfType, isNonNullType } from 'graphql-transformer-common';
 import { printer } from '@aws-amplify/amplify-prompts';
+import { FieldWrapper, ObjectDefinitionWrapper } from '@aws-amplify/graphql-transformer-core';
 
 export const applySchemaOverrides = (document: DocumentNode, existingDocument?: DocumentNode | undefined): DocumentNode => {
   if (!existingDocument) {
     return document;
   }
 
+  let updatedDocument = preserveRelationalDirectives(document, existingDocument) as any;
   const schemaVisitor = {
     FieldDefinition: {
-      leave(node: FieldDefinitionNode, key, parent, path, ancestors): any {
+      leave: (node: FieldDefinitionNode, key, parent, path, ancestors) => {
         const parentObjectType = getParentNode(ancestors);
         if (!parentObjectType || !parentObjectType?.name) {
           return;
@@ -18,14 +20,54 @@ export const applySchemaOverrides = (document: DocumentNode, existingDocument?: 
         const correspondingField = findMatchingField(node, parentObjectType, existingDocument);
         if (!correspondingField) return;
 
+        // eslint-disable-next-line consistent-return
         return applyFieldOverrides(node, correspondingField);
       },
     },
   };
 
-  const updatedDocument = visit(document, schemaVisitor);
+  updatedDocument = visit(updatedDocument, schemaVisitor);
   updatedDocument['definitions'] = [...updatedDocument['definitions'], ...getNonModelTypes(existingDocument)];
+
   return updatedDocument;
+};
+
+const preserveRelationalDirectives = (document: DocumentNode, existingDocument: DocumentNode): DocumentNode => {
+  const MODEL_DIRECTIVE_NAME = 'model';
+  const RELATIONAL_DIRECTIVES = ['hasOne', 'hasMany', 'belongsTo'];
+  const documentWrapper = document as any;
+
+  if (!existingDocument) {
+    return document;
+  }
+  existingDocument.definitions.filter(
+    (def) => def.kind === 'ObjectTypeDefinition' &&
+    def.directives.find((dir) => dir.name.value === MODEL_DIRECTIVE_NAME)
+  ).forEach((existingObject: ObjectTypeDefinitionNode) => {
+    const newObject = document.definitions.find((def) => def.kind === 'ObjectTypeDefinition' && def.name.value === existingObject.name.value) as ObjectTypeDefinitionNode;
+    if (!newObject) {
+      return;
+    }
+    const relationalFields = existingObject.fields.filter(
+      (field) => field.directives.find((dir) => RELATIONAL_DIRECTIVES.includes(dir.name.value))
+    );
+    const newObjectWrapper = new ObjectDefinitionWrapper(newObject);
+    relationalFields.forEach((relationalField: FieldDefinitionNode) => {
+      newObjectWrapper.fields.push(new FieldWrapper(relationalField));
+    });
+
+    if (relationalFields.length > 0) {
+      // If relational fields are found on a model, 
+      // remove the existing model and add the new one with the relational fields to preserve manual edits.
+      const excludedDefinitions = documentWrapper.definitions.filter((def) => def.name.value !== existingObject.name.value);
+      documentWrapper.definitions = [
+        ...excludedDefinitions,
+        newObjectWrapper.serialize(),
+      ];
+    }
+  });
+
+  return documentWrapper;
 };
 
 export const applyFieldOverrides = (field: FieldDefinitionNode, existingField: FieldDefinitionNode): FieldDefinitionNode => {

--- a/packages/amplify-graphql-schema-generator/src/schema-generator/schema-overrides.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-generator/schema-overrides.ts
@@ -40,32 +40,30 @@ const preserveRelationalDirectives = (document: DocumentNode, existingDocument: 
   if (!existingDocument) {
     return document;
   }
-  existingDocument.definitions.filter(
-    (def) => def.kind === 'ObjectTypeDefinition' &&
-    def.directives.find((dir) => dir.name.value === MODEL_DIRECTIVE_NAME)
-  ).forEach((existingObject: ObjectTypeDefinitionNode) => {
-    const newObject = document.definitions.find((def) => def.kind === 'ObjectTypeDefinition' && def.name.value === existingObject.name.value) as ObjectTypeDefinitionNode;
-    if (!newObject) {
-      return;
-    }
-    const relationalFields = existingObject.fields.filter(
-      (field) => field.directives.find((dir) => RELATIONAL_DIRECTIVES.includes(dir.name.value))
-    );
-    const newObjectWrapper = new ObjectDefinitionWrapper(newObject);
-    relationalFields.forEach((relationalField: FieldDefinitionNode) => {
-      newObjectWrapper.fields.push(new FieldWrapper(relationalField));
-    });
+  existingDocument.definitions
+    .filter((def) => def.kind === 'ObjectTypeDefinition' && def.directives.find((dir) => dir.name.value === MODEL_DIRECTIVE_NAME))
+    .forEach((existingObject: ObjectTypeDefinitionNode) => {
+      const newObject = document.definitions.find(
+        (def) => def.kind === 'ObjectTypeDefinition' && def.name.value === existingObject.name.value,
+      ) as ObjectTypeDefinitionNode;
+      if (!newObject) {
+        return;
+      }
+      const relationalFields = existingObject.fields.filter((field) =>
+        field.directives.find((dir) => RELATIONAL_DIRECTIVES.includes(dir.name.value)),
+      );
+      const newObjectWrapper = new ObjectDefinitionWrapper(newObject);
+      relationalFields.forEach((relationalField: FieldDefinitionNode) => {
+        newObjectWrapper.fields.push(new FieldWrapper(relationalField));
+      });
 
-    if (relationalFields.length > 0) {
-      // If relational fields are found on a model, 
-      // remove the existing model and add the new one with the relational fields to preserve manual edits.
-      const excludedDefinitions = documentWrapper.definitions.filter((def) => def.name.value !== existingObject.name.value);
-      documentWrapper.definitions = [
-        ...excludedDefinitions,
-        newObjectWrapper.serialize(),
-      ];
-    }
-  });
+      if (relationalFields.length > 0) {
+        // If relational fields are found on a model,
+        // remove the existing model and add the new one with the relational fields to preserve manual edits.
+        const excludedDefinitions = documentWrapper.definitions.filter((def) => def.name.value !== existingObject.name.value);
+        documentWrapper.definitions = [...excludedDefinitions, newObjectWrapper.serialize()];
+      }
+    });
 
   return documentWrapper;
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Include/Exclude Option
- Customers can specify in the input AMPLIFY to exclude or only include certain tables from being re-generated.
- Customers can not have "include" and "exclude" statements at the same time. they are mutually exclusive.

**Example:**
```
input AMPLIFY {
   exclude: [String] = ["todos", "hello"]
}
```
or
```
input AMPLIFY {
   include: [String] = ["todos", "hello"]
}
```

This change also includes preserving customer added relational fields on schema regeneration.

##### CDK / CloudFormation Parameters Changed

NA

#### Issue #, if available

NA

#### Description of how you validated changes
- Manual test
- New unit tests
- New E2E test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
