### PR TITLE
fix: optimize codegen asset upload

### DIFF
--- a/packages/amplify-graphql-api-construct/src/internal/codegen-assets.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/codegen-assets.ts
@@ -35,7 +35,11 @@ export class CodegenAssets extends Construct {
     new BucketDeployment(this, `${id}Deployment`, {
       destinationBucket: bucket,
       sources: [Source.data(MODEL_SCHEMA_KEY, props.modelSchema)],
-      memoryLimit: 512,
+      // Bucket deployment uses a Lambda that runs AWS S3 CLI to transfer assets to destination bucket.
+      // That Lambda requires higher memory setting to run fast even when processing small assets (less than 1kB).
+      // This setting has been established experimentally. Benchmark can be found in pull request description that established it.
+      // The value has been chosen to prefer the lowest cost (run time * memory demand) while providing reasonable performance.
+      memoryLimit: 1536,
     });
 
     this.modelSchemaS3Uri = getS3UriForBucketAndKey(bucket, MODEL_SCHEMA_KEY);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This change bumps s3 bucket deployment memory setting to 1536 MB, which is optimizing cost while providing reasonable performance boost until we find better solutions.

See https://docs.aws.amazon.com/lambda/latest/operatorguide/computing-power.html .

This is a follow up to https://github.com/aws-amplify/amplify-category-api/pull/1933 after gathering more data.

Full benchmarking procedure and its artifacts can be found here https://github.com/sobolk/aws-cdk/blob/bucket-upload/testapps/testapp001/hotswap_s3_summary.md .

Benchmark was run by using isolated s3 bucket deployment scenario that processes upload of 3 files that have volume ~400 Bytes when compressed.

All samples taken by:
1. Adjusting memory settings
2. Executing `npx cdk deploy` to stabilize
3. Editing asset file by appending content (to make sure new asset hash is generated)
4. Executing `npx cdk deploy --hotswap-fallback --method=direct` (in table below)

| Memory  (MB)  | Deployment time (hotswap) | Billed Lambda Duration | Estimated cost of 1000000 invocations |
|---------------|---------------------------|------------------------|---------------------------------------|
| 128 (default) | 38.48s                    | 37608ms                | $78.55                                |
| 512           | 9.91s                     | 8984ms                 | $75.07                                |
| 1024          | 5.36s                     | 4396ms                 | $73.47                                |
| 1536          | 3.67s                     | 2779ms                 | $69.68                                |
| 2048          | 3.44s                     | 2551ms                 | $85.23                                |
| 3008          | 3.18s                     | 2167ms                 | $106.29                               |
| 3009          | 3.44s                     | 2520ms                 | $123.62                               |
| 5307          | 3.41s                     | 2492ms                 | $215.45                               |
| 7076          | 3.4s                      | 2475ms                 | $285.24                               |
| 8845          | 3.08s                     | 2204ms                 | $317.49                               |
| 10240         | 3.34s                     | 2475ms                 | $412.70                               |


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
