### PR TITLE
fix: npm publish ignore tests and lambdas sources

### DIFF
--- a/packages/amplify-graphql-default-value-transformer/.npmignore
+++ b/packages/amplify-graphql-default-value-transformer/.npmignore
@@ -1,6 +1,5 @@
 **/__mocks__/**
 **/__tests__/**
 src
-vpc-db-lambda
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/amplify-graphql-model-transformer/.npmignore
+++ b/packages/amplify-graphql-model-transformer/.npmignore
@@ -1,6 +1,8 @@
 **/__mocks__/**
 **/__tests__/**
 src
-vpc-db-lambda
+publish-notification-lambda
+rds-lambda
+rds-patching-lambda
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/amplify-graphql-searchable-transformer/.npmignore
+++ b/packages/amplify-graphql-searchable-transformer/.npmignore
@@ -1,6 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
 src
-vpc-db-lambda
+streaming-lambda
 tsconfig.json
 tsconfig.tsbuildinfo


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

I've noticed that we ship unnecessary files to npm.
Repro:
- create any npm project `npm init`
- add latest `@aws-amplify/cli-internal` as dependency
- `npm install`
- search for `describe` (or some other test keyword) in node_modules.

See screenshot
![image](https://github.com/aws-amplify/amplify-category-api/assets/5849952/26b428f5-918e-4d6c-a584-4f4d7138bfb2)



<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
