### PR TITLE
fix(api): add iam auth support for admin roles with auth utils

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-mutation-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-mutation-auth.test.ts.snap
@@ -4,6 +4,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"apiKey\\",
@@ -54,6 +62,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"apiKey\\",
@@ -104,6 +120,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"apiKey\\",
@@ -133,6 +157,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"userPools\\",
@@ -183,6 +215,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"userPools\\",
@@ -233,6 +273,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"userPools\\",
@@ -262,6 +310,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"userPools\\",
@@ -314,6 +370,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"userPools\\",
@@ -366,6 +430,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"userPools\\",
@@ -397,6 +469,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"userPools\\",
@@ -449,6 +529,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"userPools\\",
@@ -501,6 +589,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"userPools\\",
@@ -532,6 +628,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -591,6 +695,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -650,6 +762,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -688,6 +808,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -741,6 +869,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -794,6 +930,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -826,6 +970,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -879,6 +1031,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -932,6 +1092,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -964,6 +1132,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"custom\\",
   \\"provider\\": \\"function\\",
@@ -1014,6 +1190,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"custom\\",
   \\"provider\\": \\"function\\",
@@ -1064,6 +1248,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"custom\\",
   \\"provider\\": \\"function\\",
@@ -1093,6 +1285,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"iam\\",
@@ -1145,6 +1345,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"iam\\",
@@ -1197,6 +1405,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"iam\\",
@@ -1228,6 +1444,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
@@ -1279,6 +1503,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
@@ -1330,6 +1562,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
@@ -1360,6 +1600,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"oidc\\",
@@ -1410,6 +1658,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"oidc\\",
@@ -1460,6 +1716,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"oidc\\",
@@ -1489,6 +1753,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"oidc\\",
@@ -1542,6 +1814,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"oidc\\",
@@ -1595,6 +1875,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"oidc\\",
@@ -1627,6 +1915,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"oidc\\",
@@ -1680,6 +1976,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"oidc\\",
@@ -1733,6 +2037,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"oidc\\",
@@ -1765,6 +2077,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -1824,6 +2144,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -1883,6 +2211,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -1921,6 +2257,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -1974,6 +2318,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -2027,6 +2379,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -2059,6 +2419,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -2112,6 +2480,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -2165,6 +2541,14 @@ exports[`Verify RDS Model level Auth rules on mutations: should successfully tra
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-query-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-query-auth.test.ts.snap
@@ -4,6 +4,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"apiKey\\"
@@ -32,6 +40,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"apiKey\\"
@@ -60,6 +76,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"userPools\\"
@@ -88,6 +112,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"userPools\\"
@@ -116,6 +148,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"userPools\\",
@@ -146,6 +186,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"userPools\\",
@@ -176,6 +224,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"userPools\\",
@@ -206,6 +262,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"userPools\\",
@@ -236,6 +300,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -272,6 +344,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -308,6 +388,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -339,6 +427,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -370,6 +466,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -401,6 +505,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -432,6 +544,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"custom\\",
   \\"provider\\": \\"function\\"
@@ -460,6 +580,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"custom\\",
   \\"provider\\": \\"function\\"
@@ -488,6 +616,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"iam\\",
@@ -518,6 +654,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"iam\\",
@@ -548,6 +692,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
@@ -577,6 +729,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
@@ -606,6 +766,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"oidc\\"
@@ -634,6 +802,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"oidc\\"
@@ -662,6 +838,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"oidc\\",
@@ -693,6 +877,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"oidc\\",
@@ -724,6 +916,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"oidc\\",
@@ -755,6 +955,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"oidc\\",
@@ -786,6 +994,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -822,6 +1038,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -858,6 +1082,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -889,6 +1121,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -920,6 +1160,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -951,6 +1199,14 @@ exports[`Verify RDS Model level Auth rules on queries: should successfully trans
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-subscription-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/rds-subscription-auth.test.ts.snap
@@ -4,6 +4,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"apiKey\\"
@@ -47,6 +55,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"apiKey\\"
@@ -90,6 +106,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"apiKey\\"
@@ -133,6 +157,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"userPools\\"
@@ -176,6 +208,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"userPools\\"
@@ -219,6 +259,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"userPools\\"
@@ -262,6 +310,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"userPools\\",
@@ -307,6 +363,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"userPools\\",
@@ -352,6 +416,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"userPools\\",
@@ -397,6 +469,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"userPools\\",
@@ -442,6 +522,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"userPools\\",
@@ -487,6 +575,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"userPools\\",
@@ -532,6 +628,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -583,6 +687,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -634,6 +746,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -685,6 +805,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -731,6 +859,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -777,6 +913,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -823,6 +967,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -869,6 +1021,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -915,6 +1075,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"userPools\\",
@@ -961,6 +1129,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"custom\\",
   \\"provider\\": \\"function\\"
@@ -1004,6 +1180,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"custom\\",
   \\"provider\\": \\"function\\"
@@ -1047,6 +1231,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"custom\\",
   \\"provider\\": \\"function\\"
@@ -1090,6 +1282,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"iam\\",
@@ -1135,6 +1335,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"iam\\",
@@ -1180,6 +1388,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"iam\\",
@@ -1225,6 +1441,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
@@ -1269,6 +1493,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
@@ -1313,6 +1545,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"public\\",
   \\"provider\\": \\"iam\\",
@@ -1357,6 +1597,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"oidc\\"
@@ -1400,6 +1648,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"oidc\\"
@@ -1443,6 +1699,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"private\\",
   \\"provider\\": \\"oidc\\"
@@ -1486,6 +1750,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"oidc\\",
@@ -1532,6 +1804,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"oidc\\",
@@ -1578,6 +1858,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"oidc\\",
@@ -1624,6 +1912,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"oidc\\",
@@ -1670,6 +1966,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"oidc\\",
@@ -1716,6 +2020,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"owner\\",
   \\"provider\\": \\"oidc\\",
@@ -1762,6 +2074,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -1813,6 +2133,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -1864,6 +2192,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -1915,6 +2251,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -1961,6 +2305,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -2007,6 +2359,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -2053,6 +2413,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -2099,6 +2467,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",
@@ -2145,6 +2521,14 @@ exports[`Verify RDS Model level Auth rules on subscriptions: should successfully
 "## [Start] Authorization rules. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $authRules = [] )
+#if( $ctx.stash.adminRoles && $ctx.stash.adminRoles.size() > 0 )
+  $util.qr($authRules.add({
+  \\"provider\\": \\"iam\\",
+  \\"type\\": \\"admin\\",
+  \\"strict\\": false,
+  \\"roles\\": $ctx.stash.adminRoles
+}))
+#end
 $util.qr($authRules.add({
   \\"type\\": \\"groups\\",
   \\"provider\\": \\"oidc\\",

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/rds-mutation-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/rds-mutation-auth.test.ts
@@ -8,7 +8,6 @@ import { AuthTransformer } from '../graphql-auth-transformer';
 import { expectStashValueLike } from './test-helpers';
 
 describe('Verify RDS Model level Auth rules on mutations:', () => {
-
   const ADMIN_UI_ROLES = ['us-fake-1_uuid_Full-access/CognitoIdentityCredentials', 'us-fake-1_uuid_Manage-only/CognitoIdentityCredentials'];
   const ADMIN_UI_ADMIN_ROLES =
     '$util.qr($ctx.stash.put(\\"adminRoles\\", [\\"us-fake-1_uuid_Full-access/CognitoIdentityCredentials\\",\\"us-fake-1_uuid_Manage-only/CognitoIdentityCredentials\\"])';

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/rds-mutation-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/rds-mutation-auth.test.ts
@@ -3,10 +3,16 @@ import { validateModelSchema } from '@aws-amplify/graphql-transformer-core';
 import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import { parse } from 'graphql';
 import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-interfaces';
-import { AuthTransformer } from '../graphql-auth-transformer';
 import { PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
+import { AuthTransformer } from '../graphql-auth-transformer';
+import { expectStashValueLike } from './test-helpers';
 
 describe('Verify RDS Model level Auth rules on mutations:', () => {
+
+  const ADMIN_UI_ROLES = ['us-fake-1_uuid_Full-access/CognitoIdentityCredentials', 'us-fake-1_uuid_Manage-only/CognitoIdentityCredentials'];
+  const ADMIN_UI_ADMIN_ROLES =
+    '$util.qr($ctx.stash.put(\\"adminRoles\\", [\\"us-fake-1_uuid_Full-access/CognitoIdentityCredentials\\",\\"us-fake-1_uuid_Manage-only/CognitoIdentityCredentials\\"])';
+
   it('should successfully transform apiKey auth rule', async () => {
     const validSchema = `
       type Post @model
@@ -565,5 +571,43 @@ describe('Verify RDS Model level Auth rules on mutations:', () => {
 
     validateModelSchema(parse(out.schema));
     parse(out.schema);
+  });
+
+  test('admin role should present in stash for rds model', () => {
+    const validSchema = `
+    type Post @model @auth(rules: [{allow: public}]) {
+      id: ID! @primaryKey
+      title: String!
+      createdAt: String
+      updatedAt: String
+    }`;
+    const modelToDatasourceMap = new Map();
+    ['Post'].forEach((model) => {
+      modelToDatasourceMap.set(model, {
+        dbType: 'MySQL',
+        provisionDB: false,
+      });
+    });
+    const out = testTransform({
+      schema: validSchema,
+      modelToDatasourceMap,
+      authConfig: {
+        defaultAuthentication: {
+          authenticationType: 'API_KEY',
+        },
+        additionalAuthenticationProviders: [
+          {
+            authenticationType: 'AWS_IAM',
+          },
+        ],
+      },
+      synthParameters: {
+        adminRoles: ADMIN_UI_ROLES,
+      },
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new AuthTransformer()],
+    });
+    expect(out).toBeDefined();
+    expect(out.schema).toContain('Post @aws_api_key @aws_iam');
+    expectStashValueLike(out, 'Post', ADMIN_UI_ADMIN_ROLES);
   });
 });

--- a/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/common.ts
+++ b/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/common.ts
@@ -53,10 +53,7 @@ export const generateAuthRulesFromRoles = (
 
 const getIamAdminRoleExpression = (): Expression =>
   iff(
-    and([
-      ref('ctx.stash.adminRoles'),
-      ref('ctx.stash.adminRoles.size() > 0'),
-    ]),
+    and([ref('ctx.stash.adminRoles'), ref('ctx.stash.adminRoles.size() > 0')]),
     qref(
       methodCall(
         ref('authRules.add'),

--- a/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/common.ts
+++ b/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/common.ts
@@ -44,11 +44,31 @@ export const generateAuthRulesFromRoles = (
   const expressions = [];
   expressions.push(qref(methodCall(ref('ctx.stash.put'), str('hasAuth'), bool(true))), set(ref('authRules'), list([])));
   const fieldNames = fields.map((field) => field.name.value);
+  expressions.push(getIamAdminRoleExpression());
   roles.forEach((role) => {
     expressions.push(convertAuthRoleToVtl(role, fieldNames, hasIdentityPoolId, hideAllowedFields));
   });
   return expressions;
 };
+
+const getIamAdminRoleExpression = (): Expression =>
+  iff(
+    and([
+      ref('ctx.stash.adminRoles'),
+      ref('ctx.stash.adminRoles.size() > 0'),
+    ]),
+    qref(
+      methodCall(
+        ref('authRules.add'),
+        obj({
+          provider: str('iam'),
+          type: str('admin'),
+          strict: bool(false),
+          roles: ref('ctx.stash.adminRoles'),
+        }),
+      ),
+    ),
+  );
 
 const convertAuthRoleToVtl = (
   role: RoleDefinition,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Adding admin roles support for IAM provider using AppSync auth utils.
- Admin roles include function roles / studio managed roles and roles defined in custom-roles.json file.
- We do partial match of the role name similar to DDB.
 
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed
NA

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available
NA

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Unit tests
- Manual test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
