### PR TITLE
fix(graphql-searchable-transformer): formatting domain name

### DIFF
--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/override/amplify-graphql-index-transformer-override.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/override/amplify-graphql-index-transformer-override.test.ts
@@ -7,8 +7,10 @@ import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import { Construct } from 'constructs';
 import { applyFileBasedOverride } from '../../../graphql-transformer/override';
 
-jest.spyOn(stateManager, 'getLocalEnvInfo').mockReturnValue({ envName: 'testEnvName' });
+jest.spyOn(stateManager, 'getLocalEnvInfo').mockReturnValue({ envName: 'testEnvName' }); // TODO EnvName can not contain capital letters
 jest.spyOn(stateManager, 'getProjectConfig').mockReturnValue({ projectName: 'testProjectName' });
+jest.spyOn(stateManager, 'getCurrentEnvName').mockReturnValue('testenv');
+jest.spyOn(stateManager, 'getMeta').mockReturnValue({ api: { testApi: { service: 'AppSync' } } });
 
 test('it overrides expected resources', () => {
   const validSchema = `

--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/override/amplify-graphql-primary-key-transformer-override.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/override/amplify-graphql-primary-key-transformer-override.test.ts
@@ -7,7 +7,7 @@ import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import { Construct } from 'constructs';
 import { applyFileBasedOverride } from '../../../graphql-transformer/override';
 
-jest.spyOn(stateManager, 'getLocalEnvInfo').mockReturnValue({ envName: 'testEnvName' });
+jest.spyOn(stateManager, 'getLocalEnvInfo').mockReturnValue({ envName: 'testEnvName' }); // TODO EnvName can not contain capital letters
 jest.spyOn(stateManager, 'getProjectConfig').mockReturnValue({ projectName: 'testProjectName' });
 
 test('it overrides expected resources', () => {

--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/override/amplify-graphql-searchable-transformer-override.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/override/amplify-graphql-searchable-transformer-override.test.ts
@@ -7,8 +7,10 @@ import { stateManager } from '@aws-amplify/amplify-cli-core';
 import { Construct } from 'constructs';
 import { applyFileBasedOverride } from '../../../graphql-transformer/override';
 
-jest.spyOn(stateManager, 'getLocalEnvInfo').mockReturnValue({ envName: 'testEnvName' });
+jest.spyOn(stateManager, 'getLocalEnvInfo').mockReturnValue({ envName: 'testEnvName' }); // Env name can not have capital letters
 jest.spyOn(stateManager, 'getProjectConfig').mockReturnValue({ projectName: 'testProjectName' });
+jest.spyOn(stateManager, 'getCurrentEnvName').mockReturnValue('testenv');
+jest.spyOn(stateManager, 'getMeta').mockReturnValue({ api: { testApi: { service: 'AppSync' } } });
 
 test('it overrides expected resources', () => {
   const validSchema = `

--- a/packages/amplify-category-api/src/graphql-transformer/override.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/override.ts
@@ -14,6 +14,7 @@ import { AmplifyApiGraphQlResourceStackTemplate } from './cdk-compat/amplify-api
  * @param scope
  * @param overrideDir
  */
+
 export function applyFileBasedOverride(scope: Construct, overrideDirPath?: string): AmplifyApiGraphQlResourceStackTemplate {
   const overrideDir = overrideDirPath ?? path.join(pathManager.getBackendDirPath(), 'api', getAppSyncAPIName());
   const overrideFilePath = path.join(overrideDir, 'build', 'override.js');

--- a/packages/amplify-graphql-api-construct/src/__tests__/__functional__/resources.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/__functional__/resources.test.ts
@@ -1,7 +1,12 @@
 import * as cdk from 'aws-cdk-lib';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 import { AmplifyGraphqlApi } from '../../amplify-graphql-api';
 import { AmplifyGraphqlSchema } from '../../amplify-graphql-schema';
+
+jest.spyOn(stateManager, 'getCurrentEnvName').mockReturnValue('testenv');
+jest.spyOn(stateManager, 'getProjectConfig').mockReturnValue({ projectName: 'testProjectName' });
+jest.spyOn(stateManager, 'getMeta').mockReturnValue({ api: { testApi: { service: 'AppSync' } } });
 
 describe('generated resource access', () => {
   describe('l1 resources', () => {

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/auth-operations.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/auth-operations.test.ts
@@ -1,11 +1,16 @@
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { ConflictHandlerType, SyncConfig } from '@aws-amplify/graphql-transformer-core';
 import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-interfaces';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-transformer';
 import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import { AccessControlMatrix } from '../accesscontrol';
 import { AuthTransformer } from '../graphql-auth-transformer';
 import { MODEL_OPERATIONS } from '../utils';
+
+jest.spyOn(stateManager, 'getCurrentEnvName').mockReturnValue('testenv');
+jest.spyOn(stateManager, 'getProjectConfig').mockReturnValue({ projectName: 'testProjectName' });
+jest.spyOn(stateManager, 'getMeta').mockReturnValue({ api: { testApi: { service: 'AppSync' } } });
 
 test('invalid granular read operation at the field level', () => {
   const authConfig: AppSyncAuthConfiguration = {

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/searchable-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/searchable-auth.test.ts
@@ -2,8 +2,13 @@ import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-transformer';
 import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-interfaces';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 import { DocumentNode, ObjectTypeDefinitionNode, Kind, FieldDefinitionNode, parse } from 'graphql';
 import { AuthTransformer, SEARCHABLE_AGGREGATE_TYPES } from '..';
+
+jest.spyOn(stateManager, 'getCurrentEnvName').mockReturnValue('testenv');
+jest.spyOn(stateManager, 'getProjectConfig').mockReturnValue({ projectName: 'testProjectName' });
+jest.spyOn(stateManager, 'getMeta').mockReturnValue({ api: { testApi: { service: 'AppSync' } } });
 
 const getObjectType = (doc: DocumentNode, type: string): ObjectTypeDefinitionNode | undefined =>
   doc.definitions.find((def) => def.kind === Kind.OBJECT_TYPE_DEFINITION && def.name.value === type) as

--- a/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-searchable.test.ts
+++ b/packages/amplify-graphql-maps-to-transformer/src/__tests__/__integ__/with-searchable.test.ts
@@ -1,8 +1,13 @@
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 import { MapsToTransformer } from '@aws-amplify/graphql-maps-to-transformer';
 import { HasManyTransformer } from '@aws-amplify/graphql-relational-transformer';
 import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-transformer';
+
+jest.spyOn(stateManager, 'getCurrentEnvName').mockReturnValue('testenv');
+jest.spyOn(stateManager, 'getProjectConfig').mockReturnValue({ projectName: 'testProjectName' });
+jest.spyOn(stateManager, 'getMeta').mockReturnValue({ api: { testApi: { service: 'AppSync' } } });
 
 const mappedSearchableSchema = /* GraphQL */ `
   type Agenda @model {

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
@@ -1,10 +1,15 @@
 import { ConflictHandlerType } from '@aws-amplify/graphql-transformer-core';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { parse } from 'graphql';
 import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import { SearchableModelTransformer } from '..';
 import { ALLOWABLE_SEARCHABLE_INSTANCE_TYPES } from '../constants';
+
+jest.spyOn(stateManager, 'getCurrentEnvName').mockReturnValue('testenv');
+jest.spyOn(stateManager, 'getProjectConfig').mockReturnValue({ projectName: 'testProjectName' });
+jest.spyOn(stateManager, 'getMeta').mockReturnValue({ api: { testApi: { service: 'AppSync' } } });
 
 test('SearchableModelTransformer validation happy case', () => {
   const validSchema = `

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
@@ -2,7 +2,7 @@ import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-int
 import { EbsDeviceVolumeType } from 'aws-cdk-lib/aws-ec2';
 import { CfnDomain, Domain, ElasticsearchVersion } from 'aws-cdk-lib/aws-elasticsearch';
 import { IRole, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
-import { CfnParameter, Fn, RemovalPolicy } from 'aws-cdk-lib';
+import { CfnParameter, RemovalPolicy } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { ResourceConstants } from 'graphql-transformer-common';
 import { setResourceName } from '@aws-amplify/graphql-transformer-core';
@@ -10,12 +10,11 @@ import { setResourceName } from '@aws-amplify/graphql-transformer-core';
 export const createSearchableDomain = (
   stack: Construct,
   parameterMap: Map<string, CfnParameter>,
-  apiId: string,
+  context: TransformerContextProvider,
   nodeToNodeEncryption: boolean,
 ): Domain => {
   const { OpenSearchEBSVolumeGB, OpenSearchInstanceType, OpenSearchInstanceCount } = ResourceConstants.PARAMETERS;
   const { OpenSearchDomainLogicalID } = ResourceConstants.RESOURCES;
-  const { HasEnvironmentParameter } = ResourceConstants.CONDITIONS;
 
   const domain = new Domain(stack, OpenSearchDomainLogicalID, {
     version: { version: '7.10' } as ElasticsearchVersion,
@@ -29,7 +28,7 @@ export const createSearchableDomain = (
     zoneAwareness: {
       enabled: false,
     },
-    domainName: Fn.conditionIf(HasEnvironmentParameter, Fn.ref('AWS::NoValue'), `d${apiId}`).toString(),
+    domainName: context.resourceHelper.generateDomainName(),
     removalPolicy: RemovalPolicy.DESTROY,
   });
 

--- a/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
@@ -306,12 +306,7 @@ export class SearchableModelTransformer extends TransformerPluginBase {
 
     const parameterMap = createParametersInStack(context.stackManager.scope);
 
-    const domain = createSearchableDomain(
-      stack,
-      parameterMap,
-      context.api.apiId,
-      context.transformParameters.enableSearchNodeToNodeEncryption,
-    );
+    const domain = createSearchableDomain(stack, parameterMap, context, context.transformParameters.enableSearchNodeToNodeEncryption);
 
     const openSearchRole = createSearchableDomainRole(context, stack, parameterMap);
 

--- a/packages/amplify-graphql-transformer-core/src/__tests__/transformer-context/resource-helper.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/transformer-context/resource-helper.test.ts
@@ -1,5 +1,10 @@
 import { GraphQLAPIProvider, TransformerResourceHelperProvider, SynthParameters } from '@aws-amplify/graphql-transformer-interfaces';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 import { TransformerResourceHelper } from '../../transformer-context/resource-helper';
+
+jest.spyOn(stateManager, 'getCurrentEnvName').mockReturnValue('testenv');
+jest.spyOn(stateManager, 'getProjectConfig').mockReturnValue({ projectName: 'testProjectName' });
+jest.spyOn(stateManager, 'getMeta').mockReturnValue({ api: { testApi: { service: 'AppSync' } } });
 
 const testEnv = 'testenv';
 const testApiId = 'testtest123';
@@ -23,6 +28,17 @@ describe('generateTableName', () => {
   it('uses model rename if specified', () => {
     resourceHelper.setModelNameMapping('TestRename', 'Test');
     expect(resourceHelper.generateTableName('TestRename')).toEqual(`Test-${testApiId}-${testEnv}`);
+  });
+});
+
+describe('generateDomainName', () => {
+  it('throws if api not initialized', () => {
+    resourceHelper = getResourceHelper(false);
+    expect(() => resourceHelper.generateDomainName()).toThrowErrorMatchingInlineSnapshot(`"API not initialized"`);
+  });
+
+  it('generate domain name', () => {
+    expect(resourceHelper.generateDomainName()).toEqual('testproj-testapi-testenv');
   });
 });
 

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -655,6 +655,8 @@ export interface TransformerResourceHelperProvider {
     // (undocumented)
     generateTableName(modelName: string): string;
     // (undocumented)
+    generateDomainName() : string;
+    // (undocumented)
     getFieldNameMapping(modelName: string, fieldName: string): string;
     // (undocumented)
     getModelFieldMap(modelName: string): ModelFieldMap;

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/resource-resource-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/resource-resource-provider.ts
@@ -2,6 +2,7 @@ import { DirectiveNode, FieldNode, ObjectTypeDefinitionNode, ObjectTypeExtension
 
 export interface TransformerResourceHelperProvider {
   generateTableName(modelName: string): string;
+  generateDomainName(): string;
   generateIAMRoleName(name: string): string;
   setModelNameMapping(modelName: string, mappedName: string): void;
   getModelNameMapping(modelName: string): string;

--- a/packages/amplify-util-mock/src/__e2e_v2__/searchable-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e_v2__/searchable-transformer.e2e.test.ts
@@ -1,6 +1,10 @@
 import { AmplifyAppSyncSimulator } from '@aws-amplify/amplify-appsync-simulator';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 import { deploy, launchDDBLocal, logDebug, GraphQLClient, terminateDDB, defaultTransformParams, transformAndSynth } from '../__e2e__/utils';
 
+jest.spyOn(stateManager, 'getCurrentEnvName').mockReturnValue('testenv');
+jest.spyOn(stateManager, 'getProjectConfig').mockReturnValue({ projectName: 'testProjectName' });
+jest.spyOn(stateManager, 'getMeta').mockReturnValue({ api: { testApi: { service: 'AppSync' } } });
 jest.setTimeout(2000000);
 
 let GRAPHQL_ENDPOINT: string;

--- a/packages/graphql-auth-transformer/src/__tests__/SearchableAuthTransformer.test.ts
+++ b/packages/graphql-auth-transformer/src/__tests__/SearchableAuthTransformer.test.ts
@@ -1,7 +1,12 @@
 import { GraphQLTransform } from 'graphql-transformer-core';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 import { SearchableModelTransformer } from 'graphql-elasticsearch-transformer';
 import { ModelAuthTransformer } from '../ModelAuthTransformer';
+
+jest.spyOn(stateManager, 'getCurrentEnvName').mockReturnValue('testenv');
+jest.spyOn(stateManager, 'getProjectConfig').mockReturnValue({ projectName: 'testProjectName' });
+jest.spyOn(stateManager, 'getMeta').mockReturnValue({ api: { testApi: { service: 'AppSync' } } });
 
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {

--- a/packages/graphql-elasticsearch-transformer/src/__tests__/SearchableModelTransformer.test.ts
+++ b/packages/graphql-elasticsearch-transformer/src/__tests__/SearchableModelTransformer.test.ts
@@ -1,6 +1,11 @@
 import { GraphQLTransform, TRANSFORM_CURRENT_VERSION, ConflictHandlerType } from 'graphql-transformer-core';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
 import { SearchableModelTransformer } from '../SearchableModelTransformer';
+
+jest.spyOn(stateManager, 'getCurrentEnvName').mockReturnValue('testenv');
+jest.spyOn(stateManager, 'getProjectConfig').mockReturnValue({ projectName: 'testProjectName' });
+jest.spyOn(stateManager, 'getMeta').mockReturnValue({ api: { testApi: { service: 'AppSync' } } });
 
 const featureFlags = {
   getBoolean: jest.fn().mockImplementation((name, defaultValue) => {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformer.e2e.test.ts
@@ -3,6 +3,7 @@ import { GraphQLTransform, ConflictHandlerType } from 'graphql-transformer-core'
 import { DynamoDBModelTransformer } from 'graphql-dynamodb-transformer';
 import { KeyTransformer } from 'graphql-key-transformer';
 import { SearchableModelTransformer } from 'graphql-elasticsearch-transformer';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 import { ModelAuthTransformer } from 'graphql-auth-transformer';
 import { Output } from 'aws-sdk/clients/cloudformation';
 import { default as moment } from 'moment';
@@ -17,6 +18,9 @@ import { resolveTestRegion } from '../testSetup';
 const region = resolveTestRegion();
 
 // tslint:disable: no-magic-numbers
+jest.spyOn(stateManager, 'getCurrentEnvName').mockReturnValue('testenv');
+jest.spyOn(stateManager, 'getProjectConfig').mockReturnValue({ projectName: 'testProjectName' });
+jest.spyOn(stateManager, 'getMeta').mockReturnValue({ api: { testApi: { service: 'AppSync' } } });
 jest.setTimeout(60000 * 60);
 
 const cf = new CloudFormationClient(region);

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformerV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableModelTransformerV2.e2e.test.ts
@@ -1,6 +1,7 @@
 import { ResourceConstants } from 'graphql-transformer-common';
 import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-transformer';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { Output } from 'aws-sdk/clients/cloudformation';
 import { default as moment } from 'moment';
@@ -14,6 +15,9 @@ import { resolveTestRegion } from '../testSetup';
 const region = resolveTestRegion();
 
 // tslint:disable: no-magic-numbers
+jest.spyOn(stateManager, 'getCurrentEnvName').mockReturnValue('testenv');
+jest.spyOn(stateManager, 'getProjectConfig').mockReturnValue({ projectName: 'testProjectName' });
+jest.spyOn(stateManager, 'getMeta').mockReturnValue({ api: { testApi: { service: 'AppSync' } } });
 jest.setTimeout(60000 * 60);
 
 const cf = new CloudFormationClient(region);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Created a new resource helper function that will generate the domain name for open search domain
- Referred to this function in the CDK
- Completed the local testing

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed
No parameters have been changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available
Solves the issue: https://github.com/aws-amplify/amplify-category-api/issues/907

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
