### PR TITLE
fix: change the ttl to integer

### DIFF
--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/override/__snapshots__/amplify-graphql-index-transformer-override.test.ts.snap
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/override/__snapshots__/amplify-graphql-index-transformer-override.test.ts.snap
@@ -50,7 +50,7 @@ $util.qr($ctx.stash.put(\\"tableName\\", \\"",
             "Ref": "SongTable",
           },
           "\\"))
-$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", \\"15\\"))
+$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", 15))
 $util.toJson({})",
         ],
       ],
@@ -106,7 +106,7 @@ $util.qr($ctx.stash.put(\\"tableName\\", \\"",
             "Ref": "SongTable",
           },
           "\\"))
-$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", \\"15\\"))
+$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", 15))
 $util.toJson({})",
         ],
       ],
@@ -162,7 +162,7 @@ $util.qr($ctx.stash.put(\\"tableName\\", \\"",
             "Ref": "SongTable",
           },
           "\\"))
-$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", \\"15\\"))
+$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", 15))
 $util.toJson({})",
         ],
       ],
@@ -218,7 +218,7 @@ $util.qr($ctx.stash.put(\\"tableName\\", \\"",
             "Ref": "SongTable",
           },
           "\\"))
-$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", \\"15\\"))
+$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", 15))
 $util.toJson({})",
         ],
       ],
@@ -280,7 +280,7 @@ $util.qr($ctx.stash.put(\\"tableName\\", \\"",
             "Ref": "SongTable",
           },
           "\\"))
-$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", \\"15\\"))
+$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", 15))
 $util.toJson({})",
         ],
       ],
@@ -342,7 +342,7 @@ $util.qr($ctx.stash.put(\\"tableName\\", \\"",
             "Ref": "SongTable",
           },
           "\\"))
-$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", \\"15\\"))
+$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", 15))
 $util.toJson({})",
         ],
       ],

--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/override/__snapshots__/amplify-graphql-primary-key-transformer-override.test.ts.snap
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/override/__snapshots__/amplify-graphql-primary-key-transformer-override.test.ts.snap
@@ -56,7 +56,7 @@ $util.qr($ctx.stash.put(\\"tableName\\", \\"",
             "Ref": "TestTable",
           },
           "\\"))
-$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", \\"25\\"))
+$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", 25))
 $util.toJson({})",
         ],
       ],
@@ -118,7 +118,7 @@ $util.qr($ctx.stash.put(\\"tableName\\", \\"",
             "Ref": "TestTable",
           },
           "\\"))
-$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", \\"25\\"))
+$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", 25))
 $util.toJson({})",
         ],
       ],
@@ -180,7 +180,7 @@ $util.qr($ctx.stash.put(\\"tableName\\", \\"",
             "Ref": "TestTable",
           },
           "\\"))
-$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", \\"25\\"))
+$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", 25))
 $util.toJson({})",
         ],
       ],
@@ -242,7 +242,7 @@ $util.qr($ctx.stash.put(\\"tableName\\", \\"",
             "Ref": "TestTable",
           },
           "\\"))
-$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", \\"25\\"))
+$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", 25))
 $util.toJson({})",
         ],
       ],
@@ -310,7 +310,7 @@ $util.qr($ctx.stash.put(\\"tableName\\", \\"",
             "Ref": "TestTable",
           },
           "\\"))
-$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", \\"25\\"))
+$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", 25))
 $util.toJson({})",
         ],
       ],
@@ -372,7 +372,7 @@ $util.qr($ctx.stash.put(\\"tableName\\", \\"",
             "Ref": "TestTable",
           },
           "\\"))
-$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", \\"25\\"))
+$util.qr($ctx.stash.put(\\"deltaSyncTableTtl\\", 25))
 $util.toJson({})",
         ],
       ],

--- a/packages/amplify-e2e-tests/src/__tests__/graphql-v2/sync_query_datastore.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/graphql-v2/sync_query_datastore.test.ts
@@ -120,6 +120,27 @@ describe('Sync query V2 resolver tests', () => {
     verifySyncQueryResult(syncResult, testSong, 'syncSongs');
   });
 
+  it('Sync query with filter on GSI and lastSync within delta ttl', async () => {
+    const testSong = {
+      id: '',
+      name: 'song123',
+      genre: 'custom',
+      lastChangedAt: 0,
+    };
+
+    const createResult = await createSong(testSong.name, testSong.genre);
+    verifyCreateSongResult(createResult, testSong, 'createSong');
+    testSong.id = createResult.data.createSong.id;
+    testSong.lastChangedAt = createResult.data.createSong._lastChangedAt;
+
+    // This will do scan on the delta table
+    const lastSync = Date.now();
+    const syncResult = await syncSongs(lastSync, {
+      and: [{ genre: { eq: testSong.genre } }],
+    });
+    verifySyncQueryResult(syncResult, testSong, 'syncSongs');
+  });
+
   it('Sync query with filter on primary key part of GSI for model with sort key works', async () => {
     const testSong = {
       id: '',

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -302,7 +302,7 @@ export class TransformerResolver implements TransformerResolverProvider {
                   return SyncUtils.syncDataSourceConfig().DeltaSyncTableTTL.toString();
                 },
               });
-              dataSource += `\n$util.qr($ctx.stash.put("deltaSyncTableTtl", "${deltaSyncTableTtl}"))`;
+              dataSource += `\n$util.qr($ctx.stash.put("deltaSyncTableTtl", ${deltaSyncTableTtl}))`;
             }
           }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes the issue with `deltaSyncTableTtl` that's being set as string causing the `minLastSync` value to be incorrectly computed.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Added E2E test. [Link to E2E](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:765eaacb-1b00-46bb-9699-b511bba68d87?region=us-east-1#)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
