### PR TITLE
fix(api): do not allow field auth on rds models

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/rds-query-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/rds-query-auth.test.ts
@@ -397,4 +397,48 @@ describe('Verify RDS Model level Auth rules on queries:', () => {
       expect(out.resolvers[resolver]).toMatchSnapshot();
     });
   });
+
+  it('should allow field auth on query type', async () => {
+    const validSchema = `
+      type Post @model
+        @auth(rules: [
+          {allow: private, provider: iam}
+          {allow: public, provider: iam}
+        ]) {
+          id: ID! @primaryKey
+          title: String!
+      }
+
+      type Query {
+        getCustomModel: Post @auth(rules: [{allow: private, provider: iam}])
+      }
+    `;
+
+    const authConfig: AppSyncAuthConfiguration = {
+      defaultAuthentication: {
+        authenticationType: 'AWS_IAM',
+      },
+      additionalAuthenticationProviders: [],
+    };
+
+    const modelToDatasourceMap = new Map();
+    ['Post'].forEach((model) => {
+      modelToDatasourceMap.set(model, {
+        dbType: 'MySQL',
+        provisionDB: false,
+      });
+    });
+
+    const out = testTransform({
+      schema: validSchema,
+      transformers: [new ModelTransformer(), new AuthTransformer(), new PrimaryKeyTransformer()],
+      authConfig,
+      modelToDatasourceMap,
+    });
+
+    expect(out).toBeDefined();
+
+    validateModelSchema(parse(out.schema));
+    parse(out.schema);
+  });
 });

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -278,6 +278,8 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
       modelDirective !== undefined,
       field.name.value,
       context.transformParameters,
+      parent,
+      context,
     );
     validateRules(rules, this.configuredAuthProviders, field.name.value);
 

--- a/packages/amplify-graphql-auth-transformer/src/utils/validations.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/validations.ts
@@ -1,5 +1,6 @@
-import { DirectiveWrapper, InvalidDirectiveError, generateGetArgumentsInput } from '@aws-amplify/graphql-transformer-core';
-import type { TransformParameters } from '@aws-amplify/graphql-transformer-interfaces';
+import { DirectiveWrapper, InvalidDirectiveError, generateGetArgumentsInput, isRDSModel } from '@aws-amplify/graphql-transformer-core';
+import type { TransformParameters, TransformerSchemaVisitStepContextProvider, TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { ObjectTypeDefinitionNode, InterfaceTypeDefinitionNode } from 'graphql';
 import { AuthRule, ConfiguredAuthProviders } from './definitions';
 
 export const validateRuleAuthStrategy = (rule: AuthRule, configuredAuthProviders: ConfiguredAuthProviders) => {
@@ -105,8 +106,16 @@ export const validateFieldRules = (
   parentHasModelDirective: boolean,
   fieldName: string,
   transformParameters: TransformParameters,
-) => {
+  parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+  context: TransformerSchemaVisitStepContextProvider,
+): void => {
   const rules = authDir.getArguments<{ rules: Array<AuthRule> }>({ rules: [] }, generateGetArgumentsInput(transformParameters)).rules;
+
+  if (!isParentTypeBuiltinType && isRDSModel(context as TransformerContextProvider, parent.name.value)) {
+    throw new InvalidDirectiveError(
+      `@auth rules are not supported on fields on relational database models. Check field "${fieldName}" on type "${parent.name.value}". Please use @auth on the type instead.`,
+    );
+  }
 
   if (rules.length === 0) {
     throw new InvalidDirectiveError(`@auth on ${fieldName} does not have any auth rules.`);

--- a/packages/amplify-graphql-auth-transformer/src/utils/validations.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/validations.ts
@@ -1,5 +1,9 @@
 import { DirectiveWrapper, InvalidDirectiveError, generateGetArgumentsInput, isRDSModel } from '@aws-amplify/graphql-transformer-core';
-import type { TransformParameters, TransformerSchemaVisitStepContextProvider, TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import type {
+  TransformParameters,
+  TransformerSchemaVisitStepContextProvider,
+  TransformerContextProvider,
+} from '@aws-amplify/graphql-transformer-interfaces';
 import { ObjectTypeDefinitionNode, InterfaceTypeDefinitionNode } from 'graphql';
 import { AuthRule, ConfiguredAuthProviders } from './definitions';
 


### PR DESCRIPTION
For the initial release, we do not support field auth on RDS models.

This change throws an error if auth directive is defined on a field of RDS models.
- Added unit tests.