### PR TITLE
feat(api): add enum support for postgres import

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/rds-postgres-import.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-postgres-import.test.ts
@@ -41,7 +41,7 @@ describe('RDS Model Directive', () => {
   const projName = 'rdsmodelapitest';
   const apiName = 'rdsapi';
 
-  let projRoot = '/private/var/folders/xg/pbsg0b5d38vfswr96p25h29c0000gs/T/amplify-e2e-tests/rdsmodelapi_adbbafcdb_7a37ab89';
+  let projRoot;
   let appSyncClient;
 
   beforeAll(async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/rds-postgres-import.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-postgres-import.test.ts
@@ -131,7 +131,7 @@ describe('RDS Model Directive', () => {
     };
 
     const queries = [
-      'CREATE TYPE contact_status AS ENUM (\'active\', \'inactive\')',
+      "CREATE TYPE contact_status AS ENUM ('active', 'inactive')",
       'CREATE TABLE Contact (id VARCHAR(40) PRIMARY KEY, firstName VARCHAR(20), lastName VARCHAR(50), strArray VARCHAR[], intArray INT[], status contact_status)',
       'CREATE TABLE Person (personId INT PRIMARY KEY, firstName VARCHAR(20), lastName VARCHAR(50))',
       'CREATE TABLE Employee (id INT PRIMARY KEY, firstName VARCHAR(20), lastName VARCHAR(50))',
@@ -217,7 +217,9 @@ describe('RDS Model Directive', () => {
     expect((contactStatusField.type as NamedTypeNode).name.value).toEqual('ContactStatus');
 
     // Verify the Enum type
-    const contactStatusEnumType = schema.definitions.find((d) => d.kind === 'EnumTypeDefinition' && d.name.value === 'ContactStatus') as EnumTypeDefinitionNode;
+    const contactStatusEnumType = schema.definitions.find(
+      (d) => d.kind === 'EnumTypeDefinition' && d.name.value === 'ContactStatus',
+    ) as EnumTypeDefinitionNode;
     expect(contactStatusEnumType).toBeDefined();
     expect(contactStatusEnumType.values.length).toEqual(2);
     expect(contactStatusEnumType.values.map((e) => e.name.value)).toEqual(expect.arrayContaining(['active', 'inactive']));

--- a/packages/amplify-graphql-schema-generator/API.md
+++ b/packages/amplify-graphql-schema-generator/API.md
@@ -55,6 +55,8 @@ export abstract class DataSourceAdapter {
     // (undocumented)
     describeTable(tableName: string): Promise<Model>;
     // (undocumented)
+    protected getEnumName(name: string): string;
+    // (undocumented)
     abstract getFields(tableName: string): Promise<Field[]>;
     // (undocumented)
     abstract getIndexes(tableName: string): Promise<Index[]>;

--- a/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-schema.test.ts.snap
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-schema.test.ts.snap
@@ -25,3 +25,51 @@ type User @refersTo(name: \\"users\\") @model {
 }
 "
 `;
+
+exports[`enum imports generates enum imports 1`] = `
+"type User @refersTo(name: \\"users\\") @model {
+  id: String! @primaryKey
+  name: String
+  status: UserStatus
+}
+
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+}
+"
+`;
+
+exports[`enum imports generates nonnull enum types correctly 1`] = `
+"type User @refersTo(name: \\"users\\") @model {
+  id: String! @primaryKey
+  name: String
+  status: UserStatus!
+}
+
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+}
+"
+`;
+
+exports[`enum imports multiple enum fields of same name must generate one graphql enum type 1`] = `
+"type Profile @refersTo(name: \\"profile\\") @model {
+  id: String! @primaryKey
+  details: String
+  profilestatus: UserStatus
+}
+
+type User @refersTo(name: \\"users\\") @model {
+  id: String! @primaryKey
+  name: String
+  status: UserStatus
+}
+
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+}
+"
+`;

--- a/packages/amplify-graphql-schema-generator/src/__tests__/generate-schema.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/generate-schema.test.ts
@@ -51,6 +51,54 @@ describe('Type name conversions', () => {
   });
 });
 
+describe('enum imports', () => {
+  it('generates enum imports', () => {
+    const dbschema = new Schema(new Engine('Postgres'));
+    const model = new Model('users');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'String' } }));
+    model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('status', { kind: 'Enum', name: 'UserStatus', values: ['ACTIVE', 'INACTIVE'] }));
+    model.setPrimaryKey(['id']);
+    dbschema.addModel(model);
+
+    const graphqlSchema = generateGraphQLSchema(dbschema);
+    expect(graphqlSchema).toMatchSnapshot();
+  });
+
+  it('multiple enum fields of same name must generate one graphql enum type', () => {
+    const dbschema = new Schema(new Engine('Postgres'));
+    let model = new Model('users');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'String' } }));
+    model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('status', { kind: 'Enum', name: 'UserStatus', values: ['ACTIVE', 'INACTIVE'] }));
+    model.setPrimaryKey(['id']);
+    dbschema.addModel(model);
+
+    model = new Model('profile');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'String' } }));
+    model.addField(new Field('details', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('profilestatus', { kind: 'Enum', name: 'UserStatus', values: ['ACTIVE', 'INACTIVE'] }));
+    model.setPrimaryKey(['id']);
+    dbschema.addModel(model);
+
+    const graphqlSchema = generateGraphQLSchema(dbschema);
+    expect(graphqlSchema).toMatchSnapshot();
+  });
+
+  it('generates nonnull enum types correctly', () => {
+    const dbschema = new Schema(new Engine('Postgres'));
+    const model = new Model('users');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'String' } }));
+    model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('status', { kind: 'NonNull', type: { kind: 'Enum', name: 'UserStatus', values: ['ACTIVE', 'INACTIVE'] } }));
+    model.setPrimaryKey(['id']);
+    dbschema.addModel(model);
+
+    const graphqlSchema = generateGraphQLSchema(dbschema);
+    expect(graphqlSchema).toMatchSnapshot();
+  });
+});
+
 describe('Field name conversions', () => {
   it('GraphQL idiomatic field name conversions', () => {
     // leave as-is

--- a/packages/amplify-graphql-schema-generator/src/datasource-adapter/datasource-adapter.ts
+++ b/packages/amplify-graphql-schema-generator/src/datasource-adapter/datasource-adapter.ts
@@ -1,3 +1,5 @@
+import { singular } from 'pluralize';
+import { toPascalCase } from 'graphql-transformer-common';
 import { Field, FieldType, Index, Model } from '../schema-representation';
 
 export abstract class DataSourceAdapter {
@@ -50,5 +52,9 @@ export abstract class DataSourceAdapter {
     this.useVPC = true;
     this.vpcSchemaInspectorLambda = vpcSchemaInspectorLambda;
     this.vpcLambdaRegion = region;
+  }
+
+  protected getEnumName(name: string): string {
+    return singular(toPascalCase(name.split('_')));
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

- Add support to import enum types on postgres datasource.
- Fix a bug where non nullable ENUM field would incorrectly import as 'String'.

##### CDK / CloudFormation Parameters Changed
NA
<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Unit tests
- E2E tests
- Manual test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
