### PR TITLE
fix: convert single action to list of actions

### DIFF
--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/__snapshots__/ecs-apigw-stack.test.ts.snap
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/__snapshots__/ecs-apigw-stack.test.ts.snap
@@ -2532,6 +2532,10 @@ exports.handler = async function({ 'CodePipeline.job': { id: jobId } }) {
                 },
               ],
             },
+            Object {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+            },
           ],
           "Version": "2012-10-17",
         },

--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/ecs-apigw-stack.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/ecs-apigw-stack.test.ts
@@ -59,6 +59,10 @@ describe('ecs stack', () => {
             },
           ],
         },
+        {
+          Effect: 'Allow',
+          Action: 's3:ListBucket',
+        },
       ],
     });
 

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/base-api-stack.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/base-api-stack.ts
@@ -576,7 +576,7 @@ export abstract class ContainersStack extends cdk.Stack {
 function jsonPolicyToCdkPolicyStatement(policy: Record<string, any>): iam.PolicyStatement {
   return new iam.PolicyStatement({
     effect: policy.Effect,
-    actions: policy.Action,
+    actions: Array.isArray(policy.Action) ? policy.Action : [policy.Action],
     resources: Array.isArray(policy.Resource) ? policy.Resource.map((r) => cdk.Token.asString(r)) : [cdk.Token.asString(policy.Resource)],
   });
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Sometimes the policies have a single action as a string instead of a list of string. I'm not sure what cases this happens in. When it is a string `iam.PolicyStatement` will split the string as if it were an array resulting in the following error.

```
Action 's' is invalid. An action string consists of a service namespace, a colon, and the name of an action. Action names can include wildcards.
```


##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if availabl

N/A

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Unit testings

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
