### PR TITLE
fix(graphql): disable default value validation for rds

### DIFF
--- a/packages/amplify-graphql-default-value-transformer/src/graphql-default-value-transformer.ts
+++ b/packages/amplify-graphql-default-value-transformer/src/graphql-default-value-transformer.ts
@@ -140,7 +140,6 @@ export class DefaultValueTransformer extends TransformerPluginBase {
     const context = ctx as TransformerContextProvider;
 
     for (const typeName of this.directiveMap.keys()) {
-
       // Set the default value only for DDB datasource. For RDS, the database will set the value.
       const isDynamoDB = isDynamoDBDatasource(ctx, typeName);
       if (!isDynamoDB) {

--- a/packages/amplify-graphql-default-value-transformer/src/graphql-default-value-transformer.ts
+++ b/packages/amplify-graphql-default-value-transformer/src/graphql-default-value-transformer.ts
@@ -1,4 +1,5 @@
 import {
+  DDB_DB_TYPE,
   DirectiveWrapper,
   generateGetArgumentsInput,
   InputObjectDefinitionWrapper,
@@ -79,7 +80,18 @@ const validate = (ctx: TransformerSchemaVisitStepContextProvider, config: Defaul
   validateModelDirective(config);
   validateFieldType(ctx, config.field.type);
   validateDirectiveArguments(config.directive);
-  validateDefaultValueType(ctx, config);
+
+  // Validate the default values only for the DynamoDB datasource.
+  // For RDS, the database determines and sets the default value. We will not validate the value in transformers.
+  const isDynamoDB = isDynamoDBDatasource(ctx, config.object.name.value);
+  if (isDynamoDB) {
+    validateDefaultValueType(ctx, config);
+  }
+};
+
+const isDynamoDBDatasource = (ctx: TransformerSchemaVisitStepContextProvider, modelName: string): boolean => {
+  const isDynamoDB = (ctx.modelToDatasourceMap.get(modelName)?.dbType ?? DDB_DB_TYPE) === DDB_DB_TYPE;
+  return isDynamoDB;
 };
 
 export class DefaultValueTransformer extends TransformerPluginBase {
@@ -128,6 +140,13 @@ export class DefaultValueTransformer extends TransformerPluginBase {
     const context = ctx as TransformerContextProvider;
 
     for (const typeName of this.directiveMap.keys()) {
+
+      // Set the default value only for DDB datasource. For RDS, the database will set the value.
+      const isDynamoDB = isDynamoDBDatasource(ctx, typeName);
+      if (!isDynamoDB) {
+        continue;
+      }
+
       const snippets: string[] = [];
       for (const config of this.directiveMap.get(typeName)!) {
         const fieldName = config.field.name.value;

--- a/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
@@ -1593,14 +1593,14 @@ describe('ModelTransformer:', () => {
       subnetAvailabilityZoneConfig: [
         {
           SubnetId: 'sub-123',
-          AvailabilityZone: 'az-123'
+          AvailabilityZone: 'az-123',
         },
         {
           SubnetId: 'sub-456',
-          AvailabilityZone: 'az-456'
+          AvailabilityZone: 'az-456',
         },
       ],
-    }
+    };
     const out = testTransform({
       schema: validSchema,
       transformers: [new ModelTransformer()],
@@ -1619,12 +1619,8 @@ describe('ModelTransformer:', () => {
     expect(sqlLambda.Properties).toBeDefined();
     expect(sqlLambda.Properties?.VpcConfig).toBeDefined();
     expect(sqlLambda.Properties?.VpcConfig?.SubnetIds).toBeDefined();
-    expect(sqlLambda.Properties?.VpcConfig?.SubnetIds).toEqual(
-      expect.arrayContaining(['sub-123', 'sub-456']),
-    );
+    expect(sqlLambda.Properties?.VpcConfig?.SubnetIds).toEqual(expect.arrayContaining(['sub-123', 'sub-456']));
     expect(sqlLambda.Properties?.VpcConfig?.SecurityGroupIds).toBeDefined();
-    expect(sqlLambda.Properties?.VpcConfig?.SecurityGroupIds).toEqual(
-      expect.arrayContaining(['sg-123']),
-    );    
+    expect(sqlLambda.Properties?.VpcConfig?.SecurityGroupIds).toEqual(expect.arrayContaining(['sg-123']));
   });
 });

--- a/packages/amplify-graphql-transformer-test-utils/API.md
+++ b/packages/amplify-graphql-transformer-test-utils/API.md
@@ -31,6 +31,7 @@ import type { SynthParameters } from '@aws-amplify/graphql-transformer-interface
 import { TransformerPluginProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import type { TransformParameters } from '@aws-amplify/graphql-transformer-interfaces';
 import { UserDefinedSlot } from '@aws-amplify/graphql-transformer-core';
+import type { VpcSubnetConfig } from '@aws-amplify/graphql-transformer-interfaces';
 
 // @public (undocumented)
 export interface AmplifyApiGraphQlResourceStackTemplate {
@@ -141,6 +142,7 @@ export type TestTransformParameters = {
     datasourceSecretParameterLocations?: Map<string, RDSConnectionSecrets>;
     customQueries?: Map<string, string>;
     overrideConfig?: OverrideConfig;
+    sqlLambdaVpcConfig?: VpcSubnetConfig;
 };
 
 // @public (undocumented)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Disable default value validation for RDS datasource. The default value exists to understand the table configuration, we do not use it in our resolvers.

When customer define defaults in the database, they can use function calls or certain database specific syntax to define the defaults (eg: CURRENT_TIMESTAMP for datetime type). In such cases, we do not want to validate or set the default value in the transformers. We will leave it up to the database to set the default value if it is not present in the input.

##### CDK / CloudFormation Parameters Changed

NA

#### Issue #, if available

NA

#### Description of how you validated changes
- Manual test
- Unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
