### PR TITLE
Split the environment variable string in half using the first = character

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/docker-compose/ecs-objects/container.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/docker-compose/ecs-objects/container.ts
@@ -57,9 +57,9 @@ class Container implements IContainerDefinitions {
     this.env_file = [].concat(env_file);
     this.environment = Array.isArray(environment)
       ? environment.reduce((acc, element) => {
-          const [key, value] = element.split('=');
+          const [key, ...value] = element.split('=');
 
-          acc[key] = value;
+          acc[key] = value.join('=');
           return acc;
         }, {} as Record<string, string>)
       : (environment as Record<string, string>);


### PR DESCRIPTION
#### Description of changes

When an environment variable in the `docker-compose.yml` file of a container contains a `=` character, such as:

```
DB_CONNECTION_PARAMETERS=replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false
```

It splits the string by the `=` character and takes the first element as the variable key and the second as the value. For the previous example, it includes the following variable on the CF stack:

```json
{
  "Name": "DB_CONNECTION_PARAMETERS",
  "Value": "replicaSet"
}
```

This Pull Request fixes that issue by splitting the string in half using the first `=` sign only, so the resulting environment variable is:

```json
{
  "Name": "DB_CONNECTION_PARAMETERS",
  "Value": "replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
}
```

##### CDK / CloudFormation Parameters Changed

- Fixed the generation of environment variables for ECS Task definitions, so they accept the character `=` in their value.

#### Description of how you validated changes

Created a `Container` instance passing to the constructor an environment variable string with the `=` sign in the value.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
