### PR TITLE
fix(api): resolver correction for userpools provider and mutation operation

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-apikey-lambda.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-apikey-lambda.test.ts
@@ -1,0 +1,463 @@
+import {
+  addApiWithAllAuthModes,
+  amplifyPush,
+  createNewProjectDir,
+  deleteDBInstance,
+  deleteProject,
+  deleteProjectDir,
+  getAppSyncApi,
+  getProjectMeta,
+  importRDSDatabase,
+  initJSProjectWithProfile,
+  setupRDSInstanceAndData,
+  sleep,
+} from 'amplify-category-api-e2e-core';
+import { existsSync, writeFileSync } from 'fs-extra';
+import generator from 'generate-password';
+import path from 'path';
+import { GQLQueryHelper } from '../query-utils/gql-helper';
+import { getConfiguredAppsyncClientAPIKeyAuth, getConfiguredAppsyncClientLambdaAuth } from '../schema-api-directives';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+describe('RDS Relational Directives', () => {
+  const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
+  
+  // Generate settings for RDS instance
+  const username = db_user;
+  const password = db_password;
+  let region = 'ap-northeast-2';
+  let port = 3306;
+  const database = 'default_db';
+  let host = 'localhost';
+  const identifier = `integtest${db_identifier}`;
+  const projName = 'rdsmodelauthtest';
+
+  let projRoot;
+  let blogApiKeyClient, postApiKeyClient, userApiKeyClient, profileApiKeyClient;
+  let blogLambdaClient, postLambdaClient, userLambdaClient, profileLambdaClient;
+
+  beforeAll(async () => {
+    projRoot = await createNewProjectDir('rdsmodelapi');
+    await initProjectAndImportSchema();
+    await amplifyPush(projRoot);
+    await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
+
+    const meta = getProjectMeta(projRoot);
+    const appRegion = meta.providers.awscloudformation.Region;
+    const { output } = meta.api.rdsmodelauth;
+    const { GraphQLAPIIdOutput, GraphQLAPIEndpointOutput, GraphQLAPIKeyOutput } = output;
+    const { graphqlApi } = await getAppSyncApi(GraphQLAPIIdOutput, appRegion);
+
+    expect(GraphQLAPIIdOutput).toBeDefined();
+    expect(GraphQLAPIEndpointOutput).toBeDefined();
+    expect(GraphQLAPIKeyOutput).toBeDefined();
+
+    console.log(`Url: ${GraphQLAPIEndpointOutput}`);
+    console.log(`API Key: ${GraphQLAPIKeyOutput}`);
+
+    expect(graphqlApi).toBeDefined();
+    expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
+
+    const apiEndPoint = GraphQLAPIEndpointOutput as string;
+    const apiKey = GraphQLAPIKeyOutput as string;
+
+    createAppSyncClients(apiEndPoint, appRegion, apiKey);
+  });
+
+  const createAppSyncClients = (apiEndPoint, appRegion, apiKey): void => {
+    const apiKeyClient = getConfiguredAppsyncClientAPIKeyAuth(apiEndPoint, appRegion, apiKey);
+    const lambdaClient = getConfiguredAppsyncClientLambdaAuth(apiEndPoint, appRegion, 'custom-authorized');
+    blogApiKeyClient = constructBlogHelper(apiKeyClient);
+    postApiKeyClient = constructPostHelper(apiKeyClient);
+    userApiKeyClient = constructUserHelper(apiKeyClient);
+    profileApiKeyClient = constructProfileHelper(apiKeyClient);
+    blogLambdaClient = constructBlogHelper(lambdaClient);
+    postLambdaClient = constructPostHelper(lambdaClient);
+    userLambdaClient = constructUserHelper(lambdaClient);
+    profileLambdaClient = constructProfileHelper(lambdaClient);
+  };
+
+  afterAll(async () => {
+    const metaFilePath = path.join(projRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
+    if (existsSync(metaFilePath)) {
+      await deleteProject(projRoot);
+    }
+    deleteProjectDir(projRoot);
+    await cleanupDatabase();
+  });
+
+  const setupDatabase = async (): Promise<void> => {
+    const dbConfig = {
+      identifier,
+      engine: 'mysql' as const,
+      dbname: database,
+      username,
+      password,
+      region,
+    };
+
+    console.log(JSON.stringify(dbConfig, null, 4));
+    const queries = [
+      'CREATE TABLE Blog (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255))',
+      'CREATE TABLE Post (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255), blogId VARCHAR(40))',
+      'CREATE TABLE User (id VARCHAR(40) PRIMARY KEY, name VARCHAR(255))',
+      'CREATE TABLE Profile (id VARCHAR(40) PRIMARY KEY, details VARCHAR(255), userId VARCHAR(40))',
+    ];
+
+    const db = await setupRDSInstanceAndData(dbConfig, queries);
+    port = db.port;
+    host = db.endpoint;
+  };
+
+  const cleanupDatabase = async (): Promise<void> => {
+    await deleteDBInstance(identifier, region);
+  };
+
+  const initProjectAndImportSchema = async (): Promise<void> => {
+    const apiName = 'rdsmodelauth';
+    await initJSProjectWithProfile(projRoot, {
+      disableAmplifyAppCreation: false,
+      name: projName,
+    });
+
+    const metaAfterInit = getProjectMeta(projRoot);
+    region = metaAfterInit.providers.awscloudformation.Region;
+    await setupDatabase();
+
+    const rdsSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.rds.graphql');
+
+    await addApiWithAllAuthModes(projRoot, { transformerVersion: 2, apiName });
+
+    await importRDSDatabase(projRoot, {
+      database,
+      host,
+      port,
+      username,
+      password,
+      useVpc: true,
+      apiExists: true,
+    });
+
+    const schema = /* GraphQL */ `
+      input AMPLIFY {
+        engine: String = "mysql"
+        globalAuthRule: AuthRule = { allow: public }
+      }
+      type Blog @model
+        @auth(rules: [{ allow: public }, { allow: custom }])
+      {
+        id: String! @primaryKey
+        content: String
+        posts: [Post] @hasMany(references: ["blogId"])
+      }
+      type Post @model
+        @auth(rules: [{ allow: public }])
+      {
+        id: String! @primaryKey
+        content: String
+        blogId: String!
+        blog: Blog @belongsTo(references: ["blogId"])
+      }
+      type User @model
+        @auth(rules: [{ allow: custom }])
+      {
+        id: String! @primaryKey
+        name: String
+        profile: Profile @hasOne(references: ["userId"])
+      }
+      type Profile @model
+        @auth(rules: [{ allow: custom }])
+      {
+        id: String! @primaryKey
+        details: String
+        userId: String!
+        user: User @belongsTo(references: ["userId"])
+      }
+    `;
+    writeFileSync(rdsSchemaFilePath, schema, 'utf8');
+  };
+
+  test('check apikey auth can perform all valid operations on blog', async () => {
+    await blogApiKeyClient.create('createBlog', {
+      id: 'B-1',
+      content: 'Blog 1',
+    });
+    await blogApiKeyClient.update('updateBlog', {
+      id: 'B-1',
+      content: 'Blog 1 updated',
+    });
+    const getBlogResult = await blogApiKeyClient.get({
+      id: 'B-1',
+    });
+    expect(getBlogResult.data.getBlog).toEqual(
+      expect.objectContaining({
+        id: 'B-1',
+        content: 'Blog 1 updated',
+      }),
+    );
+    const listBlogsResult = await blogApiKeyClient.list();
+    expect(listBlogsResult.data.listBlogs.items.length).toEqual(1);
+    expect(listBlogsResult.data.listBlogs.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'B-1',
+          content: 'Blog 1 updated',
+        }),
+      ]),
+    );
+    await blogApiKeyClient.delete('deleteBlog', {
+      id: 'B-1',
+    });
+  });
+
+  test('check lambda auth can perform all valid operations on blog', async () => {
+    await blogLambdaClient.create('createBlog', {
+      id: 'B-2',
+      content: 'Blog 2',
+    });
+    await blogLambdaClient.update('updateBlog', {
+      id: 'B-2',
+      content: 'Blog 2 updated',
+    });
+    await expect(blogLambdaClient.get({
+      id: 'B-2',
+    })).rejects.toThrow('GraphQL error: Not Authorized to access posts on type Blog');
+    await expect(blogLambdaClient.list()).rejects.toThrow('GraphQL error: Not Authorized to access posts on type Blog');
+    await blogLambdaClient.delete('deleteBlog', {
+      id: 'B-2',
+    });
+  });
+
+  test('check lambda auth can not perform any operation on post', async () => {
+    await expect(postLambdaClient.create('createPost', { id: 'P-1', content: 'Post 1', blogId: 'B-1' })).rejects.toThrow(
+      'GraphQL error: Not Authorized to access createPost on type Mutation',
+    );
+    await expect(postLambdaClient.update('updatePost', { id: 'P-1', content: 'Post 1 updated' })).rejects.toThrow(
+      'GraphQL error: Not Authorized to access updatePost on type Mutation',
+    );
+    await expect(postLambdaClient.get({ id: 'P-1' })).rejects.toThrow(
+      'GraphQL error: Not Authorized to access getPost on type Query',
+    );
+    await expect(postLambdaClient.list()).rejects.toThrow(
+      'GraphQL error: Not Authorized to access listPosts on type Query',
+    );
+    await expect(postLambdaClient.delete('deletePost', { id: 'P-1' })).rejects.toThrow(
+      'GraphQL error: Not Authorized to access deletePost on type Mutation',
+    );
+  });
+
+  test('check apikey auth can not perform any operation on user', async () => {
+    await expect(userApiKeyClient.create('createUser', { id: 'U-1', name: 'User 1' })).rejects.toThrow(
+      'GraphQL error: Not Authorized to access createUser on type Mutation',
+    );
+    await expect(userApiKeyClient.update('updateUser', { id: 'U-1', name: 'User 1 updated' })).rejects.toThrow(
+      'GraphQL error: Not Authorized to access updateUser on type Mutation',
+    );
+    await expect(userApiKeyClient.get({ id: 'U-1' })).rejects.toThrow(
+      'GraphQL error: Not Authorized to access getUser on type Query',
+    );
+    await expect(userApiKeyClient.list()).rejects.toThrow(
+      'GraphQL error: Not Authorized to access listUsers on type Query',
+    );
+    await expect(userApiKeyClient.delete('deleteUser', { id: 'U-1' })).rejects.toThrow(
+      'GraphQL error: Not Authorized to access deleteUser on type Mutation',
+    );
+  });
+  const constructBlogHelper = (client): GQLQueryHelper => {
+    const createSelectionSet = /* GraphQL */ `
+      id
+      content
+    `;
+    const updateSelectionSet = createSelectionSet;
+    const deleteSelectionSet = createSelectionSet;
+    const getSelectionSet = /* GraphQL */ `
+      query GetBlog($id: String!) {
+        getBlog(id: $id) {
+          id
+          content
+          posts {
+            items {
+              id
+              content
+            }
+          }
+        }
+      }
+    `;
+    const listSelectionSet = /* GraphQL */ `
+      query ListBlogs {
+        listBlogs {
+          items {
+            id
+            content
+            posts {
+              items {
+                id
+                content
+              }
+            }
+          }
+        }
+      }
+    `;
+    const helper = new GQLQueryHelper(client, 'Blog', {
+      mutation: {
+        create: createSelectionSet,
+        update: updateSelectionSet,
+        delete: deleteSelectionSet,
+      },
+      query: {
+        get: getSelectionSet,
+        list: listSelectionSet,
+      },
+    });
+
+    return helper;
+  };
+
+  const constructPostHelper = (client): GQLQueryHelper => {
+    const createSelectionSet = /* GraphQL */ `
+      id
+      content
+    `;
+    const updateSelectionSet = createSelectionSet;
+    const deleteSelectionSet = createSelectionSet;
+    const getSelectionSet = /* GraphQL */ `
+      query GetPost($id: String!) {
+        getPost(id: $id) {
+          id
+          content
+          blog {
+            id
+            content
+          }
+        }
+      }
+    `;
+    const listSelectionSet = /* GraphQL */ `
+      query ListPosts {
+        listPosts {
+          items {
+            id
+            content
+            blog {
+              id
+              content
+            }
+          }
+        }
+      }
+    `;
+    const helper = new GQLQueryHelper(client, 'Post', {
+      mutation: {
+        create: createSelectionSet,
+        update: updateSelectionSet,
+        delete: deleteSelectionSet,
+      },
+      query: {
+        get: getSelectionSet,
+        list: listSelectionSet,
+      },
+    });
+
+    return helper;
+  };
+
+  const constructUserHelper = (client): GQLQueryHelper => {
+    const createSelectionSet = /* GraphQL */ `
+      id
+      name
+    `;
+    const updateSelectionSet = createSelectionSet;
+    const deleteSelectionSet = createSelectionSet;
+    const getSelectionSet = /* GraphQL */ `
+      query GetUser($id: String!) {
+        getUser(id: $id) {
+          id
+          name
+          profile {
+            id
+            details
+          }
+        }
+      }
+    `;
+    const listSelectionSet = /* GraphQL */ `
+      query ListUsers {
+        listUsers {
+          items {
+            id
+            name
+            profile {
+              id
+              details
+            }
+          }
+        }
+      }
+    `;
+    const helper = new GQLQueryHelper(client, 'User', {
+      mutation: {
+        create: createSelectionSet,
+        update: updateSelectionSet,
+        delete: deleteSelectionSet,
+      },
+      query: {
+        get: getSelectionSet,
+        list: listSelectionSet,
+      },
+    });
+
+    return helper;
+  };
+
+  const constructProfileHelper = (client): GQLQueryHelper => {
+    const createSelectionSet = /* GraphQL */ `
+      id
+      details
+    `;
+    const updateSelectionSet = createSelectionSet;
+    const deleteSelectionSet = createSelectionSet;
+    const getSelectionSet = /* GraphQL */ `
+      query GetProfile($id: String!) {
+        getProfile(id: $id) {
+          id
+          details
+          user {
+            id
+            name
+          }
+        }
+      }
+    `;
+    const listSelectionSet = /* GraphQL */ `
+      query ListProfiles {
+        listProfiles {
+          items {
+            id
+            details
+            user {
+              id
+              name
+            }
+          }
+        }
+      }
+    `;
+    const helper = new GQLQueryHelper(client, 'Profile', {
+      mutation: {
+        create: createSelectionSet,
+        update: updateSelectionSet,
+        delete: deleteSelectionSet,
+      },
+      query: {
+        get: getSelectionSet,
+        list: listSelectionSet,
+      },
+    });
+
+    return helper;
+  };
+});

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-apikey-lambda.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-apikey-lambda.test.ts
@@ -23,7 +23,7 @@ import { getConfiguredAppsyncClientAPIKeyAuth, getConfiguredAppsyncClientLambdaA
 
 describe('RDS Relational Directives', () => {
   const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
-  
+
   // Generate settings for RDS instance
   const username = db_user;
   const password = db_password;
@@ -145,31 +145,23 @@ describe('RDS Relational Directives', () => {
         engine: String = "mysql"
         globalAuthRule: AuthRule = { allow: public }
       }
-      type Blog @model
-        @auth(rules: [{ allow: public }, { allow: custom }])
-      {
+      type Blog @model @auth(rules: [{ allow: public }, { allow: custom }]) {
         id: String! @primaryKey
         content: String
         posts: [Post] @hasMany(references: ["blogId"])
       }
-      type Post @model
-        @auth(rules: [{ allow: public }])
-      {
+      type Post @model @auth(rules: [{ allow: public }]) {
         id: String! @primaryKey
         content: String
         blogId: String!
         blog: Blog @belongsTo(references: ["blogId"])
       }
-      type User @model
-        @auth(rules: [{ allow: custom }])
-      {
+      type User @model @auth(rules: [{ allow: custom }]) {
         id: String! @primaryKey
         name: String
         profile: Profile @hasOne(references: ["userId"])
       }
-      type Profile @model
-        @auth(rules: [{ allow: custom }])
-      {
+      type Profile @model @auth(rules: [{ allow: custom }]) {
         id: String! @primaryKey
         details: String
         userId: String!
@@ -221,9 +213,11 @@ describe('RDS Relational Directives', () => {
       id: 'B-2',
       content: 'Blog 2 updated',
     });
-    await expect(blogLambdaClient.get({
-      id: 'B-2',
-    })).rejects.toThrow('GraphQL error: Not Authorized to access posts on type Blog');
+    await expect(
+      blogLambdaClient.get({
+        id: 'B-2',
+      }),
+    ).rejects.toThrow('GraphQL error: Not Authorized to access posts on type Blog');
     await expect(blogLambdaClient.list()).rejects.toThrow('GraphQL error: Not Authorized to access posts on type Blog');
     await blogLambdaClient.delete('deleteBlog', {
       id: 'B-2',
@@ -237,12 +231,8 @@ describe('RDS Relational Directives', () => {
     await expect(postLambdaClient.update('updatePost', { id: 'P-1', content: 'Post 1 updated' })).rejects.toThrow(
       'GraphQL error: Not Authorized to access updatePost on type Mutation',
     );
-    await expect(postLambdaClient.get({ id: 'P-1' })).rejects.toThrow(
-      'GraphQL error: Not Authorized to access getPost on type Query',
-    );
-    await expect(postLambdaClient.list()).rejects.toThrow(
-      'GraphQL error: Not Authorized to access listPosts on type Query',
-    );
+    await expect(postLambdaClient.get({ id: 'P-1' })).rejects.toThrow('GraphQL error: Not Authorized to access getPost on type Query');
+    await expect(postLambdaClient.list()).rejects.toThrow('GraphQL error: Not Authorized to access listPosts on type Query');
     await expect(postLambdaClient.delete('deletePost', { id: 'P-1' })).rejects.toThrow(
       'GraphQL error: Not Authorized to access deletePost on type Mutation',
     );
@@ -255,12 +245,8 @@ describe('RDS Relational Directives', () => {
     await expect(userApiKeyClient.update('updateUser', { id: 'U-1', name: 'User 1 updated' })).rejects.toThrow(
       'GraphQL error: Not Authorized to access updateUser on type Mutation',
     );
-    await expect(userApiKeyClient.get({ id: 'U-1' })).rejects.toThrow(
-      'GraphQL error: Not Authorized to access getUser on type Query',
-    );
-    await expect(userApiKeyClient.list()).rejects.toThrow(
-      'GraphQL error: Not Authorized to access listUsers on type Query',
-    );
+    await expect(userApiKeyClient.get({ id: 'U-1' })).rejects.toThrow('GraphQL error: Not Authorized to access getUser on type Query');
+    await expect(userApiKeyClient.list()).rejects.toThrow('GraphQL error: Not Authorized to access listUsers on type Query');
     await expect(userApiKeyClient.delete('deleteUser', { id: 'U-1' })).rejects.toThrow(
       'GraphQL error: Not Authorized to access deleteUser on type Mutation',
     );

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-apikey-lambda.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-apikey-lambda.test.ts
@@ -54,9 +54,6 @@ describe('RDS Relational Directives', () => {
     expect(GraphQLAPIEndpointOutput).toBeDefined();
     expect(GraphQLAPIKeyOutput).toBeDefined();
 
-    console.log(`Url: ${GraphQLAPIEndpointOutput}`);
-    console.log(`API Key: ${GraphQLAPIKeyOutput}`);
-
     expect(graphqlApi).toBeDefined();
     expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
 
@@ -98,7 +95,6 @@ describe('RDS Relational Directives', () => {
       region,
     };
 
-    console.log(JSON.stringify(dbConfig, null, 4));
     const queries = [
       'CREATE TABLE Blog (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255))',
       'CREATE TABLE Post (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255), blogId VARCHAR(40))',

--- a/packages/amplify-e2e-tests/src/schema-api-directives/authHelper.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/authHelper.ts
@@ -117,6 +117,18 @@ export function getConfiguredAppsyncClientIAMAuth(url: string, region: string): 
   });
 }
 
+export const getConfiguredAppsyncClientLambdaAuth = (url: string, region: string, token: string): any => {
+  return new AWSAppSyncClient({
+    url,
+    region,
+    disableOffline: true,
+    auth: {
+      type: AUTH_TYPE.AWS_LAMBDA,
+      token,
+    },
+  });
+};
+
 export async function signInUser(username: string, password: string) {
   const user = await Auth.signIn(username, password);
   return user;

--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -66,7 +66,7 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "branches": 68,
+        "branches": 80,
         "functions": 80,
         "lines": 80
       }

--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -66,7 +66,7 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "branches": 80,
+        "branches": 68,
         "functions": 80,
         "lines": 80
       }

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-mutation-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-mutation-auth.test.ts.snap
@@ -1071,7 +1071,7 @@ $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.authRole,
-  \\"cognitoIdentityPoolId\\": $ctx.identity.cognitoIdentityPoolId,
+  \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
 #set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
@@ -1121,7 +1121,7 @@ $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.authRole,
-  \\"cognitoIdentityPoolId\\": $ctx.identity.cognitoIdentityPoolId,
+  \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
 #set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
@@ -1171,7 +1171,7 @@ $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.authRole,
-  \\"cognitoIdentityPoolId\\": $ctx.identity.cognitoIdentityPoolId,
+  \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
 #set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )
@@ -1202,7 +1202,7 @@ $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.unauthRole,
-  \\"cognitoIdentityPoolId\\": $ctx.identity.cognitoIdentityPoolId,
+  \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
 #set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
@@ -1252,7 +1252,7 @@ $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.unauthRole,
-  \\"cognitoIdentityPoolId\\": $ctx.identity.cognitoIdentityPoolId,
+  \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
 #set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
@@ -1302,7 +1302,7 @@ $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.unauthRole,
-  \\"cognitoIdentityPoolId\\": $ctx.identity.cognitoIdentityPoolId,
+  \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
 #set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-mutation-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-mutation-auth.test.ts.snap
@@ -9,7 +9,7 @@ $util.qr($authRules.add({
   \\"provider\\": \\"apiKey\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input, null) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -57,7 +57,7 @@ $util.qr($authRules.add({
   \\"provider\\": \\"apiKey\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -105,7 +105,7 @@ $util.qr($authRules.add({
   \\"provider\\": \\"apiKey\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -134,7 +134,7 @@ $util.qr($authRules.add({
   \\"provider\\": \\"userPools\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input, null) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -182,7 +182,7 @@ $util.qr($authRules.add({
   \\"provider\\": \\"userPools\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -230,7 +230,7 @@ $util.qr($authRules.add({
   \\"provider\\": \\"userPools\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -262,7 +262,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"sub::username\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input, null) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -313,7 +313,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"sub::username\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -364,7 +364,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"sub::username\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -396,7 +396,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"sub::username\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"owners\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input, null) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -447,7 +447,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"sub::username\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"owners\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -498,7 +498,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"sub::username\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"owners\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -536,7 +536,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input, null) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -593,7 +593,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -650,7 +650,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -682,7 +682,7 @@ $util.qr($authRules.add({
   \\"groupClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"group\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input, null) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -733,7 +733,7 @@ $util.qr($authRules.add({
   \\"groupClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"group\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -784,7 +784,7 @@ $util.qr($authRules.add({
   \\"groupClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"group\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -816,7 +816,7 @@ $util.qr($authRules.add({
   \\"groupClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"groups\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input, null) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -867,7 +867,7 @@ $util.qr($authRules.add({
   \\"groupClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"groups\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -918,7 +918,7 @@ $util.qr($authRules.add({
   \\"groupClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"groups\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -947,7 +947,7 @@ $util.qr($authRules.add({
   \\"provider\\": \\"function\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input, null) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -995,7 +995,7 @@ $util.qr($authRules.add({
   \\"provider\\": \\"function\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1043,7 +1043,7 @@ $util.qr($authRules.add({
   \\"provider\\": \\"function\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1074,7 +1074,7 @@ $util.qr($authRules.add({
   \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input, null) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1124,7 +1124,7 @@ $util.qr($authRules.add({
   \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1174,7 +1174,7 @@ $util.qr($authRules.add({
   \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1205,7 +1205,7 @@ $util.qr($authRules.add({
   \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input, null) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1255,7 +1255,7 @@ $util.qr($authRules.add({
   \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1305,7 +1305,7 @@ $util.qr($authRules.add({
   \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1334,7 +1334,7 @@ $util.qr($authRules.add({
   \\"provider\\": \\"userPools\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input, null) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1382,7 +1382,7 @@ $util.qr($authRules.add({
   \\"provider\\": \\"userPools\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1430,7 +1430,7 @@ $util.qr($authRules.add({
   \\"provider\\": \\"userPools\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1462,7 +1462,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"sub::username\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input, null) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1513,7 +1513,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"sub::username\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1564,7 +1564,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"sub::username\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1596,7 +1596,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"sub::username\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"owners\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input, null) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1647,7 +1647,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"sub::username\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"owners\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1698,7 +1698,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"sub::username\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"owners\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1736,7 +1736,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input, null) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1793,7 +1793,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1850,7 +1850,7 @@ $util.qr($authRules.add({
   \\"identityClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1882,7 +1882,7 @@ $util.qr($authRules.add({
   \\"groupClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"group\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input, null) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1933,7 +1933,7 @@ $util.qr($authRules.add({
   \\"groupClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"group\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -1984,7 +1984,7 @@ $util.qr($authRules.add({
   \\"groupClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"group\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -2016,7 +2016,7 @@ $util.qr($authRules.add({
   \\"groupClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"groups\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input, null) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -2067,7 +2067,7 @@ $util.qr($authRules.add({
   \\"groupClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"groups\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end
@@ -2118,7 +2118,7 @@ $util.qr($authRules.add({
   \\"groupClaim\\": \\"cognito:groups\\",
   \\"allowedFields\\":   [\\"id\\", \\"title\\", \\"groups\\"]
 }))
-#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.source) )
+#set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.result) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
   $util.unauthorized()
 #end

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-query-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-query-auth.test.ts.snap
@@ -496,7 +496,7 @@ $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.authRole,
-  \\"cognitoIdentityPoolId\\": $ctx.identity.cognitoIdentityPoolId
+  \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\"
 }))
 #set( $authResult = $util.authRules.queryAuth($authRules) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
@@ -526,7 +526,7 @@ $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.authRole,
-  \\"cognitoIdentityPoolId\\": $ctx.identity.cognitoIdentityPoolId
+  \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\"
 }))
 #set( $authResult = $util.authRules.queryAuth($authRules) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
@@ -556,7 +556,7 @@ $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.unauthRole,
-  \\"cognitoIdentityPoolId\\": $ctx.identity.cognitoIdentityPoolId
+  \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\"
 }))
 #set( $authResult = $util.authRules.queryAuth($authRules) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
@@ -586,7 +586,7 @@ $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.unauthRole,
-  \\"cognitoIdentityPoolId\\": $ctx.identity.cognitoIdentityPoolId
+  \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\"
 }))
 #set( $authResult = $util.authRules.queryAuth($authRules) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-subscription-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-subscription-auth.test.ts.snap
@@ -1100,7 +1100,7 @@ $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.authRole,
-  \\"cognitoIdentityPoolId\\": $ctx.identity.cognitoIdentityPoolId
+  \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\"
 }))
 #set( $authResult = $util.authRules.subscriptionAuth($authRules) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
@@ -1145,7 +1145,7 @@ $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.authRole,
-  \\"cognitoIdentityPoolId\\": $ctx.identity.cognitoIdentityPoolId
+  \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\"
 }))
 #set( $authResult = $util.authRules.subscriptionAuth($authRules) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
@@ -1190,7 +1190,7 @@ $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.authRole,
-  \\"cognitoIdentityPoolId\\": $ctx.identity.cognitoIdentityPoolId
+  \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\"
 }))
 #set( $authResult = $util.authRules.subscriptionAuth($authRules) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
@@ -1235,7 +1235,7 @@ $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.unauthRole,
-  \\"cognitoIdentityPoolId\\": $ctx.identity.cognitoIdentityPoolId
+  \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\"
 }))
 #set( $authResult = $util.authRules.subscriptionAuth($authRules) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
@@ -1280,7 +1280,7 @@ $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.unauthRole,
-  \\"cognitoIdentityPoolId\\": $ctx.identity.cognitoIdentityPoolId
+  \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\"
 }))
 #set( $authResult = $util.authRules.subscriptionAuth($authRules) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
@@ -1325,7 +1325,7 @@ $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.unauthRole,
-  \\"cognitoIdentityPoolId\\": $ctx.identity.cognitoIdentityPoolId
+  \\"cognitoIdentityPoolId\\": \\"TEST_IDENTITY_POOL_ID\\"
 }))
 #set( $authResult = $util.authRules.subscriptionAuth($authRules) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/rds-mutation-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/rds-mutation-auth.test.ts
@@ -17,7 +17,7 @@ describe('Verify RDS Model level Auth rules on mutations:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer()],
+      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
       modelToDatasourceMap: new Map(
         Object.entries({
           Post: {
@@ -104,6 +104,9 @@ describe('Verify RDS Model level Auth rules on mutations:', () => {
     const authConfig: AppSyncAuthConfiguration = {
       defaultAuthentication: {
         authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+        userPoolConfig: {
+          userPoolId: 'TEST_USER_POOL_ID',
+        },
       },
       additionalAuthenticationProviders: [],
     };
@@ -118,7 +121,7 @@ describe('Verify RDS Model level Auth rules on mutations:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer()],
+      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
       authConfig,
       modelToDatasourceMap,
     });
@@ -266,7 +269,7 @@ describe('Verify RDS Model level Auth rules on mutations:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer()],
+      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
       authConfig,
       modelToDatasourceMap,
     });
@@ -359,7 +362,7 @@ describe('Verify RDS Model level Auth rules on mutations:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer()],
+      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
       authConfig,
       modelToDatasourceMap: new Map(
         Object.entries({
@@ -426,7 +429,7 @@ describe('Verify RDS Model level Auth rules on mutations:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer()],
+      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
       authConfig,
       modelToDatasourceMap,
     });

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/rds-mutation-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/rds-mutation-auth.test.ts
@@ -17,7 +17,7 @@ describe('Verify RDS Model level Auth rules on mutations:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
+      transformers: [new ModelTransformer(), new AuthTransformer({ identityPoolId: 'TEST_IDENTITY_POOL_ID' })],
       modelToDatasourceMap: new Map(
         Object.entries({
           Post: {
@@ -121,7 +121,7 @@ describe('Verify RDS Model level Auth rules on mutations:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
+      transformers: [new ModelTransformer(), new AuthTransformer({ identityPoolId: 'TEST_IDENTITY_POOL_ID' })],
       authConfig,
       modelToDatasourceMap,
     });
@@ -269,7 +269,7 @@ describe('Verify RDS Model level Auth rules on mutations:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
+      transformers: [new ModelTransformer(), new AuthTransformer({ identityPoolId: 'TEST_IDENTITY_POOL_ID' })],
       authConfig,
       modelToDatasourceMap,
     });
@@ -362,7 +362,7 @@ describe('Verify RDS Model level Auth rules on mutations:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
+      transformers: [new ModelTransformer(), new AuthTransformer({ identityPoolId: 'TEST_IDENTITY_POOL_ID' })],
       authConfig,
       modelToDatasourceMap: new Map(
         Object.entries({
@@ -429,7 +429,7 @@ describe('Verify RDS Model level Auth rules on mutations:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
+      transformers: [new ModelTransformer(), new AuthTransformer({ identityPoolId: 'TEST_IDENTITY_POOL_ID' })],
       authConfig,
       modelToDatasourceMap,
     });

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/rds-query-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/rds-query-auth.test.ts
@@ -17,7 +17,7 @@ describe('Verify RDS Model level Auth rules on queries:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer()],
+      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
       modelToDatasourceMap: new Map(
         Object.entries({
           Post: {
@@ -98,6 +98,9 @@ describe('Verify RDS Model level Auth rules on queries:', () => {
     const authConfig: AppSyncAuthConfiguration = {
       defaultAuthentication: {
         authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+        userPoolConfig: {
+          userPoolId: 'TEST_USER_POOL_ID',
+        },
       },
       additionalAuthenticationProviders: [],
     };
@@ -112,7 +115,7 @@ describe('Verify RDS Model level Auth rules on queries:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer()],
+      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
       authConfig,
       modelToDatasourceMap,
     });
@@ -236,7 +239,7 @@ describe('Verify RDS Model level Auth rules on queries:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer()],
+      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
       authConfig,
       modelToDatasourceMap,
     });
@@ -305,7 +308,7 @@ describe('Verify RDS Model level Auth rules on queries:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer()],
+      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
       authConfig,
       modelToDatasourceMap: new Map(
         Object.entries({
@@ -366,7 +369,7 @@ describe('Verify RDS Model level Auth rules on queries:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer()],
+      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
       authConfig,
       modelToDatasourceMap,
     });

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/rds-query-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/rds-query-auth.test.ts
@@ -17,7 +17,7 @@ describe('Verify RDS Model level Auth rules on queries:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
+      transformers: [new ModelTransformer(), new AuthTransformer({ identityPoolId: 'TEST_IDENTITY_POOL_ID' })],
       modelToDatasourceMap: new Map(
         Object.entries({
           Post: {
@@ -115,7 +115,7 @@ describe('Verify RDS Model level Auth rules on queries:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
+      transformers: [new ModelTransformer(), new AuthTransformer({ identityPoolId: 'TEST_IDENTITY_POOL_ID' })],
       authConfig,
       modelToDatasourceMap,
     });
@@ -239,7 +239,7 @@ describe('Verify RDS Model level Auth rules on queries:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
+      transformers: [new ModelTransformer(), new AuthTransformer({ identityPoolId: 'TEST_IDENTITY_POOL_ID' })],
       authConfig,
       modelToDatasourceMap,
     });
@@ -308,7 +308,7 @@ describe('Verify RDS Model level Auth rules on queries:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
+      transformers: [new ModelTransformer(), new AuthTransformer({ identityPoolId: 'TEST_IDENTITY_POOL_ID' })],
       authConfig,
       modelToDatasourceMap: new Map(
         Object.entries({
@@ -369,7 +369,7 @@ describe('Verify RDS Model level Auth rules on queries:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
+      transformers: [new ModelTransformer(), new AuthTransformer({ identityPoolId: 'TEST_IDENTITY_POOL_ID' })],
       authConfig,
       modelToDatasourceMap,
     });

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/rds-subscription-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/rds-subscription-auth.test.ts
@@ -17,7 +17,7 @@ describe('Verify RDS Model level Auth rules on subscriptions:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer()],
+      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
       modelToDatasourceMap: new Map(
         Object.entries({
           Post: {
@@ -105,6 +105,9 @@ describe('Verify RDS Model level Auth rules on subscriptions:', () => {
     const authConfig: AppSyncAuthConfiguration = {
       defaultAuthentication: {
         authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+        userPoolConfig: {
+          userPoolId: 'TEST_USER_POOL_ID',
+        },
       },
       additionalAuthenticationProviders: [],
     };
@@ -119,7 +122,7 @@ describe('Verify RDS Model level Auth rules on subscriptions:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer()],
+      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
       authConfig,
       modelToDatasourceMap,
     });
@@ -273,7 +276,7 @@ describe('Verify RDS Model level Auth rules on subscriptions:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer()],
+      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
       authConfig,
       modelToDatasourceMap,
     });
@@ -372,7 +375,7 @@ describe('Verify RDS Model level Auth rules on subscriptions:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer()],
+      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
       authConfig,
       modelToDatasourceMap: new Map(
         Object.entries({
@@ -440,7 +443,7 @@ describe('Verify RDS Model level Auth rules on subscriptions:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer()],
+      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
       authConfig,
       modelToDatasourceMap,
     });

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/rds-subscription-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/rds-subscription-auth.test.ts
@@ -17,7 +17,7 @@ describe('Verify RDS Model level Auth rules on subscriptions:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
+      transformers: [new ModelTransformer(), new AuthTransformer({ identityPoolId: 'TEST_IDENTITY_POOL_ID' })],
       modelToDatasourceMap: new Map(
         Object.entries({
           Post: {
@@ -122,7 +122,7 @@ describe('Verify RDS Model level Auth rules on subscriptions:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
+      transformers: [new ModelTransformer(), new AuthTransformer({ identityPoolId: 'TEST_IDENTITY_POOL_ID' })],
       authConfig,
       modelToDatasourceMap,
     });
@@ -276,7 +276,7 @@ describe('Verify RDS Model level Auth rules on subscriptions:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
+      transformers: [new ModelTransformer(), new AuthTransformer({ identityPoolId: 'TEST_IDENTITY_POOL_ID' })],
       authConfig,
       modelToDatasourceMap,
     });
@@ -375,7 +375,7 @@ describe('Verify RDS Model level Auth rules on subscriptions:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
+      transformers: [new ModelTransformer(), new AuthTransformer({ identityPoolId: 'TEST_IDENTITY_POOL_ID' })],
       authConfig,
       modelToDatasourceMap: new Map(
         Object.entries({
@@ -443,7 +443,7 @@ describe('Verify RDS Model level Auth rules on subscriptions:', () => {
 
     const out = testTransform({
       schema: validSchema,
-      transformers: [new ModelTransformer(), new AuthTransformer({identityPoolId: 'TEST_IDENTITY_POOL_ID'})],
+      transformers: [new ModelTransformer(), new AuthTransformer({ identityPoolId: 'TEST_IDENTITY_POOL_ID' })],
       authConfig,
       modelToDatasourceMap,
     });

--- a/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/common.ts
+++ b/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/common.ts
@@ -165,7 +165,10 @@ const getAllowedFields = (role: RoleDefinition, fields: string[]): string[] => {
 
 export const validateAuthResult = (): Expression => {
   return compoundExpression([
-    iff(or([not(ref('authResult')), parens(and([ref('authResult'), not(ref('authResult.authorized'))]))]), methodCall(ref('util.unauthorized'))),
+    iff(
+      or([not(ref('authResult')), parens(and([ref('authResult'), not(ref('authResult.authorized'))]))]),
+      methodCall(ref('util.unauthorized')),
+    ),
   ]);
 };
 

--- a/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/common.ts
+++ b/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/common.ts
@@ -90,7 +90,7 @@ const convertAuthRoleToVtl = (role: RoleDefinition, fields: string[], hideAllowe
           type: str(role.strategy),
           provider: str('iam'),
           roleArn: role.strategy === 'public' ? ref('ctx.stash.unauthRole') : ref('ctx.stash.authRole'),
-          cognitoIdentityPoolId: str(identityPoolId),
+          cognitoIdentityPoolId: identityPoolId ? str(identityPoolId) : nul(),
           ...(showAllowedFields && { allowedFields: list(allowedFields) }),
         }),
       ),

--- a/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/common.ts
+++ b/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/common.ts
@@ -39,17 +39,18 @@ export const generateAuthRulesFromRoles = (
   roles: Array<RoleDefinition>,
   fields: Readonly<FieldDefinitionNode[]>,
   hideAllowedFields = false,
+  identityPoolId?: string,
 ): Expression[] => {
   const expressions = [];
   expressions.push(qref(methodCall(ref('ctx.stash.put'), str('hasAuth'), bool(true))), set(ref('authRules'), list([])));
   const fieldNames = fields.map((field) => field.name.value);
   roles.forEach((role) => {
-    expressions.push(convertAuthRoleToVtl(role, fieldNames, hideAllowedFields));
+    expressions.push(convertAuthRoleToVtl(role, fieldNames, hideAllowedFields, identityPoolId));
   });
   return expressions;
 };
 
-const convertAuthRoleToVtl = (role: RoleDefinition, fields: string[], hideAllowedFields = false): Expression => {
+const convertAuthRoleToVtl = (role: RoleDefinition, fields: string[], hideAllowedFields = false, identityPoolId?: string): Expression => {
   const allowedFields = getAllowedFields(role, fields).map((field) => str(field));
   const showAllowedFields = allowedFields && !hideAllowedFields && allowedFields.length > 0;
   // Api Key
@@ -89,7 +90,7 @@ const convertAuthRoleToVtl = (role: RoleDefinition, fields: string[], hideAllowe
           type: str(role.strategy),
           provider: str('iam'),
           roleArn: role.strategy === 'public' ? ref('ctx.stash.unauthRole') : ref('ctx.stash.authRole'),
-          cognitoIdentityPoolId: ref('ctx.identity.cognitoIdentityPoolId'),
+          cognitoIdentityPoolId: str(identityPoolId),
           ...(showAllowedFields && { allowedFields: list(allowedFields) }),
         }),
       ),

--- a/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/mutation.ts
+++ b/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/mutation.ts
@@ -1,4 +1,4 @@
-import { compoundExpression, list, methodCall, obj, printBlock, qref, ref, set, str } from 'graphql-mapping-template';
+import { compoundExpression, list, methodCall, nul, obj, printBlock, qref, ref, set, str } from 'graphql-mapping-template';
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { FieldDefinitionNode, ObjectTypeDefinitionNode } from 'graphql';
 import { ConfiguredAuthProviders, RoleDefinition } from '../../../utils';
@@ -42,8 +42,8 @@ const generateMutationExpression = (
     set(
       ref('authResult'),
       includeExistingRecord
-        ? methodCall(ref('util.authRules.mutationAuth'), ref('authRules'), str(operation), ref('ctx.args.input'), ref('ctx.source'))
-        : methodCall(ref('util.authRules.mutationAuth'), ref('authRules'), str(operation), ref('ctx.args.input')),
+        ? methodCall(ref('util.authRules.mutationAuth'), ref('authRules'), str(operation), ref('ctx.args.input'), ref('ctx.result'))
+        : methodCall(ref('util.authRules.mutationAuth'), ref('authRules'), str(operation), ref('ctx.args.input'), nul()),
     ),
   );
   expressions.push(validateAuthResult(), constructAuthorizedInputStatement('ctx.args.input'), emptyPayload);

--- a/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/mutation.ts
+++ b/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/mutation.ts
@@ -10,7 +10,7 @@ export const generateAuthExpressionForCreate = (
   roles: Array<RoleDefinition>,
   fields: ReadonlyArray<FieldDefinitionNode>,
 ): string => {
-  return generateMutationExpression(roles, fields, 'create');
+  return generateMutationExpression(roles, fields, 'create', false, providers.identityPoolId);
 };
 
 export const generateAuthExpressionForUpdate = (
@@ -18,7 +18,7 @@ export const generateAuthExpressionForUpdate = (
   roles: Array<RoleDefinition>,
   fields: ReadonlyArray<FieldDefinitionNode>,
 ): string => {
-  return generateMutationExpression(roles, fields, 'update', true);
+  return generateMutationExpression(roles, fields, 'update', true, providers.identityPoolId);
 };
 
 export const generateAuthExpressionForDelete = (
@@ -26,7 +26,7 @@ export const generateAuthExpressionForDelete = (
   roles: Array<RoleDefinition>,
   fields: ReadonlyArray<FieldDefinitionNode>,
 ): string => {
-  return generateMutationExpression(roles, fields, 'delete', true);
+  return generateMutationExpression(roles, fields, 'delete', true, providers.identityPoolId);
 };
 
 const generateMutationExpression = (
@@ -34,9 +34,10 @@ const generateMutationExpression = (
   fields: ReadonlyArray<FieldDefinitionNode>,
   operation: 'create' | 'update' | 'delete',
   includeExistingRecord = false,
+  identityPoolId?: string,
 ): string => {
   const expressions = [];
-  expressions.push(compoundExpression(generateAuthRulesFromRoles(roles, fields)));
+  expressions.push(compoundExpression(generateAuthRulesFromRoles(roles, fields, false, identityPoolId)));
   expressions.push(
     set(
       ref('authResult'),

--- a/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/query.ts
+++ b/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/query.ts
@@ -14,7 +14,7 @@ export const generateAuthExpressionForQueries = (
   indexName: string | undefined,
 ): string => {
   const expressions = [];
-  expressions.push(compoundExpression(generateAuthRulesFromRoles(roles, fields, true)));
+  expressions.push(compoundExpression(generateAuthRulesFromRoles(roles, fields, true, providers.identityPoolId)));
   expressions.push(set(ref('authResult'), methodCall(ref('util.authRules.queryAuth'), ref('authRules'))));
   expressions.push(validateAuthResult(), constructAuthFilter(), emptyPayload);
   return printBlock('Authorization rules')(compoundExpression(expressions));
@@ -27,7 +27,7 @@ export const generateAuthExpressionForField = (
   fieldName: string = undefined,
 ): string => {
   const expressions = [];
-  expressions.push(compoundExpression(generateAuthRulesFromRoles(roles, fields, true)));
+  expressions.push(compoundExpression(generateAuthRulesFromRoles(roles, fields, true, providers.identityPoolId)));
   expressions.push(set(ref('authResult'), methodCall(ref('util.authRules.queryAuth'), ref('authRules'))));
   expressions.push(validateAuthResult(), emptyPayload);
   return printBlock('Authorization rules')(compoundExpression(expressions));
@@ -61,7 +61,7 @@ export const generateAuthExpressionForRelationQuery = (
   fields: ReadonlyArray<FieldDefinitionNode>,
 ): string => {
   const expressions = [];
-  expressions.push(compoundExpression(generateAuthRulesFromRoles(roles, fields, true)));
+  expressions.push(compoundExpression(generateAuthRulesFromRoles(roles, fields, true, providers.identityPoolId)));
   expressions.push(set(ref('authResult'), methodCall(ref('util.authRules.queryAuth'), ref('authRules'))));
   expressions.push(validateAuthResult(), constructAuthFilter(), emptyPayload);
   return printBlock('Authorization rules')(compoundExpression(expressions));

--- a/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/subscription.ts
+++ b/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/subscription.ts
@@ -4,7 +4,7 @@ import { emptyPayload, generateAuthRulesFromRoles, validateAuthResult } from './
 
 export const generateAuthExpressionForSubscriptions = (providers: ConfiguredAuthProviders, roles: Array<RoleDefinition>): string => {
   const expressions = [];
-  expressions.push(compoundExpression(generateAuthRulesFromRoles(roles, [], true)));
+  expressions.push(compoundExpression(generateAuthRulesFromRoles(roles, [], true, providers.identityPoolId)));
   expressions.push(set(ref('authResult'), methodCall(ref('util.authRules.subscriptionAuth'), ref('authRules'))));
   expressions.push(validateAuthResult());
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Minor resolver changes after E2E testing in ICN region after AppSync deployment of AuthUtils.
Add E2E test for Api Key and Lambda auth on queries and mutations.

##### CDK / CloudFormation Parameters Changed
NA
<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Manual test
- E2E test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
