### PR TITLE
fix: treating id field as implicit primary key which we miss today

### DIFF
--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -135,24 +135,24 @@ batch:
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: api_1_resolvers_sync_query_datastore_api_6
+    - identifier: rds_pg_refersTo_api_1_resolvers_sync_query_datastore
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts|src/__tests__/api_6.test.ts
+            src/__tests__/rds-pg-refersTo.test.ts|src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: api_lambda_auth_api_9
+    - identifier: api_6_api_lambda_auth_api_9
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/graphql-v2/api_lambda_auth.test.ts|src/__tests__/api_9.test.ts
-          CLI_REGION: us-west-2
+            src/__tests__/api_6.test.ts|src/__tests__/graphql-v2/api_lambda_auth.test.ts|src/__tests__/api_9.test.ts
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: function_migration
@@ -426,7 +426,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-5.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_datastore
@@ -435,7 +435,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: us-east-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -445,7 +445,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_searchable
@@ -454,7 +454,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-searchable.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-west-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry

--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -135,24 +135,24 @@ batch:
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: rds_pg_refersTo_api_1_resolvers_sync_query_datastore
+    - identifier: api_1_resolvers_sync_query_datastore_api_6
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/rds-pg-refersTo.test.ts|src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts|src/__tests__/api_6.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: api_6_api_lambda_auth_api_9
+    - identifier: api_lambda_auth_api_9
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/api_6.test.ts|src/__tests__/graphql-v2/api_lambda_auth.test.ts|src/__tests__/api_9.test.ts
-          CLI_REGION: ap-southeast-1
+            src/__tests__/graphql-v2/api_lambda_auth.test.ts|src/__tests__/api_9.test.ts
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: function_migration
@@ -426,7 +426,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-5.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_datastore
@@ -435,7 +435,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: ap-southeast-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -445,7 +445,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_searchable
@@ -454,7 +454,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-searchable.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: us-east-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
@@ -4064,6 +4064,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.createSong.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.createSong.req.vtl": "## [Start] Create Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -4152,6 +4163,16 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.deleteSong.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Mutation.deleteSong.req.vtl": "## [Start] Delete Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $DeleteRequest = {
@@ -4234,6 +4255,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.updateSong.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.updateSong.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -4379,6 +4411,12 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.getSong.preAuth.1.req.vtl": "## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Query.getSong.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -4432,6 +4470,25 @@ $util.unauthorized()
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.listSongs.preAuth.1.req.vtl": "## [Start] Set query expression for key **
+#if( !$util.isNull($ctx.args.sortDirection) )
+  $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
+#end
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($ctx.args.id) )
+  #set( $modelQueryExpression.expression = \\"#id = :id\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#id\\": \\"id\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":id\\": {
+      \\"S\\": \\"$ctx.args.id\\"
+  }
+} )
+#end
+## [End] Set query expression for key **
+$util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
+{}",
   "Query.listSongs.req.vtl": "## [Start] List Request. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $limit = $util.defaultIfNull($args.limit, 100) )
@@ -4563,6 +4620,139 @@ $util.toJson($ctx.result)",
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
   "Query.syncSongs.preAuth.1.req.vtl": "## [Start] Set map initialization for @key **
+#set( $index = \\"\\" )
+#set( $scan = true )
+#set( $filterMap = {} )
+#set( $QueryMap = {} )
+#set( $PkMap = {} )
+#set( $SkMap = {} )
+#set( $filterArgsMap = {} )
+#if( $ctx.stash.QueryRequest )
+  #return
+#end
+#set( $queryRequestVariables = {} )
+## [End] Set map initialization for @key **
+## [Start] Set query expression for @key **
+$util.qr($QueryMap.put('id' , 'dbTable'))
+$util.qr($PkMap.put('id' , 'dbTable'))
+$util.qr($SkMap.put(\\"dbTable\\", []))
+## [End] Set query expression for @key **
+## [Start] Set query expression for @key **
+#set( $filterArgsMap = $ctx.args.filter.get(\\"and\\") )
+#set( $isLastSyncInDeltaTTLWindow = false )
+#set( $minLastSync = $util.time.nowEpochMilliSeconds() - $ctx.stash.deltaSyncTableTtl * 60 * 1000 )
+#if( !$util.isNull($ctx.args.lastSync) && $ctx.args.lastSync != 0 && $minLastSync <= $ctx.args.lastSync )
+  #set( $isLastSyncInDeltaTTLWindow = true )
+#end
+#if( !$util.isNullOrEmpty($filterArgsMap) && !$isLastSyncInDeltaTTLWindow )
+  #set( $json = $filterArgsMap )
+  #foreach( $item in $json )
+    #set( $ind = $foreach.index )
+    #foreach( $entry in $item.entrySet() )
+      #if( $ind == 0 && !$util.isNullOrEmpty($entry.value.eq) && !$util.isNullOrEmpty($PkMap.get($entry.key)) )
+        #set( $pk = $entry.key )
+        #set( $scan = false )
+        #set( $queryRequestVariables.partitionKey = $pk )
+        #set( $queryRequestVariables.sortKeys = $SkMap.get($PkMap.get($pk)) )
+        #set( $queryRequestVariables.partitionKeyFilter = {} )
+        $util.qr($queryRequestVariables.partitionKeyFilter.put($pk, {'eq': $entry.value.eq}))
+        $util.qr($ctx.args.put($pk,$entry.value.eq))
+        #set( $index = $PkMap.get($pk) )
+      #end
+      #if( $ind == 1 && !$util.isNullOrEmpty($pk) && !$util.isNullOrEmpty($QueryMap.get(\\"\${pk}+$entry.key\\")) )
+        #set( $sk = $entry.key )
+        $util.qr($ctx.args.put($sk,$entry.value))
+        #set( $index = $QueryMap.get(\\"\${pk}+$sk\\") )
+      #else
+        #if( $ind > 0 )
+          $util.qr($filterMap.put($entry.key,$entry.value))
+        #end
+      #end
+    #end
+  #end
+#else
+  #set( $filterMap = $ctx.args.filter )
+#end
+## [End] Set query expression for @key **
+## [Start] Set Primary Key initialization @key **
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($pk) )
+  #set( $modelQueryExpression.expression = \\"#pk = :pk\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#pk\\": \\"$pk\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":pk\\": $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($pk)))
+} )
+#end
+## [End] Set Primary Key initialization @key **
+## [Start] Applying Key Condition **
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).beginsWith) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND begins_with(#sortKey, :sortKey)\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).beginsWith))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).between) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey BETWEEN :sortKey0 AND :sortKey1\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).between[0]))))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).between[1]))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).eq) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey = :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).eq))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).lt) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey < :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).lt))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).le) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey <= :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).le))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).gt) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey > :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).gt))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).ge) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey >= :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).ge))))
+#end
+## [End] Applying Key Condition **
+## [Start]  Set query expression for @key **
+#if( !$scan )
+  #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
+  #set( $ctx.stash.QueryRequestVariables = $queryRequestVariables )
+  #set( $ctx.stash.QueryRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Sync\\",
+  \\"limit\\": $limit,
+  \\"lastSync\\": $util.defaultIfNull($ctx.args.lastSync, null),
+  \\"query\\": $modelQueryExpression
+} )
+  #if( !$util.isNull($ctx.args.sortDirection)
+                    && $ctx.args.sortDirection == \\"DESC\\" )
+    #set( $ctx.stash.QueryRequest.scanIndexForward = false )
+  #else
+    #set( $ctx.stash.QueryRequest.scanIndexForward = true )
+  #end
+#if( $context.args.nextToken ) #set( $ctx.stash.QueryRequest.nextToken = $context.args.nextToken ) #end
+  #if( !$util.isNullOrEmpty($filterMap) && $util.toJson($filterMap) != $util.toJson({}) )
+    #set( $ctx.stash.QueryRequest.filter = $filterMap )
+  #end
+  #if( $index != \\"dbTable\\" )
+    #set( $ctx.stash.QueryRequest.index = $index )
+  #end
+#end
+$util.toJson({})
+## [End]  Set query expression for @key **
+",
+  "Query.syncSongs.preAuth.2.req.vtl": "## [Start] Set map initialization for @key **
 #set( $index = \\"\\" )
 #set( $scan = true )
 #set( $filterMap = {} )
@@ -4859,6 +5049,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.createSong.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.createSong.req.vtl": "## [Start] Create Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -4947,6 +5148,16 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.deleteSong.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Mutation.deleteSong.req.vtl": "## [Start] Delete Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $DeleteRequest = {
@@ -5029,6 +5240,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.updateSong.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.updateSong.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -5174,6 +5396,12 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.getSong.preAuth.1.req.vtl": "## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Query.getSong.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5227,6 +5455,25 @@ $util.unauthorized()
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.listSongs.preAuth.1.req.vtl": "## [Start] Set query expression for key **
+#if( !$util.isNull($ctx.args.sortDirection) )
+  $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
+#end
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($ctx.args.id) )
+  #set( $modelQueryExpression.expression = \\"#id = :id\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#id\\": \\"id\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":id\\": {
+      \\"S\\": \\"$ctx.args.id\\"
+  }
+} )
+#end
+## [End] Set query expression for key **
+$util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
+{}",
   "Query.listSongs.req.vtl": "## [Start] List Request. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $limit = $util.defaultIfNull($args.limit, 100) )
@@ -5374,6 +5621,139 @@ $util.toJson({})
 $util.qr($QueryMap.put('genre' , 'byGenre'))
 $util.qr($PkMap.put('genre' , 'byGenre'))
 $util.qr($SkMap.put(\\"byGenre\\", []))
+## [End] Set query expression for @key **
+## [Start] Set query expression for @key **
+#set( $filterArgsMap = $ctx.args.filter.get(\\"and\\") )
+#set( $isLastSyncInDeltaTTLWindow = false )
+#set( $minLastSync = $util.time.nowEpochMilliSeconds() - $ctx.stash.deltaSyncTableTtl * 60 * 1000 )
+#if( !$util.isNull($ctx.args.lastSync) && $ctx.args.lastSync != 0 && $minLastSync <= $ctx.args.lastSync )
+  #set( $isLastSyncInDeltaTTLWindow = true )
+#end
+#if( !$util.isNullOrEmpty($filterArgsMap) && !$isLastSyncInDeltaTTLWindow )
+  #set( $json = $filterArgsMap )
+  #foreach( $item in $json )
+    #set( $ind = $foreach.index )
+    #foreach( $entry in $item.entrySet() )
+      #if( $ind == 0 && !$util.isNullOrEmpty($entry.value.eq) && !$util.isNullOrEmpty($PkMap.get($entry.key)) )
+        #set( $pk = $entry.key )
+        #set( $scan = false )
+        #set( $queryRequestVariables.partitionKey = $pk )
+        #set( $queryRequestVariables.sortKeys = $SkMap.get($PkMap.get($pk)) )
+        #set( $queryRequestVariables.partitionKeyFilter = {} )
+        $util.qr($queryRequestVariables.partitionKeyFilter.put($pk, {'eq': $entry.value.eq}))
+        $util.qr($ctx.args.put($pk,$entry.value.eq))
+        #set( $index = $PkMap.get($pk) )
+      #end
+      #if( $ind == 1 && !$util.isNullOrEmpty($pk) && !$util.isNullOrEmpty($QueryMap.get(\\"\${pk}+$entry.key\\")) )
+        #set( $sk = $entry.key )
+        $util.qr($ctx.args.put($sk,$entry.value))
+        #set( $index = $QueryMap.get(\\"\${pk}+$sk\\") )
+      #else
+        #if( $ind > 0 )
+          $util.qr($filterMap.put($entry.key,$entry.value))
+        #end
+      #end
+    #end
+  #end
+#else
+  #set( $filterMap = $ctx.args.filter )
+#end
+## [End] Set query expression for @key **
+## [Start] Set Primary Key initialization @key **
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($pk) )
+  #set( $modelQueryExpression.expression = \\"#pk = :pk\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#pk\\": \\"$pk\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":pk\\": $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($pk)))
+} )
+#end
+## [End] Set Primary Key initialization @key **
+## [Start] Applying Key Condition **
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).beginsWith) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND begins_with(#sortKey, :sortKey)\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).beginsWith))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).between) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey BETWEEN :sortKey0 AND :sortKey1\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).between[0]))))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).between[1]))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).eq) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey = :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).eq))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).lt) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey < :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).lt))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).le) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey <= :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).le))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).gt) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey > :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).gt))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).ge) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey >= :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).ge))))
+#end
+## [End] Applying Key Condition **
+## [Start]  Set query expression for @key **
+#if( !$scan )
+  #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
+  #set( $ctx.stash.QueryRequestVariables = $queryRequestVariables )
+  #set( $ctx.stash.QueryRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Sync\\",
+  \\"limit\\": $limit,
+  \\"lastSync\\": $util.defaultIfNull($ctx.args.lastSync, null),
+  \\"query\\": $modelQueryExpression
+} )
+  #if( !$util.isNull($ctx.args.sortDirection)
+                    && $ctx.args.sortDirection == \\"DESC\\" )
+    #set( $ctx.stash.QueryRequest.scanIndexForward = false )
+  #else
+    #set( $ctx.stash.QueryRequest.scanIndexForward = true )
+  #end
+#if( $context.args.nextToken ) #set( $ctx.stash.QueryRequest.nextToken = $context.args.nextToken ) #end
+  #if( !$util.isNullOrEmpty($filterMap) && $util.toJson($filterMap) != $util.toJson({}) )
+    #set( $ctx.stash.QueryRequest.filter = $filterMap )
+  #end
+  #if( $index != \\"dbTable\\" )
+    #set( $ctx.stash.QueryRequest.index = $index )
+  #end
+#end
+$util.toJson({})
+## [End]  Set query expression for @key **
+",
+  "Query.syncSongs.preAuth.2.req.vtl": "## [Start] Set map initialization for @key **
+#set( $index = \\"\\" )
+#set( $scan = true )
+#set( $filterMap = {} )
+#set( $QueryMap = {} )
+#set( $PkMap = {} )
+#set( $SkMap = {} )
+#set( $filterArgsMap = {} )
+#if( $ctx.stash.QueryRequest )
+  #return
+#end
+#set( $queryRequestVariables = {} )
+## [End] Set map initialization for @key **
+## [Start] Set query expression for @key **
+$util.qr($QueryMap.put('id' , 'dbTable'))
+$util.qr($PkMap.put('id' , 'dbTable'))
+$util.qr($SkMap.put(\\"dbTable\\", []))
 ## [End] Set query expression for @key **
 ## [Start] Set query expression for @key **
 #set( $filterArgsMap = $ctx.args.filter.get(\\"and\\") )

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
@@ -804,6 +804,783 @@ $util.toJson(null)
 }
 `;
 
+exports[`RDS primary key transformer tests id is treated as implicit primaryKey and necessary resolver resources are generated 1`] = `
+Object {
+  "Mutation.createSong.init.1.req.vtl": "## [Start] Initialization default values. **
+$util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
+#set( $createdAt = $util.time.nowISO8601() )
+$util.qr($ctx.stash.defaultValues.put(\\"id\\", $util.autoId()))
+$util.qr($ctx.stash.defaultValues.put(\\"createdAt\\", $createdAt))
+$util.qr($ctx.stash.defaultValues.put(\\"updatedAt\\", $createdAt))
+$util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": {}
+})
+## [End] Initialization default values. **",
+  "Mutation.createSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Mutation.createSong.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
+  "Mutation.createSong.req.vtl": "## [Start] Create Request template. **
+#set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+## Set the default values to put request **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+## copy the values from input **
+$util.qr($mergedValues.putAll($util.defaultIfNull($args.input, {})))
+## set the typename **
+$util.qr($mergedValues.put(\\"__typename\\", \\"Song\\"))
+#set( $PutObject = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"PutItem\\",
+  \\"attributeValues\\":   $util.dynamodb.toMapValues($mergedValues),
+  \\"condition\\": $condition
+} )
+#if( $args.condition )
+  $util.qr($ctx.stash.conditions.add($args.condition))
+#end
+## Begin - key condition **
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $keyConditionExpr = {} )
+  #set( $keyConditionExprNames = {} )
+  #foreach( $entry in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    $util.qr($keyConditionExpr.put(\\"keyCondition$velocityCount\\", {
+  \\"attributeExists\\": false
+}))
+    $util.qr($keyConditionExprNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+  $util.qr($ctx.stash.conditions.add($keyConditionExpr))
+#else
+  $util.qr($ctx.stash.conditions.add({
+  \\"id\\": {
+      \\"attributeExists\\": false
+  }
+}))
+#end
+## End - key condition **
+## Start condition block **
+#if( $ctx.stash.conditions && $ctx.stash.conditions.size() != 0 )
+  #set( $mergedConditions = {
+  \\"and\\": $ctx.stash.conditions
+} )
+  #set( $Conditions = $util.parseJson($util.transform.toDynamoDBConditionExpression($mergedConditions)) )
+  #if( $Conditions.expressionValues && $Conditions.expressionValues.size() == 0 )
+    #set( $Conditions = {
+  \\"expression\\": $Conditions.expression,
+  \\"expressionNames\\": $Conditions.expressionNames
+} )
+  #end
+  ## End condition block **
+#end
+#if( $Conditions )
+  #if( $keyConditionExprNames )
+    $util.qr($Conditions.expressionNames.putAll($keyConditionExprNames))
+  #end
+  $util.qr($PutObject.put(\\"condition\\", $Conditions))
+#end
+#if( $ctx.stash.metadata.modelObjectKey )
+  $util.qr($PutObject.put(\\"key\\", $ctx.stash.metadata.modelObjectKey))
+#else
+  #set( $Key = {
+  \\"id\\":   $util.dynamodb.toDynamoDB($mergedValues.id)
+} )
+  $util.qr($PutObject.put(\\"key\\", $Key))
+#end
+$util.toJson($PutObject)
+## [End] Create Request template. **",
+  "Mutation.createSong.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#else
+  $util.toJson($ctx.result)
+#end
+## [End] ResponseTemplate. **",
+  "Mutation.deleteSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Mutation.deleteSong.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+{}",
+  "Mutation.deleteSong.req.vtl": "## [Start] Delete Request template. **
+#set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+#set( $DeleteRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"DeleteItem\\"
+} )
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $Key = $ctx.stash.metadata.modelObjectKey )
+#else
+  #set( $Key = {
+  \\"id\\":   $util.dynamodb.toDynamoDB($args.input.id)
+} )
+#end
+$util.qr($DeleteRequest.put(\\"key\\", $Key))
+## Begin - key condition **
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $keyConditionExpr = {} )
+  #set( $keyConditionExprNames = {} )
+  #foreach( $entry in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    $util.qr($keyConditionExpr.put(\\"keyCondition$velocityCount\\", {
+  \\"attributeExists\\": true
+}))
+    $util.qr($keyConditionExprNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+  $util.qr($ctx.stash.conditions.add($keyConditionExpr))
+#else
+  $util.qr($ctx.stash.conditions.add({
+  \\"id\\": {
+      \\"attributeExists\\": true
+  }
+}))
+#end
+## End - key condition **
+#if( $args.condition )
+  $util.qr($ctx.stash.conditions.add($args.condition))
+#end
+## Start condition block **
+#if( $ctx.stash.conditions && $ctx.stash.conditions.size() != 0 )
+  #set( $mergedConditions = {
+  \\"and\\": $ctx.stash.conditions
+} )
+  #set( $Conditions = $util.parseJson($util.transform.toDynamoDBConditionExpression($mergedConditions)) )
+  #if( $Conditions.expressionValues && $Conditions.expressionValues.size() == 0 )
+    #set( $Conditions = {
+  \\"expression\\": $Conditions.expression,
+  \\"expressionNames\\": $Conditions.expressionNames
+} )
+  #end
+  ## End condition block **
+#end
+#if( $Conditions )
+  #if( $keyConditionExprNames )
+    $util.qr($Conditions.expressionNames.putAll($keyConditionExprNames))
+  #end
+  $util.qr($DeleteRequest.put(\\"condition\\", $Conditions))
+#end
+$util.qr($DeleteRequest.put(\\"_version\\", $util.defaultIfNull($args.input[\\"_version\\"], 0)))
+$util.toJson($DeleteRequest)
+## [End] Delete Request template. **",
+  "Mutation.deleteSong.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#else
+  $util.toJson($ctx.result)
+#end
+## [End] ResponseTemplate. **",
+  "Mutation.updateSong.init.1.req.vtl": "## [Start] Initialization default values. **
+$util.qr($ctx.stash.put(\\"defaultValues\\", $util.defaultIfNull($ctx.stash.defaultValues, {})))
+#set( $updatedAt = $util.time.nowISO8601() )
+$util.qr($ctx.stash.defaultValues.put(\\"updatedAt\\", $updatedAt))
+$util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": {}
+})
+## [End] Initialization default values. **",
+  "Mutation.updateSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Mutation.updateSong.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
+  "Mutation.updateSong.req.vtl": "## [Start] Mutation Update resolver. **
+#set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+## Set the default values to put request **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+## copy the values from input **
+$util.qr($mergedValues.putAll($util.defaultIfNull($args.input, {})))
+## set the typename **
+## Initialize the vars for creating ddb expression **
+#set( $expNames = {} )
+#set( $expValues = {} )
+#set( $expSet = {} )
+#set( $expAdd = {} )
+#set( $expRemove = [] )
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $Key = $ctx.stash.metadata.modelObjectKey )
+#else
+  #set( $Key = {
+  \\"id\\":   $util.dynamodb.toDynamoDB($args.input.id)
+} )
+#end
+## Model key **
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $keyFields = [\\"_version\\", \\"_deleted\\", \\"_lastChangedAt\\"] )
+  #foreach( $entry in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    $util.qr($keyFields.add(\\"$entry.key\\"))
+  #end
+#else
+  #set( $keyFields = [\\"id\\", \\"_version\\", \\"_deleted\\", \\"_lastChangedAt\\"] )
+#end
+#foreach( $entry in $util.map.copyAndRemoveAllKeys($mergedValues, $keyFields).entrySet() )
+  #if( !$util.isNull($ctx.stash.metadata.dynamodbNameOverrideMap) && $ctx.stash.metadata.dynamodbNameOverrideMap.containsKey(\\"$entry.key\\") )
+    #set( $entryKeyAttributeName = $ctx.stash.metadata.dynamodbNameOverrideMap.get(\\"$entry.key\\") )
+  #else
+    #set( $entryKeyAttributeName = $entry.key )
+  #end
+  #if( $util.isNull($entry.value) )
+    #set( $discard = $expRemove.add(\\"#$entryKeyAttributeName\\") )
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+  #else
+    $util.qr($expSet.put(\\"#$entryKeyAttributeName\\", \\":$entryKeyAttributeName\\"))
+    $util.qr($expNames.put(\\"#$entryKeyAttributeName\\", \\"$entry.key\\"))
+    $util.qr($expValues.put(\\":$entryKeyAttributeName\\", $util.dynamodb.toDynamoDB($entry.value)))
+  #end
+#end
+#set( $expression = \\"\\" )
+#if( !$expSet.isEmpty() )
+  #set( $expression = \\"SET\\" )
+  #foreach( $entry in $expSet.entrySet() )
+    #set( $expression = \\"$expression $entry.key = $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expAdd.isEmpty() )
+  #set( $expression = \\"$expression ADD\\" )
+  #foreach( $entry in $expAdd.entrySet() )
+    #set( $expression = \\"$expression $entry.key $entry.value\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#if( !$expRemove.isEmpty() )
+  #set( $expression = \\"$expression REMOVE\\" )
+  #foreach( $entry in $expRemove )
+    #set( $expression = \\"$expression $entry\\" )
+    #if( $foreach.hasNext() )
+      #set( $expression = \\"$expression,\\" )
+    #end
+  #end
+#end
+#set( $update = {} )
+$util.qr($update.put(\\"expression\\", \\"$expression\\"))
+#if( !$expNames.isEmpty() )
+  $util.qr($update.put(\\"expressionNames\\", $expNames))
+#end
+#if( !$expValues.isEmpty() )
+  $util.qr($update.put(\\"expressionValues\\", $expValues))
+#end
+## Begin - key condition **
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $keyConditionExpr = {} )
+  #set( $keyConditionExprNames = {} )
+  #foreach( $entry in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    $util.qr($keyConditionExpr.put(\\"keyCondition$velocityCount\\", {
+  \\"attributeExists\\": true
+}))
+    $util.qr($keyConditionExprNames.put(\\"#keyCondition$velocityCount\\", \\"$entry.key\\"))
+  #end
+  $util.qr($ctx.stash.conditions.add($keyConditionExpr))
+#else
+  $util.qr($ctx.stash.conditions.add({
+  \\"id\\": {
+      \\"attributeExists\\": true
+  }
+}))
+#end
+## End - key condition **
+#if( $args.condition )
+  $util.qr($ctx.stash.conditions.add($args.condition))
+#end
+## Start condition block **
+#if( $ctx.stash.conditions && $ctx.stash.conditions.size() != 0 )
+  #set( $mergedConditions = {
+  \\"and\\": $ctx.stash.conditions
+} )
+  #set( $Conditions = $util.parseJson($util.transform.toDynamoDBConditionExpression($mergedConditions)) )
+  #if( $Conditions.expressionValues && $Conditions.expressionValues.size() == 0 )
+    #set( $Conditions = {
+  \\"expression\\": $Conditions.expression,
+  \\"expressionNames\\": $Conditions.expressionNames
+} )
+  #end
+  ## End condition block **
+#end
+#set( $UpdateItem = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"UpdateItem\\",
+  \\"key\\": $Key,
+  \\"update\\": $update,
+  \\"_version\\": $util.defaultIfNull($args.input[\\"_version\\"], 0)
+} )
+#if( $Conditions )
+  #if( $keyConditionExprNames )
+    $util.qr($Conditions.expressionNames.putAll($keyConditionExprNames))
+  #end
+  $util.qr($UpdateItem.put(\\"condition\\", $Conditions))
+#end
+$util.toJson($UpdateItem)
+## [End] Mutation Update resolver. **",
+  "Mutation.updateSong.res.vtl": "## [Start] ResponseTemplate. **
+$util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#else
+  $util.toJson($ctx.result)
+#end
+## [End] ResponseTemplate. **",
+  "Query.getSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Query.getSong.preAuth.1.req.vtl": "## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id)
+}))
+## [End] Set the primary key. **
+{}",
+  "Query.getSong.req.vtl": "## [Start] Get Request template. **
+#set( $GetRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\"
+} )
+#if( $ctx.stash.metadata.modelObjectKey )
+  #set( $expression = \\"\\" )
+  #set( $expressionNames = {} )
+  #set( $expressionValues = {} )
+  #foreach( $item in $ctx.stash.metadata.modelObjectKey.entrySet() )
+    #set( $expression = \\"$expression#keyCount$velocityCount = :valueCount$velocityCount AND \\" )
+    $util.qr($expressionNames.put(\\"#keyCount$velocityCount\\", $item.key))
+    $util.qr($expressionValues.put(\\":valueCount$velocityCount\\", $item.value))
+  #end
+  #set( $expression = $expression.replaceAll(\\"AND $\\", \\"\\") )
+  #set( $query = {
+  \\"expression\\": $expression,
+  \\"expressionNames\\": $expressionNames,
+  \\"expressionValues\\": $expressionValues
+} )
+#else
+  #set( $query = {
+  \\"expression\\": \\"id = :id\\",
+  \\"expressionValues\\": {
+      \\":id\\":     $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.id))
+  }
+} )
+#end
+$util.qr($GetRequest.put(\\"query\\", $query))
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
+#end
+$util.toJson($GetRequest)
+## [End] Get Request template. **",
+  "Query.getSong.res.vtl": "## [Start] Get Response template. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#end
+#if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  $util.toJson($ctx.result.items[0])
+#else
+  #if( $ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+$util.unauthorized()
+  #end
+  $util.toJson(null)
+#end
+## [End] Get Response template. **",
+  "Query.listSongs.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Query.listSongs.preAuth.1.req.vtl": "## [Start] Set query expression for key **
+#if( !$util.isNull($ctx.args.sortDirection) )
+  $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
+#end
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($ctx.args.id) )
+  #set( $modelQueryExpression.expression = \\"#id = :id\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#id\\": \\"id\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":id\\": {
+      \\"S\\": \\"$ctx.args.id\\"
+  }
+} )
+#end
+## [End] Set query expression for key **
+$util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
+{}",
+  "Query.listSongs.req.vtl": "## [Start] List Request. **
+#set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+#set( $limit = $util.defaultIfNull($args.limit, 100) )
+#set( $ListRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"limit\\": $limit
+} )
+#if( $args.nextToken )
+  #set( $ListRequest.nextToken = $args.nextToken )
+#end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($args.filter) )
+    #set( $filter = {
+  \\"and\\":   [$filter, $args.filter]
+} )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($args.filter) )
+    #set( $filter = $args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( $util.isNullOrEmpty($filterExpression) )
+    $util.error(\\"Unable to process the filter expression\\", \\"Unrecognized Filter\\")
+  #end
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterExpression.expressionValues.size() == 0 )
+      $util.qr($filterExpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $ListRequest.filter = $filterExpression )
+  #end
+#end
+#if( !$util.isNull($ctx.stash.modelQueryExpression) && !$util.isNullOrEmpty($ctx.stash.modelQueryExpression.expression) )
+  $util.qr($ListRequest.put(\\"operation\\", \\"Query\\"))
+  $util.qr($ListRequest.put(\\"query\\", $ctx.stash.modelQueryExpression))
+  #if( !$util.isNull($args.sortDirection) && $args.sortDirection == \\"DESC\\" )
+    #set( $ListRequest.scanIndexForward = false )
+  #else
+    #set( $ListRequest.scanIndexForward = true )
+  #end
+#else
+  $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
+#end
+#if( !$util.isNull($ctx.stash.metadata.index) )
+  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+#end
+$util.toJson($ListRequest)
+## [End] List Request. **",
+  "Query.listSongs.res.vtl": "## [Start] ResponseTemplate. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#else
+  $util.toJson($ctx.result)
+#end
+## [End] ResponseTemplate. **",
+  "Query.syncSongs.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Query.syncSongs.preAuth.1.req.vtl": "## [Start] Set map initialization for @key **
+#set( $index = \\"\\" )
+#set( $scan = true )
+#set( $filterMap = {} )
+#set( $QueryMap = {} )
+#set( $PkMap = {} )
+#set( $SkMap = {} )
+#set( $filterArgsMap = {} )
+#if( $ctx.stash.QueryRequest )
+  #return
+#end
+#set( $queryRequestVariables = {} )
+## [End] Set map initialization for @key **
+## [Start] Set query expression for @key **
+$util.qr($QueryMap.put('id' , 'dbTable'))
+$util.qr($PkMap.put('id' , 'dbTable'))
+$util.qr($SkMap.put(\\"dbTable\\", []))
+## [End] Set query expression for @key **
+## [Start] Set query expression for @key **
+#set( $filterArgsMap = $ctx.args.filter.get(\\"and\\") )
+#set( $isLastSyncInDeltaTTLWindow = false )
+#set( $minLastSync = $util.time.nowEpochMilliSeconds() - $ctx.stash.deltaSyncTableTtl * 60 * 1000 )
+#if( !$util.isNull($ctx.args.lastSync) && $ctx.args.lastSync != 0 && $minLastSync <= $ctx.args.lastSync )
+  #set( $isLastSyncInDeltaTTLWindow = true )
+#end
+#if( !$util.isNullOrEmpty($filterArgsMap) && !$isLastSyncInDeltaTTLWindow )
+  #set( $json = $filterArgsMap )
+  #foreach( $item in $json )
+    #set( $ind = $foreach.index )
+    #foreach( $entry in $item.entrySet() )
+      #if( $ind == 0 && !$util.isNullOrEmpty($entry.value.eq) && !$util.isNullOrEmpty($PkMap.get($entry.key)) )
+        #set( $pk = $entry.key )
+        #set( $scan = false )
+        #set( $queryRequestVariables.partitionKey = $pk )
+        #set( $queryRequestVariables.sortKeys = $SkMap.get($PkMap.get($pk)) )
+        #set( $queryRequestVariables.partitionKeyFilter = {} )
+        $util.qr($queryRequestVariables.partitionKeyFilter.put($pk, {'eq': $entry.value.eq}))
+        $util.qr($ctx.args.put($pk,$entry.value.eq))
+        #set( $index = $PkMap.get($pk) )
+      #end
+      #if( $ind == 1 && !$util.isNullOrEmpty($pk) && !$util.isNullOrEmpty($QueryMap.get(\\"\${pk}+$entry.key\\")) )
+        #set( $sk = $entry.key )
+        $util.qr($ctx.args.put($sk,$entry.value))
+        #set( $index = $QueryMap.get(\\"\${pk}+$sk\\") )
+      #else
+        #if( $ind > 0 )
+          $util.qr($filterMap.put($entry.key,$entry.value))
+        #end
+      #end
+    #end
+  #end
+#else
+  #set( $filterMap = $ctx.args.filter )
+#end
+## [End] Set query expression for @key **
+## [Start] Set Primary Key initialization @key **
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($pk) )
+  #set( $modelQueryExpression.expression = \\"#pk = :pk\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#pk\\": \\"$pk\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":pk\\": $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($pk)))
+} )
+#end
+## [End] Set Primary Key initialization @key **
+## [Start] Applying Key Condition **
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).beginsWith) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND begins_with(#sortKey, :sortKey)\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).beginsWith))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).between) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey BETWEEN :sortKey0 AND :sortKey1\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).between[0]))))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).between[1]))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).eq) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey = :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).eq))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).lt) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey < :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).lt))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).le) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey <= :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).le))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).gt) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey > :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).gt))))
+#end
+#if( !$util.isNull($ctx.args.get($sk)) && !$util.isNull($ctx.args.get($sk).ge) )
+  #set( $modelQueryExpression.expression = \\"$modelQueryExpression.expression AND #sortKey >= :sortKey\\" )
+  $util.qr($modelQueryExpression.expressionNames.put(\\"#sortKey\\", $sk))
+  $util.qr($modelQueryExpression.expressionValues.put(\\":sortKey\\", $util.parseJson($util.dynamodb.toDynamoDBJson($ctx.args.get($sk).ge))))
+#end
+## [End] Applying Key Condition **
+## [Start]  Set query expression for @key **
+#if( !$scan )
+  #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
+  #set( $ctx.stash.QueryRequestVariables = $queryRequestVariables )
+  #set( $ctx.stash.QueryRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Sync\\",
+  \\"limit\\": $limit,
+  \\"lastSync\\": $util.defaultIfNull($ctx.args.lastSync, null),
+  \\"query\\": $modelQueryExpression
+} )
+  #if( !$util.isNull($ctx.args.sortDirection)
+                    && $ctx.args.sortDirection == \\"DESC\\" )
+    #set( $ctx.stash.QueryRequest.scanIndexForward = false )
+  #else
+    #set( $ctx.stash.QueryRequest.scanIndexForward = true )
+  #end
+#if( $context.args.nextToken ) #set( $ctx.stash.QueryRequest.nextToken = $context.args.nextToken ) #end
+  #if( !$util.isNullOrEmpty($filterMap) && $util.toJson($filterMap) != $util.toJson({}) )
+    #set( $ctx.stash.QueryRequest.filter = $filterMap )
+  #end
+  #if( $index != \\"dbTable\\" )
+    #set( $ctx.stash.QueryRequest.index = $index )
+  #end
+#end
+$util.toJson({})
+## [End]  Set query expression for @key **
+",
+  "Query.syncSongs.req.vtl": "## [Start] Sync Request template. **
+#set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+#set( $queryFilterContainsAuthField = false )
+#set( $authFilterContainsSortKey = false )
+#set( $useScan = true )
+#if( $util.isNullOrEmpty($ctx.stash.authFilter) && $ctx.stash.QueryRequest )
+  #set( $useScan = false )
+#end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( $ctx.stash.QueryRequestVariables.partitionKey )
+    #foreach( $filterItem in $ctx.stash.authFilter.or )
+      #if( $filterItem.get($ctx.stash.QueryRequestVariables.partitionKey) )
+        #set( $queryFilterContainsAuthField = true )
+      #end
+    #end
+    #if( !$queryFilterContainsAuthField )
+      #foreach( $filterItem in $ctx.stash.authFilter.or )
+        #foreach( $sortKey in $ctx.stash.QueryRequestVariables.sortKeys )
+          #if( $filterItem.get($sortKey) )
+            #set( $authFilterContainsSortKey = true )
+          #end
+        #end
+      #end
+      #if( !$authFilterContainsSortKey )
+        #if( !$util.isNullOrEmpty($ctx.stash.QueryRequest.filter) )
+          #set( $ctx.stash.QueryRequest.filter = {
+  \\"and\\":   [$ctx.stash.QueryRequest.filter, $ctx.stash.authFilter]
+} )
+        #else
+          #set( $ctx.stash.QueryRequest.filter = $ctx.stash.authFilter )
+        #end
+        #set( $useScan = false )
+      #end
+    #else
+      #foreach( $filterItem in $ctx.stash.authFilter.or )
+        #if( $util.toJson($filterItem) == $util.toJson($ctx.stash.QueryRequestVariables.partitionKeyFilter) )
+          #set( $useScan = false )
+        #end
+      #end
+    #end
+  #end
+  #if( !$util.isNullOrEmpty($args.filter) )
+    #set( $filter = {
+  \\"and\\":   [$filter, $args.filter]
+} )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($args.filter) )
+    #set( $filter = $args.filter )
+  #end
+#end
+#if( !$util.isNullOrEmpty($filter) )
+  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+  #if( !$util.isNullOrBlank($filterExpression.expression) )
+    #if( $filterExpression.expressionValues.size() == 0 )
+      $util.qr($filterExpression.remove(\\"expressionValues\\"))
+    #end
+    #set( $filter = $filterExpression )
+  #end
+#end
+#if( !$useScan )
+  #if( $ctx.stash.QueryRequest.filter )
+    #set( $ctx.stash.QueryRequest.filter = $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.QueryRequest.filter)) )
+  #end
+  $util.toJson($ctx.stash.QueryRequest)
+#else
+{
+      \\"version\\": \\"2018-05-29\\",
+      \\"operation\\": \\"Sync\\",
+      \\"filter\\":     #if( $filter )
+$util.toJson($filter)
+    #else
+null
+    #end,
+      \\"limit\\": $util.defaultIfNull($args.limit, 100),
+      \\"lastSync\\": $util.toJson($util.defaultIfNull($args.lastSync, null)),
+      \\"nextToken\\": $util.toJson($util.defaultIfNull($args.nextToken, null))
+  }
+#end
+## [End] Sync Request template. **",
+  "Query.syncSongs.res.vtl": "## [Start] ResponseTemplate. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type, $ctx.result)
+#else
+  $util.toJson($ctx.result)
+#end
+## [End] ResponseTemplate. **",
+  "Subscription.onCreateSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Subscription.onCreateSong.req.vtl": "## [Start] Subscription Request template. **
+$util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": {}
+})
+## [End] Subscription Request template. **",
+  "Subscription.onCreateSong.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
+$util.toJson(null)
+## [End] Subscription Response template. **",
+  "Subscription.onDeleteSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Subscription.onDeleteSong.req.vtl": "## [Start] Subscription Request template. **
+$util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": {}
+})
+## [End] Subscription Request template. **",
+  "Subscription.onDeleteSong.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
+$util.toJson(null)
+## [End] Subscription Response template. **",
+  "Subscription.onUpdateSong.postAuth.1.req.vtl": "## [Start] Sandbox Mode Disabled. **
+#if( !$ctx.stash.get(\\"hasAuth\\") )
+  $util.unauthorized()
+#end
+$util.toJson({})
+## [End] Sandbox Mode Disabled. **",
+  "Subscription.onUpdateSong.req.vtl": "## [Start] Subscription Request template. **
+$util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": {}
+})
+## [End] Subscription Request template. **",
+  "Subscription.onUpdateSong.res.vtl": "## [Start] Subscription Response template. **
+#if( !$util.isNullOrEmpty($ctx.args.filter) )
+$extensions.setSubscriptionFilter($util.transform.toSubscriptionFilter($ctx.args.filter))
+#end
+$util.toJson(null)
+## [End] Subscription Response template. **",
+}
+`;
+
 exports[`RDS primary key transformer tests individual resolvers can be made null by @model 1`] = `
 Object {
   "Mutation.createTest.init.1.req.vtl": "## [Start] Initialization default values. **

--- a/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-primary-key-transformer.test.ts
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-primary-key-transformer.test.ts
@@ -1037,6 +1037,50 @@ describe('RDS primary key transformer tests', () => {
 
     validateModelSchema(parse(definition));
   });
+
+  it('having id as implicit primary key is identical to it being explicit', () => {
+    const implicitSchema = `
+      type Song @model {
+        id: ID!
+        name: String!
+        genre: String!
+      }
+    `;
+    const explicitSchema = `
+      type Song @model {
+        id: ID! @primaryKey
+        name: String!
+        genre: String!
+      }
+    `;
+
+    const implicitOutput = testTransform({
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+      resolverConfig: {
+        project: {
+          ConflictDetection: 'VERSION',
+          ConflictHandler: ConflictHandlerType.AUTOMERGE,
+        },
+      },
+      schema: implicitSchema,
+    });
+    const explicitOutput = testTransform({
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+      resolverConfig: {
+        project: {
+          ConflictDetection: 'VERSION',
+          ConflictHandler: ConflictHandlerType.AUTOMERGE,
+        },
+      },
+      schema: implicitSchema,
+    });
+
+    expect(implicitOutput).toBeDefined();
+    expect(explicitOutput).toBeDefined();
+    validateModelSchema(parse(implicitOutput.schema));
+    expect(implicitOutput.schema).toEqual(explicitOutput.schema);
+    expect(implicitOutput.resolvers).toEqual(explicitOutput.resolvers);
+  });
 });
 
 const getDDBTableResources = (stack: any): string[] => {

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
@@ -12153,6 +12153,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.createFriendship.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.createFriendship.req.vtl": "## [Start] Create Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -12252,6 +12263,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.createParent.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.createParent.req.vtl": "## [Start] Create Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -12351,6 +12373,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.createPost.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.createPost.req.vtl": "## [Start] Create Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -12442,6 +12475,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.createPostAuthor.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.createPostAuthor.req.vtl": "## [Start] Create Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -12541,6 +12585,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.createPostModel.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.createPostModel.req.vtl": "## [Start] Create Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -12948,6 +13003,16 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.deleteFriendship.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Mutation.deleteFriendship.req.vtl": "## [Start] Delete Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $DeleteRequest = {
@@ -13020,6 +13085,16 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.deleteParent.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Mutation.deleteParent.req.vtl": "## [Start] Delete Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $DeleteRequest = {
@@ -13092,6 +13167,16 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.deletePost.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Mutation.deletePost.req.vtl": "## [Start] Delete Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $DeleteRequest = {
@@ -13164,6 +13249,16 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.deletePostAuthor.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Mutation.deletePostAuthor.req.vtl": "## [Start] Delete Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $DeleteRequest = {
@@ -13236,6 +13331,16 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.deletePostModel.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Mutation.deletePostModel.req.vtl": "## [Start] Delete Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $DeleteRequest = {
@@ -13659,6 +13764,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.updateFriendship.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.updateFriendship.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -13812,6 +13928,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.updateParent.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.updateParent.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -13965,6 +14092,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.updatePost.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.updatePost.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -14118,6 +14256,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.updatePostAuthor.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.updatePostAuthor.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -14271,6 +14420,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.updatePostModel.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.updatePostModel.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -15168,6 +15328,12 @@ $util.unauthorized()
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.getFriendship.preAuth.1.req.vtl": "## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Query.getFriendship.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -15221,6 +15387,12 @@ $util.unauthorized()
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.getParent.preAuth.1.req.vtl": "## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Query.getParent.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -15274,6 +15446,12 @@ $util.unauthorized()
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.getPost.preAuth.1.req.vtl": "## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Query.getPost.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -15327,6 +15505,12 @@ $util.unauthorized()
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.getPostAuthor.preAuth.1.req.vtl": "## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Query.getPostAuthor.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -15380,6 +15564,12 @@ $util.unauthorized()
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.getPostModel.preAuth.1.req.vtl": "## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Query.getPostModel.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -15678,6 +15868,25 @@ $util.toJson($ListRequest)
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.listFriendships.preAuth.1.req.vtl": "## [Start] Set query expression for key **
+#if( !$util.isNull($ctx.args.sortDirection) )
+  $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
+#end
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($ctx.args.id) )
+  #set( $modelQueryExpression.expression = \\"#id = :id\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#id\\": \\"id\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":id\\": {
+      \\"S\\": \\"$ctx.args.id\\"
+  }
+} )
+#end
+## [End] Set query expression for key **
+$util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
+{}",
   "Query.listFriendships.req.vtl": "## [Start] List Request. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $limit = $util.defaultIfNull($args.limit, 100) )
@@ -15741,6 +15950,25 @@ $util.toJson($ListRequest)
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.listParents.preAuth.1.req.vtl": "## [Start] Set query expression for key **
+#if( !$util.isNull($ctx.args.sortDirection) )
+  $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
+#end
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($ctx.args.id) )
+  #set( $modelQueryExpression.expression = \\"#id = :id\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#id\\": \\"id\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":id\\": {
+      \\"S\\": \\"$ctx.args.id\\"
+  }
+} )
+#end
+## [End] Set query expression for key **
+$util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
+{}",
   "Query.listParents.req.vtl": "## [Start] List Request. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $limit = $util.defaultIfNull($args.limit, 100) )
@@ -15804,6 +16032,25 @@ $util.toJson($ListRequest)
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.listPostAuthors.preAuth.1.req.vtl": "## [Start] Set query expression for key **
+#if( !$util.isNull($ctx.args.sortDirection) )
+  $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
+#end
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($ctx.args.id) )
+  #set( $modelQueryExpression.expression = \\"#id = :id\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#id\\": \\"id\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":id\\": {
+      \\"S\\": \\"$ctx.args.id\\"
+  }
+} )
+#end
+## [End] Set query expression for key **
+$util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
+{}",
   "Query.listPostAuthors.req.vtl": "## [Start] List Request. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $limit = $util.defaultIfNull($args.limit, 100) )
@@ -15867,6 +16114,25 @@ $util.toJson($ListRequest)
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.listPostModels.preAuth.1.req.vtl": "## [Start] Set query expression for key **
+#if( !$util.isNull($ctx.args.sortDirection) )
+  $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
+#end
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($ctx.args.id) )
+  #set( $modelQueryExpression.expression = \\"#id = :id\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#id\\": \\"id\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":id\\": {
+      \\"S\\": \\"$ctx.args.id\\"
+  }
+} )
+#end
+## [End] Set query expression for key **
+$util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
+{}",
   "Query.listPostModels.req.vtl": "## [Start] List Request. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $limit = $util.defaultIfNull($args.limit, 100) )
@@ -15930,6 +16196,25 @@ $util.toJson($ListRequest)
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.listPosts.preAuth.1.req.vtl": "## [Start] Set query expression for key **
+#if( !$util.isNull($ctx.args.sortDirection) )
+  $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
+#end
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($ctx.args.id) )
+  #set( $modelQueryExpression.expression = \\"#id = :id\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#id\\": \\"id\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":id\\": {
+      \\"S\\": \\"$ctx.args.id\\"
+  }
+} )
+#end
+## [End] Set query expression for key **
+$util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
+{}",
   "Query.listPosts.req.vtl": "## [Start] List Request. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $limit = $util.defaultIfNull($args.limit, 100) )

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
@@ -198,7 +198,7 @@ type Query {
   getModelB(id: ID!, sortId: ID!): ModelB
   listModelBS(id: ID, sortId: ModelIDKeyConditionInput, filter: ModelModelBFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelModelBConnection
   getModelAModelB(id: ID!): ModelAModelB
-  listModelAModelBS(filter: ModelModelAModelBFilterInput, limit: Int, nextToken: String): ModelModelAModelBConnection
+  listModelAModelBS(id: ID, filter: ModelModelAModelBFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelModelAModelBConnection
 }
 
 input ModelModelAConditionInput {
@@ -722,6 +722,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.createModelAModelB.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.createModelAModelB.req.vtl": "## [Start] Create Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -996,6 +1007,16 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.deleteModelAModelB.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Mutation.deleteModelAModelB.req.vtl": "## [Start] Delete Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $DeleteRequest = {
@@ -1325,6 +1346,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.updateModelAModelB.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.updateModelAModelB.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -1694,6 +1726,12 @@ $util.unauthorized()
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.getModelAModelB.preAuth.1.req.vtl": "## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Query.getModelAModelB.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -1807,6 +1845,25 @@ $util.unauthorized()
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.listModelAModelBS.preAuth.1.req.vtl": "## [Start] Set query expression for key **
+#if( !$util.isNull($ctx.args.sortDirection) )
+  $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
+#end
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($ctx.args.id) )
+  #set( $modelQueryExpression.expression = \\"#id = :id\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#id\\": \\"id\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":id\\": {
+      \\"S\\": \\"$ctx.args.id\\"
+  }
+} )
+#end
+## [End] Set query expression for key **
+$util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
+{}",
   "Query.listModelAModelBS.req.vtl": "## [Start] List Request. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $limit = $util.defaultIfNull($args.limit, 100) )
@@ -3482,7 +3539,7 @@ type Query {
   getModelB(id: ID!, sortId: ID!): ModelB
   listModelBS(id: ID, sortId: ModelIDKeyConditionInput, filter: ModelModelBFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelModelBConnection
   getModelAModelB(id: ID!): ModelAModelB
-  listModelAModelBS(filter: ModelModelAModelBFilterInput, limit: Int, nextToken: String): ModelModelAModelBConnection
+  listModelAModelBS(id: ID, filter: ModelModelAModelBFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelModelAModelBConnection
 }
 
 input ModelModelAConditionInput {
@@ -3879,9 +3936,9 @@ type Query {
   getModelA(id: ID!, sortId: ID!): ModelA
   listModelAS(id: ID, sortId: ModelIDKeyConditionInput, filter: ModelModelAFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelModelAConnection
   getModelB(id: ID!): ModelB
-  listModelBS(filter: ModelModelBFilterInput, limit: Int, nextToken: String): ModelModelBConnection
+  listModelBS(id: ID, filter: ModelModelBFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelModelBConnection
   getModelAModelB(id: ID!): ModelAModelB
-  listModelAModelBS(filter: ModelModelAModelBFilterInput, limit: Int, nextToken: String): ModelModelAModelBConnection
+  listModelAModelBS(id: ID, filter: ModelModelAModelBFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelModelAModelBConnection
 }
 
 input ModelModelAConditionInput {
@@ -4224,11 +4281,11 @@ input ModelFooFilterInput {
 
 type Query {
   getFoo(id: ID!): Foo
-  listFoos(filter: ModelFooFilterInput, limit: Int, nextToken: String): ModelFooConnection
+  listFoos(id: ID, filter: ModelFooFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelFooConnection
   getBar(id: ID!): Bar
-  listBars(filter: ModelBarFilterInput, limit: Int, nextToken: String): ModelBarConnection
+  listBars(id: ID, filter: ModelBarFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelBarConnection
   getFooBar(id: ID!): FooBar
-  listFooBars(filter: ModelFooBarFilterInput, limit: Int, nextToken: String): ModelFooBarConnection
+  listFooBars(id: ID, filter: ModelFooBarFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelFooBarConnection
 }
 
 input ModelFooConditionInput {
@@ -4610,6 +4667,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.createBar.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.createBar.req.vtl": "## [Start] Create Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -4701,6 +4769,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.createFoo.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.createFoo.req.vtl": "## [Start] Create Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -4792,6 +4871,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.createFooBar.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.createFooBar.req.vtl": "## [Start] Create Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -4880,6 +4970,16 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.deleteBar.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Mutation.deleteBar.req.vtl": "## [Start] Delete Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $DeleteRequest = {
@@ -4952,6 +5052,16 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.deleteFoo.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Mutation.deleteFoo.req.vtl": "## [Start] Delete Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $DeleteRequest = {
@@ -5024,6 +5134,16 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.deleteFooBar.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Mutation.deleteFooBar.req.vtl": "## [Start] Delete Request template. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $DeleteRequest = {
@@ -5105,6 +5225,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.updateBar.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.updateBar.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -5258,6 +5389,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.updateFoo.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.updateFoo.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -5411,6 +5553,17 @@ $util.toJson({
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Mutation.updateFooBar.preAuth.1.req.vtl": "## [Start] Merge default values and inputs. **
+#set( $mergedValues = $util.defaultIfNull($ctx.stash.defaultValues, {}) )
+$util.qr($mergedValues.putAll($util.defaultIfNull($ctx.args.input, {})))
+## [End] Merge default values and inputs. **
+## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($mergedValues.id)
+}))
+## [End] Set the primary key. **
+
+{}",
   "Mutation.updateFooBar.req.vtl": "## [Start] Mutation Update resolver. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 ## Set the default values to put request **
@@ -5555,6 +5708,12 @@ $util.qr($ctx.result.put(\\"__operation\\", \\"Mutation\\"))
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.getBar.preAuth.1.req.vtl": "## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Query.getBar.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5608,6 +5767,12 @@ $util.unauthorized()
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.getFoo.preAuth.1.req.vtl": "## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Query.getFoo.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5661,6 +5826,12 @@ $util.unauthorized()
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.getFooBar.preAuth.1.req.vtl": "## [Start] Set the primary key. **
+$util.qr($ctx.stash.metadata.put(\\"modelObjectKey\\", {
+  \\"id\\": $util.dynamodb.toDynamoDB($ctx.args.id)
+}))
+## [End] Set the primary key. **
+{}",
   "Query.getFooBar.req.vtl": "## [Start] Get Request template. **
 #set( $GetRequest = {
   \\"version\\": \\"2018-05-29\\",
@@ -5714,6 +5885,25 @@ $util.unauthorized()
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.listBars.preAuth.1.req.vtl": "## [Start] Set query expression for key **
+#if( !$util.isNull($ctx.args.sortDirection) )
+  $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
+#end
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($ctx.args.id) )
+  #set( $modelQueryExpression.expression = \\"#id = :id\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#id\\": \\"id\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":id\\": {
+      \\"S\\": \\"$ctx.args.id\\"
+  }
+} )
+#end
+## [End] Set query expression for key **
+$util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
+{}",
   "Query.listBars.req.vtl": "## [Start] List Request. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $limit = $util.defaultIfNull($args.limit, 100) )
@@ -5777,6 +5967,25 @@ $util.toJson($ListRequest)
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.listFooBars.preAuth.1.req.vtl": "## [Start] Set query expression for key **
+#if( !$util.isNull($ctx.args.sortDirection) )
+  $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
+#end
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($ctx.args.id) )
+  #set( $modelQueryExpression.expression = \\"#id = :id\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#id\\": \\"id\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":id\\": {
+      \\"S\\": \\"$ctx.args.id\\"
+  }
+} )
+#end
+## [End] Set query expression for key **
+$util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
+{}",
   "Query.listFooBars.req.vtl": "## [Start] List Request. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $limit = $util.defaultIfNull($args.limit, 100) )
@@ -5840,6 +6049,25 @@ $util.toJson($ListRequest)
 #end
 $util.toJson({})
 ## [End] Sandbox Mode Disabled. **",
+  "Query.listFoos.preAuth.1.req.vtl": "## [Start] Set query expression for key **
+#if( !$util.isNull($ctx.args.sortDirection) )
+  $util.error(\\"sortDirection is not supported for List operations without a Sort key defined.\\", \\"InvalidArgumentsError\\")
+#end
+#set( $modelQueryExpression = {} )
+#if( !$util.isNull($ctx.args.id) )
+  #set( $modelQueryExpression.expression = \\"#id = :id\\" )
+  #set( $modelQueryExpression.expressionNames = {
+  \\"#id\\": \\"id\\"
+} )
+  #set( $modelQueryExpression.expressionValues = {
+  \\":id\\": {
+      \\"S\\": \\"$ctx.args.id\\"
+  }
+} )
+#end
+## [End] Set query expression for key **
+$util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
+{}",
   "Query.listFoos.req.vtl": "## [Start] List Request. **
 #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
 #set( $limit = $util.defaultIfNull($args.limit, 100) )


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The primary key transformer does not recognize the default `id: ID!` field on a model as implicit primary key and hence does not generate any resolvers for that field. One of the issues arising this is that the `preAuth` slot for Sync Queries is not generated which causes the Sync to be slow as it scans the whole table even if the filter is specified on the `id` field by the customers. Other side effects include missing `pre-Auth` slots that set the primary key information for CRUD operation resolvers for the models.
Please see the snapshot changes for the full change set.
This could be a breaking change since we're generating several new resolver slots and their overall evaluation might break existing apps.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
