### PR TITLE
chore: update container templates to use node18 and aws sdk v3

### DIFF
--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/express/Dockerfile
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/express/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/node:14-prod-debian-10
+FROM public.ecr.aws/bitnami/node:18-debian-10
 
 ENV PORT=8080
 EXPOSE 8080

--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/express/DynamoDBActions.js
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/express/DynamoDBActions.js
@@ -1,5 +1,7 @@
-const AWS = require('aws-sdk');
-const docClient = new AWS.DynamoDB.DocumentClient();
+const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
+const { DynamoDB } = require('@aws-sdk/client-dynamodb');
+
+const docClient = DynamoDBDocument.from(new DynamoDB());
 
 const TableName = process.env.STORAGE_POSTS_NAME;
 
@@ -16,7 +18,7 @@ const addPostToDDB = async ({ id, title, author, description, topic }) => {
     TableName: TableName
   }
   try {
-    const data = await docClient.put(params).promise()
+    const data = await docClient.put(params)
     return params.Item;
   } catch (err) {
     console.log('Error: ' + err);
@@ -30,7 +32,7 @@ const scanPostsFromDDB = async () => {
   }
 
   try {
-    const data = await docClient.scan(params).promise();
+    const data = await docClient.scan(params);
     return data.Items;
   } catch (err) {
     console.log('Error: ' + err);
@@ -45,7 +47,7 @@ const getPostFromDDB = async (id) => {
     Key: { id: key },
   }
   try {
-    const data = await docClient.get(params).promise()
+    const data = await docClient.get(params)
     return data.Item;
   } catch (err) {
     console.log('Error: ' + err);

--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/express/package.json
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/express/package.json
@@ -8,7 +8,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "aws-sdk": "^2.1113.0",
+    "@aws-sdk/lib-dynamodb": "^3.398.0",
+    "@aws-sdk/client-dynamodb": "^3.398.0",
     "axios": "^0.21.4",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",

--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/dockerfile-rest-express/Dockerfile
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/dockerfile-rest-express/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/node:14-prod-debian-10
+FROM public.ecr.aws/bitnami/node:18-debian-10
 
 ENV PORT=8080
 EXPOSE 8080

--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/dockerfile-rest-express/DynamoDBActions.js
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/dockerfile-rest-express/DynamoDBActions.js
@@ -1,5 +1,7 @@
-const AWS = require('aws-sdk');
-const docClient = new AWS.DynamoDB.DocumentClient();
+const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
+const { DynamoDB } = require('@aws-sdk/client-dynamodb');
+
+const docClient = DynamoDBDocument.from(new DynamoDB());
 
 const TableName = process.env.STORAGE_POSTS_NAME;
 
@@ -16,7 +18,7 @@ const addPostToDDB = async ({ id, title, author, description, topic }) => {
         TableName: TableName
     }
     try {
-        const data = await docClient.put(params).promise()
+        const data = await docClient.put(params)
         return params.Item;
     } catch (err) {
         console.log('Error: ' + err);
@@ -30,7 +32,7 @@ const scanPostsFromDDB = async () => {
     }
 
     try {
-        const data = await docClient.scan(params).promise();
+        const data = await docClient.scan(params);
         return data.Items;
     } catch (err) {
         console.log('Error: ' + err);
@@ -45,7 +47,7 @@ const getPostFromDDB = async (id) => {
         Key: { id: key },
     }
     try {
-        const data = await docClient.get(params).promise()
+        const data = await docClient.get(params)
         return data.Item;
     } catch (err) {
         console.log('Error: ' + err);

--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/dockerfile-rest-express/package.json
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/dockerfile-rest-express/package.json
@@ -9,7 +9,8 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-      "aws-sdk": "^2.1113.0",
+      "@aws-sdk/lib-dynamodb": "^3.398.0",
+      "@aws-sdk/client-dynamodb": "^3.398.0",
       "body-parser": "^1.19.0",
       "express": "^4.17.1"
     }

--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/graphql-express/Dockerfile
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/graphql-express/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/node:14-prod-debian-10
+FROM public.ecr.aws/bitnami/node:18-debian-10
 
 WORKDIR /usr/src/app
 COPY package*.json ./

--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/graphql-express/package.json
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/graphql-express/package.json
@@ -7,7 +7,8 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "aws-sdk": "^2.1113.0",
+        "@aws-sdk/lib-dynamodb": "^3.398.0",
+        "@aws-sdk/client-dynamodb": "^3.398.0",
         "express": "^4.17.1",
         "express-graphql": "^0.11.0",
         "graphql": "^15.4.0"

--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/graphql-express/resolvers.js
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/graphql-express/resolvers.js
@@ -1,5 +1,7 @@
-const AWS = require('aws-sdk');
-const docClient = new AWS.DynamoDB.DocumentClient();
+const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
+const { DynamoDB } = require('@aws-sdk/client-dynamodb');
+
+const docClient = DynamoDBDocument.from(new DynamoDB());
 
 const TableName = process.env.STORAGE_POSTS_NAME;
 
@@ -15,7 +17,7 @@ const addPostToDDB = async ({ id, title, author, description, topic }) => {
         TableName: TableName
     }
     try {
-        const data = await docClient.put(params).promise()
+        const data = await docClient.put(params)
         return params.Item;
     } catch (err) {
         return err
@@ -28,7 +30,7 @@ const scanPostsFromDDB = async () => {
     }
 
     try {
-        const data = await docClient.scan(params).promise();
+        const data = await docClient.scan(params);
         return data.Items;
     } catch (err) {
         console.log(err);
@@ -42,7 +44,7 @@ const getPostFromDDB = async (id) => {
         Key: id,
     }
     try {
-        const data = await docClient.get(params).promise()
+        const data = await docClient.get(params)
         return data.Item;
     } catch (err) {
         return err


### PR DESCRIPTION
#### Description of changes
For the 3 sample nodejs-based container apps, flip to using nodejs18 and aws sdk v3.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A, EOL for Nodejs14

#### Description of how you validated changes
Manually deployed via `setup-dev` to test these three apps after the changes, verifying they successfully deploy.

Unit + E2E Tests
#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
