### PR TITLE
fix: enable autoDeleteObjects on the codegen bucket

### DIFF
--- a/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
+++ b/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
@@ -134,7 +134,7 @@ export class AmplifyGraphqlApi<SchemaType = AmplifyGraphqlApiResources> extends 
       },
     });
 
-    this.codegenAssets = new CodegenAssets(this, 'CodegenAssets', { modelSchema: processedSchema });
+    this.codegenAssets = new CodegenAssets(this, 'AmplifyCodegenAssets', { modelSchema: processedSchema });
 
     this.resources = getGeneratedResources(this);
     this.generatedFunctionSlots = getGeneratedFunctionSlots(assetManager.resolverAssets);

--- a/packages/amplify-graphql-api-construct/src/internal/codegen-assets.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/codegen-assets.ts
@@ -27,7 +27,10 @@ export class CodegenAssets extends Construct {
   constructor(scope: Construct, id: string, props: CodegenAssetsProps) {
     super(scope, id);
 
-    const bucket = new Bucket(this, `${id}Bucket`, { removalPolicy: RemovalPolicy.DESTROY });
+    const bucket = new Bucket(this, `${id}Bucket`, {
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
 
     new BucketDeployment(this, `${id}Deployment`, {
       destinationBucket: bucket,


### PR DESCRIPTION
#### Description of changes
Enable `autoDeleteObjects` on the codegen assets bucket, since we're currently failing deletion to that resource, the assets are useless after a stack is deleted.

Also, update id of the assets bucket resources, to align w/ backend deployment expectations.

##### CDK / CloudFormation Parameters Changed
Yes, `autoDeleteObjects` is set on the codegen assets bucket.

#### Issue #, if available
N/A

#### Description of how you validated changes
Tests + Build, and verified manually in a CDK app.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
