### PR TITLE
fix(apigw): replace path param with wildcard

### DIFF
--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/__snapshots__/apigw-stack-builder.test.ts.snap
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/__snapshots__/apigw-stack-builder.test.ts.snap
@@ -1,0 +1,846 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AmplifyApigwResourceStack addIamPolicyResourceForUserPoolGroup should generate correct IAM policies when {} is used in path 1`] = `
+Object {
+  "adminGroupbookisbnPolicy": Object {
+    "Properties": Object {
+      "PolicyDocument": Object {
+        "Statement": Array [
+          Object {
+            "Action": "execute-api:Invoke",
+            "Effect": "Allow",
+            "Resource": Array [
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/POST/book/*",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/PUT/book/*",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/PATCH/book/*",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/GET/book/*",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/DELETE/book/*",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/POST/book/*/*",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/PUT/book/*/*",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/PATCH/book/*/*",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/GET/book/*/*",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/DELETE/book/*/*",
+                  ],
+                ],
+              },
+            ],
+          },
+        ],
+        "Version": "2012-10-17",
+      },
+      "PolicyName": "mockRestAPIName-bookisbn-admin-group-policy",
+      "Roles": Array [
+        Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "mockAuthRoleLogicalId",
+              },
+              "adminGroupRole",
+            ],
+          ],
+        },
+      ],
+    },
+    "Type": "AWS::IAM::Policy",
+  },
+  "adminGroupitemsidfoobarPolicy": Object {
+    "Properties": Object {
+      "PolicyDocument": Object {
+        "Statement": Array [
+          Object {
+            "Action": "execute-api:Invoke",
+            "Effect": "Allow",
+            "Resource": Array [
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/POST/items/*/foobar",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/PUT/items/*/foobar",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/PATCH/items/*/foobar",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/GET/items/*/foobar",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/DELETE/items/*/foobar",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/POST/items/*/foobar/*",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/PUT/items/*/foobar/*",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/PATCH/items/*/foobar/*",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/GET/items/*/foobar/*",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/DELETE/items/*/foobar/*",
+                  ],
+                ],
+              },
+            ],
+          },
+        ],
+        "Version": "2012-10-17",
+      },
+      "PolicyName": "mockRestAPIName-itemsidfoobar-admin-group-policy",
+      "Roles": Array [
+        Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "mockAuthRoleLogicalId",
+              },
+              "adminGroupRole",
+            ],
+          ],
+        },
+      ],
+    },
+    "Type": "AWS::IAM::Policy",
+  },
+  "memberGroupbookisbnPolicy": Object {
+    "Properties": Object {
+      "PolicyDocument": Object {
+        "Statement": Array [
+          Object {
+            "Action": "execute-api:Invoke",
+            "Effect": "Allow",
+            "Resource": Array [
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/GET/book/*",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/GET/book/*/*",
+                  ],
+                ],
+              },
+            ],
+          },
+        ],
+        "Version": "2012-10-17",
+      },
+      "PolicyName": "mockRestAPIName-bookisbn-member-group-policy",
+      "Roles": Array [
+        Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "mockAuthRoleLogicalId",
+              },
+              "memberGroupRole",
+            ],
+          ],
+        },
+      ],
+    },
+    "Type": "AWS::IAM::Policy",
+  },
+  "memberGroupitemsidfoobarPolicy": Object {
+    "Properties": Object {
+      "PolicyDocument": Object {
+        "Statement": Array [
+          Object {
+            "Action": "execute-api:Invoke",
+            "Effect": "Allow",
+            "Resource": Array [
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/GET/items/*/foobar",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:execute-api:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "mockRestAPIName",
+                    },
+                    "/",
+                    Object {
+                      "Fn::If": Array [
+                        "ShouldNotCreateEnvResources",
+                        "Prod",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    },
+                    "/GET/items/*/foobar/*",
+                  ],
+                ],
+              },
+            ],
+          },
+        ],
+        "Version": "2012-10-17",
+      },
+      "PolicyName": "mockRestAPIName-itemsidfoobar-member-group-policy",
+      "Roles": Array [
+        Object {
+          "Fn::Join": Array [
+            "-",
+            Array [
+              Object {
+                "Ref": "mockAuthRoleLogicalId",
+              },
+              "memberGroupRole",
+            ],
+          ],
+        },
+      ],
+    },
+    "Type": "AWS::IAM::Policy",
+  },
+}
+`;

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.test.ts
@@ -57,16 +57,9 @@ describe('AmplifyApigwResourceStack', () => {
           permissions: {
             setting: PermissionSetting.PRIVATE,
             groups: {
-              'admin': [
-                CrudOperation.CREATE,
-                CrudOperation.UPDATE,
-                CrudOperation.READ,
-                CrudOperation.DELETE,
-              ],
-              'member': [
-                CrudOperation.READ,
-              ]
-            }
+              admin: [CrudOperation.CREATE, CrudOperation.UPDATE, CrudOperation.READ, CrudOperation.DELETE],
+              member: [CrudOperation.READ],
+            },
           },
         },
         '/items/{id}/foobar': {
@@ -74,16 +67,9 @@ describe('AmplifyApigwResourceStack', () => {
           permissions: {
             setting: PermissionSetting.PRIVATE,
             groups: {
-              'admin': [
-                CrudOperation.CREATE,
-                CrudOperation.UPDATE,
-                CrudOperation.READ,
-                CrudOperation.DELETE,
-              ],
-              'member': [
-                CrudOperation.READ,
-              ]
-            }
+              admin: [CrudOperation.CREATE, CrudOperation.UPDATE, CrudOperation.READ, CrudOperation.DELETE],
+              member: [CrudOperation.READ],
+            },
           },
         },
       },

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.test.ts
@@ -1,7 +1,8 @@
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { AmplifyApigwResourceStack } from '../../../../provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder';
-import { PermissionSetting } from '../../../../provider-utils/awscloudformation/cdk-stack-builder/types';
+import { CrudOperation, PermissionSetting } from '../../../../provider-utils/awscloudformation/cdk-stack-builder/types';
+import { convertCrudOperationsToCfnPermissions } from '../../../../provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-transform';
 
 describe('AmplifyApigwResourceStack', () => {
   test('generateStackResources should synthesize the way we expected', () => {
@@ -43,5 +44,65 @@ describe('AmplifyApigwResourceStack', () => {
         Ref: 'myapi',
       },
     });
+  });
+  test('addIamPolicyResourceForUserPoolGroup should generate correct IAM policies when {} is used in path', () => {
+    const app = new cdk.App();
+    const mockResourceName = 'mockRestAPIName';
+    const mockAuthRoleLogicalId = 'mockAuthRoleLogicalId';
+    const cliInputs = {
+      version: 1,
+      paths: {
+        '/book/{isbn}': {
+          lambdaFunction: 'lambdaFunction1',
+          permissions: {
+            setting: PermissionSetting.PRIVATE,
+            groups: {
+              'admin': [
+                CrudOperation.CREATE,
+                CrudOperation.UPDATE,
+                CrudOperation.READ,
+                CrudOperation.DELETE,
+              ],
+              'member': [
+                CrudOperation.READ,
+              ]
+            }
+          },
+        },
+        '/items/{id}/foobar': {
+          lambdaFunction: 'lambdaFunction2',
+          permissions: {
+            setting: PermissionSetting.PRIVATE,
+            groups: {
+              'admin': [
+                CrudOperation.CREATE,
+                CrudOperation.UPDATE,
+                CrudOperation.READ,
+                CrudOperation.DELETE,
+              ],
+              'member': [
+                CrudOperation.READ,
+              ]
+            }
+          },
+        },
+      },
+    };
+    const amplifyApigwStack = new AmplifyApigwResourceStack(app, 'amplifyapigwstack', cliInputs);
+    const pathsWithUserPoolGroups = Object.entries(cliInputs.paths).filter(([_, path]) => !!path?.permissions?.groups);
+    for (const [pathName, path] of pathsWithUserPoolGroups) {
+      for (const [groupName, crudOps] of Object.entries(path.permissions.groups)) {
+        amplifyApigwStack.addIamPolicyResourceForUserPoolGroup(
+          mockResourceName,
+          mockAuthRoleLogicalId,
+          groupName,
+          pathName,
+          convertCrudOperationsToCfnPermissions(crudOps),
+        );
+      }
+    }
+
+    const template = Template.fromStack(amplifyApigwStack);
+    expect(template.findResources('AWS::IAM::Policy')).toMatchSnapshot();
   });
 });

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-builder.ts
@@ -99,7 +99,8 @@ export class AmplifyApigwResourceStack extends cdk.Stack implements AmplifyApigw
 
   // eslint-disable-next-line class-methods-use-this
   private _craftPolicyDocument(apiResourceName: string, pathName: string, supportedOperations: string[]) {
-    const paths = [pathName, appendToUrlPath(pathName, '*')];
+    const policyPathName = pathName.replace(/{[a-zA-Z0-9-]+}/g, '*');
+    const paths = [policyPathName, appendToUrlPath(policyPathName, '*')];
     const resources = paths.flatMap((path) =>
       supportedOperations.map((op) =>
         cdk.Fn.join('', [

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-transform.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-transform.ts
@@ -242,7 +242,7 @@ export class ApigwStackTransform {
   }
 }
 
-function convertCrudOperationsToCfnPermissions(crudOps: CrudOperation[]) {
+export function convertCrudOperationsToCfnPermissions(crudOps: CrudOperation[]) {
   const opMap: Record<CrudOperation, string[]> = {
     [CrudOperation.CREATE]: ['/POST'],
     [CrudOperation.READ]: ['/GET'],


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

When a REST API path contained a path parameter (`/path/{param}`) and this API had an IAM policy associated with it (when user group is used for auth), we were putting this path directly in the resource of the policy, meaning it would never match. This PR replaces `{param}` path components in the policy resource with a wildcard (*).

A previous [PR](https://github.com/aws-amplify/amplify-cli/pull/5092) addressed the issue in the legacy add REST API process. This PR is to fix the same issue for current approach.

#### Description of changes
Updates the User Group Policy generation to substitute path parameters with wildcards.

**New IAM policy:**
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Action": "execute-api:Invoke",
            "Resource": [
                "arn:aws:execute-api:us-west-2:0123456789012:abcdefghijk/dev/GET/book/*",
                "arn:aws:execute-api:us-west-2:0123456789012:abcdefghijk/dev/GET/book/*/*",
                "arn:aws:execute-api:us-west-2:0123456789012:abcdefghijk/dev/GET/item/*/foobar",
                "arn:aws:execute-api:us-west-2:0123456789012:abcdefghijk/dev/GET/item/*/foobar/*"
            ],
            "Effect": "Allow"
        }
    ]
}
```
**Old invalid policy:**
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Action": "execute-api:Invoke",
            "Resource": [
                "arn:aws:execute-api:us-west-2:0123456789012:abcdefghijk/dev/GET/book/{isbn}",
                "arn:aws:execute-api:us-west-2:0123456789012:abcdefghijk/dev/GET/book/{isbn}/*",
                "arn:aws:execute-api:us-west-2:0123456789012:abcdefghijk/dev/GET/item/{id}/foobar",
                "arn:aws:execute-api:us-west-2:0123456789012:abcdefghijk/dev/GET/item/{id}/foobar/*"
            ],
            "Effect": "Allow"
        }
    ]
}
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available
✅ Closes: #1680
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
`yarn test`
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
