### PR TITLE
test(api): e2e for iam provider on rds models

### DIFF
--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -24,9 +24,13 @@ export function getSchemaPath(schemaName: string): string {
   return path.join(__dirname, '..', '..', '..', 'amplify-e2e-tests', 'schemas', schemaName);
 }
 
-export const apiGqlCompile = (cwd: string, testingWithLatestCodebase = false, settings?: {
-  forceCompile?: boolean;
-}): Promise<void> => {
+export const apiGqlCompile = (
+  cwd: string,
+  testingWithLatestCodebase = false,
+  settings?: {
+    forceCompile?: boolean;
+  },
+): Promise<void> => {
   const params = ['api', 'gql-compile'];
   if (settings?.forceCompile) {
     params.push('--force');
@@ -42,7 +46,7 @@ export const apiGqlCompile = (cwd: string, testingWithLatestCodebase = false, se
         }
       });
   });
-}
+};
 
 export interface AddApiOptions {
   apiName: string;

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -24,9 +24,15 @@ export function getSchemaPath(schemaName: string): string {
   return path.join(__dirname, '..', '..', '..', 'amplify-e2e-tests', 'schemas', schemaName);
 }
 
-export function apiGqlCompile(cwd: string, testingWithLatestCodebase: boolean = false) {
+export const apiGqlCompile = (cwd: string, testingWithLatestCodebase = false, settings?: {
+  forceCompile?: boolean;
+}): Promise<void> => {
+  const params = ['api', 'gql-compile'];
+  if (settings?.forceCompile) {
+    params.push('--force');
+  }
   return new Promise<void>((resolve, reject) => {
-    spawn(getCLIPath(testingWithLatestCodebase), ['api', 'gql-compile'], { cwd, stripColors: true })
+    spawn(getCLIPath(testingWithLatestCodebase), params, { cwd, stripColors: true })
       .wait('GraphQL schema compiled successfully.')
       .run((err: Error) => {
         if (!err) {

--- a/packages/amplify-e2e-core/src/categories/auth.ts
+++ b/packages/amplify-e2e-core/src/categories/auth.ts
@@ -1740,3 +1740,46 @@ export function updateAuthMFAConfiguration(projectDir: string, settings: any = {
     .sendCarriageReturn()
     .runAsync();
 }
+
+export const enableUserPoolUnauthenticatedAccess = async (cwd: string, settings: any = {}): Promise<void> => {
+  return spawn(getCLIPath(settings.testingWithLatestCodebase), ['update', 'auth'], { cwd, stripColors: true })
+    .wait('What do you want to do')
+    .sendKeyDown()
+    .sendCarriageReturn() // Walkthrough all the auth configurations
+    .wait('Select the authentication/authorization services that you want to use')
+    .sendCarriageReturn()
+    .wait('Allow unauthenticated logins')
+    .sendKeyUp()
+    .sendCarriageReturn() // Yes
+    .wait('Do you want to enable 3rd party authentication providers in your identity pool')
+    .sendKeyDown() // No
+    .sendCarriageReturn()
+    .wait('Do you want to add User Pool Groups')
+    .sendKeyDown() // No
+    .sendCarriageReturn()
+    .wait('Do you want to add an admin queries API')
+    .sendKeyDown() // No
+    .sendCarriageReturn()
+    .wait('Multifactor authentication (MFA) user login options')
+    .sendCarriageReturn() // OFF
+    .wait('Email based user registration/forgot password')
+    .sendCarriageReturn() // Enabled
+    .wait('Specify an email verification subject')
+    .sendCarriageReturn()
+    .wait('Specify an email verification message')
+    .sendCarriageReturn()
+    .wait('Do you want to override the default password policy for this User Pool')
+    .sendCarriageReturn()
+    .wait('Specify the app\'s refresh token expiration period (in days)')
+    .sendCarriageReturn()
+    .wait('Do you want to specify the user attributes this app can read and write')
+    .sendCarriageReturn()
+    .wait('Do you want to enable any of the following capabilities')
+    .sendCarriageReturn()
+    .wait('Do you want to use an OAuth flow')
+    .sendKeyDown() // No
+    .sendCarriageReturn()
+    .wait('Do you want to configure Lambda Triggers for Cognito')
+    .sendConfirmNo()
+    .runAsync();
+};

--- a/packages/amplify-e2e-core/src/categories/auth.ts
+++ b/packages/amplify-e2e-core/src/categories/auth.ts
@@ -1770,7 +1770,7 @@ export const enableUserPoolUnauthenticatedAccess = async (cwd: string, settings:
     .sendCarriageReturn()
     .wait('Do you want to override the default password policy for this User Pool')
     .sendCarriageReturn()
-    .wait('Specify the app\'s refresh token expiration period (in days)')
+    .wait("Specify the app's refresh token expiration period (in days)")
     .sendCarriageReturn()
     .wait('Do you want to specify the user attributes this app can read and write')
     .sendCarriageReturn()

--- a/packages/amplify-e2e-core/src/init/amplifyPush.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPush.ts
@@ -32,9 +32,13 @@ export type LayerPushSettings = {
 /**
  * Function to test amplify push with verbose status
  */
-export function amplifyPush(cwd: string, testingWithLatestCodebase = false, settings?: {
-  skipCodegen?: boolean;
-}): Promise<void> {
+export function amplifyPush(
+  cwd: string,
+  testingWithLatestCodebase = false,
+  settings?: {
+    skipCodegen?: boolean;
+  },
+): Promise<void> {
   return new Promise((resolve, reject) => {
     // Test detailed status
     spawn(getCLIPath(testingWithLatestCodebase), ['status', '-v'], { cwd, stripColors: true, noOutputTimeout: pushTimeoutMS })
@@ -50,20 +54,20 @@ export function amplifyPush(cwd: string, testingWithLatestCodebase = false, sett
       .sendConfirmYes();
 
     if (!settings?.skipCodegen) {
-      pushCommands.wait('Do you want to generate code for your newly created GraphQL API')
+      pushCommands
+        .wait('Do you want to generate code for your newly created GraphQL API')
         .sendConfirmNo()
         .wait('Do you want to generate code for your newly created GraphQL API')
         .sendConfirmNo();
     }
 
-    pushCommands.wait(/.*/)
-      .run((err: Error) => {
-        if (!err) {
-          resolve();
-        } else {
-          reject(err);
-        }
-      });
+    pushCommands.wait(/.*/).run((err: Error) => {
+      if (!err) {
+        resolve();
+      } else {
+        reject(err);
+      }
+    });
   });
 }
 

--- a/packages/amplify-e2e-core/src/init/amplifyPush.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPush.ts
@@ -32,7 +32,9 @@ export type LayerPushSettings = {
 /**
  * Function to test amplify push with verbose status
  */
-export function amplifyPush(cwd: string, testingWithLatestCodebase = false): Promise<void> {
+export function amplifyPush(cwd: string, testingWithLatestCodebase = false, settings?: {
+  skipCodegen?: boolean;
+}): Promise<void> {
   return new Promise((resolve, reject) => {
     // Test detailed status
     spawn(getCLIPath(testingWithLatestCodebase), ['status', '-v'], { cwd, stripColors: true, noOutputTimeout: pushTimeoutMS })
@@ -43,12 +45,18 @@ export function amplifyPush(cwd: string, testingWithLatestCodebase = false): Pro
         }
       });
     // Test amplify push
-    spawn(getCLIPath(testingWithLatestCodebase), ['push'], { cwd, stripColors: true, noOutputTimeout: pushTimeoutMS })
+    const pushCommands = spawn(getCLIPath(testingWithLatestCodebase), ['push'], { cwd, stripColors: true, noOutputTimeout: pushTimeoutMS })
       .wait('Are you sure you want to continue?')
-      .sendConfirmYes()
-      .wait('Do you want to generate code for your newly created GraphQL API')
-      .sendConfirmNo()
-      .wait(/.*/)
+      .sendConfirmYes();
+
+    if (!settings?.skipCodegen) {
+      pushCommands.wait('Do you want to generate code for your newly created GraphQL API')
+        .sendConfirmNo()
+        .wait('Do you want to generate code for your newly created GraphQL API')
+        .sendConfirmNo();
+    }
+
+    pushCommands.wait(/.*/)
       .run((err: Error) => {
         if (!err) {
           resolve();

--- a/packages/amplify-e2e-core/src/utils/rds.ts
+++ b/packages/amplify-e2e-core/src/utils/rds.ts
@@ -8,6 +8,7 @@ import {
 import { EC2Client, AuthorizeSecurityGroupIngressCommand, RevokeSecurityGroupIngressCommand } from '@aws-sdk/client-ec2';
 import { knex } from 'knex';
 import axios from 'axios';
+import { sleep } from './sleep';
 
 const DEFAULT_DB_INSTANCE_TYPE = 'db.m5.large';
 const DEFAULT_DB_STORAGE = 8;
@@ -105,6 +106,8 @@ export const setupRDSInstanceAndData = async (
         }),
       ),
     );
+
+    await sleep(1 * 60 * 1000); // Delay for the security rules to take effect
 
     const dbAdapter = new RDSTestDataProvider({
       host: dbConfig.endpoint,

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts
@@ -1,0 +1,866 @@
+import {
+  addApiWithAllAuthModes,
+  amplifyPush,
+  createNewProjectDir,
+  deleteDBInstance,
+  deleteProject,
+  deleteProjectDir,
+  getAppSyncApi,
+  getProjectMeta,
+  importRDSDatabase,
+  initJSProjectWithProfile,
+  setupRDSInstanceAndData,
+  sleep,
+  enableUserPoolUnauthenticatedAccess,
+} from 'amplify-category-api-e2e-core';
+import { existsSync, writeFileSync } from 'fs-extra';
+import generator from 'generate-password';
+import path from 'path';
+import gql from 'graphql-tag';
+import { GQLQueryHelper } from '../query-utils/gql-helper';
+import { GRAPHQL_AUTH_MODE } from '@aws-amplify/api';
+import * as Observable from 'zen-observable';
+import {
+  configureAmplify,
+  getConfiguredAppsyncClientIAMAuth,
+  setupUser,
+  signInUser,
+  getConfiguredAppsyncClientAPIKeyAuth,
+  getConfiguredAppsyncClientLambdaAuth,
+} from '../schema-api-directives';
+import { Auth, API } from 'aws-amplify';
+import { getUserPoolId } from '../schema-api-directives/authHelper';
+import { reconfigureAmplifyAPI, withTimeOut } from '../utils/api';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+// to deal with subscriptions in node env
+(global as any).WebSocket = require('ws');
+
+// delay times
+const SUBSCRIPTION_DELAY = 10000;
+const SUBSCRIPTION_TIMEOUT = 10000;
+
+describe('RDS Relational Directives', () => {
+  const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
+
+  // Generate settings for RDS instance
+  const username = db_user;
+  const password = db_password;
+  let region = 'us-east-1';
+  let port = 3306;
+  const database = 'default_db';
+  let host = 'localhost';
+  const identifier = `integtest${db_identifier}`;
+  const projName = 'rdsmodelauthtest';
+
+  let projRoot;
+  let blogIAMUnauthClient, postIAMUnauthClient, userIAMUnauthClient, profileIAMUnauthClient;
+  let blogIAMAuthClient, postIAMAuthClient, userIAMAuthClient, profileIAMAuthClient;
+  let userApiKeyClient;
+  let userLambdaClient;
+  let apiEndPoint;
+
+  beforeAll(async () => {
+    projRoot = await createNewProjectDir('rdsmodelapi');
+    await initProjectAndImportSchema();
+    await amplifyPush(projRoot);
+
+    await apiGqlCompile(projRoot, false, {
+      forceCompile: true,
+    });
+    await amplifyPush(projRoot, false, {
+      skipCodegen: true,
+    });
+    await sleep(1 * 60 * 1000); // Wait for a minute for the VPC endpoints to be live.
+
+    const meta = getProjectMeta(projRoot);
+    const appRegion = meta.providers.awscloudformation.Region;
+    const { output } = meta.api.rdsmodelauth;
+    const { GraphQLAPIIdOutput, GraphQLAPIEndpointOutput, GraphQLAPIKeyOutput } = output;
+    const { graphqlApi } = await getAppSyncApi(GraphQLAPIIdOutput, appRegion);
+
+    expect(GraphQLAPIIdOutput).toBeDefined();
+    expect(GraphQLAPIEndpointOutput).toBeDefined();
+    expect(GraphQLAPIKeyOutput).toBeDefined();
+
+    expect(graphqlApi).toBeDefined();
+    expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
+
+    apiEndPoint = GraphQLAPIEndpointOutput as string;
+    const apiKey = GraphQLAPIKeyOutput as string;
+
+    await createAppSyncClients(appRegion, apiKey);
+  });
+
+  const createAppSyncClients = async (appRegion, apiKey): Promise<void> => {
+    configureAmplify(projRoot);
+    const unAuthCredentials = await Auth.currentCredentials();
+    const [cognito_username, cognito_password] = ['test@test.com', 'Password123!']
+    const userPoolId = getUserPoolId(projRoot);
+    await setupUser(userPoolId, cognito_username, cognito_password);
+
+    await sleep(30 * 1000); // Wait for 30 seconds for the user to be available in Cognito.
+    await signInUser(cognito_username, cognito_password);
+    const authCredentials = await Auth.currentCredentials();
+    
+    const unauthAppSyncClient = getConfiguredAppsyncClientIAMAuth(apiEndPoint, appRegion, unAuthCredentials);
+    const authAppSyncClient = getConfiguredAppsyncClientIAMAuth(apiEndPoint, appRegion, authCredentials);
+    const apiKeyClient = getConfiguredAppsyncClientAPIKeyAuth(apiEndPoint, appRegion, apiKey);
+    const lambdaClient = getConfiguredAppsyncClientLambdaAuth(apiEndPoint, appRegion, 'custom-authorized');
+
+    blogIAMUnauthClient = constructBlogHelper(unauthAppSyncClient);
+    postIAMUnauthClient = constructPostHelper(unauthAppSyncClient);
+    userIAMUnauthClient = constructUserHelper(unauthAppSyncClient);
+    profileIAMUnauthClient = constructProfileHelper(unauthAppSyncClient);
+    blogIAMAuthClient = constructBlogHelper(authAppSyncClient);
+    postIAMAuthClient = constructPostHelper(authAppSyncClient);
+    userIAMAuthClient = constructUserHelper(authAppSyncClient);
+    profileIAMAuthClient = constructProfileHelper(authAppSyncClient);
+    userApiKeyClient = constructUserHelper(apiKeyClient);
+    userLambdaClient = constructUserHelper(lambdaClient);
+  };
+
+  afterAll(async () => {
+    const metaFilePath = path.join(projRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
+    if (existsSync(metaFilePath)) {
+      await deleteProject(projRoot);
+    }
+    deleteProjectDir(projRoot);
+    await cleanupDatabase();
+  });
+
+  const setupDatabase = async (): Promise<void> => {
+    const dbConfig = {
+      identifier,
+      engine: 'mysql' as const,
+      dbname: database,
+      username,
+      password,
+      region,
+    };
+
+    const queries = [
+      'CREATE TABLE Blog (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255))',
+      'CREATE TABLE Post (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255), blogId VARCHAR(40))',
+      'CREATE TABLE User (id VARCHAR(40) PRIMARY KEY, name VARCHAR(255))',
+      'CREATE TABLE Profile (id VARCHAR(40) PRIMARY KEY, details VARCHAR(255), userId VARCHAR(40))',
+    ];
+
+    const db = await setupRDSInstanceAndData(dbConfig, queries);
+    port = db.port;
+    host = db.endpoint;
+  };
+
+  const cleanupDatabase = async (): Promise<void> => {
+    await deleteDBInstance(identifier, region);
+  };
+
+  const initProjectAndImportSchema = async (): Promise<void> => {
+    const apiName = 'rdsmodelauth';
+    await initJSProjectWithProfile(projRoot, {
+      disableAmplifyAppCreation: false,
+      name: projName,
+    });
+
+    const metaAfterInit = getProjectMeta(projRoot);
+    region = metaAfterInit.providers.awscloudformation.Region;
+    await setupDatabase();
+
+    const rdsSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.rds.graphql');
+
+    await addApiWithAllAuthModes(projRoot, { transformerVersion: 2, apiName });
+    await enableUserPoolUnauthenticatedAccess(projRoot);
+
+    await importRDSDatabase(projRoot, {
+      database,
+      host,
+      port,
+      username,
+      password,
+      useVpc: true,
+      apiExists: true,
+    });
+
+    const schema = /* GraphQL */ `
+      input AMPLIFY {
+        engine: String = "mysql"
+        globalAuthRule: AuthRule = { allow: public }
+      }
+      type Blog @model @auth(rules: [{ allow: private, provider: iam }]) {
+        id: String! @primaryKey
+        content: String
+        posts: [Post] @hasMany(references: ["blogId"])
+      }
+      type Post @model @auth(rules: [{ allow: private, provider: iam }]) {
+        id: String! @primaryKey
+        content: String
+        blogId: String!
+        blog: Blog @belongsTo(references: ["blogId"])
+      }
+      type User @model @auth(rules: [{ allow: public, provider: iam }, { allow: custom }]) {
+        id: String! @primaryKey
+        name: String
+        profile: Profile @hasOne(references: ["userId"])
+      }
+      type Profile @model @auth(rules: [{ allow: public, provider: iam }, { allow: custom }]) {
+        id: String! @primaryKey
+        details: String
+        userId: String!
+        user: User @belongsTo(references: ["userId"])
+      }
+    `;
+    writeFileSync(rdsSchemaFilePath, schema, 'utf8');
+  };
+
+  test('check iam private auth can subscribe to oncreate event on blog', async () => {
+    reconfigureAmplifyAPI(apiEndPoint, region, 'AWS_IAM');
+
+    // Check onCreate subscription
+    const observer = API.graphql({
+      query: gql`
+        subscription OnCreateBlog {
+          onCreateBlog {
+            id
+            content
+          }
+        }
+      `,
+      authMode: GRAPHQL_AUTH_MODE.AWS_IAM,
+    }) as unknown as Observable<any>;
+    
+    let subscription: ZenObservable.Subscription;
+    const subscriptionPromise = new Promise((resolve, _) => {
+      subscription = observer.subscribe((event: any) => {
+        const blog = event.value.data.onCreateBlog;
+        subscription.unsubscribe();
+        expect(blog).toBeDefined();
+        expect(blog).toEqual(
+          expect.objectContaining({
+            id: 'B-1',
+            content: 'Blog 1',
+          }),
+        );
+        resolve(undefined);
+      }, (err) => {
+        console.log(JSON.stringify(err.error.errors, null, 4));
+        throw new Error('IAM client should be able to subscribe on blog');
+      });
+    });
+  
+    await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
+  
+    await blogIAMAuthClient.create('createBlog', {
+      id: 'B-1',
+      content: 'Blog 1',
+    });
+  
+    return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateBlog Subscription timed out', () => {
+      subscription?.unsubscribe();
+    });
+  });
+
+  test('check iam private auth can subscribe to oncreate event on blog with runtime filter', async () => {
+    reconfigureAmplifyAPI(apiEndPoint, region, 'AWS_IAM');
+
+    // Check onCreate subscription
+    const observer = API.graphql({
+      query: gql`
+        subscription OnCreateBlog($filter: ModelSubscriptionBlogFilterInput) {
+          onCreateBlog(filter: $filter) {
+            id
+            content
+          }
+        }
+      `,
+      variables: {
+        filter: {
+          content: {
+            eq: 'Blog 3',
+          },
+        },
+      },
+      authMode: GRAPHQL_AUTH_MODE.AWS_IAM,
+    }) as unknown as Observable<any>;
+    
+    let subscription: ZenObservable.Subscription;
+    const subscriptionPromise = new Promise((resolve, _) => {
+      subscription = observer.subscribe((event: any) => {
+        const blog = event.value.data.onCreateBlog;
+        subscription.unsubscribe();
+        expect(blog).toBeDefined();
+        expect(blog).toEqual(
+          expect.objectContaining({
+            id: 'B-3',
+            content: 'Blog 3',
+          }),
+        );
+        resolve(undefined);
+      }, (err) => {
+        console.log(JSON.stringify(err.error.errors, null, 4));
+        throw new Error('IAM client should be able to subscribe on blog');
+      });
+    });
+  
+    await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
+  
+    await blogIAMAuthClient.create('createBlog', {
+      id: 'B-2',
+      content: 'Blog 2',
+    });
+
+    await blogIAMAuthClient.create('createBlog', {
+      id: 'B-3',
+      content: 'Blog 3',
+    });
+  
+    return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateBlog Subscription timed out', () => {
+      subscription?.unsubscribe();
+    });
+  });
+
+  test('check iam private auth can subscribe to onupdate event on blog', async () => {
+    reconfigureAmplifyAPI(apiEndPoint, region, 'AWS_IAM');
+
+    // Check onUpdate subscription
+    const observer = API.graphql({
+      query: gql`
+        subscription OnUpdateBlog {
+          onUpdateBlog {
+            id
+            content
+          }
+        }
+      `,
+      authMode: GRAPHQL_AUTH_MODE.AWS_IAM,
+    }) as unknown as Observable<any>;
+    
+    let subscription: ZenObservable.Subscription;
+    const subscriptionPromise = new Promise((resolve, _) => {
+      subscription = observer.subscribe((event: any) => {
+        const blog = event.value.data.onUpdateBlog;
+        subscription.unsubscribe();
+        expect(blog).toBeDefined();
+        expect(blog).toEqual(
+          expect.objectContaining({
+            id: 'B-1',
+            content: 'Blog 1 - Updated',
+          }),
+        );
+        resolve(undefined);
+      }, (err) => {
+        console.log(JSON.stringify(err.error.errors, null, 4));
+        throw new Error('IAM client should be able to subscribe on blog');
+      });
+    });
+  
+    await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
+  
+    await blogIAMAuthClient.update('updateBlog', {
+      id: 'B-1',
+      content: 'Blog 1 - Updated',
+    });
+  
+    return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnUpdateBlog Subscription timed out', () => {
+      subscription?.unsubscribe();
+    });
+  });
+
+  test('check iam private auth can subscribe to ondelete event on blog', async () => {
+    reconfigureAmplifyAPI(apiEndPoint, region, 'AWS_IAM');
+
+    // Check onDelete subscription
+    const observer = API.graphql({
+      query: gql`
+        subscription OnDeleteBlog {
+          onDeleteBlog {
+            id
+            content
+          }
+        }
+      `,
+      authMode: GRAPHQL_AUTH_MODE.AWS_IAM,
+    }) as unknown as Observable<any>;
+    
+    let subscription: ZenObservable.Subscription;
+    const subscriptionPromise = new Promise((resolve, _) => {
+      subscription = observer.subscribe((event: any) => {
+        const blog = event.value.data.onDeleteBlog;
+        subscription.unsubscribe();
+        expect(blog).toBeDefined();
+        expect(blog).toEqual(
+          expect.objectContaining({
+            id: 'B-1',
+            content: 'Blog 1 - Updated',
+          }),
+        );
+        resolve(undefined);
+      }, (err) => {
+        console.log(JSON.stringify(err.error.errors, null, 4));
+        throw new Error('IAM client should be able to subscribe on blog');
+      });
+    });
+  
+    await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
+  
+    await blogIAMAuthClient.delete('deleteBlog', {
+      id: 'B-1',
+    });
+  
+    return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnDeleteBlog Subscription timed out', () => {
+      subscription?.unsubscribe();
+    });
+  });
+
+  test('check api key should not be able to subscribe on blog', async () => {
+    const observer = API.graphql({
+      query: gql`
+        subscription OnCreateBlog {
+          onCreateBlog {
+            id
+            content
+          }
+        }
+      `,
+      authMode: GRAPHQL_AUTH_MODE.API_KEY,
+    }) as unknown as Observable<any>;
+    let subscription: ZenObservable.Subscription;
+    const subscriptionPromise = new Promise((resolve, _) => {
+      subscription = observer.subscribe((event: any) => {
+        throw new Error('Should not have received any event');
+        resolve(undefined);
+      }, (err) => {
+        expect(err.error.errors[0].message).toEqual(expect.stringContaining('Not Authorized to access onCreateBlog on type Subscription'));
+        resolve(undefined);
+      });
+    });
+  
+    await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
+  
+    return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateBlog Subscription timed out', () => {
+      subscription?.unsubscribe();
+    });
+  });
+
+  test('check lambda auth can subscribe to oncreate event on user', async () => {
+    reconfigureAmplifyAPI(apiEndPoint, region, 'AWS_LAMBDA');
+
+    // Check onCreate subscription
+    const observer = API.graphql({
+      query: gql`
+        subscription OnCreateUser {
+          onCreateUser {
+            id
+            name
+          }
+        }
+      `,
+      authMode: GRAPHQL_AUTH_MODE.AWS_LAMBDA,
+      authToken: 'custom-authorized',
+    }) as unknown as Observable<any>;
+    
+    let subscription: ZenObservable.Subscription;
+    const subscriptionPromise = new Promise((resolve, _) => {
+      subscription = observer.subscribe((event: any) => {
+        const user = event.value.data.onCreateUser;
+        subscription.unsubscribe();
+        expect(user).toBeDefined();
+        expect(user).toEqual(
+          expect.objectContaining({
+            id: 'U-1',
+            name: 'User 1',
+          }),
+        );
+        resolve(undefined);
+      }, (err) => {
+        console.log(JSON.stringify(err.error.errors, null, 4));
+        throw new Error('Lambda client should be able to subscribe on user');
+      });
+    });
+  
+    await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
+  
+    await userLambdaClient.create('createUser', {
+      id: 'U-1',
+      name: 'User 1',
+    });
+  
+    return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateUser Subscription timed out', () => {
+      subscription?.unsubscribe();
+    });
+  });
+
+  test('check lambda auth can subscribe to oncreate event on user with runtime filter', async () => {
+    reconfigureAmplifyAPI(apiEndPoint, region, 'AWS_LAMBDA');
+
+    // Check onCreate subscription
+    const observer = API.graphql({
+      query: gql`
+        subscription OnCreateUser($filter: ModelSubscriptionUserFilterInput) {
+          onCreateUser(filter: $filter) {
+            id
+            name
+          }
+        }
+      `,
+      variables: {
+        filter: {
+          name: {
+            eq: 'User 3',
+          },
+        },
+      },
+      authMode: GRAPHQL_AUTH_MODE.AWS_LAMBDA,
+      authToken: 'custom-authorized',
+    }) as unknown as Observable<any>;
+    
+    let subscription: ZenObservable.Subscription;
+    const subscriptionPromise = new Promise((resolve, _) => {
+      subscription = observer.subscribe((event: any) => {
+        const user = event.value.data.onCreateUser;
+        subscription.unsubscribe();
+        expect(user).toBeDefined();
+        expect(user).toEqual(
+          expect.objectContaining({
+            id: 'U-3',
+            name: 'User 3',
+          }),
+        );
+        resolve(undefined);
+      }, (err) => {
+        console.log(JSON.stringify(err.error.errors, null, 4));
+        throw new Error('Lambda client should be able to subscribe on user');
+      });
+    });
+  
+    await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
+  
+    await userLambdaClient.create('createUser', {
+      id: 'U-2',
+      name: 'User 2',
+    });
+
+    await userLambdaClient.create('createUser', {
+      id: 'U-3',
+      name: 'User 3',
+    });
+  
+    return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateUser Subscription timed out', () => {
+      subscription?.unsubscribe();
+    });
+  });
+
+  test('check lambda auth can subscribe to onupdate event on user with runtime filter', async () => {
+    reconfigureAmplifyAPI(apiEndPoint, region, 'AWS_LAMBDA');
+
+    // Check onUpdate subscription
+    const observer = API.graphql({
+      query: gql`
+        subscription OnUpdateUser($filter: ModelSubscriptionUserFilterInput) {
+          onUpdateUser(filter: $filter) {
+            id
+            name
+          }
+        }
+      `,
+      variables: {
+        filter: {
+          name: {
+            eq: 'User 3 - Updated',
+          },
+        },
+      },
+      authMode: GRAPHQL_AUTH_MODE.AWS_LAMBDA,
+      authToken: 'custom-authorized',
+    }) as unknown as Observable<any>;
+    
+    let subscription: ZenObservable.Subscription;
+    const subscriptionPromise = new Promise((resolve, _) => {
+      subscription = observer.subscribe((event: any) => {
+        const user = event.value.data.onUpdateUser;
+        subscription.unsubscribe();
+        expect(user).toBeDefined();
+        expect(user).toEqual(
+          expect.objectContaining({
+            id: 'U-3',
+            name: 'User 3 - Updated',
+          }),
+        );
+        resolve(undefined);
+      }, (err) => {
+        console.log(JSON.stringify(err.error.errors, null, 4));
+        throw new Error('Lambda client should be able to subscribe on user');
+      });
+    });
+  
+    await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
+  
+    await userLambdaClient.update('updateUser', {
+      id: 'U-2',
+      name: 'User 2 - Updated',
+    });
+
+    await userLambdaClient.update('updateUser', {
+      id: 'U-3',
+      name: 'User 3 - Updated',
+    });
+  
+    return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnUpdateUser Subscription timed out', () => {
+      subscription?.unsubscribe();
+    });
+  });
+
+  test('check lambda auth can subscribe to ondelete event on user with runtime filter', async () => {
+    reconfigureAmplifyAPI(apiEndPoint, region, 'AWS_LAMBDA');
+
+    // Check onDelete subscription
+    const observer = API.graphql({
+      query: gql`
+        subscription OnDeleteUser($filter: ModelSubscriptionUserFilterInput) {
+          onDeleteUser(filter: $filter) {
+            id
+            name
+          }
+        }
+      `,
+      variables: {
+        filter: {
+          name: {
+            eq: 'User 3 - Updated',
+          },
+        },
+      },
+      authMode: GRAPHQL_AUTH_MODE.AWS_LAMBDA,
+      authToken: 'custom-authorized',
+    }) as unknown as Observable<any>;
+    
+    let subscription: ZenObservable.Subscription;
+    const subscriptionPromise = new Promise((resolve, _) => {
+      subscription = observer.subscribe((event: any) => {
+        const user = event.value.data.onDeleteUser;
+        subscription.unsubscribe();
+        expect(user).toBeDefined();
+        expect(user).toEqual(
+          expect.objectContaining({
+            id: 'U-3',
+            name: 'User 3 - Updated',
+          }),
+        );
+        resolve(undefined);
+      }, (err) => {
+        console.log(JSON.stringify(err.error.errors, null, 4));
+        throw new Error('Lambda client should be able to subscribe on user');
+      });
+    });
+  
+    await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
+  
+    await userLambdaClient.delete('deleteUser', {
+      id: 'U-2',
+    });
+
+    await userLambdaClient.delete('deleteUser', {
+      id: 'U-3',
+    });
+  
+    return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnDeleteUser Subscription timed out', () => {
+      subscription?.unsubscribe();
+    });
+  });
+
+  const constructBlogHelper = (client): GQLQueryHelper => {
+    const createSelectionSet = /* GraphQL */ `
+      id
+      content
+    `;
+    const updateSelectionSet = createSelectionSet;
+    const deleteSelectionSet = createSelectionSet;
+    const getSelectionSet = /* GraphQL */ `
+      query GetBlog($id: String!) {
+        getBlog(id: $id) {
+          id
+          content
+          posts {
+            items {
+              id
+              content
+            }
+          }
+        }
+      }
+    `;
+    const listSelectionSet = /* GraphQL */ `
+      query ListBlogs {
+        listBlogs {
+          items {
+            id
+            content
+            posts {
+              items {
+                id
+                content
+              }
+            }
+          }
+        }
+      }
+    `;
+    const helper = new GQLQueryHelper(client, 'Blog', {
+      mutation: {
+        create: createSelectionSet,
+        update: updateSelectionSet,
+        delete: deleteSelectionSet,
+      },
+      query: {
+        get: getSelectionSet,
+        list: listSelectionSet,
+      },
+    });
+
+    return helper;
+  };
+
+  const constructPostHelper = (client): GQLQueryHelper => {
+    const createSelectionSet = /* GraphQL */ `
+      id
+      content
+    `;
+    const updateSelectionSet = createSelectionSet;
+    const deleteSelectionSet = createSelectionSet;
+    const getSelectionSet = /* GraphQL */ `
+      query GetPost($id: String!) {
+        getPost(id: $id) {
+          id
+          content
+          blog {
+            id
+            content
+          }
+        }
+      }
+    `;
+    const listSelectionSet = /* GraphQL */ `
+      query ListPosts {
+        listPosts {
+          items {
+            id
+            content
+            blog {
+              id
+              content
+            }
+          }
+        }
+      }
+    `;
+    const helper = new GQLQueryHelper(client, 'Post', {
+      mutation: {
+        create: createSelectionSet,
+        update: updateSelectionSet,
+        delete: deleteSelectionSet,
+      },
+      query: {
+        get: getSelectionSet,
+        list: listSelectionSet,
+      },
+    });
+
+    return helper;
+  };
+
+  const constructUserHelper = (client): GQLQueryHelper => {
+    const createSelectionSet = /* GraphQL */ `
+      id
+      name
+    `;
+    const updateSelectionSet = createSelectionSet;
+    const deleteSelectionSet = createSelectionSet;
+    const getSelectionSet = /* GraphQL */ `
+      query GetUser($id: String!) {
+        getUser(id: $id) {
+          id
+          name
+          profile {
+            id
+            details
+          }
+        }
+      }
+    `;
+    const listSelectionSet = /* GraphQL */ `
+      query ListUsers {
+        listUsers {
+          items {
+            id
+            name
+            profile {
+              id
+              details
+            }
+          }
+        }
+      }
+    `;
+    const helper = new GQLQueryHelper(client, 'User', {
+      mutation: {
+        create: createSelectionSet,
+        update: updateSelectionSet,
+        delete: deleteSelectionSet,
+      },
+      query: {
+        get: getSelectionSet,
+        list: listSelectionSet,
+      },
+    });
+
+    return helper;
+  };
+
+  const constructProfileHelper = (client): GQLQueryHelper => {
+    const createSelectionSet = /* GraphQL */ `
+      id
+      details
+    `;
+    const updateSelectionSet = createSelectionSet;
+    const deleteSelectionSet = createSelectionSet;
+    const getSelectionSet = /* GraphQL */ `
+      query GetProfile($id: String!) {
+        getProfile(id: $id) {
+          id
+          details
+          user {
+            id
+            name
+          }
+        }
+      }
+    `;
+    const listSelectionSet = /* GraphQL */ `
+      query ListProfiles {
+        listProfiles {
+          items {
+            id
+            details
+            user {
+              id
+              name
+            }
+          }
+        }
+      }
+    `;
+    const helper = new GQLQueryHelper(client, 'Profile', {
+      mutation: {
+        create: createSelectionSet,
+        update: updateSelectionSet,
+        delete: deleteSelectionSet,
+      },
+      query: {
+        get: getSelectionSet,
+        list: listSelectionSet,
+      },
+    });
+
+    return helper;
+  };
+});

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts
@@ -12,6 +12,7 @@ import {
   setupRDSInstanceAndData,
   sleep,
   enableUserPoolUnauthenticatedAccess,
+  apiGqlCompile,
 } from 'amplify-category-api-e2e-core';
 import { existsSync, writeFileSync } from 'fs-extra';
 import generator from 'generate-password';

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts
@@ -96,14 +96,14 @@ describe('RDS Relational Directives', () => {
   const createAppSyncClients = async (appRegion, apiKey): Promise<void> => {
     configureAmplify(projRoot);
     const unAuthCredentials = await Auth.currentCredentials();
-    const [cognito_username, cognito_password] = ['test@test.com', 'Password123!']
+    const [cognito_username, cognito_password] = ['test@test.com', 'Password123!'];
     const userPoolId = getUserPoolId(projRoot);
     await setupUser(userPoolId, cognito_username, cognito_password);
 
     await sleep(30 * 1000); // Wait for 30 seconds for the user to be available in Cognito.
     await signInUser(cognito_username, cognito_password);
     const authCredentials = await Auth.currentCredentials();
-    
+
     const unauthAppSyncClient = getConfiguredAppsyncClientIAMAuth(apiEndPoint, appRegion, unAuthCredentials);
     const authAppSyncClient = getConfiguredAppsyncClientIAMAuth(apiEndPoint, appRegion, authCredentials);
     const apiKeyClient = getConfiguredAppsyncClientAPIKeyAuth(apiEndPoint, appRegion, apiKey);
@@ -228,33 +228,36 @@ describe('RDS Relational Directives', () => {
       `,
       authMode: GRAPHQL_AUTH_MODE.AWS_IAM,
     }) as unknown as Observable<any>;
-    
+
     let subscription: ZenObservable.Subscription;
     const subscriptionPromise = new Promise((resolve, _) => {
-      subscription = observer.subscribe((event: any) => {
-        const blog = event.value.data.onCreateBlog;
-        subscription.unsubscribe();
-        expect(blog).toBeDefined();
-        expect(blog).toEqual(
-          expect.objectContaining({
-            id: 'B-1',
-            content: 'Blog 1',
-          }),
-        );
-        resolve(undefined);
-      }, (err) => {
-        console.log(JSON.stringify(err.error.errors, null, 4));
-        throw new Error('IAM client should be able to subscribe on blog');
-      });
+      subscription = observer.subscribe(
+        (event: any) => {
+          const blog = event.value.data.onCreateBlog;
+          subscription.unsubscribe();
+          expect(blog).toBeDefined();
+          expect(blog).toEqual(
+            expect.objectContaining({
+              id: 'B-1',
+              content: 'Blog 1',
+            }),
+          );
+          resolve(undefined);
+        },
+        (err) => {
+          console.log(JSON.stringify(err.error.errors, null, 4));
+          throw new Error('IAM client should be able to subscribe on blog');
+        },
+      );
     });
-  
+
     await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
-  
+
     await blogIAMAuthClient.create('createBlog', {
       id: 'B-1',
       content: 'Blog 1',
     });
-  
+
     return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateBlog Subscription timed out', () => {
       subscription?.unsubscribe();
     });
@@ -282,28 +285,31 @@ describe('RDS Relational Directives', () => {
       },
       authMode: GRAPHQL_AUTH_MODE.AWS_IAM,
     }) as unknown as Observable<any>;
-    
+
     let subscription: ZenObservable.Subscription;
     const subscriptionPromise = new Promise((resolve, _) => {
-      subscription = observer.subscribe((event: any) => {
-        const blog = event.value.data.onCreateBlog;
-        subscription.unsubscribe();
-        expect(blog).toBeDefined();
-        expect(blog).toEqual(
-          expect.objectContaining({
-            id: 'B-3',
-            content: 'Blog 3',
-          }),
-        );
-        resolve(undefined);
-      }, (err) => {
-        console.log(JSON.stringify(err.error.errors, null, 4));
-        throw new Error('IAM client should be able to subscribe on blog');
-      });
+      subscription = observer.subscribe(
+        (event: any) => {
+          const blog = event.value.data.onCreateBlog;
+          subscription.unsubscribe();
+          expect(blog).toBeDefined();
+          expect(blog).toEqual(
+            expect.objectContaining({
+              id: 'B-3',
+              content: 'Blog 3',
+            }),
+          );
+          resolve(undefined);
+        },
+        (err) => {
+          console.log(JSON.stringify(err.error.errors, null, 4));
+          throw new Error('IAM client should be able to subscribe on blog');
+        },
+      );
     });
-  
+
     await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
-  
+
     await blogIAMAuthClient.create('createBlog', {
       id: 'B-2',
       content: 'Blog 2',
@@ -313,7 +319,7 @@ describe('RDS Relational Directives', () => {
       id: 'B-3',
       content: 'Blog 3',
     });
-  
+
     return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateBlog Subscription timed out', () => {
       subscription?.unsubscribe();
     });
@@ -334,33 +340,36 @@ describe('RDS Relational Directives', () => {
       `,
       authMode: GRAPHQL_AUTH_MODE.AWS_IAM,
     }) as unknown as Observable<any>;
-    
+
     let subscription: ZenObservable.Subscription;
     const subscriptionPromise = new Promise((resolve, _) => {
-      subscription = observer.subscribe((event: any) => {
-        const blog = event.value.data.onUpdateBlog;
-        subscription.unsubscribe();
-        expect(blog).toBeDefined();
-        expect(blog).toEqual(
-          expect.objectContaining({
-            id: 'B-1',
-            content: 'Blog 1 - Updated',
-          }),
-        );
-        resolve(undefined);
-      }, (err) => {
-        console.log(JSON.stringify(err.error.errors, null, 4));
-        throw new Error('IAM client should be able to subscribe on blog');
-      });
+      subscription = observer.subscribe(
+        (event: any) => {
+          const blog = event.value.data.onUpdateBlog;
+          subscription.unsubscribe();
+          expect(blog).toBeDefined();
+          expect(blog).toEqual(
+            expect.objectContaining({
+              id: 'B-1',
+              content: 'Blog 1 - Updated',
+            }),
+          );
+          resolve(undefined);
+        },
+        (err) => {
+          console.log(JSON.stringify(err.error.errors, null, 4));
+          throw new Error('IAM client should be able to subscribe on blog');
+        },
+      );
     });
-  
+
     await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
-  
+
     await blogIAMAuthClient.update('updateBlog', {
       id: 'B-1',
       content: 'Blog 1 - Updated',
     });
-  
+
     return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnUpdateBlog Subscription timed out', () => {
       subscription?.unsubscribe();
     });
@@ -381,32 +390,35 @@ describe('RDS Relational Directives', () => {
       `,
       authMode: GRAPHQL_AUTH_MODE.AWS_IAM,
     }) as unknown as Observable<any>;
-    
+
     let subscription: ZenObservable.Subscription;
     const subscriptionPromise = new Promise((resolve, _) => {
-      subscription = observer.subscribe((event: any) => {
-        const blog = event.value.data.onDeleteBlog;
-        subscription.unsubscribe();
-        expect(blog).toBeDefined();
-        expect(blog).toEqual(
-          expect.objectContaining({
-            id: 'B-1',
-            content: 'Blog 1 - Updated',
-          }),
-        );
-        resolve(undefined);
-      }, (err) => {
-        console.log(JSON.stringify(err.error.errors, null, 4));
-        throw new Error('IAM client should be able to subscribe on blog');
-      });
+      subscription = observer.subscribe(
+        (event: any) => {
+          const blog = event.value.data.onDeleteBlog;
+          subscription.unsubscribe();
+          expect(blog).toBeDefined();
+          expect(blog).toEqual(
+            expect.objectContaining({
+              id: 'B-1',
+              content: 'Blog 1 - Updated',
+            }),
+          );
+          resolve(undefined);
+        },
+        (err) => {
+          console.log(JSON.stringify(err.error.errors, null, 4));
+          throw new Error('IAM client should be able to subscribe on blog');
+        },
+      );
     });
-  
+
     await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
-  
+
     await blogIAMAuthClient.delete('deleteBlog', {
       id: 'B-1',
     });
-  
+
     return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnDeleteBlog Subscription timed out', () => {
       subscription?.unsubscribe();
     });
@@ -426,17 +438,22 @@ describe('RDS Relational Directives', () => {
     }) as unknown as Observable<any>;
     let subscription: ZenObservable.Subscription;
     const subscriptionPromise = new Promise((resolve, _) => {
-      subscription = observer.subscribe((event: any) => {
-        throw new Error('Should not have received any event');
-        resolve(undefined);
-      }, (err) => {
-        expect(err.error.errors[0].message).toEqual(expect.stringContaining('Not Authorized to access onCreateBlog on type Subscription'));
-        resolve(undefined);
-      });
+      subscription = observer.subscribe(
+        (event: any) => {
+          throw new Error('Should not have received any event');
+          resolve(undefined);
+        },
+        (err) => {
+          expect(err.error.errors[0].message).toEqual(
+            expect.stringContaining('Not Authorized to access onCreateBlog on type Subscription'),
+          );
+          resolve(undefined);
+        },
+      );
     });
-  
+
     await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
-  
+
     return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateBlog Subscription timed out', () => {
       subscription?.unsubscribe();
     });
@@ -458,33 +475,36 @@ describe('RDS Relational Directives', () => {
       authMode: GRAPHQL_AUTH_MODE.AWS_LAMBDA,
       authToken: 'custom-authorized',
     }) as unknown as Observable<any>;
-    
+
     let subscription: ZenObservable.Subscription;
     const subscriptionPromise = new Promise((resolve, _) => {
-      subscription = observer.subscribe((event: any) => {
-        const user = event.value.data.onCreateUser;
-        subscription.unsubscribe();
-        expect(user).toBeDefined();
-        expect(user).toEqual(
-          expect.objectContaining({
-            id: 'U-1',
-            name: 'User 1',
-          }),
-        );
-        resolve(undefined);
-      }, (err) => {
-        console.log(JSON.stringify(err.error.errors, null, 4));
-        throw new Error('Lambda client should be able to subscribe on user');
-      });
+      subscription = observer.subscribe(
+        (event: any) => {
+          const user = event.value.data.onCreateUser;
+          subscription.unsubscribe();
+          expect(user).toBeDefined();
+          expect(user).toEqual(
+            expect.objectContaining({
+              id: 'U-1',
+              name: 'User 1',
+            }),
+          );
+          resolve(undefined);
+        },
+        (err) => {
+          console.log(JSON.stringify(err.error.errors, null, 4));
+          throw new Error('Lambda client should be able to subscribe on user');
+        },
+      );
     });
-  
+
     await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
-  
+
     await userLambdaClient.create('createUser', {
       id: 'U-1',
       name: 'User 1',
     });
-  
+
     return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateUser Subscription timed out', () => {
       subscription?.unsubscribe();
     });
@@ -513,28 +533,31 @@ describe('RDS Relational Directives', () => {
       authMode: GRAPHQL_AUTH_MODE.AWS_LAMBDA,
       authToken: 'custom-authorized',
     }) as unknown as Observable<any>;
-    
+
     let subscription: ZenObservable.Subscription;
     const subscriptionPromise = new Promise((resolve, _) => {
-      subscription = observer.subscribe((event: any) => {
-        const user = event.value.data.onCreateUser;
-        subscription.unsubscribe();
-        expect(user).toBeDefined();
-        expect(user).toEqual(
-          expect.objectContaining({
-            id: 'U-3',
-            name: 'User 3',
-          }),
-        );
-        resolve(undefined);
-      }, (err) => {
-        console.log(JSON.stringify(err.error.errors, null, 4));
-        throw new Error('Lambda client should be able to subscribe on user');
-      });
+      subscription = observer.subscribe(
+        (event: any) => {
+          const user = event.value.data.onCreateUser;
+          subscription.unsubscribe();
+          expect(user).toBeDefined();
+          expect(user).toEqual(
+            expect.objectContaining({
+              id: 'U-3',
+              name: 'User 3',
+            }),
+          );
+          resolve(undefined);
+        },
+        (err) => {
+          console.log(JSON.stringify(err.error.errors, null, 4));
+          throw new Error('Lambda client should be able to subscribe on user');
+        },
+      );
     });
-  
+
     await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
-  
+
     await userLambdaClient.create('createUser', {
       id: 'U-2',
       name: 'User 2',
@@ -544,7 +567,7 @@ describe('RDS Relational Directives', () => {
       id: 'U-3',
       name: 'User 3',
     });
-  
+
     return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnCreateUser Subscription timed out', () => {
       subscription?.unsubscribe();
     });
@@ -573,28 +596,31 @@ describe('RDS Relational Directives', () => {
       authMode: GRAPHQL_AUTH_MODE.AWS_LAMBDA,
       authToken: 'custom-authorized',
     }) as unknown as Observable<any>;
-    
+
     let subscription: ZenObservable.Subscription;
     const subscriptionPromise = new Promise((resolve, _) => {
-      subscription = observer.subscribe((event: any) => {
-        const user = event.value.data.onUpdateUser;
-        subscription.unsubscribe();
-        expect(user).toBeDefined();
-        expect(user).toEqual(
-          expect.objectContaining({
-            id: 'U-3',
-            name: 'User 3 - Updated',
-          }),
-        );
-        resolve(undefined);
-      }, (err) => {
-        console.log(JSON.stringify(err.error.errors, null, 4));
-        throw new Error('Lambda client should be able to subscribe on user');
-      });
+      subscription = observer.subscribe(
+        (event: any) => {
+          const user = event.value.data.onUpdateUser;
+          subscription.unsubscribe();
+          expect(user).toBeDefined();
+          expect(user).toEqual(
+            expect.objectContaining({
+              id: 'U-3',
+              name: 'User 3 - Updated',
+            }),
+          );
+          resolve(undefined);
+        },
+        (err) => {
+          console.log(JSON.stringify(err.error.errors, null, 4));
+          throw new Error('Lambda client should be able to subscribe on user');
+        },
+      );
     });
-  
+
     await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
-  
+
     await userLambdaClient.update('updateUser', {
       id: 'U-2',
       name: 'User 2 - Updated',
@@ -604,7 +630,7 @@ describe('RDS Relational Directives', () => {
       id: 'U-3',
       name: 'User 3 - Updated',
     });
-  
+
     return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnUpdateUser Subscription timed out', () => {
       subscription?.unsubscribe();
     });
@@ -633,28 +659,31 @@ describe('RDS Relational Directives', () => {
       authMode: GRAPHQL_AUTH_MODE.AWS_LAMBDA,
       authToken: 'custom-authorized',
     }) as unknown as Observable<any>;
-    
+
     let subscription: ZenObservable.Subscription;
     const subscriptionPromise = new Promise((resolve, _) => {
-      subscription = observer.subscribe((event: any) => {
-        const user = event.value.data.onDeleteUser;
-        subscription.unsubscribe();
-        expect(user).toBeDefined();
-        expect(user).toEqual(
-          expect.objectContaining({
-            id: 'U-3',
-            name: 'User 3 - Updated',
-          }),
-        );
-        resolve(undefined);
-      }, (err) => {
-        console.log(JSON.stringify(err.error.errors, null, 4));
-        throw new Error('Lambda client should be able to subscribe on user');
-      });
+      subscription = observer.subscribe(
+        (event: any) => {
+          const user = event.value.data.onDeleteUser;
+          subscription.unsubscribe();
+          expect(user).toBeDefined();
+          expect(user).toEqual(
+            expect.objectContaining({
+              id: 'U-3',
+              name: 'User 3 - Updated',
+            }),
+          );
+          resolve(undefined);
+        },
+        (err) => {
+          console.log(JSON.stringify(err.error.errors, null, 4));
+          throw new Error('Lambda client should be able to subscribe on user');
+        },
+      );
     });
-  
+
     await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
-  
+
     await userLambdaClient.delete('deleteUser', {
       id: 'U-2',
     });
@@ -662,7 +691,7 @@ describe('RDS Relational Directives', () => {
     await userLambdaClient.delete('deleteUser', {
       id: 'U-3',
     });
-  
+
     return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'OnDeleteUser Subscription timed out', () => {
       subscription?.unsubscribe();
     });

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-iam.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-iam.test.ts
@@ -11,12 +11,22 @@ import {
   initJSProjectWithProfile,
   setupRDSInstanceAndData,
   sleep,
+  enableUserPoolUnauthenticatedAccess,
 } from 'amplify-category-api-e2e-core';
 import { existsSync, writeFileSync } from 'fs-extra';
 import generator from 'generate-password';
 import path from 'path';
 import { GQLQueryHelper } from '../query-utils/gql-helper';
-import { getConfiguredAppsyncClientAPIKeyAuth, getConfiguredAppsyncClientLambdaAuth } from '../schema-api-directives';
+import {
+  configureAmplify,
+  getConfiguredAppsyncClientIAMAuth,
+  setupUser,
+  signInUser,
+  getConfiguredAppsyncClientAPIKeyAuth,
+  getConfiguredAppsyncClientLambdaAuth,
+} from '../schema-api-directives';
+import { Auth } from 'aws-amplify';
+import { getUserPoolId } from '../schema-api-directives/authHelper';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -35,14 +45,21 @@ describe('RDS Relational Directives', () => {
   const projName = 'rdsmodelauthtest';
 
   let projRoot;
-  let blogApiKeyClient, postApiKeyClient, userApiKeyClient, profileApiKeyClient;
-  let blogLambdaClient, postLambdaClient, userLambdaClient, profileLambdaClient;
+  let blogIAMUnauthClient, postIAMUnauthClient, userIAMUnauthClient, profileIAMUnauthClient;
+  let blogIAMAuthClient, postIAMAuthClient, userIAMAuthClient, profileIAMAuthClient;
+  let userApiKeyClient;
+  let userLambdaClient;
 
   beforeAll(async () => {
     projRoot = await createNewProjectDir('rdsmodelapi');
     await initProjectAndImportSchema();
     await amplifyPush(projRoot);
-    await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
+
+    // Enable unauthenticated access to the Cognito resource and push again
+    await enableUserPoolUnauthenticatedAccess(projRoot);
+    await amplifyPush(projRoot);
+
+    await sleep(1 * 60 * 1000); // Wait for a minute for the VPC endpoints to be live.
 
     const meta = getProjectMeta(projRoot);
     const appRegion = meta.providers.awscloudformation.Region;
@@ -60,20 +77,33 @@ describe('RDS Relational Directives', () => {
     const apiEndPoint = GraphQLAPIEndpointOutput as string;
     const apiKey = GraphQLAPIKeyOutput as string;
 
-    createAppSyncClients(apiEndPoint, appRegion, apiKey);
+    await createAppSyncClients(apiEndPoint, appRegion, apiKey);
   });
 
-  const createAppSyncClients = (apiEndPoint, appRegion, apiKey): void => {
+  const createAppSyncClients = async (apiEndPoint, appRegion, apiKey): Promise<void> => {
+    configureAmplify(projRoot);
+    const unAuthCredentials = await Auth.currentCredentials();
+    const [cognito_username, cognito_password] = ['test@test.com', 'Password123!']
+    const userPoolId = getUserPoolId(projRoot);
+    await setupUser(userPoolId, cognito_username, cognito_password);
+    await signInUser(cognito_username, cognito_password);
+    const authCredentials = await Auth.currentCredentials();
+    
+    const unauthAppSyncClient = getConfiguredAppsyncClientIAMAuth(apiEndPoint, appRegion, unAuthCredentials);
+    const authAppSyncClient = getConfiguredAppsyncClientIAMAuth(apiEndPoint, appRegion, authCredentials);
     const apiKeyClient = getConfiguredAppsyncClientAPIKeyAuth(apiEndPoint, appRegion, apiKey);
     const lambdaClient = getConfiguredAppsyncClientLambdaAuth(apiEndPoint, appRegion, 'custom-authorized');
-    blogApiKeyClient = constructBlogHelper(apiKeyClient);
-    postApiKeyClient = constructPostHelper(apiKeyClient);
+
+    blogIAMUnauthClient = constructBlogHelper(unauthAppSyncClient);
+    postIAMUnauthClient = constructPostHelper(unauthAppSyncClient);
+    userIAMUnauthClient = constructUserHelper(unauthAppSyncClient);
+    profileIAMUnauthClient = constructProfileHelper(unauthAppSyncClient);
+    blogIAMAuthClient = constructBlogHelper(authAppSyncClient);
+    postIAMAuthClient = constructPostHelper(authAppSyncClient);
+    userIAMAuthClient = constructUserHelper(authAppSyncClient);
+    profileIAMAuthClient = constructProfileHelper(authAppSyncClient);
     userApiKeyClient = constructUserHelper(apiKeyClient);
-    profileApiKeyClient = constructProfileHelper(apiKeyClient);
-    blogLambdaClient = constructBlogHelper(lambdaClient);
-    postLambdaClient = constructPostHelper(lambdaClient);
     userLambdaClient = constructUserHelper(lambdaClient);
-    profileLambdaClient = constructProfileHelper(lambdaClient);
   };
 
   afterAll(async () => {
@@ -141,23 +171,23 @@ describe('RDS Relational Directives', () => {
         engine: String = "mysql"
         globalAuthRule: AuthRule = { allow: public }
       }
-      type Blog @model @auth(rules: [{ allow: public }, { allow: custom }]) {
+      type Blog @model @auth(rules: [{ allow: private, provider: iam }]) {
         id: String! @primaryKey
         content: String
         posts: [Post] @hasMany(references: ["blogId"])
       }
-      type Post @model @auth(rules: [{ allow: public }]) {
+      type Post @model @auth(rules: [{ allow: private, provider: iam }]) {
         id: String! @primaryKey
         content: String
         blogId: String!
         blog: Blog @belongsTo(references: ["blogId"])
       }
-      type User @model @auth(rules: [{ allow: custom }]) {
+      type User @model @auth(rules: [{ allow: public, provider: iam }, { allow: custom }]) {
         id: String! @primaryKey
         name: String
         profile: Profile @hasOne(references: ["userId"])
       }
-      type Profile @model @auth(rules: [{ allow: custom }]) {
+      type Profile @model @auth(rules: [{ allow: public, provider: iam }, { allow: custom }]) {
         id: String! @primaryKey
         details: String
         userId: String!
@@ -167,16 +197,16 @@ describe('RDS Relational Directives', () => {
     writeFileSync(rdsSchemaFilePath, schema, 'utf8');
   };
 
-  test('check apikey auth can perform all valid operations on blog', async () => {
-    await blogApiKeyClient.create('createBlog', {
+  test('check iam private auth can perform all valid operations on blog', async () => {
+    await blogIAMAuthClient.create('createBlog', {
       id: 'B-1',
       content: 'Blog 1',
     });
-    await blogApiKeyClient.update('updateBlog', {
+    await blogIAMAuthClient.update('updateBlog', {
       id: 'B-1',
       content: 'Blog 1 updated',
     });
-    const getBlogResult = await blogApiKeyClient.get({
+    const getBlogResult = await blogIAMAuthClient.get({
       id: 'B-1',
     });
     expect(getBlogResult.data.getBlog).toEqual(
@@ -185,7 +215,7 @@ describe('RDS Relational Directives', () => {
         content: 'Blog 1 updated',
       }),
     );
-    const listBlogsResult = await blogApiKeyClient.list();
+    const listBlogsResult = await blogIAMAuthClient.list();
     expect(listBlogsResult.data.listBlogs.items.length).toEqual(1);
     expect(listBlogsResult.data.listBlogs.items).toEqual(
       expect.arrayContaining([
@@ -195,43 +225,75 @@ describe('RDS Relational Directives', () => {
         }),
       ]),
     );
-    await blogApiKeyClient.delete('deleteBlog', {
+    await blogIAMAuthClient.delete('deleteBlog', {
       id: 'B-1',
     });
   });
 
-  test('check lambda auth can perform all valid operations on blog', async () => {
-    await blogLambdaClient.create('createBlog', {
-      id: 'B-2',
-      content: 'Blog 2',
+  test('check iam public auth can perform all valid operations on user', async () => {
+    await userIAMUnauthClient.create('createUser', {
+      id: 'U-1',
+      name: 'User 1',
     });
-    await blogLambdaClient.update('updateBlog', {
-      id: 'B-2',
-      content: 'Blog 2 updated',
+    await userIAMUnauthClient.update('updateUser', {
+      id: 'U-1',
+      name: 'User 1 updated',
     });
-    await expect(
-      blogLambdaClient.get({
-        id: 'B-2',
+    const getUserResult = await userIAMUnauthClient.get({
+      id: 'U-1',
+    });
+    expect(getUserResult.data.getUser).toEqual(
+      expect.objectContaining({
+        id: 'U-1',
+        name: 'User 1 updated',
       }),
-    ).rejects.toThrow('GraphQL error: Not Authorized to access posts on type Blog');
-    await expect(blogLambdaClient.list()).rejects.toThrow('GraphQL error: Not Authorized to access posts on type Blog');
-    await blogLambdaClient.delete('deleteBlog', {
-      id: 'B-2',
+    );
+    const listUsersResult = await userIAMUnauthClient.list();
+    expect(listUsersResult.data.listUsers.items.length).toEqual(1);
+    expect(listUsersResult.data.listUsers.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'U-1',
+          name: 'User 1 updated',
+        }),
+      ]),
+    );
+    await userIAMUnauthClient.delete('deleteUser', {
+      id: 'U-1',
     });
   });
 
-  test('check lambda auth can not perform any operation on post', async () => {
-    await expect(postLambdaClient.create('createPost', { id: 'P-1', content: 'Post 1', blogId: 'B-1' })).rejects.toThrow(
-      'GraphQL error: Not Authorized to access createPost on type Mutation',
+  test('on multi auth model - check lambda auth can perform all valid operations on user', async () => {
+    await userLambdaClient.create('createUser', {
+      id: 'U-2',
+      name: 'User 2',
+    });
+    await userLambdaClient.update('updateUser', {
+      id: 'U-2',
+      name: 'User 2 updated',
+    });
+    const getUserResult = await userLambdaClient.get({
+      id: 'U-2',
+    });
+    expect(getUserResult.data.getUser).toEqual(
+      expect.objectContaining({
+        id: 'U-2',
+        name: 'User 2 updated',
+      }),
     );
-    await expect(postLambdaClient.update('updatePost', { id: 'P-1', content: 'Post 1 updated' })).rejects.toThrow(
-      'GraphQL error: Not Authorized to access updatePost on type Mutation',
+    const listUsersResult = await userLambdaClient.list();
+    expect(listUsersResult.data.listUsers.items.length).toEqual(1);
+    expect(listUsersResult.data.listUsers.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'U-2',
+          name: 'User 2 updated',
+        }),
+      ]),
     );
-    await expect(postLambdaClient.get({ id: 'P-1' })).rejects.toThrow('GraphQL error: Not Authorized to access getPost on type Query');
-    await expect(postLambdaClient.list()).rejects.toThrow('GraphQL error: Not Authorized to access listPosts on type Query');
-    await expect(postLambdaClient.delete('deletePost', { id: 'P-1' })).rejects.toThrow(
-      'GraphQL error: Not Authorized to access deletePost on type Mutation',
-    );
+    await userLambdaClient.delete('deleteUser', {
+      id: 'U-2',
+    });
   });
 
   test('check apikey auth can not perform any operation on user', async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-iam.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-iam.test.ts
@@ -83,12 +83,12 @@ describe('RDS Relational Directives', () => {
   const createAppSyncClients = async (apiEndPoint, appRegion, apiKey): Promise<void> => {
     configureAmplify(projRoot);
     const unAuthCredentials = await Auth.currentCredentials();
-    const [cognito_username, cognito_password] = ['test@test.com', 'Password123!']
+    const [cognito_username, cognito_password] = ['test@test.com', 'Password123!'];
     const userPoolId = getUserPoolId(projRoot);
     await setupUser(userPoolId, cognito_username, cognito_password);
     await signInUser(cognito_username, cognito_password);
     const authCredentials = await Auth.currentCredentials();
-    
+
     const unauthAppSyncClient = getConfiguredAppsyncClientIAMAuth(apiEndPoint, appRegion, unAuthCredentials);
     const authAppSyncClient = getConfiguredAppsyncClientIAMAuth(apiEndPoint, appRegion, authCredentials);
     const apiKeyClient = getConfiguredAppsyncClientAPIKeyAuth(apiEndPoint, appRegion, apiKey);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/authHelper.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/authHelper.ts
@@ -101,7 +101,11 @@ export function getConfiguredAppsyncClientAPIKeyAuth(url: string, region: string
   });
 }
 
-export function getConfiguredAppsyncClientIAMAuth(url: string, region: string): any {
+export const getConfiguredAppsyncClientIAMAuth = (url: string, region: string, credentials?: {
+  accessKeyId: string,
+  secretAccessKey: string,
+  sessionToken: string,
+}): any => {
   return new AWSAppSyncClient({
     url,
     region,
@@ -109,13 +113,13 @@ export function getConfiguredAppsyncClientIAMAuth(url: string, region: string): 
     auth: {
       type: AUTH_TYPE.AWS_IAM,
       credentials: {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-        sessionToken: process.env.AWS_SESSION_TOKEN,
+        accessKeyId: credentials?.accessKeyId ?? process.env.AWS_ACCESS_KEY_ID,
+        secretAccessKey: credentials?.secretAccessKey ?? process.env.AWS_SECRET_ACCESS_KEY,
+        sessionToken: credentials?.sessionToken ?? process.env.AWS_SESSION_TOKEN,
       },
     },
   });
-}
+};
 
 export const getConfiguredAppsyncClientLambdaAuth = (url: string, region: string, token: string): any => {
   return new AWSAppSyncClient({

--- a/packages/amplify-e2e-tests/src/schema-api-directives/authHelper.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/authHelper.ts
@@ -101,11 +101,15 @@ export function getConfiguredAppsyncClientAPIKeyAuth(url: string, region: string
   });
 }
 
-export const getConfiguredAppsyncClientIAMAuth = (url: string, region: string, credentials?: {
-  accessKeyId: string,
-  secretAccessKey: string,
-  sessionToken: string,
-}): any => {
+export const getConfiguredAppsyncClientIAMAuth = (
+  url: string,
+  region: string,
+  credentials?: {
+    accessKeyId: string;
+    secretAccessKey: string;
+    sessionToken: string;
+  },
+): any => {
   return new AWSAppSyncClient({
     url,
     region,

--- a/packages/amplify-e2e-tests/src/utils/api.ts
+++ b/packages/amplify-e2e-tests/src/utils/api.ts
@@ -1,0 +1,52 @@
+import { API } from 'aws-amplify';
+
+export const reconfigureAmplifyAPI = (url: string, region: string, appSyncAuthType: string, apiKey?: string): void => {
+  if (appSyncAuthType === 'API_KEY') {
+    API.configure({
+      aws_appsync_graphqlEndpoint: url,
+      aws_appsync_region: region,
+      aws_appsync_authenticationType: appSyncAuthType,
+      aws_appsync_apiKey: apiKey,
+    });
+  } else {
+    API.configure({
+      aws_appsync_graphqlEndpoint: url,
+      aws_appsync_region: region,
+      aws_appsync_authenticationType: appSyncAuthType,
+    });
+  }
+};
+
+export async function withTimeOut<T>(
+  promiseToWait: Promise<T>,
+  timeout: number,
+  timeoutMessage?: string,
+  cleanupFn?: () => void,
+): Promise<T> {
+  const timeoutPromise = new Promise<T>((_, reject) => {
+    setTimeout(async () => {
+      if (cleanupFn) {
+        await cleanupFn();
+      }
+      reject(new Error(timeoutMessage || 'Waiting timed out'));
+    }, timeout);
+  });
+  return Promise.race([promiseToWait, timeoutPromise]);
+}
+
+export async function expectTimeOut(
+  promiseToWait: Promise<any>,
+  timeout: number,
+  timeoutMessage: string,
+  cleanupFn?: () => void,
+): Promise<string> {
+  const timeoutPromise = new Promise<string>((resolve, _) => {
+    setTimeout(async () => {
+      if (cleanupFn) {
+        await cleanupFn();
+      }
+      resolve(timeoutMessage);
+    }, timeout);
+  });
+  return Promise.race([promiseToWait, timeoutPromise]);
+}

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-mutation-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-mutation-auth.test.ts.snap
@@ -1202,7 +1202,6 @@ $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.unauthRole,
-  \\"cognitoIdentityPoolId\\": $ctx.stash.identityPoolId,
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
 #set( $authResult = $util.authRules.mutationAuth($authRules, \\"create\\", $ctx.args.input, null) )
@@ -1252,7 +1251,6 @@ $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.unauthRole,
-  \\"cognitoIdentityPoolId\\": $ctx.stash.identityPoolId,
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
 #set( $authResult = $util.authRules.mutationAuth($authRules, \\"update\\", $ctx.args.input, $ctx.result) )
@@ -1302,7 +1300,6 @@ $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
   \\"roleArn\\": $ctx.stash.unauthRole,
-  \\"cognitoIdentityPoolId\\": $ctx.stash.identityPoolId,
   \\"allowedFields\\":   [\\"id\\", \\"title\\"]
 }))
 #set( $authResult = $util.authRules.mutationAuth($authRules, \\"delete\\", $ctx.args.input, $ctx.result) )

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-query-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-query-auth.test.ts.snap
@@ -555,8 +555,7 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
-  \\"roleArn\\": $ctx.stash.unauthRole,
-  \\"cognitoIdentityPoolId\\": $ctx.stash.identityPoolId
+  \\"roleArn\\": $ctx.stash.unauthRole
 }))
 #set( $authResult = $util.authRules.queryAuth($authRules) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
@@ -585,8 +584,7 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
-  \\"roleArn\\": $ctx.stash.unauthRole,
-  \\"cognitoIdentityPoolId\\": $ctx.stash.identityPoolId
+  \\"roleArn\\": $ctx.stash.unauthRole
 }))
 #set( $authResult = $util.authRules.queryAuth($authRules) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-subscription-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-subscription-auth.test.ts.snap
@@ -1234,8 +1234,7 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
-  \\"roleArn\\": $ctx.stash.unauthRole,
-  \\"cognitoIdentityPoolId\\": $ctx.stash.identityPoolId
+  \\"roleArn\\": $ctx.stash.unauthRole
 }))
 #set( $authResult = $util.authRules.subscriptionAuth($authRules) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
@@ -1279,8 +1278,7 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
-  \\"roleArn\\": $ctx.stash.unauthRole,
-  \\"cognitoIdentityPoolId\\": $ctx.stash.identityPoolId
+  \\"roleArn\\": $ctx.stash.unauthRole
 }))
 #set( $authResult = $util.authRules.subscriptionAuth($authRules) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )
@@ -1324,8 +1322,7 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
-  \\"roleArn\\": $ctx.stash.unauthRole,
-  \\"cognitoIdentityPoolId\\": $ctx.stash.identityPoolId
+  \\"roleArn\\": $ctx.stash.unauthRole
 }))
 #set( $authResult = $util.authRules.subscriptionAuth($authRules) )
 #if( !$authResult || ($authResult && !$authResult.authorized) )

--- a/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/common.ts
+++ b/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/common.ts
@@ -95,7 +95,7 @@ const convertAuthRoleToVtl = (
           type: str(role.strategy),
           provider: str('iam'),
           roleArn: role.strategy === 'public' ? ref('ctx.stash.unauthRole') : ref('ctx.stash.authRole'),
-          ...(role.strategy === 'private' && { cognitoIdentityPoolId: identityPoolId ? str(identityPoolId) : nul() }),
+          ...(role.strategy === 'private' && { cognitoIdentityPoolId: hasIdentityPoolId ? ref('ctx.stash.identityPoolId') : nul() }),
           ...(showAllowedFields && { allowedFields: list(allowedFields) }),
         }),
       ),

--- a/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/common.ts
+++ b/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/common.ts
@@ -95,7 +95,7 @@ const convertAuthRoleToVtl = (
           type: str(role.strategy),
           provider: str('iam'),
           roleArn: role.strategy === 'public' ? ref('ctx.stash.unauthRole') : ref('ctx.stash.authRole'),
-          cognitoIdentityPoolId: hasIdentityPoolId ? ref('ctx.stash.identityPoolId') : nul(),
+          ...(role.strategy === 'private' && { cognitoIdentityPoolId: identityPoolId ? str(identityPoolId) : nul() }),
           ...(showAllowedFields && { allowedFields: list(allowedFields) }),
         }),
       ),

--- a/packages/amplify-graphql-schema-generator/src/__tests__/vpc-helper.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/vpc-helper.test.ts
@@ -6,7 +6,7 @@ import {
   DescribeDBSubnetGroupsCommandOutput,
 } from '@aws-sdk/client-rds';
 
-import { getHostVpc } from '../vpc-helper';
+import { getHostVpc } from '../utils/vpc-helper';
 
 const sendSpy = jest.spyOn(RDSClient.prototype, 'send');
 


### PR DESCRIPTION
Adding E2E tests for Auth Directive IAM provider support.
- Covers IAM public and private rules. (Public rule strictly gives access to unauthRule and private rule gives access to the logged in users).
- Mutli-auth scenarios with API key, lambda and IAM for queries, mutations and subscriptions.