### PR TITLE
feat(api): always use vpc for aws rds instances and clusters 

### DIFF
--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -38,6 +38,7 @@
     "@aws-cdk/aws-apigatewayv2-alpha": "~2.80.0-alpha.0",
     "@aws-sdk/client-iam": "3.338.0",
     "@aws-sdk/client-lambda": "3.338.0",
+    "@aws-sdk/client-ec2": "3.338.0",
     "@graphql-tools/merge": "^6.0.18",
     "@octokit/rest": "^18.0.9",
     "aws-sdk": "^2.1113.0",

--- a/packages/amplify-category-api/src/provider-utils/vpc-utils.ts
+++ b/packages/amplify-category-api/src/provider-utils/vpc-utils.ts
@@ -1,0 +1,14 @@
+import { SubnetAvailabilityZone } from '@aws-amplify/graphql-transformer-interfaces';
+import { EC2Client, DescribeSubnetsCommand } from '@aws-sdk/client-ec2';
+
+export const getAvaliabilityZoneOfSubnets = async (subnetIds: string[], region: string): Promise<SubnetAvailabilityZone[]> => {
+  const ec2 = new EC2Client({ region });
+  const command = new DescribeSubnetsCommand({
+    SubnetIds: subnetIds,
+  });
+  const subnets = await ec2.send(command);
+  return subnets.Subnets?.map((subnet) => ({
+    SubnetId: subnet.SubnetId,
+    AvailabilityZone: subnet.AvailabilityZone,
+  }));
+};

--- a/packages/amplify-e2e-core/src/utils/rds.ts
+++ b/packages/amplify-e2e-core/src/utils/rds.ts
@@ -257,3 +257,14 @@ export class RDSTestDataProvider {
     }
   }
 }
+
+export const getResource = (resources: Map<string, any>, resourcePrefix: string, resourceType: string): any => {
+  const keys = Array.from(Object.keys(resources)).filter((key) => key.startsWith(resourcePrefix));
+  for (const key of keys) {
+    const resource = resources[key];
+    if (resource.Type === resourceType) {
+      return resource;
+    }
+  }
+  return undefined;
+};

--- a/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
@@ -12,6 +12,7 @@ import {
   importRDSDatabase,
   initJSProjectWithProfile,
   updateSchema,
+  getResource,
 } from 'amplify-category-api-e2e-core';
 import { existsSync, readFileSync } from 'fs-extra';
 import generator from 'generate-password';
@@ -223,16 +224,6 @@ describe('RDS Tests', () => {
     expect(result.data.listComponents.items.length).toEqual(0);
   });
 });
-
-const getResource = (resources: Map<string, any>, resourcePrefix: string, resourceType: string): any => {
-  const keys = Array.from(Object.keys(resources)).filter((key) => key.startsWith(resourcePrefix));
-  for (const key of keys) {
-    const resource = resources[key];
-    if (resource.Type === resourceType) {
-      return resource;
-    }
-  }
-};
 
 const listComponents = async (client) => {
   const listComponentsQuery = /* GraphQL */ `

--- a/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
@@ -25,6 +25,7 @@ import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
 (global as any).fetch = require('node-fetch');
 
 const CDK_FUNCTION_TYPE = 'AWS::Lambda::Function';
+const CDK_VPC_ENDPOINT_TYPE = 'AWS::EC2::VPCEndpoint';
 const CDK_SUBSCRIPTION_TYPE = 'AWS::SNS::Subscription';
 const APPSYNC_DATA_SOURCE_TYPE = 'AWS::AppSync::DataSource';
 
@@ -63,7 +64,7 @@ describe('RDS Tests', () => {
     deleteProjectDir(projRoot);
   });
 
-  const setupDatabase = async () => {
+  const setupDatabase = async (): Promise<void> => {
     const db = await createRDSInstance({
       identifier,
       engine: 'mysql',
@@ -77,7 +78,7 @@ describe('RDS Tests', () => {
     host = db.endpoint;
   };
 
-  const cleanupDatabase = async () => {
+  const cleanupDatabase = async (): Promise<void> => {
     await deleteDBInstance(identifier, region);
   };
 
@@ -151,6 +152,12 @@ describe('RDS Tests', () => {
     expect(rdsLambdaFunction.Properties.VpcConfig.SecurityGroupIds).toBeDefined();
     expect(rdsLambdaFunction.Properties.VpcConfig.SecurityGroupIds.length).toBeGreaterThan(0);
 
+    expect(getResource(resources, 'RDSVpcEndpointssm', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'RDSVpcEndpointssmmessages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'RDSVpcEndpointkms', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'RDSVpcEndpointec2', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'RDSVpcEndpointec2messages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+
     // Validate patching lambda and subscription
     const rdsPatchingLambdaFunction = getResource(resources, 'RDSPatchingLambdaLogicalID', CDK_FUNCTION_TYPE);
     expect(rdsPatchingLambdaFunction).toBeDefined();
@@ -207,12 +214,13 @@ describe('RDS Tests', () => {
     // VPC will not have VPC endpoints for SSM defined and the security group's inbound rule for port 443 is not defined.
     // Expect the listComponents query to fail with an error.
     expect(appSyncClient).toBeDefined();
-    try {
-      await listComponents(appSyncClient);
-      throw new Error('Expected listComponents to fail.');
-    } catch (err) {
-      expect(err.message).toEqual('GraphQL error: Unable to get the database credentials. Check the logs for more details.');
-    }
+
+    const result = await listComponents(appSyncClient);
+    expect(result).toBeDefined();
+    expect(result.data).toBeDefined();
+    expect(result.data.listComponents).toBeDefined();
+    expect(result.data.listComponents.items).toBeDefined();
+    expect(result.data.listComponents.items.length).toEqual(0);
   });
 });
 
@@ -227,7 +235,7 @@ const getResource = (resources: Map<string, any>, resourcePrefix: string, resour
 };
 
 const listComponents = async (client) => {
-  const listComponents = /* GraphQL */ `
+  const listComponentsQuery = /* GraphQL */ `
     query listComponents {
       listComponents {
         items {
@@ -239,7 +247,7 @@ const listComponents = async (client) => {
     }
   `;
   const listResult: any = await client.query({
-    query: gql(listComponents),
+    query: gql(listComponentsQuery),
     fetchPolicy: 'no-cache',
   });
 

--- a/packages/amplify-e2e-tests/src/__tests__/rds-model-v2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-model-v2.test.ts
@@ -87,7 +87,7 @@ describe('RDS Model Directive', () => {
 
   afterEach(async () => {});
 
-  const setupDatabase = async () => {
+  const setupDatabase = async (): Promise<void> => {
     // This test performs the below
     // 1. Create a RDS Instance
     // 2. Add the external IP address of the current machine to security group inbound rule to allow public access
@@ -126,7 +126,7 @@ describe('RDS Model Directive', () => {
     dbAdapter.cleanup();
   };
 
-  const cleanupDatabase = async () => {
+  const cleanupDatabase = async (): Promise<void> => {
     // 1. Remove the IP address from the security group
     // 2. Delete the RDS instance
     await removeRDSPortInboundRule({

--- a/packages/amplify-e2e-tests/src/__tests__/rds-model-v2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-model-v2.test.ts
@@ -13,6 +13,7 @@ import {
   importRDSDatabase,
   initJSProjectWithProfile,
   removeRDSPortInboundRule,
+  getResource,
 } from 'amplify-category-api-e2e-core';
 import { existsSync, readFileSync } from 'fs-extra';
 import generator from 'generate-password';
@@ -23,6 +24,9 @@ import gql from 'graphql-tag';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
+
+const CDK_FUNCTION_TYPE = 'AWS::Lambda::Function';
+const CDK_VPC_ENDPOINT_TYPE = 'AWS::EC2::VPCEndpoint';
 
 describe('RDS Model Directive', () => {
   const publicIpCidr = '0.0.0.0/0';
@@ -47,11 +51,16 @@ describe('RDS Model Directive', () => {
     await initProjectAndImportSchema();
     await amplifyPush(projRoot);
 
+    await verifyApiEndpointAndCreateClient();
+    verifySQLLambdaIsInVpc();
+  });
+
+  const verifyApiEndpointAndCreateClient = async (): Promise<void> => {
     const meta = getProjectMeta(projRoot);
-    const region = meta.providers.awscloudformation.Region;
+    const appRegion = meta.providers.awscloudformation.Region;
     const { output } = meta.api.rdsapi;
     const { GraphQLAPIIdOutput, GraphQLAPIEndpointOutput, GraphQLAPIKeyOutput } = output;
-    const { graphqlApi } = await getAppSyncApi(GraphQLAPIIdOutput, region);
+    const { graphqlApi } = await getAppSyncApi(GraphQLAPIIdOutput, appRegion);
 
     expect(GraphQLAPIIdOutput).toBeDefined();
     expect(GraphQLAPIEndpointOutput).toBeDefined();
@@ -72,7 +81,33 @@ describe('RDS Model Directive', () => {
         apiKey,
       },
     });
-  });
+  };
+
+  const verifySQLLambdaIsInVpc = (): void => {
+    // Validate the generated resources in the CloudFormation template
+    const apisDirectory = path.join(projRoot, 'amplify', 'backend', 'api');
+    const apiDirectory = path.join(apisDirectory, 'rdsapi');
+    const cfnRDSTemplateFile = path.join(apiDirectory, 'build', 'stacks', 'RdsApiStack.json');
+    const cfnTemplate = JSON.parse(readFileSync(cfnRDSTemplateFile, 'utf8'));
+    expect(cfnTemplate.Resources).toBeDefined();
+    const resources = cfnTemplate.Resources;
+
+    // Validate if the SQL lambda function has VPC configuration even if the database is accessible through internet
+    const rdsLambdaFunction = getResource(resources, 'RDSLambdaLogicalID', CDK_FUNCTION_TYPE);
+    expect(rdsLambdaFunction).toBeDefined();
+    expect(rdsLambdaFunction.Properties).toBeDefined();
+    expect(rdsLambdaFunction.Properties.VpcConfig).toBeDefined();
+    expect(rdsLambdaFunction.Properties.VpcConfig.SubnetIds).toBeDefined();
+    expect(rdsLambdaFunction.Properties.VpcConfig.SubnetIds.length).toBeGreaterThan(0);
+    expect(rdsLambdaFunction.Properties.VpcConfig.SecurityGroupIds).toBeDefined();
+    expect(rdsLambdaFunction.Properties.VpcConfig.SecurityGroupIds.length).toBeGreaterThan(0);
+
+    expect(getResource(resources, 'RDSVpcEndpointssm', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'RDSVpcEndpointssmmessages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'RDSVpcEndpointkms', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'RDSVpcEndpointec2', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'RDSVpcEndpointec2messages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+  };
 
   afterAll(async () => {
     const metaFilePath = path.join(projRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
@@ -82,10 +117,6 @@ describe('RDS Model Directive', () => {
     deleteProjectDir(projRoot);
     await cleanupDatabase();
   });
-
-  beforeEach(async () => {});
-
-  afterEach(async () => {});
 
   const setupDatabase = async (): Promise<void> => {
     // This test performs the below
@@ -137,7 +168,7 @@ describe('RDS Model Directive', () => {
     await deleteDBInstance(identifier, region);
   };
 
-  const initProjectAndImportSchema = async () => {
+  const initProjectAndImportSchema = async (): Promise<void> => {
     const apiName = 'rdsapi';
     await initJSProjectWithProfile(projRoot, {
       disableAmplifyAppCreation: false,
@@ -342,25 +373,25 @@ describe('RDS Model Directive', () => {
     try {
       await createContact('Jason', 'Bourne', contact1.data.createContact.id);
     } catch (err) {
-      checkGenericError(err?.message);
+      await checkGenericError(err?.message);
     }
 
     const nonExistentId = 'doesnotexist';
     try {
       await updateContact(nonExistentId, 'David', 'Jones');
     } catch (err) {
-      checkGenericError(err?.message);
+      await checkGenericError(err?.message);
     }
 
     try {
       await deleteContact(nonExistentId);
     } catch (err) {
-      checkGenericError(err?.message);
+      await checkGenericError(err?.message);
     }
   });
 
   // CURDL on Contact table helpers
-  const createContact = async (firstName: string, lastName: string, id?: string) => {
+  const createContact = async (firstName: string, lastName: string, id?: string): Promise<Record<string, any>> => {
     const createMutation = /* GraphQL */ `
       mutation CreateContact($input: CreateContactInput!, $condition: ModelContactConditionInput) {
         createContact(input: $input, condition: $condition) {
@@ -390,7 +421,7 @@ describe('RDS Model Directive', () => {
     return createResult;
   };
 
-  const updateContact = async (id: string, firstName: string, lastName: string) => {
+  const updateContact = async (id: string, firstName: string, lastName: string): Promise<Record<string, any>> => {
     const updateMutation = /* GraphQL */ `
       mutation UpdateContact($input: UpdateContactInput!, $condition: ModelContactConditionInput) {
         updateContact(input: $input, condition: $condition) {
@@ -416,7 +447,7 @@ describe('RDS Model Directive', () => {
     return updateResult;
   };
 
-  const deleteContact = async (id: string) => {
+  const deleteContact = async (id: string): Promise<Record<string, any>> => {
     const deleteMutation = /* GraphQL */ `
       mutation DeleteContact($input: DeleteContactInput!, $condition: ModelContactConditionInput) {
         deleteContact(input: $input, condition: $condition) {
@@ -440,7 +471,7 @@ describe('RDS Model Directive', () => {
     return deleteResult;
   };
 
-  const getContact = async (id: string) => {
+  const getContact = async (id: string): Promise<Record<string, any>> => {
     const getQuery = /* GraphQL */ `
       query GetContact($id: String!) {
         getContact(id: $id) {
@@ -462,7 +493,7 @@ describe('RDS Model Directive', () => {
     return getResult;
   };
 
-  const listContacts = async () => {
+  const listContacts = async (): Promise<Record<string, any>> => {
     const listQuery = /* GraphQL */ `
       query ListContact {
         listContacts {
@@ -483,7 +514,7 @@ describe('RDS Model Directive', () => {
   };
 
   // CURDL on Student table helpers
-  const createStudent = async (studentId: number, classId: string, firstName: string, lastName: string) => {
+  const createStudent = async (studentId: number, classId: string, firstName: string, lastName: string): Promise<Record<string, any>> => {
     const createMutation = /* GraphQL */ `
       mutation CreateStuden($input: CreateStudentInput!, $condition: ModelStudentConditionInput) {
         createStudent(input: $input, condition: $condition) {
@@ -511,7 +542,7 @@ describe('RDS Model Directive', () => {
     return createResult;
   };
 
-  const updateStudent = async (studentId: number, classId: string, firstName: string, lastName: string) => {
+  const updateStudent = async (studentId: number, classId: string, firstName: string, lastName: string): Promise<Record<string, any>> => {
     const updateMutation = /* GraphQL */ `
       mutation UpdateStudent($input: UpdateStudentInput!, $condition: ModelStudentConditionInput) {
         updateStudent(input: $input, condition: $condition) {
@@ -539,7 +570,7 @@ describe('RDS Model Directive', () => {
     return updateResult;
   };
 
-  const deleteStudent = async (studentId: number, classId: string) => {
+  const deleteStudent = async (studentId: number, classId: string): Promise<Record<string, any>> => {
     const deleteMutation = /* GraphQL */ `
       mutation DeleteStudent($input: DeleteStudentInput!, $condition: ModelStudentConditionInput) {
         deleteStudent(input: $input, condition: $condition) {
@@ -565,7 +596,7 @@ describe('RDS Model Directive', () => {
     return deleteResult;
   };
 
-  const getStudent = async (studentId: number, classId: string) => {
+  const getStudent = async (studentId: number, classId: string): Promise<Record<string, any>> => {
     const getQuery = /* GraphQL */ `
       query GetStudent($studentId: Int!, $classId: String!) {
         getStudent(studentId: $studentId, classId: $classId) {
@@ -589,7 +620,7 @@ describe('RDS Model Directive', () => {
     return getResult;
   };
 
-  const listStudents = async (limit: number = 100, nextToken: string | null = null, filter: any = null) => {
+  const listStudents = async (limit = 100, nextToken: string | null = null, filter: any = null): Promise<Record<string, any>> => {
     const listQuery = /* GraphQL */ `
       query ListStudents($limit: Int, $nextToken: String, $filter: ModelStudentFilterInput) {
         listStudents(limit: $limit, nextToken: $nextToken, filter: $filter) {
@@ -616,7 +647,7 @@ describe('RDS Model Directive', () => {
     return listResult;
   };
 
-  const checkGenericError = async (errorMessage?: string) => {
+  const checkGenericError = async (errorMessage?: string): Promise<void> => {
     expect(errorMessage).toBeDefined();
     expect(errorMessage).toEqual('GraphQL error: Error processing the request. Check the logs for more details.');
   };

--- a/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
+++ b/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
@@ -18,7 +18,11 @@ export const run = async (event): Promise<any> => {
 };
 
 const createSSMClient = (): void => {
-  secretsClient = new SSMClient({});
+  const DNS_SEPERATOR = ':';
+  const endpoint = process.env.SSM_ENDPOINT?.split(DNS_SEPERATOR).pop();
+  secretsClient = new SSMClient({
+    endpoint: `https://${endpoint}`,
+  });
 };
 
 const wait10SecondsAndThrowError = async (): Promise<void> => {

--- a/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
@@ -194,7 +194,7 @@ const addVpcEndpoint = (scope: Construct, sqlLambdaVpcConfig: VpcSubnetConfig, s
 const addVpcEndpointForSecretsManager = (
   scope: Construct,
   sqlLambdaVpcConfig: VpcSubnetConfig,
-): { service: string, endpoint: CfnVPCEndpoint }[] => {
+): { service: string; endpoint: CfnVPCEndpoint }[] => {
   const services = ['ssm', 'ssmmessages', 'ec2', 'ec2messages', 'kms'];
   return services.map((service) => {
     return {

--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -82,7 +82,7 @@ import { TypeNode } from 'graphql';
 import { TypeSystemDefinitionNode } from 'graphql';
 import { UnionTypeDefinitionNode } from 'graphql';
 import { UnionTypeExtensionNode } from 'graphql';
-import { VpcConfig } from '@aws-amplify/graphql-transformer-interfaces';
+import type { VpcSubnetConfig } from '@aws-amplify/graphql-transformer-interfaces';
 
 // @public (undocumented)
 export const APICategory = "api";
@@ -243,7 +243,7 @@ export interface GraphQLTransformOptions {
     // (undocumented)
     readonly resolverConfig?: ResolverConfig;
     // (undocumented)
-    readonly sqlLambdaVpcConfig?: VpcConfig;
+    readonly sqlLambdaVpcConfig?: VpcSubnetConfig;
     // Warning: (ae-forgotten-export) The symbol "StackMapping" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -14,6 +14,7 @@ import type {
   StackManagerProvider,
   TransformParameterProvider,
   TransformParameters,
+  VpcSubnetConfig,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import { AuthorizationMode, AuthorizationType } from 'aws-cdk-lib/aws-appsync';
 import { Aws, CfnOutput, Fn, Stack } from 'aws-cdk-lib';
@@ -86,7 +87,7 @@ export interface GraphQLTransformOptions {
   readonly host?: TransformHostProvider;
   readonly userDefinedSlots?: Record<string, UserDefinedSlot[]>;
   readonly resolverConfig?: ResolverConfig;
-  readonly sqlLambdaVpcConfig?: VpcConfig;
+  readonly sqlLambdaVpcConfig?: VpcSubnetConfig;
   readonly rdsLayerMapping?: RDSLayerMapping;
 }
 
@@ -113,7 +114,7 @@ export class GraphQLTransform {
 
   private readonly userDefinedSlots: Record<string, UserDefinedSlot[]>;
 
-  private readonly sqlLambdaVpcConfig?: VpcConfig;
+  private readonly sqlLambdaVpcConfig?: VpcSubnetConfig;
   private readonly transformParameters: TransformParameters;
 
   // A map from `${directive}.${typename}.${fieldName?}`: true
@@ -146,7 +147,6 @@ export class GraphQLTransform {
     this.stackMappingOverrides = options.stackMapping || {};
     this.userDefinedSlots = options.userDefinedSlots || ({} as Record<string, UserDefinedSlot[]>);
     this.resolverConfig = options.resolverConfig || {};
-    this.sqlLambdaVpcConfig = options.sqlLambdaVpcConfig;
     this.sqlLambdaVpcConfig = options.sqlLambdaVpcConfig;
     this.transformParameters = {
       ...defaultTransformParameters,

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
@@ -6,7 +6,6 @@ import {
   TransformerContextProvider,
   TransformerDataSourceManagerProvider,
   AppSyncAuthConfiguration,
-  VpcConfig,
   RDSLayerMapping,
   SynthParameters,
 } from '@aws-amplify/graphql-transformer-interfaces';
@@ -15,6 +14,7 @@ import type {
   NestedStackProvider,
   TransformParameterProvider,
   TransformParameters,
+  VpcSubnetConfig,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import { TransformerContextMetadataProvider } from '@aws-amplify/graphql-transformer-interfaces/src/transformer-context/transformer-context-provider';
 import { DocumentNode } from 'graphql';
@@ -76,7 +76,7 @@ export class TransformerContext implements TransformerContextProvider {
 
   public readonly datasourceSecretParameterLocations: Map<string, RDSConnectionSecrets>;
 
-  public readonly sqlLambdaVpcConfig?: VpcConfig;
+  public readonly sqlLambdaVpcConfig?: VpcSubnetConfig;
 
   public readonly rdsLayerMapping?: RDSLayerMapping;
 
@@ -98,7 +98,7 @@ export class TransformerContext implements TransformerContextProvider {
     transformParameters: TransformParameters,
     resolverConfig?: ResolverConfig,
     datasourceSecretParameterLocations?: Map<string, RDSConnectionSecrets>,
-    sqlLambdaVpcConfig?: VpcConfig,
+    sqlLambdaVpcConfig?: VpcSubnetConfig,
     rdsLayerMapping?: RDSLayerMapping,
   ) {
     assetManager.setAssetProvider(assetProvider);

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -312,6 +312,12 @@ export interface StackManagerProvider {
 }
 
 // @public (undocumented)
+export type SubnetAvailabilityZone = {
+    SubnetId: string;
+    AvailabilityZone: string;
+};
+
+// @public (undocumented)
 export enum SubscriptionFieldType {
     // (undocumented)
     ON_CREATE = "ON_CREATE",
@@ -431,7 +437,7 @@ export interface TransformerContextProvider {
     // (undocumented)
     resourceHelper: TransformerResourceHelperProvider;
     // (undocumented)
-    readonly sqlLambdaVpcConfig?: VpcConfig;
+    readonly sqlLambdaVpcConfig?: VpcSubnetConfig;
     // (undocumented)
     stackManager: StackManagerProvider;
     // (undocumented)
@@ -757,6 +763,12 @@ export type VpcConfig = {
     vpcId: string;
     subnetIds: string[];
     securityGroupIds: string[];
+};
+
+// @public (undocumented)
+export type VpcSubnetConfig = {
+    vpcConfig: VpcConfig;
+    subnetAvailabilityZoneConfig: SubnetAvailabilityZone[];
 };
 
 // Warnings were encountered during analysis:

--- a/packages/amplify-graphql-transformer-interfaces/src/graphql-api-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/graphql-api-provider.ts
@@ -69,6 +69,16 @@ export type VpcConfig = {
   securityGroupIds: string[];
 };
 
+export type SubnetAvailabilityZone = {
+  SubnetId: string;
+  AvailabilityZone: string;
+};
+
+export type VpcSubnetConfig = {
+  vpcConfig: VpcConfig;
+  subnetAvailabilityZoneConfig: SubnetAvailabilityZone[];
+};
+
 export type RDSLayerMapping = {
   [key: string]: {
     layerRegion: string;

--- a/packages/amplify-graphql-transformer-interfaces/src/index.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/index.ts
@@ -28,6 +28,8 @@ export {
   AppSyncAuthMode,
   UserPoolConfig,
   VpcConfig,
+  VpcSubnetConfig,
+  SubnetAvailabilityZone,
   SearchableDataSourceOptions,
   RDSLayerMapping,
 } from './graphql-api-provider';

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
@@ -1,5 +1,5 @@
 import { DocumentNode } from 'graphql';
-import { AppSyncAuthConfiguration, GraphQLAPIProvider, RDSLayerMapping, VpcConfig } from '../graphql-api-provider';
+import { AppSyncAuthConfiguration, GraphQLAPIProvider, RDSLayerMapping, VpcSubnetConfig } from '../graphql-api-provider';
 import { TransformerDataSourceManagerProvider, DatasourceType } from './transformer-datasource-provider';
 import { TransformerProviderRegistry } from './transformer-provider-registry';
 import { TransformerContextOutputProvider } from './transformer-context-output-provider';
@@ -37,7 +37,7 @@ export interface TransformerContextProvider {
 
   isProjectUsingDataStore(): boolean;
   getResolverConfig<ResolverConfig>(): ResolverConfig | undefined;
-  readonly sqlLambdaVpcConfig?: VpcConfig;
+  readonly sqlLambdaVpcConfig?: VpcSubnetConfig;
   readonly rdsLayerMapping?: RDSLayerMapping;
 }
 

--- a/packages/amplify-graphql-transformer-test-utils/src/test-transform.ts
+++ b/packages/amplify-graphql-transformer-test-utils/src/test-transform.ts
@@ -1,5 +1,5 @@
 import { AppSyncAuthConfiguration, TransformerPluginProvider, TransformerLogLevel } from '@aws-amplify/graphql-transformer-interfaces';
-import type { TransformParameters } from '@aws-amplify/graphql-transformer-interfaces';
+import type { TransformParameters, VpcSubnetConfig } from '@aws-amplify/graphql-transformer-interfaces';
 import {
   DatasourceType,
   GraphQLTransform,
@@ -22,6 +22,7 @@ export type TestTransformParameters = {
   datasourceSecretParameterLocations?: Map<string, RDSConnectionSecrets>;
   customQueries?: Map<string, string>;
   overrideConfig?: OverrideConfig;
+  sqlLambdaVpcConfig?: VpcSubnetConfig;
 };
 
 /**
@@ -41,6 +42,7 @@ export const testTransform = (params: TestTransformParameters): DeploymentResour
     userDefinedSlots,
     stackMapping,
     transformParameters,
+    sqlLambdaVpcConfig,
   } = params;
 
   const transform = new GraphQLTransform({
@@ -50,6 +52,7 @@ export const testTransform = (params: TestTransformParameters): DeploymentResour
     transformParameters,
     userDefinedSlots,
     resolverConfig,
+    sqlLambdaVpcConfig,
   });
 
   const transformManager = new TransformManager(overrideConfig);

--- a/packages/amplify-graphql-transformer/API.md
+++ b/packages/amplify-graphql-transformer/API.md
@@ -20,7 +20,7 @@ import { TransformerPluginProvider } from '@aws-amplify/graphql-transformer-inte
 import { TransformParameterProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import type { TransformParameters } from '@aws-amplify/graphql-transformer-interfaces/src';
 import { UserDefinedSlot } from '@aws-amplify/graphql-transformer-core';
-import { VpcConfig } from '@aws-amplify/graphql-transformer-interfaces';
+import { VpcSubnetConfig } from '@aws-amplify/graphql-transformer-interfaces';
 
 // @public (undocumented)
 export const constructTransform: (config: TransformConfig) => GraphQLTransform;
@@ -38,7 +38,7 @@ export type ExecuteTransformConfig = TransformConfig & {
     customQueries?: Map<string, string>;
     datasourceSecretParameterLocations?: Map<string, RDSConnectionSecrets>;
     printTransformerLog?: (log: TransformerLog) => void;
-    sqlLambdaVpcConfig?: VpcConfig;
+    sqlLambdaVpcConfig?: VpcSubnetConfig;
     rdsLayerMapping?: RDSLayerMapping;
     scope: Construct;
     nestedStackProvider: NestedStackProvider;
@@ -55,7 +55,7 @@ export type TransformConfig = {
     userDefinedSlots?: Record<string, UserDefinedSlot[]>;
     stackMapping?: Record<string, string>;
     transformParameters: TransformParameters;
-    sqlLambdaVpcConfig?: VpcConfig;
+    sqlLambdaVpcConfig?: VpcSubnetConfig;
     rdsLayerMapping?: RDSLayerMapping;
 };
 

--- a/packages/amplify-graphql-transformer/src/graphql-transformer.ts
+++ b/packages/amplify-graphql-transformer/src/graphql-transformer.ts
@@ -19,7 +19,7 @@ import {
   TransformerPluginProvider,
   TransformerLog,
   TransformerLogLevel,
-  VpcConfig,
+  VpcSubnetConfig,
   RDSLayerMapping,
   NestedStackProvider,
   AssetProvider,
@@ -60,7 +60,7 @@ export type TransformConfig = {
   userDefinedSlots?: Record<string, UserDefinedSlot[]>;
   stackMapping?: Record<string, string>;
   transformParameters: TransformParameters;
-  sqlLambdaVpcConfig?: VpcConfig;
+  sqlLambdaVpcConfig?: VpcSubnetConfig;
   rdsLayerMapping?: RDSLayerMapping;
 };
 
@@ -130,7 +130,7 @@ export type ExecuteTransformConfig = TransformConfig & {
   customQueries?: Map<string, string>;
   datasourceSecretParameterLocations?: Map<string, RDSConnectionSecrets>;
   printTransformerLog?: (log: TransformerLog) => void;
-  sqlLambdaVpcConfig?: VpcConfig;
+  sqlLambdaVpcConfig?: VpcSubnetConfig;
   rdsLayerMapping?: RDSLayerMapping;
   scope: Construct;
   nestedStackProvider: NestedStackProvider;


### PR DESCRIPTION
#### Description of changes
- Deploy the SQL lambda in VPC if the database is in VPC regardless whether the database is accessible through internet or not.
- Add VPC endpoints required to read the secrets if the database is in a VPC.
- Inject the SSM VPC endpoints to SQL lambda environment variable.
- SQL lambda uses SSM endpoint from the environment variable.

##### CDK / CloudFormation Parameters Changed
NA

#### Issue #, if available
NA

#### Description of how you validated changes
- Manual test
- E2E tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
