### PR TITLE
chore: add ap-east-1 (HKG) region

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/supported-datasources.ts
+++ b/packages/amplify-category-api/src/provider-utils/supported-datasources.ts
@@ -35,6 +35,7 @@ export const supportedDataSources = {
       'us-east-2',
       'us-west-1',
       'us-west-2',
+      'ap-east-1',
       'ap-south-1',
       'ap-southeast-1',
       'ap-southeast-2',

--- a/packages/amplify-e2e-core/src/utils/pinpoint.ts
+++ b/packages/amplify-e2e-core/src/utils/pinpoint.ts
@@ -30,6 +30,7 @@ const serviceRegionMap = {
   'us-west-2': 'us-west-2',
   'cn-north-1': 'us-west-2',
   'cn-northwest-1': 'us-west-2',
+  'ap-east-1': 'ap-northeast-2',
   'ap-south-1': 'ap-south-1',
   'ap-northeast-3': 'us-west-2',
   'ap-northeast-2': 'ap-northeast-2',


### PR DESCRIPTION
#### Description of changes

This PR enables support in ap-east-1 region (HKG). Associated with https://github.com/aws-amplify/amplify-cli/pull/13332
 
##### CDK / CloudFormation Parameters Changed
N/A
#### Issue #, if available
N/A
#### Description of how you validated changes

I set `ap-east-1` in my ~/.aws/config for my amplify profile and created an app.

I ran:
amplify-dev init
amplify-dev add api (default graphQL options)
amplify-dev push

I was able to observe the stack successfully deployed to HKG.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
