### PR TITLE
fix: pass in and use correct lambda arn for lambdaauthorizers

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/all-auth-modes.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/all-auth-modes.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { createNewProjectDir, deleteProjectDir } from 'amplify-category-api-e2e-core';
 import { initCDKProject, cdkDeploy, cdkDestroy } from '../commands';
-import { graphql } from '../graphql-request';
+import { graphql, graphqlRequestWithLambda } from '../graphql-request';
 
 jest.setTimeout(1000 * 60 * 60 /* 1 hour */);
 
@@ -41,5 +41,21 @@ describe('CDK Auth Modes', () => {
       `,
     );
     expect(createResult.statusCode).toEqual(200);
+
+    const listTodosQuery = /* GraphQL */ `
+      query LIST_TODOS {
+        listTodos {
+          items {
+            id
+          }
+        }
+      }
+    `;
+
+    const listWithInvalidTokenResult = await graphqlRequestWithLambda(apiEndpoint, 'badtoken', listTodosQuery);
+    expect(listWithInvalidTokenResult.statusCode).toEqual(401);
+
+    const listWithValidTokenResult = await graphqlRequestWithLambda(apiEndpoint, 'letmein', listTodosQuery);
+    expect(listWithValidTokenResult.statusCode).toEqual(200);
   });
 });

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/all-auth-modes.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/all-auth-modes.test.ts
@@ -53,7 +53,7 @@ describe('CDK Auth Modes', () => {
     `;
 
     const listWithInvalidTokenResult = await graphqlRequestWithLambda(apiEndpoint, 'badtoken', listTodosQuery);
-    expect(listWithInvalidTokenResult.statusCode).toEqual(401);
+    expect(listWithInvalidTokenResult.statusCode).toEqual(400);
 
     const listWithValidTokenResult = await graphqlRequestWithLambda(apiEndpoint, 'letmein', listTodosQuery);
     expect(listWithValidTokenResult.statusCode).toEqual(200);

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/all-auth-modes/authorizer.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/all-auth-modes/authorizer.ts
@@ -1,3 +1,3 @@
-export const handler = (): void => {
-  throw new Error('Not Implemented');
-};
+export const handler = async ({ authorizationToken }: { authorizationToken: string }): Promise<{ isAuthorized: boolean }> => ({
+  isAuthorized: authorizationToken === 'letmein',
+});

--- a/packages/amplify-graphql-api-construct-tests/src/graphql-request.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/graphql-request.ts
@@ -5,24 +5,13 @@ export type GraphqlResponse = {
   body: any;
 };
 
-export const graphql = async (apiEndpoint: string, apiKey: string, query: string): Promise<GraphqlResponse> => {
-  const options = {
-    method: 'POST',
-    headers: {
-      'x-api-key': apiKey,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ query }),
-  };
-
-  const request = new Request(apiEndpoint, options);
-
+const graphqlRequest = async (apiEndpoint: string, payload: any): Promise<GraphqlResponse> => {
   let statusCode = 200;
   let body;
   let response;
 
   try {
-    response = await fetch(request);
+    response = await fetch(new Request(apiEndpoint, payload));
     body = await response.json();
     if (body.errors) statusCode = 400;
   } catch (error) {
@@ -43,3 +32,23 @@ export const graphql = async (apiEndpoint: string, apiKey: string, query: string
     body: body,
   };
 };
+
+export const graphql = async (apiEndpoint: string, apiKey: string, query: string): Promise<GraphqlResponse> =>
+  graphqlRequest(apiEndpoint, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query }),
+  });
+
+export const graphqlRequestWithLambda = async (apiEndpoint: string, authToken: string, query: string): Promise<GraphqlResponse> =>
+  graphqlRequest(apiEndpoint, {
+    method: 'POST',
+    headers: {
+      Authorization: authToken,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query }),
+  });

--- a/packages/amplify-graphql-api-construct/src/internal/authorization-modes.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/authorization-modes.ts
@@ -9,6 +9,7 @@ import {
   OIDCAuthorizationConfig,
   UserPoolAuthorizationConfig,
 } from '../types';
+import { ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 
 type AuthorizationConfigMode =
   | (IAMAuthorizationConfig & { type: 'AWS_IAM' })
@@ -89,6 +90,12 @@ const convertAuthConfigToAppSyncAuth = (authModes: AuthorizationModes): AppSyncA
   if (authProviders.length > 1 && !authModes.defaultAuthorizationMode) {
     throw new Error('A defaultAuthorizationMode is required if multiple authorization modes are configured.');
   }
+
+  // Enable appsync to invoke a provided lambda authorizer function
+  authModes.lambdaConfig?.function.addPermission('appsync-auth-invoke', {
+    principal: new ServicePrincipal('appsync.amazonaws.com'),
+    action: 'lambda:InvokeFunction',
+  });
 
   // In the case of a single mode, defaultAuthorizationMode is not required, just use the provided value.
   if (authProviders.length === 1) {

--- a/packages/amplify-graphql-api-construct/src/internal/authorization-modes.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/authorization-modes.ts
@@ -56,6 +56,7 @@ const convertAuthModeToAuthProvider = (authMode: AuthorizationConfigMode): AppSy
       return {
         authenticationType,
         lambdaAuthorizerConfig: {
+          lambdaArn: authMode.function.functionArn,
           lambdaFunction: authMode.function.functionName,
           ttlSeconds: authMode.ttl.toSeconds(),
         },

--- a/packages/amplify-graphql-transformer-core/src/graphql-api.ts
+++ b/packages/amplify-graphql-transformer-core/src/graphql-api.ts
@@ -371,7 +371,7 @@ export class GraphQLApi extends GraphqlApiBase implements GraphQLAPIProvider {
       return undefined;
     }
     return {
-      authorizerUri: this.lambdaArnKey(config.lambdaFunction),
+      authorizerUri: config.lambdaArn ?? this.lambdaArnKey(config.lambdaFunction),
       authorizerResultTtlInSeconds: config.ttlSeconds,
       identityValidationExpression: '',
     };

--- a/packages/amplify-graphql-transformer-core/src/utils/authType.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/authType.ts
@@ -76,6 +76,7 @@ export const adoptAuthMode = (
       return {
         authorizationType: authType,
         lambdaAuthorizerConfig: {
+          lambdaArn: entry.lambdaAuthorizerConfig!.lambdaArn,
           lambdaFunction: entry.lambdaAuthorizerConfig!.lambdaFunction,
           ttlSeconds: strToNumber(entry.lambdaAuthorizerConfig!.ttlSeconds),
         },

--- a/packages/amplify-graphql-transformer-interfaces/src/graphql-api-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/graphql-api-provider.ts
@@ -62,7 +62,8 @@ export interface LambdaConfig {
   lambdaFunction: string;
 
   /**
-   * Actually lambda Arn, if provided this will circumvent the arn construction when building the API auth mode config.
+   * The ARN of an existing Lambda function. If provided, this will circumvent the ARN construction when building the API auth mode config. The ARN must refer to the same function
+   * named in `lambdaFunction`.
    */
   lambdaArn?: string;
 

--- a/packages/amplify-graphql-transformer-interfaces/src/graphql-api-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/graphql-api-provider.ts
@@ -56,8 +56,19 @@ export interface OpenIDConnectConfig {
 }
 
 export interface LambdaConfig {
+  /**
+   * Function name, excluding optional `-{env}` suffix.
+   */
   lambdaFunction: string;
+
+  /**
+   * Actually lambda Arn, if provided this will circumvent the arn construction when building the API auth mode config.
+   */
   lambdaArn?: string;
+
+  /**
+   * Optional auth response time to live.
+   */
   ttlSeconds?: number;
 }
 

--- a/packages/amplify-graphql-transformer-interfaces/src/graphql-api-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/graphql-api-provider.ts
@@ -57,6 +57,7 @@ export interface OpenIDConnectConfig {
 
 export interface LambdaConfig {
   lambdaFunction: string;
+  lambdaArn?: string;
   ttlSeconds?: number;
 }
 


### PR DESCRIPTION
#### Description of changes
Lambda authorizers were still computing an ARN which included `-NONE` at the end, to align w/ older amplify convention. This is no longer guaranteed, given the lambda can be created in a normal CDK app, instead pass in the IFunction ARN in a CDK context, and use that when available.

Updated the all-auth-roles e2e test for CDK to flex this functionality.

##### CDK / CloudFormation Parameters Changed
Yes, GraphqlApi auth config for lambda will use the arn if possible.

#### Issue #, if available
N/A

#### Description of how you validated changes
Updated E2E test and manually.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
