### PR TITLE
feat: infer refersTo for models in the import flow and preserve edits during schema regeneration

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
@@ -113,7 +113,7 @@ describe('RDS Tests', () => {
     // Generated schema should contain the types with model directive
     // db is one of the default table in mysql database
     const dbObjectType = schema.definitions.find(
-      (d) => d.kind === 'ObjectTypeDefinition' && d.name.value === 'db',
+      (d) => d.kind === 'ObjectTypeDefinition' && d.name.value === 'Db',
     ) as ObjectTypeDefinitionNode;
     expect(dbObjectType).toBeDefined();
     expect(dbObjectType.directives.find((d) => d.name.value === 'model')).toBeDefined();

--- a/packages/amplify-e2e-tests/src/__tests__/rds-v2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-v2.test.ts
@@ -87,7 +87,7 @@ describe('RDS Tests', () => {
       database: db.dbName,
     });
     await dbAdapter.runQuery([
-      'CREATE TABLE Contacts (ID INT PRIMARY KEY, FirstName VARCHAR(20), LastName VARCHAR(50))',
+      'CREATE TABLE Contact (ID INT PRIMARY KEY, FirstName VARCHAR(20), LastName VARCHAR(50))',
       'CREATE TABLE Person (ID INT PRIMARY KEY, FirstName VARCHAR(20), LastName VARCHAR(50))',
       'CREATE TABLE Employee (ID INT PRIMARY KEY, FirstName VARCHAR(20), LastName VARCHAR(50))',
     ]);
@@ -128,27 +128,27 @@ describe('RDS Tests', () => {
     const schema = parse(schemaContent);
 
     // Generated schema should contains the types and fields from the database
-    const contactsObjectType = schema.definitions.find(
-      (d) => d.kind === 'ObjectTypeDefinition' && d.name.value === 'Contacts',
+    const contactObjectType = schema.definitions.find(
+      (d) => d.kind === 'ObjectTypeDefinition' && d.name.value === 'Contact',
     ) as ObjectTypeDefinitionNode;
     const personObjectType = schema.definitions.find((d) => d.kind === 'ObjectTypeDefinition' && d.name.value === 'Person');
     const employeeObjectType = schema.definitions.find((d) => d.kind === 'ObjectTypeDefinition' && d.name.value === 'Employee');
 
-    expect(contactsObjectType).toBeDefined();
+    expect(contactObjectType).toBeDefined();
     expect(personObjectType).toBeDefined();
     expect(employeeObjectType).toBeDefined();
 
-    // Verify the fields in the generated schema on type 'Contacts'
-    const contactsIdFieldType = contactsObjectType.fields.find((f) => f.name.value === 'ID');
-    const contactsFirstNameFieldType = contactsObjectType.fields.find((f) => f.name.value === 'FirstName');
-    const contactsLastNameFieldType = contactsObjectType.fields.find((f) => f.name.value === 'LastName');
+    // Verify the fields in the generated schema on type 'Contact'
+    const contactIdFieldType = contactObjectType.fields.find((f) => f.name.value === 'ID');
+    const contactFirstNameFieldType = contactObjectType.fields.find((f) => f.name.value === 'FirstName');
+    const contactLastNameFieldType = contactObjectType.fields.find((f) => f.name.value === 'LastName');
 
-    expect(contactsIdFieldType).toBeDefined();
-    expect(contactsFirstNameFieldType).toBeDefined();
-    expect(contactsLastNameFieldType).toBeDefined();
+    expect(contactIdFieldType).toBeDefined();
+    expect(contactFirstNameFieldType).toBeDefined();
+    expect(contactLastNameFieldType).toBeDefined();
 
     // PrimaryKey directive must be defined on Id field.
-    expect(contactsIdFieldType.directives.find((d) => d.name.value === 'primaryKey')).toBeDefined();
+    expect(contactIdFieldType.directives.find((d) => d.name.value === 'primaryKey')).toBeDefined();
   });
 
   // This test must be updated if the rds layer mapping file is updated

--- a/packages/amplify-graphql-schema-generator/API.md
+++ b/packages/amplify-graphql-schema-generator/API.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { DirectiveNode } from 'graphql';
 import { DocumentNode } from 'graphql';
 import { FieldDefinitionNode } from 'graphql';
 import { ObjectTypeDefinitionNode } from 'graphql';
@@ -15,10 +16,19 @@ export const applyFieldOverrides: (field: FieldDefinitionNode, existingField: Fi
 export const applyJSONFieldTypeOverrides: (field: FieldDefinitionNode, existingField: FieldDefinitionNode) => FieldDefinitionNode;
 
 // @public (undocumented)
+export const applyModelNameOverrides: (obj: ObjectTypeDefinitionNode, existingObj: ObjectTypeDefinitionNode) => ObjectTypeDefinitionNode;
+
+// @public (undocumented)
+export const applyModelOverrides: (obj: ObjectTypeDefinitionNode, existingObj: ObjectTypeDefinitionNode) => ObjectTypeDefinitionNode;
+
+// @public (undocumented)
 export const applySchemaOverrides: (document: DocumentNode, existingDocument?: DocumentNode | undefined) => DocumentNode;
 
 // @public (undocumented)
 export const checkDestructiveNullabilityChange: (field: FieldDefinitionNode, existingField: FieldDefinitionNode) => void;
+
+// @public (undocumented)
+export const convertToGraphQLTypeName: (modelName: string) => string;
 
 // @public (undocumented)
 export interface CustomType {
@@ -123,6 +133,9 @@ export const getHostVpc: (hostname: string, region: string) => Promise<VpcConfig
 
 // @public (undocumented)
 export const getParentNode: (ancestors: any[]) => ObjectTypeDefinitionNode | undefined;
+
+// @public (undocumented)
+export const getRefersToDirective: (name: string) => DirectiveNode;
 
 // @public (undocumented)
 export class Index {

--- a/packages/amplify-graphql-schema-generator/API.md
+++ b/packages/amplify-graphql-schema-generator/API.md
@@ -229,6 +229,9 @@ export interface NonNullType {
 }
 
 // @public (undocumented)
+export const printSchema: (document: DocumentNode) => string;
+
+// @public (undocumented)
 export const provisionSchemaInspectorLambda: (lambdaName: string, vpc: VpcConfig, region: string) => Promise<void>;
 
 // @public (undocumented)

--- a/packages/amplify-graphql-schema-generator/package.json
+++ b/packages/amplify-graphql-schema-generator/package.json
@@ -38,7 +38,9 @@
     "graphql": "^15.5.0",
     "knex": "~2.4.0",
     "mysql2": "~2.3.3",
-    "ora": "^4.0.3"
+    "ora": "^4.0.3",
+    "pluralize": "^8.0.0",
+    "@types/pluralize": "^0.0.29"
   },
   "peerDependencies": {
     "@aws-amplify/amplify-prompts": "^2.8.1-aug-transformer-mv-bump.0"

--- a/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-schema.test.ts.snap
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-schema.test.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Type name conversions infers refersTo from model name 1`] = `
+"type User @refersTo(name: \\"users\\") @model {
+  id: String! @primaryKey
+  name: String
+}
+
+type Profile @refersTo(name: \\"profile\\") @model {
+  id: String! @primaryKey
+  details: String
+}
+"
+`;

--- a/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-schema.test.ts.snap
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-schema.test.ts.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Type name conversions infers refersTo from model name 1`] = `
-"type User @refersTo(name: \\"users\\") @model {
-  id: String! @primaryKey
-  name: String
-}
-
-type Profile @refersTo(name: \\"profile\\") @model {
+"type Profile @refersTo(name: \\"profile\\") @model {
   id: String! @primaryKey
   details: String
+}
+
+type User @refersTo(name: \\"users\\") @model {
+  id: String! @primaryKey
+  name: String
 }
 "
 `;

--- a/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/mysql-datasource-adapter.test.ts.snap
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/mysql-datasource-adapter.test.ts.snap
@@ -31,17 +31,17 @@ type Post @model {
 `;
 
 exports[`testDataSourceAdapter generate schema retains hasOne and belongsTo relationship and removes the non-relational fields added manually 1`] = `
-"type User @model {
-  id: Int! @primaryKey
-  name: String
-  profile: Profile @hasOne(references: [\\"userId\\"])
-}
-
-type Profile @model {
+"type Profile @model {
   id: Int! @primaryKey
   content: String
   userId: Int!
   user: User @belongsTo(references: [\\"userId\\"])
+}
+
+type User @model {
+  id: Int! @primaryKey
+  name: String
+  profile: Profile @hasOne(references: [\\"userId\\"])
 }
 "
 `;
@@ -106,15 +106,15 @@ type Task @refersTo(name: \\"Tasks\\") @model {
 `;
 
 exports[`testDataSourceAdapter test generate graphql schema on model with enum field 1`] = `
-"enum Profile_type {
-  Manager
-  Employee
-}
-
-type Profile @model {
+"type Profile @model {
   id: Int! @primaryKey
   name: String
   type: Profile_type
+}
+
+enum Profile_type {
+  Manager
+  Employee
 }
 "
 `;

--- a/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/mysql-datasource-adapter.test.ts.snap
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/mysql-datasource-adapter.test.ts.snap
@@ -75,7 +75,7 @@ exports[`testDataSourceAdapter generates primary key fields as required without 
 `;
 
 exports[`testDataSourceAdapter include option should import only the given tables 1`] = `
-"type Tasks @model {
+"type Task @refersTo(name: \\"Tasks\\") @model {
   id: String! @primaryKey(sortKeyFields: [\\"title\\"])
   title: String @index(name: \\"tasks_title\\") @index(name: \\"tasks_title_description\\", sortKeyFields: [\\"description\\"])
   description: String
@@ -96,7 +96,7 @@ type Country @model {
   name: String
 }
 
-type Tasks @model {
+type Task @refersTo(name: \\"Tasks\\") @model {
   id: String! @primaryKey(sortKeyFields: [\\"title\\"])
   title: String @index(name: \\"tasks_title\\") @index(name: \\"tasks_title_description\\", sortKeyFields: [\\"description\\"])
   description: String

--- a/packages/amplify-graphql-schema-generator/src/__tests__/generate-schema.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/generate-schema.test.ts
@@ -1,0 +1,37 @@
+import { convertToGraphQLTypeName } from '../schema-generator/generate-schema';
+import { Engine, Field, Model, Schema } from '../schema-representation';
+import { generateGraphQLSchema } from '../schema-generator';
+
+describe('Type name conversions', () => {
+  it('GraphQL idiomatic type name conversions', () => {
+    // Singularize and Pascal case
+    expect(convertToGraphQLTypeName('posts')).toEqual('Post');
+    // Singularize
+    expect(convertToGraphQLTypeName('Salaries')).toEqual('Salary');
+    expect(convertToGraphQLTypeName('Lotuses')).toEqual('Lotus');
+    // Pascal case
+    expect(convertToGraphQLTypeName('employees_salaries')).toEqual('EmployeesSalary');
+    // Remove special characters not supported in GraphQL
+    expect(convertToGraphQLTypeName('Employees_salaries-Tables')).toEqual('EmployeesSalariesTable');
+    expect(convertToGraphQLTypeName('_employee_Salaries-tables')).toEqual('EmployeeSalariesTable');
+    expect(convertToGraphQLTypeName('Employees$salaries-#Table%log@Rates!types')).toEqual('EmployeesSalariesTableLogRatesType');
+  });
+
+  it('infers refersTo from model name', () => {
+    const dbschema = new Schema(new Engine('MySQL'));
+    let model = new Model('users');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'String' } }));
+    model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
+    model.setPrimaryKey(['id']);
+    dbschema.addModel(model);
+
+    model = new Model('profile');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'String' } }));
+    model.addField(new Field('details', { kind: 'Scalar', name: 'String' }));
+    model.setPrimaryKey(['id']);
+    dbschema.addModel(model);
+
+    const graphqlSchema = generateGraphQLSchema(dbschema);
+    expect(graphqlSchema).toMatchSnapshot();
+  });
+});

--- a/packages/amplify-graphql-schema-generator/src/__tests__/generate-schema.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/generate-schema.test.ts
@@ -1,6 +1,7 @@
-import { convertToGraphQLTypeName } from '../schema-generator/generate-schema';
+import { convertToGraphQLTypeName, printSchema } from '../schema-generator/generate-schema';
 import { Engine, Field, Model, Schema } from '../schema-representation';
 import { generateGraphQLSchema } from '../schema-generator';
+import { parse } from 'graphql';
 
 describe('Type name conversions', () => {
   it('GraphQL idiomatic type name conversions', () => {
@@ -33,5 +34,28 @@ describe('Type name conversions', () => {
 
     const graphqlSchema = generateGraphQLSchema(dbschema);
     expect(graphqlSchema).toMatchSnapshot();
+  });
+});
+
+describe('Format generated schema', () => {
+  it('generates schema with consistent type ordering', () => {
+    const document = parse(`
+        type User @model {
+            id: ID!
+        }
+        type Profile @model {
+            id: ID!
+        }
+    `);
+    expect(printSchema(document)).toMatchInlineSnapshot(`
+      "type Profile @model {
+        id: ID!
+      }
+
+      type User @model {
+        id: ID!
+      }
+      "
+    `);
   });
 });

--- a/packages/amplify-graphql-schema-generator/src/__tests__/mysql-datasource-adapter.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/mysql-datasource-adapter.test.ts
@@ -1,7 +1,6 @@
 import { DataSourceAdapter, MySQLDataSourceAdapter } from '../datasource-adapter';
 import { Engine, Field, FieldType, Index, Model, Schema } from '../schema-representation';
 import { generateGraphQLSchema, isComputeExpression } from '../schema-generator';
-import { parse } from 'graphql';
 import { gql } from 'graphql-transformer-core';
 
 class TestDataSourceAdapter extends DataSourceAdapter {

--- a/packages/amplify-graphql-schema-generator/src/__tests__/schema-overrides.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/schema-overrides.test.ts
@@ -231,6 +231,80 @@ describe('apply schema overrides for JSON fields', () => {
   });
 });
 
+describe('apply schema overrides for models with refersTo', () => {
+  it('should be the same if no edits are made', () => {
+    const document = parse(`
+            type Post @refersTo(name: "posts") @model {
+                id: ID!
+                name: String
+            }
+        `);
+    const editedSchema = `
+            type Post @refersTo(name: "posts") @model {
+                id: ID!
+                name: String
+            }
+        `;
+    const editedDocument = parse(editedSchema);
+    const updatedDocument = applySchemaOverrides(document, editedDocument);
+    stringsMatchWithoutWhitespace(print(updatedDocument), editedSchema);
+  });
+
+  it('should allow type name overrides', () => {
+    const document = parse(`
+            type Post @refersTo(name: "posts") @model {
+                id: ID!
+                name: String
+            }
+        `);
+    const editedSchema = `
+            type MyPost @refersTo(name: "posts") @model {
+                id: ID!
+                name: String
+            }
+        `;
+    const editedDocument = parse(editedSchema);
+    const updatedDocument = applySchemaOverrides(document, editedDocument);
+    stringsMatchWithoutWhitespace(print(updatedDocument), editedSchema);
+  });
+
+  it('should allow removing inferred model name mappings', () => {
+    const document = parse(`
+            type Post @refersTo(name: "posts") @model {
+                id: ID!
+                title: String
+            }
+        `);
+    const editedSchema = `
+            type posts @model {
+                id: ID!
+                title: String
+            }
+        `;
+    const editedDocument = parse(editedSchema);
+    const updatedDocument = applySchemaOverrides(document, editedDocument);
+    stringsMatchWithoutWhitespace(print(updatedDocument), editedSchema);
+  });
+
+  it('should allow adding refersTo to models', () => {
+    const document = parse(`
+            type Post @model {
+                id: ID!
+                title: String
+            }
+        `);
+    const editedSchema = `
+            type MyPost @refersTo(name: "Post") @model {
+                id: ID!
+                title: String
+            }
+        `;
+    const editedDocument = parse(editedSchema);
+    const updatedDocument = applySchemaOverrides(document, editedDocument);
+    stringsMatchWithoutWhitespace(print(updatedDocument), editedSchema);
+  });
+});
+
 const stringsMatchWithoutWhitespace = (actual: string, expected: string) => {
   expect(actual.replace(/\s/g, '')).toEqual(expected.replace(/\s/g, ''));
 };

--- a/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
@@ -338,7 +338,7 @@ export const isComputeExpression = (value: string) => {
   return false;
 };
 
-export const getRefersToDirective = (name: string): DirectiveNode | undefined => {
+export const getRefersToDirective = (name: string): DirectiveNode => {
   return {
     kind: Kind.DIRECTIVE,
     name: {

--- a/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
@@ -8,6 +8,7 @@ import {
   ListValueNode,
   StringValueNode,
   DirectiveNode,
+  ObjectTypeDefinitionNode,
 } from 'graphql';
 import { EnumType, Field, Index, Model, Schema } from '../schema-representation';
 import { applySchemaOverrides } from './schema-overrides';
@@ -57,7 +58,7 @@ export const generateGraphQLSchema = (schema: Schema, existingSchemaDocument?: D
   });
 
   const documentWithOverrides = applySchemaOverrides(document as DocumentNode, existingSchemaDocument);
-  const schemaStr = print(documentWithOverrides);
+  const schemaStr = printSchema(documentWithOverrides);
   return schemaStr;
 };
 
@@ -367,4 +368,23 @@ export const convertToGraphQLTypeName = (modelName: string): string => {
 
   // Convert to PascalCase and Singularize
   return singular(toPascalCase(cleanedInput?.split('_')));
+};
+
+export const printSchema = (document: DocumentNode): string => {
+  const sortedDocument = sortDocument(document);
+  return print(sortedDocument);
+};
+
+const sortDocument = (document: DocumentNode): DocumentNode => {
+  const documentWrapper = document as any;
+  documentWrapper.definitions = [...document?.definitions].sort((def1, def2) => {
+    if ((def1 as ObjectTypeDefinitionNode)?.name?.value > (def2 as ObjectTypeDefinitionNode)?.name?.value) {
+      return 1;
+    }
+    if ((def1 as ObjectTypeDefinitionNode)?.name?.value < (def2 as ObjectTypeDefinitionNode)?.name?.value) {
+      return -1;
+    }
+    return 0;
+  });
+  return documentWrapper;
 };

--- a/packages/amplify-graphql-schema-generator/src/schema-generator/schema-overrides.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-generator/schema-overrides.ts
@@ -52,9 +52,8 @@ const preserveRelationalDirectives = (document: DocumentNode, existingDocument: 
   existingDocument.definitions
     .filter((def) => def.kind === 'ObjectTypeDefinition' && def.directives.find((dir) => dir.name.value === MODEL_DIRECTIVE_NAME))
     .forEach((existingObject: ObjectTypeDefinitionNode) => {
-      const newObject = document.definitions.find(
-        (def) => def.kind === 'ObjectTypeDefinition' && def.name.value === existingObject.name.value,
-      ) as ObjectTypeDefinitionNode;
+      const existingTableName = getTableName(existingObject);
+      const newObject = findMatchingModel(existingTableName, document);
       if (!newObject) {
         return;
       }
@@ -69,7 +68,7 @@ const preserveRelationalDirectives = (document: DocumentNode, existingDocument: 
       if (relationalFields.length > 0) {
         // If relational fields are found on a model,
         // remove the existing model and add the new one with the relational fields to preserve manual edits.
-        const excludedDefinitions = documentWrapper.definitions.filter((def) => def.name.value !== existingObject.name.value);
+        const excludedDefinitions = documentWrapper.definitions.filter((def) => getTableName(def) !== existingTableName);
         documentWrapper.definitions = [...excludedDefinitions, newObjectWrapper.serialize()];
       }
     });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- Adds `@refersTo` to model objects automatically during `import api` if the table name is not idiomatic GraphQL type name.
- Preserves any manual edits to automatically inferred model name mappings during `api generate-schema`.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Added unit and E2E tests
[First run](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:354a4cb4-a2cd-4246-89e1-07bbe95bc130?region=us-east-1#) and [second](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:d711487c-5db2-4091-a387-3ad666f94fc7?region=us-east-1) after fixing a test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
