### PR TITLE
fix: Fix schema import for RDS clusters in VPCs

### DIFF
--- a/packages/amplify-graphql-schema-generator/src/utils/__tests__/vpc-helper.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/utils/__tests__/vpc-helper.test.ts
@@ -1,0 +1,248 @@
+import {
+  RDSClient,
+  DescribeDBClustersCommandOutput,
+  DescribeDBInstancesCommandOutput,
+  DescribeDBSubnetGroupsCommandOutput,
+} from '@aws-sdk/client-rds';
+
+import {
+  getHostVpc,
+} from '../vpc-helper';
+
+
+const sendSpy = jest.spyOn(RDSClient.prototype, 'send');
+
+describe('detect VPC settings', () => {
+
+  it('should detect VPC settings for an RDS instance', async () => {
+    // TS complains about resolving values in the spy.
+    // Cast it through never to overcome the compile error.
+    sendSpy
+      .mockResolvedValueOnce(instanceResponse as never);
+
+    const result = await getHostVpc(
+      'mock-rds-cluster-instance-1.aaaaaaaaaaaa.us-west-2.rds.amazonaws.com',
+      'us-west-2'
+    );
+
+    expect(result).toBeDefined();
+  });
+
+  it('should detect VPC settings for an RDS cluster', async () => {
+
+    // TS complains about resolving values in the spy.
+    // Cast it through never to overcome the compile error.
+    sendSpy
+      .mockResolvedValueOnce(instanceResponse as never)
+      .mockResolvedValueOnce(clusterResponse as never)
+      .mockResolvedValueOnce(subnetResponse as never);
+
+    const result = await getHostVpc(
+      'mock-rds-cluster.cluster-abc123.us-west-2.rds.amazonaws.com',
+      'us-west-2'
+    );
+
+    expect(result).toBeDefined();
+  });
+
+});
+
+const instanceResponse: DescribeDBInstancesCommandOutput = {
+  '$metadata': {},
+    'DBInstances': [
+        {
+            'DBInstanceIdentifier': 'mock-rds-cluster-instance-1',
+            'DBInstanceClass': 'db.serverless',
+            'Engine': 'aurora-mysql',
+            'DBInstanceStatus': 'available',
+            'MasterUsername': 'admin',
+            'Endpoint': {
+                'Address': 'mock-rds-cluster-instance-1.aaaaaaaaaaaa.us-west-2.rds.amazonaws.com',
+                'Port': 3306,
+                'HostedZoneId': 'Z1AAAAAAAAAAAA'
+            },
+            'AllocatedStorage': 1,
+            'InstanceCreateTime': new Date(),
+            'PreferredBackupWindow': '09:08-09:38',
+            'BackupRetentionPeriod': 1,
+            'DBSecurityGroups': [],
+            'VpcSecurityGroups': [
+                {
+                    'VpcSecurityGroupId': 'sg-abc123',
+                    'Status': 'active'
+                }
+            ],
+            'DBParameterGroups': [
+                {
+                    'DBParameterGroupName': 'default.aurora-mysql8.0',
+                    'ParameterApplyStatus': 'in-sync'
+                }
+            ],
+            'AvailabilityZone': 'us-west-2b',
+            'DBSubnetGroup': {
+                'DBSubnetGroupName': 'default-vpc-abc123',
+                'DBSubnetGroupDescription': 'Created from the RDS Management Console',
+                'VpcId': 'vpc-aaaaaaaaaaaaaaaaa',
+                'SubnetGroupStatus': 'Complete',
+                'Subnets': [
+                    {
+                        'SubnetIdentifier': 'subnet-1111111111',
+                        'SubnetAvailabilityZone': {
+                            'Name': 'us-west-2b'
+                        },
+                        'SubnetOutpost': {},
+                        'SubnetStatus': 'Active'
+                    },
+                    {
+                        'SubnetIdentifier': 'subnet-2222222222',
+                        'SubnetAvailabilityZone': {
+                            'Name': 'us-west-2b'
+                        },
+                        'SubnetOutpost': {},
+                        'SubnetStatus': 'Active'
+                    }
+                ]
+            },
+            'PreferredMaintenanceWindow': 'sat:06:40-sat:07:10',
+            'PendingModifiedValues': {},
+            'MultiAZ': false,
+            'EngineVersion': '8.0.mysql_aurora.3.04.0',
+            'AutoMinorVersionUpgrade': true,
+            'ReadReplicaDBInstanceIdentifiers': [],
+            'LicenseModel': 'general-public-license',
+            'OptionGroupMemberships': [
+                {
+                    'OptionGroupName': 'default:aurora-mysql-8-0',
+                    'Status': 'in-sync'
+                }
+            ],
+            'PubliclyAccessible': true,
+            'StorageType': 'aurora',
+            'DbInstancePort': 0,
+            'DBClusterIdentifier': 'mock-rds-cluster',
+            'StorageEncrypted': true,
+            'KmsKeyId': 'arn:aws:kms:us-west-2:123456789012:key/11112222-3333-4444-aaaa-bbbbbbbbbbbb',
+            'DbiResourceId': 'db-IDAAAAAAAAAAAAAAAAAAAAAAAA',
+            'CACertificateIdentifier': 'rds-ca-2019',
+            'DomainMemberships': [],
+            'CopyTagsToSnapshot': false,
+            'MonitoringInterval': 60,
+            'EnhancedMonitoringResourceArn': 'arn:aws:logs:us-west-2:123456789012:log-group:RDSOSMetrics:log-stream:db-IDAAAAAAAAAAAAAAAAAAAAAAAA',
+            'MonitoringRoleArn': 'arn:aws:iam::123456789012:role/rds-monitoring-role',
+            'PromotionTier': 1,
+            'DBInstanceArn': 'arn:aws:rds:us-west-2:123456789012:db:mock-rds-cluster-instance-1',
+            'IAMDatabaseAuthenticationEnabled': false,
+            'PerformanceInsightsEnabled': true,
+            'PerformanceInsightsKMSKeyId': 'arn:aws:kms:us-west-2:123456789012:key/11112222-3333-4444-aaaa-bbbbbbbbbbbb',
+            'PerformanceInsightsRetentionPeriod': 7,
+            'DeletionProtection': false,
+            'AssociatedRoles': [],
+            'TagList': [],
+            'CustomerOwnedIpEnabled': false,
+            'BackupTarget': 'region',
+            'NetworkType': 'IPV4'
+        }
+    ]
+};
+
+const clusterResponse: DescribeDBClustersCommandOutput = {
+  '$metadata': {},
+  'DBClusters': [
+    {
+      'AllocatedStorage': 1,
+      'AvailabilityZones': [
+        'us-west-2c',
+        'us-west-2b',
+        'us-west-2a'
+      ],
+      'BackupRetentionPeriod': 1,
+      'DBClusterIdentifier': 'mock-rds-cluster',
+      'DBClusterParameterGroup': 'default.aurora-mysql8.0',
+      'DBSubnetGroup': 'default-vpc-abc123',
+      'Status': 'available',
+      'EarliestRestorableTime': new Date(),
+      'Endpoint': 'mock-rds-cluster.cluster-abc123.us-west-2.rds.amazonaws.com',
+      'ReaderEndpoint': 'mock-rds-cluster.cluster.cluster-ro-abc123.us-west-2.rds.amazonaws.com',
+      'MultiAZ': false,
+      'Engine': 'aurora-mysql',
+      'EngineVersion': '8.0.mysql_aurora.3.04.0',
+      'LatestRestorableTime': new Date(),
+      'Port': 3306,
+      'MasterUsername': 'admin',
+      'PreferredBackupWindow': '09:08-09:38',
+      'PreferredMaintenanceWindow': 'thu:06:19-thu:06:49',
+      'ReadReplicaIdentifiers': [],
+      'DBClusterMembers': [
+        {
+          'DBInstanceIdentifier': 'mock-rds-cluster-instance-1',
+          'IsClusterWriter': true,
+          'DBClusterParameterGroupStatus': 'in-sync',
+          'PromotionTier': 1
+        }
+      ],
+      'VpcSecurityGroups': [
+        {
+          'VpcSecurityGroupId': 'sg-abc123',
+          'Status': 'active'
+        }
+      ],
+      'HostedZoneId': 'Z1AAAA0A000A0A',
+      'StorageEncrypted': true,
+      'KmsKeyId': 'arn:aws:kms:us-west-2:123456789012:key/11112222-3333-4444-aaaa-bbbbbbbbbbbb',
+      'DbClusterResourceId': 'cluster-00AAAAAAAAAAAAAAAAAAAAAAAA',
+      'DBClusterArn': 'arn:aws:rds:us-west-2:123456789012:cluster:mock-rds-cluster',
+      'AssociatedRoles': [],
+      'IAMDatabaseAuthenticationEnabled': false,
+      'ClusterCreateTime': new Date(),
+      'EngineMode': 'provisioned',
+      'DeletionProtection': true,
+      'HttpEndpointEnabled': false,
+      'ActivityStreamStatus': 'stopped',
+      'CopyTagsToSnapshot': true,
+      'CrossAccountClone': false,
+      'DomainMemberships': [],
+      'TagList': [],
+      'AutoMinorVersionUpgrade': true,
+      'ServerlessV2ScalingConfiguration': {
+        'MinCapacity': 8,
+        'MaxCapacity': 64
+      },
+      'NetworkType': 'IPV4'
+    }
+  ]
+};
+
+const subnetResponse: DescribeDBSubnetGroupsCommandOutput = {
+  '$metadata': {},
+  'DBSubnetGroups': [
+    {
+      'DBSubnetGroupName': 'default-vpc-abc123',
+      'DBSubnetGroupDescription': 'Created from the RDS Management Console',
+      'VpcId': 'vpc-aaaaaaaaaaaaaaaaa',
+      'SubnetGroupStatus': 'Complete',
+      'Subnets': [
+        {
+          'SubnetIdentifier': 'subnet-1111111111',
+          'SubnetAvailabilityZone': {
+            'Name': 'us-west-2b'
+          },
+          'SubnetOutpost': {},
+          'SubnetStatus': 'Active'
+        },
+        {
+          'SubnetIdentifier': 'subnet-2222222222',
+          'SubnetAvailabilityZone': {
+            'Name': 'us-west-2b'
+          },
+          'SubnetOutpost': {},
+          'SubnetStatus': 'Active'
+        }
+      ],
+      'DBSubnetGroupArn': 'arn:aws:rds:us-west-2:123456789012:subgrp:default-vpc-abc123',
+      'SupportedNetworkTypes': [
+        'IPV4'
+      ]
+    }
+  ]
+}
+;

--- a/packages/amplify-graphql-schema-generator/src/utils/vpc-helper.ts
+++ b/packages/amplify-graphql-schema-generator/src/utils/vpc-helper.ts
@@ -139,7 +139,7 @@ const getSubnetIds = async (
  * @param region AWS region.
  */
 export const getHostVpc = async (hostname: string, region: string): Promise<VpcConfig | undefined> =>
-  checkHostInDBInstances(hostname, region) ?? checkHostInDBClusters(hostname, region);
+  await checkHostInDBInstances(hostname, region) ?? await checkHostInDBClusters(hostname, region);
 
 /**
  * Provisions a lambda function to introspect the database schema.
@@ -150,7 +150,7 @@ export const getHostVpc = async (hostname: string, region: string): Promise<VpcC
 export const provisionSchemaInspectorLambda = async (lambdaName: string, vpc: VpcConfig, region: string): Promise<void> => {
   const roleName = `${lambdaName}-execution-role`;
   let createLambda = true;
-  const iamRole = await createRoleIfNotExists(roleName);
+  const iamRole = await createRoleIfNotExists(roleName, region);
   const existingLambda = await getSchemaInspectorLambda(lambdaName, region);
   spinner.start('Provisioning a function to introspect the database schema...');
   try {
@@ -237,13 +237,13 @@ const updateSchemaInspectorLambda = async (lambdaName: string, region: string): 
   await lambdaClient.send(new UpdateFunctionCodeCommand(params));
 };
 
-const createRoleIfNotExists = async (roleName): Promise<Role> => {
-  let role = await getRole(roleName);
+const createRoleIfNotExists = async (roleName: string, region: string): Promise<Role> => {
+  let role = await getRole(roleName, region);
   // Wait for role created with SDK to propagate.
   // Otherwise it will throw error "The role defined for the function cannot be assumed by Lambda" while creating the lambda.
   const ROLE_PROPAGATION_DELAY = 10000;
   if (!role) {
-    role = await createRole(roleName);
+    role = await createRole(roleName, region);
     await sleep(ROLE_PROPAGATION_DELAY);
   }
   return role;
@@ -255,8 +255,8 @@ const createRoleIfNotExists = async (roleName): Promise<Role> => {
  */
 export const sleep = async (milliseconds: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, milliseconds));
 
-const createPolicy = async (policyName: string): Promise<Policy | undefined> => {
-  const client = new IAMClient({});
+const createPolicy = async (policyName: string, region: string): Promise<Policy | undefined> => {
+  const client = new IAMClient({ region });
   const command = new CreatePolicyCommand({
     PolicyName: policyName,
     PolicyDocument: JSON.stringify({
@@ -275,9 +275,9 @@ const createPolicy = async (policyName: string): Promise<Policy | undefined> => 
   return result.Policy;
 };
 
-const createRole = async (roleName): Promise<Role | undefined> => {
-  const client = new IAMClient({});
-  const policy = await createPolicy(`${roleName}-policy`);
+const createRole = async (roleName: string, region: string): Promise<Role | undefined> => {
+  const client = new IAMClient({ region });
+  const policy = await createPolicy(`${roleName}-policy`, region);
   const command = new CreateRoleCommand({
     AssumeRolePolicyDocument: JSON.stringify({
       Version: '2012-10-17',
@@ -304,8 +304,8 @@ const createRole = async (roleName): Promise<Role | undefined> => {
   return result.Role;
 };
 
-const getRole = async (roleName): Promise<Role | undefined> => {
-  const client = new IAMClient({});
+const getRole = async (roleName: string, region: string): Promise<Role | undefined> => {
+  const client = new IAMClient({ region });
   const command = new GetRoleCommand({
     RoleName: roleName,
   });


### PR DESCRIPTION
#### Description of changes

Fixes schema imports for RDS clusters in VPCs:

1. Added `await`s to `getHostVpc`. The null coalescing evaluation never evaluated the right hand side since `checkHostInDBInstances` returns a perfectly non-null Promise that rejects. :)
1. Added a couple of tests for `getHostVpc` using mocked data to represent instance & cluster configs. These aren't comprehensive by any stretch, but get us to test 1. It's reasonable to add e2e tests for the cluster case as well, but I'll do that under a separate PR if desired
1. Added regions to all IAMClient constructions. IAMClient calls fail if there isn't a default region set, which at least my config doesn't have.

##### CDK / CloudFormation Parameters Changed

N/A

#### Issue #, if available

N/A

#### Description of how you validated changes

1. New unit test
2. Local testing

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~~Relevant documentation is changed or added (and PR referenced)~~
- [ ] ~~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~~
- [ ] ~~Any CDK or CloudFormation parameter changes are called out explicitly~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
