### PR TITLE
feat: add amplify metadata to stack description if none is provided

### DIFF
--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -3603,7 +3603,7 @@
         },
         "locationInModule": {
           "filename": "src/amplify-graphql-api.ts",
-          "line": 62
+          "line": 63
         },
         "parameters": [
           {
@@ -3629,7 +3629,7 @@
       "kind": "class",
       "locationInModule": {
         "filename": "src/amplify-graphql-api.ts",
-        "line": 45
+        "line": 46
       },
       "name": "AmplifyGraphqlApi",
       "properties": [
@@ -3641,7 +3641,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 60
+            "line": 61
           },
           "name": "generatedFunctionSlots",
           "type": {
@@ -3673,7 +3673,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 49
+            "line": 50
           },
           "name": "resources",
           "type": {
@@ -5941,5 +5941,5 @@
     }
   },
   "version": "0.7.1",
-  "fingerprint": "KwRHsB46zjolWeHkFK3QZjt6bEXqi7R2jcSIoF4a8Ng="
+  "fingerprint": "FbHIY5Fhg/iELzf8taJRHhBTQCmyO8ln9zV7Jexmt3Q="
 }

--- a/packages/amplify-graphql-api-construct/src/__tests__/internal/amplify-metadata.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/internal/amplify-metadata.test.ts
@@ -1,0 +1,74 @@
+import * as os from 'os';
+import { Construct } from 'constructs';
+import { Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { addAmplifyMetadataToStackDescription } from '../../internal/amplify-metadata';
+
+jest.mock('os', () => ({
+  ...jest.requireActual('os'),
+  platform: jest.fn(),
+}));
+
+const platformOsMap: [string, string][] = [
+  ['Mac', 'darwin'],
+  ['Windows', 'win32'],
+  ['Linux', 'linux'],
+  ['Other', 'unknown'],
+];
+
+describe('addAmplifyMetadataToStackDescription', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test.each(platformOsMap)(
+    'sets metadata in description for %s platform with no description set',
+    (platformName: string, osName: string) => {
+      // Initialize Mocks
+      (os.platform as any).mockReturnValue(osName);
+
+      // Set up Stack
+      const stack = new Stack(undefined, 'TestStack');
+      const construct = new Construct(stack, 'TestConstruct');
+
+      // Attach Metadata
+      addAmplifyMetadataToStackDescription(construct);
+
+      // Retrieve Description from Synthesized Stack
+      const template = Template.fromStack(stack);
+      const description = (template as any).template.Description;
+
+      // Validate Description contents
+      expect(description).toBeDefined();
+      const metadataPayload = JSON.parse(description);
+      expect(Object.keys(metadataPayload).length).toEqual(4);
+      expect(metadataPayload.createdOn).toEqual(platformName);
+      expect(metadataPayload.createdBy).toEqual('AmplifyCDK');
+      expect(metadataPayload.createdWith).toMatch(/^[0-9]*\.[0-9]*\.[0-9]*/);
+      expect(metadataPayload.stackType).toEqual('graphql-api');
+    },
+  );
+
+  test.each(platformOsMap)(
+    'does not set metadata in description for %s platform with existing description',
+    (_: string, osName: string) => {
+      // Initialize Mocks
+      (os.platform as any).mockReturnValue(osName);
+
+      // Set up Stack
+      const stack = new Stack(undefined, 'TestStack', { description: 'I have a description' });
+      const construct = new Construct(stack, 'TestConstruct');
+
+      // Attach Metadata
+      addAmplifyMetadataToStackDescription(construct);
+
+      // Retrieve Description from Synthesized Stack
+      const template = Template.fromStack(stack);
+      const description = (template as any).template.Description;
+
+      // Validate Description contents
+      expect(description).toBeDefined();
+      expect(() => JSON.parse(description)).toThrowError();
+    },
+  );
+});

--- a/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
+++ b/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
@@ -11,6 +11,7 @@ import {
   getGeneratedResources,
   getGeneratedFunctionSlots,
   CodegenAssets,
+  addAmplifyMetadataToStackDescription,
 } from './internal';
 import type { AmplifyGraphqlApiResources, AmplifyGraphqlApiProps, FunctionSlot, IBackendOutputStorageStrategy } from './types';
 import { parseUserDefinedSlots, validateFunctionSlots, separateSlots } from './internal/user-defined-slots';
@@ -74,6 +75,8 @@ export class AmplifyGraphqlApi extends Construct {
       functionNameMap,
       outputStorageStrategy,
     } = props;
+
+    addAmplifyMetadataToStackDescription(scope);
 
     const { authConfig, identityPoolId, adminRoles, authSynthParameters } =
       convertAuthorizationModesToTransformerAuthConfig(authorizationConfig);

--- a/packages/amplify-graphql-api-construct/src/internal/amplify-metadata.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/amplify-metadata.ts
@@ -1,0 +1,70 @@
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+/**
+ * Given a scope, search up for the parent stack. This should be the nearest stack object.
+ * @param scope the scope to search up against.
+ * @returns the stack, if one can be found, else throws an error.
+ */
+const getStackForScope = (scope: Construct): Stack => {
+  const stacksInHierarchy = scope.node.scopes.filter((parentScope) => 'templateOptions' in parentScope);
+  if (stacksInHierarchy.length === 0) {
+    throw new Error('No Stack Found in Construct Scope');
+  }
+  return stacksInHierarchy.reverse()[0] as Stack;
+};
+
+/**
+ * Compute the platform string, based on
+ * https://github.com/aws-amplify/amplify-cli/blob/88da2c9fca04d6ce734b078868d02c110db7d6a3/packages/amplify-provider-awscloudformation/src/template-description-utils.ts#L60-L70
+ * @returns the platform string
+ */
+const getPlatform = (): string => {
+  switch (os.platform()) {
+    case 'darwin':
+      return 'Mac';
+    case 'win32':
+      return 'Windows';
+    case 'linux':
+      return 'Linux';
+    default:
+      return 'Other';
+  }
+};
+
+const getLibraryVersion = (): string => {
+  const packageJsonPath = path.join(__dirname, '..', '..', 'package.json');
+  if (!fs.existsSync(packageJsonPath)) {
+    throw new Error('Could not load determine library version for metadata generation.');
+  }
+  const packageJsonContents = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+  const libraryVersion = packageJsonContents.version;
+  if (!libraryVersion) {
+    throw new Error('Library version could not be read from package json for metadata generation.');
+  }
+  return libraryVersion;
+};
+
+/**
+ * Compute the bi-metadata string to embed somewhere in the stack
+ * @returns the metadata string to compute amplify attribution
+ */
+const getAttributionMetadata = (): Record<string, string> => ({
+  createdOn: getPlatform(),
+  createdBy: 'AmplifyCDK',
+  createdWith: getLibraryVersion(),
+  stackType: 'graphql-api',
+});
+
+/**
+ * If possible, attach the stack description to the parent stack.
+ * @param scope the scope we will use to append metadata
+ */
+export const addAmplifyMetadataToStackDescription = (scope: Construct): void => {
+  const stack = getStackForScope(scope);
+  if (!stack.templateOptions.description || stack.templateOptions.description === '') {
+    stack.templateOptions.description = JSON.stringify(getAttributionMetadata());
+  }
+};

--- a/packages/amplify-graphql-api-construct/src/internal/index.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/index.ts
@@ -4,3 +4,4 @@ export * from './default-parameters';
 export * from './conflict-resolution';
 export * from './asset-manager';
 export * from './codegen-assets';
+export * from './amplify-metadata';


### PR DESCRIPTION
#### Description of changes
Add amplify metadata to root stack description if none is set already (e.g. don't override customer description).

##### CDK / CloudFormation Parameters Changed
No, only updating the description conditionally.

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit tests, validate in a tag release before shipping.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
