### PR TITLE
chore: Rename DatasourceType to DataSourceType

### DIFF
--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/utils.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/utils.test.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { DatasourceType } from '@aws-amplify/graphql-transformer-core';
+import { DataSourceType } from '@aws-amplify/graphql-transformer-core';
 import * as fs from 'fs-extra';
 import { $TSContext, CloudformationProviderFacade, pathManager, JSONUtilities } from '@aws-amplify/amplify-cli-core';
 import { mergeUserConfigWithTransformOutput, writeDeploymentToDisk, getAdminRoles } from '../../graphql-transformer/utils';
@@ -74,7 +74,7 @@ describe('graphql transformer utils', () => {
           pipelineFunctions: {},
           resolvers: {},
           stacks: {},
-          modelToDatasourceMap: new Map<string, DatasourceType>(),
+          modelToDatasourceMap: new Map<string, DataSourceType>(),
           config: { Version: 5, ElasticsearchWarning: true },
           customQueries: new Map<string, string>(),
         } as TransformerProjectConfig;
@@ -97,7 +97,7 @@ describe('graphql transformer utils', () => {
             'Query.listTodos.req.vtl': '$util.unauthorized\n',
           },
           stacks: {},
-          modelToDatasourceMap: new Map<string, DatasourceType>(),
+          modelToDatasourceMap: new Map<string, DataSourceType>(),
           config: { Version: 5, ElasticsearchWarning: true },
           customQueries: new Map<string, string>(),
         } as TransformerProjectConfig;
@@ -120,7 +120,7 @@ describe('graphql transformer utils', () => {
           },
           resolvers: {},
           stacks: {},
-          modelToDatasourceMap: new Map<string, DatasourceType>(),
+          modelToDatasourceMap: new Map<string, DataSourceType>(),
           config: { Version: 5, ElasticsearchWarning: true },
           customQueries: new Map<string, string>(),
         } as TransformerProjectConfig;
@@ -207,7 +207,7 @@ describe('graphql transformer utils', () => {
               },
             },
           },
-          modelToDatasourceMap: new Map<string, DatasourceType>(),
+          modelToDatasourceMap: new Map<string, DataSourceType>(),
           config: { Version: 5, ElasticsearchWarning: true },
         } as unknown as TransformerProjectConfig;
       });

--- a/packages/amplify-category-api/src/graphql-transformer/cdk-compat/project-config.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/cdk-compat/project-config.ts
@@ -1,4 +1,4 @@
-import { TransformConfig, DatasourceType } from 'graphql-transformer-core';
+import { TransformConfig, DataSourceType } from 'graphql-transformer-core';
 
 export type Template = {
   Parameters: Record<string, any>;
@@ -14,6 +14,6 @@ export interface TransformerProjectConfig {
   resolvers: Record<string, string>;
   stacks: Record<string, Template>;
   config: TransformConfig;
-  modelToDatasourceMap: Map<string, DatasourceType>;
+  modelToDatasourceMap: Map<string, DataSourceType>;
   customQueries: Map<string, string>;
 }

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import {
   RDSConnectionSecrets,
-  DatasourceType,
+  DataSourceType,
   UserDefinedSlot,
   isImportedRDSType,
   DBType,
@@ -206,7 +206,7 @@ const buildAPIProject = async (context: $TSContext, opts: TransformerProjectOpti
   checkForUnsupportedDirectives(schema, opts.projectConfig.modelToDatasourceMap);
 
   const { modelToDatasourceMap } = opts.projectConfig;
-  const datasourceMapValues: Array<DatasourceType> = modelToDatasourceMap ? Array.from(modelToDatasourceMap.values()) : [];
+  const datasourceMapValues: Array<DataSourceType> = modelToDatasourceMap ? Array.from(modelToDatasourceMap.values()) : [];
   const datasourceSecretMap = new Map<string, RDSConnectionSecrets>();
   let sqlLambdaVpcConfig: VpcConfig | undefined;
   if (datasourceMapValues.some((value) => isImportedRDSType(value))) {

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
@@ -1,8 +1,8 @@
 import { parse, FieldDefinitionNode, ObjectTypeDefinitionNode, visit } from 'graphql';
 import _ from 'lodash';
-import { DatasourceType, isImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { DataSourceType, isImportedRDSType } from '@aws-amplify/graphql-transformer-core';
 
-export const checkForUnsupportedDirectives = (schema: string, modelToDatasourceMap: Map<string, DatasourceType>): void => {
+export const checkForUnsupportedDirectives = (schema: string, modelToDatasourceMap: Map<string, DataSourceType>): void => {
   const unsupportedRDSDirectives = ['searchable', 'predictions', 'function', 'manyToMany', 'http', 'mapsTo'];
   if (_.isEmpty(schema) || _.isEmpty(modelToDatasourceMap)) {
     return;

--- a/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
+++ b/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
@@ -260,11 +260,11 @@ export class AmplifyGraphqlApi extends Construct {
     );
 
     if (!extendedConfig.modelToDatasourceMap || extendedConfig.modelToDatasourceMap.size === 0) {
-      const defaultDatasourceType = {
+      const defaultDataSourceType = {
         dbType: modelDataSourceBinding.bindingType,
         provisionDB: false,
       };
-      extendedConfig.modelToDatasourceMap = constructDataSourceMap(extendedConfig.schema, defaultDatasourceType);
+      extendedConfig.modelToDatasourceMap = constructDataSourceMap(extendedConfig.schema, defaultDataSourceType);
     }
 
     extendedConfig.sqlLambdaVpcConfig = {

--- a/packages/amplify-graphql-default-value-transformer/src/__tests__/amplify-grapphql-default-value-transformer.test.ts
+++ b/packages/amplify-graphql-default-value-transformer/src/__tests__/amplify-grapphql-default-value-transformer.test.ts
@@ -1,5 +1,5 @@
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
-import { DatasourceType, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
+import { DataSourceType, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
 import { parse } from 'graphql';
 import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import { DefaultValueTransformer } from '..';
@@ -322,7 +322,7 @@ describe('DefaultValueModelTransformer:', () => {
       }
     `;
 
-    const modelToDatasourceMap = new Map<string, DatasourceType>();
+    const modelToDatasourceMap = new Map<string, DataSourceType>();
     modelToDatasourceMap.set('Note', {
       dbType: 'MySQL',
       provisionDB: false,

--- a/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-primary-key-transformer.test.ts
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-primary-key-transformer.test.ts
@@ -1,5 +1,5 @@
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
-import { validateModelSchema, DatasourceType } from '@aws-amplify/graphql-transformer-core';
+import { validateModelSchema, DataSourceType } from '@aws-amplify/graphql-transformer-core';
 import { Template } from 'aws-cdk-lib/assertions';
 import { Kind, parse } from 'graphql';
 import _ from 'lodash';
@@ -726,7 +726,7 @@ test('lowercase model names generate the correct get/list query arguments', () =
 });
 
 describe('RDS primary key transformer tests', () => {
-  const modelToDatasourceMap = new Map<string, DatasourceType>();
+  const modelToDatasourceMap = new Map<string, DataSourceType>();
   modelToDatasourceMap.set('Test', {
     dbType: 'MySQL',
     provisionDB: false,

--- a/packages/amplify-graphql-index-transformer/src/resolvers/resolvers.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers/resolvers.ts
@@ -1,5 +1,5 @@
 import { generateApplyDefaultsToInputTemplate } from '@aws-amplify/graphql-model-transformer';
-import { MappingTemplate, DatasourceType, DDB_DB_TYPE, DBType } from '@aws-amplify/graphql-transformer-core';
+import { MappingTemplate, DataSourceType, DDB_DB_TYPE, DBType } from '@aws-amplify/graphql-transformer-core';
 import { DataSourceProvider, TransformerContextProvider, TransformerResolverProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { DynamoDbDataSource } from 'aws-cdk-lib/aws-appsync';
 import { Table } from 'aws-cdk-lib/aws-dynamodb';
@@ -863,7 +863,7 @@ export function getDBType(ctx: TransformerContextProvider, modelName: string) {
   return dbType;
 }
 
-export const getVTLGenerator = (dbInfo: DatasourceType | undefined): RDSIndexVTLGenerator | DynamoDBIndexVTLGenerator => {
+export const getVTLGenerator = (dbInfo: DataSourceType | undefined): RDSIndexVTLGenerator | DynamoDBIndexVTLGenerator => {
   const dbType = dbInfo ? dbInfo.dbType : DDB_DB_TYPE;
   if (dbType === DDB_DB_TYPE) {
     return new DynamoDBIndexVTLGenerator();

--- a/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
@@ -1,7 +1,7 @@
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import {
   ConflictHandlerType,
-  DatasourceType,
+  DataSourceType,
   validateModelSchema,
   MYSQL_DB_TYPE,
   POSTGRES_DB_TYPE,
@@ -1563,7 +1563,7 @@ describe('ModelTransformer:', () => {
         }
       `;
 
-      const modelToDatasourceMap = new Map<string, DatasourceType>();
+      const modelToDatasourceMap = new Map<string, DataSourceType>();
       modelToDatasourceMap.set('Note', {
         dbType: dbType,
         provisionDB: false,
@@ -1589,7 +1589,7 @@ describe('ModelTransformer:', () => {
         }
       `;
 
-      const modelToDatasourceMap = new Map<string, DatasourceType>();
+      const modelToDatasourceMap = new Map<string, DataSourceType>();
       modelToDatasourceMap.set('Note', {
         dbType: dbType,
         provisionDB: false,
@@ -1639,7 +1639,7 @@ describe('ModelTransformer:', () => {
         }
       `;
 
-      const modelToDatasourceMap = new Map<string, DatasourceType>();
+      const modelToDatasourceMap = new Map<string, DataSourceType>();
       modelToDatasourceMap.set('Note', {
         dbType: dbType,
         provisionDB: false,
@@ -1664,7 +1664,7 @@ describe('ModelTransformer:', () => {
           name: String
         }
       `;
-      const modelToDatasourceMap = new Map<string, DatasourceType>();
+      const modelToDatasourceMap = new Map<string, DataSourceType>();
       modelToDatasourceMap.set('Post', {
         dbType: dbType,
         provisionDB: false,
@@ -1701,7 +1701,7 @@ describe('ModelTransformer:', () => {
     }
     `;
 
-    const modelToDatasourceMap = new Map<string, DatasourceType>();
+    const modelToDatasourceMap = new Map<string, DataSourceType>();
     modelToDatasourceMap.set('Note', {
       dbType: rdsDatasources[0],
       provisionDB: false,

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -11,7 +11,7 @@ import {
   ObjectDefinitionWrapper,
   SyncUtils,
   TransformerModelBase,
-  DatasourceType,
+  DataSourceType,
 } from '@aws-amplify/graphql-transformer-core';
 import {
   AppSyncDataSourceType,
@@ -130,7 +130,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
 
   private resourceGeneratorMap: Map<string, ModelResourceGenerator> = new Map<string, ModelResourceGenerator>();
 
-  private modelToDatasourceMap: Map<string, DatasourceType> = new Map<string, DatasourceType>();
+  private modelToDatasourceMap: Map<string, DataSourceType> = new Map<string, DataSourceType>();
 
   /**
    * A Map to hold the directive configuration
@@ -146,7 +146,7 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
   }
 
   before = (ctx: TransformerBeforeStepContextProvider): void => {
-    const datasourceMapValues: Array<DatasourceType> = Array.from(ctx.modelToDatasourceMap.values());
+    const datasourceMapValues: Array<DataSourceType> = Array.from(ctx.modelToDatasourceMap.values());
     if (datasourceMapValues.some((value) => value.dbType === DDB_DB_TYPE && value.provisionDB)) {
       this.resourceGeneratorMap.get(DDB_DB_TYPE)?.enableGenerator();
       this.resourceGeneratorMap.get(DDB_DB_TYPE)?.enableProvisioned();

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-belongs-to-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-belongs-to-transformer.test.ts
@@ -1,6 +1,6 @@
 import { IndexTransformer, PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
-import { DatasourceType, GraphQLTransform, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
+import { DataSourceType, GraphQLTransform, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
 import { DocumentNode, Kind, parse } from 'graphql';
 import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import { BelongsToTransformer, HasManyTransformer, HasOneTransformer } from '..';
@@ -742,7 +742,7 @@ describe('@belongsTo connection field nullability tests', () => {
 
 describe('@belongsTo directive with RDS datasource', () => {
   test('happy case should generate correct resolvers', () => {
-    const modelToDatasourceMap = new Map<string, DatasourceType>();
+    const modelToDatasourceMap = new Map<string, DataSourceType>();
     modelToDatasourceMap.set('User', {
       dbType: 'MySQL',
       provisionDB: false,
@@ -782,7 +782,7 @@ describe('@belongsTo directive with RDS datasource', () => {
   });
 
   test('composite key should generate correct resolvers', () => {
-    const modelToDatasourceMap = new Map<string, DatasourceType>();
+    const modelToDatasourceMap = new Map<string, DataSourceType>();
     modelToDatasourceMap.set('User', {
       dbType: 'MySQL',
       provisionDB: false,

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
@@ -1,6 +1,6 @@
 import { IndexTransformer, PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
-import { ConflictHandlerType, DatasourceType, GraphQLTransform, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
+import { ConflictHandlerType, DataSourceType, GraphQLTransform, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
 import { Kind, parse } from 'graphql';
 import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import { BelongsToTransformer, HasManyTransformer, HasOneTransformer } from '..';
@@ -932,7 +932,7 @@ describe('@hasMany connection field nullability tests', () => {
 
 describe('@hasMany directive with RDS datasource', () => {
   test('happy case should generate correct resolvers', () => {
-    const modelToDatasourceMap = new Map<string, DatasourceType>();
+    const modelToDatasourceMap = new Map<string, DataSourceType>();
     modelToDatasourceMap.set('Blog', {
       dbType: 'MySQL',
       provisionDB: false,
@@ -971,7 +971,7 @@ describe('@hasMany directive with RDS datasource', () => {
   });
 
   test('composite key should generate correct resolvers', () => {
-    const modelToDatasourceMap = new Map<string, DatasourceType>();
+    const modelToDatasourceMap = new Map<string, DataSourceType>();
     modelToDatasourceMap.set('System', {
       dbType: 'MySQL',
       provisionDB: false,

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-one-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-one-transformer.test.ts
@@ -1,6 +1,6 @@
 import { PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
-import { ConflictHandlerType, DatasourceType, GraphQLTransform, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
+import { ConflictHandlerType, DataSourceType, GraphQLTransform, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
 import { DocumentNode, Kind, parse } from 'graphql';
 import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import { HasManyTransformer, HasOneTransformer } from '..';
@@ -747,7 +747,7 @@ describe('@hasOne connection field nullability tests', () => {
 
 describe('@hasOne directive with RDS datasource', () => {
   test('happy case should generate correct resolvers', () => {
-    const modelToDatasourceMap = new Map<string, DatasourceType>();
+    const modelToDatasourceMap = new Map<string, DataSourceType>();
     modelToDatasourceMap.set('User', {
       dbType: 'MySQL',
       provisionDB: false,
@@ -786,7 +786,7 @@ describe('@hasOne directive with RDS datasource', () => {
   });
 
   test('composite key should generate correct resolvers', () => {
-    const modelToDatasourceMap = new Map<string, DatasourceType>();
+    const modelToDatasourceMap = new Map<string, DataSourceType>();
     modelToDatasourceMap.set('User', {
       dbType: 'MySQL',
       provisionDB: false,

--- a/packages/amplify-graphql-relational-transformer/src/graphql-belongs-to-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-belongs-to-transformer.ts
@@ -3,7 +3,7 @@ import {
   DDB_DB_TYPE,
   DirectiveWrapper,
   generateGetArgumentsInput,
-  getDatasourceType,
+  getDataSourceType,
   InvalidDirectiveError,
   TransformerPluginBase,
   isRDSModel,
@@ -154,7 +154,7 @@ export class BelongsToTransformer extends TransformerPluginBase {
     const context = ctx as TransformerContextProvider;
 
     for (const config of this.directiveList) {
-      const dbType = getDatasourceType(config.field.type, context);
+      const dbType = getDataSourceType(config.field.type, context);
       if (dbType === DDB_DB_TYPE) {
         config.relatedTypeIndex = getRelatedTypeIndex(config, context);
       } else if (isRDSDBType(dbType)) {
@@ -168,7 +168,7 @@ export class BelongsToTransformer extends TransformerPluginBase {
     const context = ctx as TransformerContextProvider;
 
     for (const config of this.directiveList) {
-      const dbType = getDatasourceType(config.field.type, context);
+      const dbType = getDataSourceType(config.field.type, context);
       const generator = getGenerator(dbType);
       generator.makeBelongsToGetItemConnectionWithKeyResolver(config, context);
     }
@@ -178,7 +178,7 @@ export class BelongsToTransformer extends TransformerPluginBase {
 const validate = (config: BelongsToDirectiveConfiguration, ctx: TransformerContextProvider): void => {
   const { field, object } = config;
 
-  const dbType = getDatasourceType(field.type, ctx);
+  const dbType = getDataSourceType(field.type, ctx);
   config.relatedType = getRelatedType(config, ctx);
 
   if (dbType === DDB_DB_TYPE) {

--- a/packages/amplify-graphql-relational-transformer/src/graphql-has-many-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-has-many-transformer.ts
@@ -4,7 +4,7 @@ import {
   DDB_DB_TYPE,
   DirectiveWrapper,
   generateGetArgumentsInput,
-  getDatasourceType,
+  getDataSourceType,
   InvalidDirectiveError,
   isRDSDBType,
   TransformerPluginBase,
@@ -161,7 +161,7 @@ export class HasManyTransformer extends TransformerPluginBase {
     const context = ctx as TransformerContextProvider;
 
     for (const config of this.directiveList) {
-      const dbType = getDatasourceType(config.field.type, context);
+      const dbType = getDataSourceType(config.field.type, context);
       if (dbType === DDB_DB_TYPE) {
         config.relatedTypeIndex = getRelatedTypeIndex(config, context, config.indexName);
       } else if (isRDSDBType(dbType)) {
@@ -176,7 +176,7 @@ export class HasManyTransformer extends TransformerPluginBase {
     const context = ctx as TransformerContextProvider;
 
     for (const config of this.directiveList) {
-      const dbType = getDatasourceType(config.field.type, context);
+      const dbType = getDataSourceType(config.field.type, context);
       if (dbType === DDB_DB_TYPE) {
         updateTableForConnection(config, context);
       }
@@ -193,7 +193,7 @@ const makeQueryResolver = (config: HasManyDirectiveConfiguration, ctx: Transform
 const validate = (config: HasManyDirectiveConfiguration, ctx: TransformerContextProvider): void => {
   const { field } = config;
 
-  const dbType = getDatasourceType(field.type, ctx);
+  const dbType = getDataSourceType(field.type, ctx);
   config.relatedType = getRelatedType(config, ctx);
 
   if (dbType === DDB_DB_TYPE) {

--- a/packages/amplify-graphql-relational-transformer/src/graphql-has-one-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-has-one-transformer.ts
@@ -3,7 +3,7 @@ import {
   DDB_DB_TYPE,
   DirectiveWrapper,
   generateGetArgumentsInput,
-  getDatasourceType,
+  getDataSourceType,
   InvalidDirectiveError,
   isRDSModel,
   isRDSDBType,
@@ -185,7 +185,7 @@ export class HasOneTransformer extends TransformerPluginBase {
     const context = ctx as TransformerContextProvider;
 
     for (const config of this.directiveList) {
-      const dbType = getDatasourceType(config.field.type, context);
+      const dbType = getDataSourceType(config.field.type, context);
       if (dbType === DDB_DB_TYPE) {
         config.relatedTypeIndex = getRelatedTypeIndex(config, context);
       } else if (isRDSDBType(dbType)) {
@@ -199,7 +199,7 @@ export class HasOneTransformer extends TransformerPluginBase {
     const context = ctx as TransformerContextProvider;
 
     for (const config of this.directiveList) {
-      const dbType = getDatasourceType(config.field.type, context);
+      const dbType = getDataSourceType(config.field.type, context);
       const generator = getGenerator(dbType);
       generator.makeHasOneGetItemConnectionWithKeyResolver(config, context);
     }
@@ -209,7 +209,7 @@ export class HasOneTransformer extends TransformerPluginBase {
 const validate = (config: HasOneDirectiveConfiguration, ctx: TransformerContextProvider): void => {
   const { field } = config;
 
-  const dbType = getDatasourceType(field.type, ctx);
+  const dbType = getDataSourceType(field.type, ctx);
   config.relatedType = getRelatedType(config, ctx);
 
   if (dbType === DDB_DB_TYPE) {

--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -111,7 +111,7 @@ export const enum ConflictHandlerType {
 }
 
 // @public (undocumented)
-export const constructDataSourceMap: (schema: string, datasourceType: DatasourceType) => Map<string, DatasourceType>;
+export const constructDataSourceMap: (schema: string, datasourceType: DataSourceType) => Map<string, DataSourceType>;
 
 // @public (undocumented)
 function createSyncLambdaIAMPolicy(context: TransformerContextProvider, scope: Construct, name: string, region?: string): iam.Policy;
@@ -122,7 +122,7 @@ function createSyncLambdaIAMPolicy(context: TransformerContextProvider, scope: C
 function createSyncTable(context: TransformerContext): void;
 
 // @public (undocumented)
-export interface DatasourceType {
+export interface DataSourceType {
     // (undocumented)
     dbType: DBType;
     // (undocumented)
@@ -190,7 +190,7 @@ export type GetArgumentsOptions = {
 };
 
 // @public (undocumented)
-export const getDatasourceType: (type: TypeNode, ctx: TransformerContextProvider) => DBType;
+export const getDataSourceType: (type: TypeNode, ctx: TransformerContextProvider) => DBType;
 
 // @public (undocumented)
 export const getEngineFromDBType: (dbType: DBType) => ImportedRDSType;
@@ -201,7 +201,7 @@ export const getEngineFromDBType: (dbType: DBType) => ImportedRDSType;
 export const getFieldNameFor: (op: Operation, typeName: string) => string;
 
 // @public (undocumented)
-export const getImportedRDSType: (modelToDatasourceMap: Map<string, DatasourceType>) => DBType;
+export const getImportedRDSType: (modelToDatasourceMap: Map<string, DataSourceType>) => DBType;
 
 // @public (undocumented)
 export const getKeySchema: (table: any, indexName?: string) => any;
@@ -354,7 +354,7 @@ export class InvalidTransformerError extends Error {
 }
 
 // @public (undocumented)
-export const isImportedRDSType: (dbInfo: DatasourceType) => boolean;
+export const isImportedRDSType: (dbInfo: DataSourceType) => boolean;
 
 // @public (undocumented)
 function isLambdaSyncConfig(syncConfig: SyncConfig): syncConfig is SyncConfigLambda;

--- a/packages/amplify-graphql-transformer-core/src/config/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/config/index.ts
@@ -1,2 +1,2 @@
-export { DatasourceType, DBType } from './project-config';
+export { DataSourceType, DBType } from './project-config';
 export * from './transformer-config';

--- a/packages/amplify-graphql-transformer-core/src/config/project-config.ts
+++ b/packages/amplify-graphql-transformer-core/src/config/project-config.ts
@@ -1,6 +1,6 @@
 export type DBType = 'MySQL' | 'DDB' | 'Postgres';
 
-export interface DatasourceType {
+export interface DataSourceType {
   dbType: DBType;
   provisionDB: boolean;
 }

--- a/packages/amplify-graphql-transformer-core/src/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/index.ts
@@ -13,7 +13,7 @@ export {
   SyncConfigServer,
   SyncConfigLambda,
   TransformConfig,
-  DatasourceType,
+  DataSourceType,
   DBType,
 } from './config/index';
 export {
@@ -28,7 +28,7 @@ export {
   DirectiveWrapper,
   APICategory,
   getPrimaryKeyFields,
-  getDatasourceType,
+  getDataSourceType,
   setResourceName,
   getResourceName,
   isRDSModel,

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -43,7 +43,7 @@ import { TransformerOutput } from '../transformer-context/output';
 import { adoptAuthModes } from '../utils/authType';
 import { MappingTemplate } from '../cdk-compat';
 import { TransformerPreProcessContext } from '../transformer-context/pre-process-context';
-import { DatasourceType } from '../config/project-config';
+import { DataSourceType } from '../config/project-config';
 import { defaultTransformParameters } from '../transformer-context/transform-parameters';
 import * as SyncUtils from './sync-utils';
 import { UserDefinedSlot, DatasourceTransformationConfig } from './types';
@@ -207,7 +207,7 @@ export class GraphQLTransform {
       assetProvider,
       synthParameters,
       parsedDocument,
-      datasourceConfig?.modelToDatasourceMap ?? new Map<string, DatasourceType>(),
+      datasourceConfig?.modelToDatasourceMap ?? new Map<string, DataSourceType>(),
       datasourceConfig?.customQueries ?? new Map<string, string>(),
       this.stackMappingOverrides,
       this.authConfig,

--- a/packages/amplify-graphql-transformer-core/src/transformation/types.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/types.ts
@@ -1,5 +1,5 @@
 import { RDSLayerMapping } from '@aws-amplify/graphql-transformer-interfaces';
-import { DatasourceType } from '../config';
+import { DataSourceType } from '../config';
 import { RDSConnectionSecrets } from '../types';
 
 export type UserDefinedSlot = {
@@ -16,7 +16,7 @@ export type UserDefinedResolver = {
 };
 
 export type DatasourceTransformationConfig = {
-  modelToDatasourceMap?: Map<string, DatasourceType>;
+  modelToDatasourceMap?: Map<string, DataSourceType>;
   datasourceSecretParameterLocations?: Map<string, RDSConnectionSecrets>;
   rdsLayerMapping?: RDSLayerMapping;
   customQueries?: Map<string, string>;

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
@@ -19,7 +19,7 @@ import type {
 import { TransformerContextMetadataProvider } from '@aws-amplify/graphql-transformer-interfaces/src/transformer-context/transformer-context-provider';
 import { DocumentNode } from 'graphql';
 import { Construct } from 'constructs';
-import { DatasourceType } from '../config/project-config';
+import { DataSourceType } from '../config/project-config';
 import { ResolverConfig } from '../config/transformer-config';
 import { RDSConnectionSecrets } from '../types';
 import { TransformerDataSourceManager } from './datasource';
@@ -72,7 +72,7 @@ export class TransformerContext implements TransformerContextProvider {
 
   private resolverConfig: ResolverConfig | undefined;
 
-  public readonly modelToDatasourceMap: Map<string, DatasourceType>;
+  public readonly modelToDatasourceMap: Map<string, DataSourceType>;
 
   public readonly datasourceSecretParameterLocations: Map<string, RDSConnectionSecrets>;
 
@@ -91,7 +91,7 @@ export class TransformerContext implements TransformerContextProvider {
     assetProvider: AssetProvider,
     public readonly synthParameters: SynthParameters,
     public readonly inputDocument: DocumentNode,
-    modelToDatasourceMap: Map<string, DatasourceType>,
+    modelToDatasourceMap: Map<string, DataSourceType>,
     customQueries: Map<string, string>,
     stackMapping: Record<string, string>,
     authConfig: AppSyncAuthConfiguration,

--- a/packages/amplify-graphql-transformer-core/src/types/import-appsync-api-types.ts
+++ b/packages/amplify-graphql-transformer-core/src/types/import-appsync-api-types.ts
@@ -35,5 +35,5 @@ export const MYSQL_DB_TYPE = 'MySQL';
 export const DDB_DB_TYPE = 'DDB';
 export const POSTGRES_DB_TYPE = 'Postgres';
 
-export type ModelDatasourceType = 'DDB' | 'MySQL' | 'Postgres';
+export type ModelDataSourceType = 'DDB' | 'MySQL' | 'Postgres';
 export type SQLDBType = 'MySQL' | 'Postgres';

--- a/packages/amplify-graphql-transformer-core/src/types/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/types/index.ts
@@ -9,6 +9,6 @@ export {
   RDSConnectionSecrets,
   ImportedDataSourceConfig,
   RDSDataSourceConfig,
-  ModelDatasourceType,
+  ModelDataSourceType,
   SQLDBType,
 } from './import-appsync-api-types';

--- a/packages/amplify-graphql-transformer-core/src/utils/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/index.ts
@@ -2,11 +2,11 @@ export { getPrimaryKeyFields } from './model-util';
 export { DirectiveWrapper, GetArgumentsOptions, generateGetArgumentsInput } from './directive-wrapper';
 export { collectDirectives, collectDirectivesByTypeNames } from './type-map-utils';
 export { stripDirectives } from './strip-directives';
-export { getTable, getKeySchema, getSortKeyFieldNames, getDatasourceType } from './schema-utils';
+export { getTable, getKeySchema, getSortKeyFieldNames, getDataSourceType } from './schema-utils';
 export { DEFAULT_SCHEMA_DEFINITION } from './defaultSchema';
 export {
   getParameterStoreSecretPath,
-  getModelDatasourceType,
+  getModelDataSourceType,
   isDynamoDBModel,
   isRDSModel,
   isImportedRDSType,

--- a/packages/amplify-graphql-transformer-core/src/utils/rds-util.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/rds-util.ts
@@ -2,8 +2,8 @@ import path from 'path';
 import _ from 'lodash';
 import { parse, Kind, ObjectTypeDefinitionNode } from 'graphql';
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { DDB_DB_TYPE, MYSQL_DB_TYPE, ModelDatasourceType, POSTGRES_DB_TYPE } from '../types';
-import { DatasourceType, DBType } from '../config';
+import { DDB_DB_TYPE, MYSQL_DB_TYPE, ModelDataSourceType, POSTGRES_DB_TYPE } from '../types';
+import { DataSourceType, DBType } from '../config';
 import { APICategory } from './api-category';
 import { ImportedRDSType } from '../types';
 
@@ -40,7 +40,7 @@ export const getParameterStoreSecretPath = (
  * @param typename Model name
  * @returns datasource type
  */
-export const getModelDatasourceType = (ctx: TransformerContextProvider, typename: string): ModelDatasourceType => {
+export const getModelDataSourceType = (ctx: TransformerContextProvider, typename: string): ModelDataSourceType => {
   const config = ctx.modelToDatasourceMap.get(typename);
   return config?.dbType || DDB_DB_TYPE;
 };
@@ -52,7 +52,7 @@ export const getModelDatasourceType = (ctx: TransformerContextProvider, typename
  * @returns boolean
  */
 export const isDynamoDBModel = (ctx: TransformerContextProvider, typename: string): boolean => {
-  return getModelDatasourceType(ctx, typename) === DDB_DB_TYPE;
+  return getModelDataSourceType(ctx, typename) === DDB_DB_TYPE;
 };
 
 /**
@@ -62,8 +62,8 @@ export const isDynamoDBModel = (ctx: TransformerContextProvider, typename: strin
  * @returns boolean
  */
 export const isRDSModel = (ctx: TransformerContextProvider, typename: string): boolean => {
-  const modelDatasourceType = getModelDatasourceType(ctx, typename);
-  return [MYSQL_DB_TYPE, POSTGRES_DB_TYPE].includes(modelDatasourceType);
+  const modelDataSourceType = getModelDataSourceType(ctx, typename);
+  return [MYSQL_DB_TYPE, POSTGRES_DB_TYPE].includes(modelDataSourceType);
 };
 
 /**
@@ -71,7 +71,7 @@ export const isRDSModel = (ctx: TransformerContextProvider, typename: string): b
  * @param dbInfo Datasource information
  * @returns boolean
  */
-export const isImportedRDSType = (dbInfo: DatasourceType): boolean => {
+export const isImportedRDSType = (dbInfo: DataSourceType): boolean => {
   return isRDSDBType(dbInfo?.dbType) && !dbInfo?.provisionDB;
 };
 
@@ -86,9 +86,9 @@ export const isRDSDBType = (dbType: DBType): boolean => {
  * @param datasourceType the datasource type for each model to be associated with
  * @returns a map of model names to datasource types
  */
-export const constructDataSourceMap = (schema: string, datasourceType: DatasourceType): Map<string, DatasourceType> => {
+export const constructDataSourceMap = (schema: string, datasourceType: DataSourceType): Map<string, DataSourceType> => {
   const parsedSchema = parse(schema);
-  const result = new Map<string, DatasourceType>();
+  const result = new Map<string, DataSourceType>();
   parsedSchema.definitions
     .filter((obj) => obj.kind === Kind.OBJECT_TYPE_DEFINITION && obj.directives?.some((dir) => dir.name.value === 'model'))
     .forEach((type) => {
@@ -119,7 +119,7 @@ export const getEngineFromDBType = (dbType: DBType): ImportedRDSType => {
  * @param modelToDatasourceMap Array of datasource types
  * @returns datasource type
  */
-export const getImportedRDSType = (modelToDatasourceMap: Map<string, DatasourceType>): DBType => {
+export const getImportedRDSType = (modelToDatasourceMap: Map<string, DataSourceType>): DBType => {
   const datasourceMapValues = Array.from(modelToDatasourceMap?.values());
   const dbTypes = new Set(datasourceMapValues?.filter((value) => isImportedRDSType(value))?.map((value) => value?.dbType));
   if (dbTypes.size > 1) {

--- a/packages/amplify-graphql-transformer-core/src/utils/schema-utils.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/schema-utils.ts
@@ -53,6 +53,6 @@ export const getSortKeyFieldNames = (type: ObjectTypeDefinitionNode): string[] =
 /**
  * Get DB type from the transformer context
  */
-export const getDatasourceType = (type: TypeNode, ctx: TransformerContextProvider): DBType => {
+export const getDataSourceType = (type: TypeNode, ctx: TransformerContextProvider): DBType => {
   return ctx.modelToDatasourceMap.get(getBaseType(type))?.dbType ?? DDB_DB_TYPE;
 };

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -155,7 +155,7 @@ export interface DataSourceProvider extends BackedDataSource {
 }
 
 // @public (undocumented)
-export interface DatasourceType {
+export interface DataSourceType {
     // (undocumented)
     dbType: DBType;
     // (undocumented)
@@ -436,7 +436,7 @@ export interface TransformerContextProvider {
     // (undocumented)
     metadata: TransformerContextMetadataProvider;
     // (undocumented)
-    modelToDatasourceMap: Map<string, DatasourceType>;
+    modelToDatasourceMap: Map<string, DataSourceType>;
     // (undocumented)
     output: TransformerContextOutputProvider;
     // (undocumented)

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/index.ts
@@ -4,7 +4,7 @@ export {
   AppSyncDataSourceType,
   DataSourceInstance,
   DBType,
-  DatasourceType,
+  DataSourceType,
 } from './transformer-datasource-provider';
 export { TransformerContextOutputProvider } from './transformer-context-output-provider';
 export { TransformerProviderRegistry } from './transformer-provider-registry';

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
@@ -1,6 +1,6 @@
 import { DocumentNode } from 'graphql';
 import { AppSyncAuthConfiguration, GraphQLAPIProvider, RDSLayerMapping, VpcConfig } from '../graphql-api-provider';
-import { TransformerDataSourceManagerProvider, DatasourceType } from './transformer-datasource-provider';
+import { TransformerDataSourceManagerProvider, DataSourceType } from './transformer-datasource-provider';
 import { TransformerProviderRegistry } from './transformer-provider-registry';
 import { TransformerContextOutputProvider } from './transformer-context-output-provider';
 import { StackManagerProvider } from './stack-manager-provider';
@@ -24,7 +24,7 @@ export interface TransformerContextProvider {
   providerRegistry: TransformerProviderRegistry;
 
   inputDocument: DocumentNode;
-  modelToDatasourceMap: Map<string, DatasourceType>;
+  modelToDatasourceMap: Map<string, DataSourceType>;
   datasourceSecretParameterLocations: Map<string, TransformerSecrets>;
   output: TransformerContextOutputProvider;
   stackManager: StackManagerProvider;

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-datasource-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-datasource-provider.ts
@@ -36,7 +36,7 @@ export type DBType = 'DDB' | 'MySQL' | 'Postgres';
  * Configuration for a datasource. Defines the underlying database engine, and instructs the tranformer whether to provision the database
  * storage or whether it already exists.
  */
-export interface DatasourceType {
+export interface DataSourceType {
   dbType: DBType;
   provisionDB: boolean;
 }

--- a/packages/amplify-graphql-transformer-test-utils/API.md
+++ b/packages/amplify-graphql-transformer-test-utils/API.md
@@ -21,7 +21,7 @@ import { CfnRole } from 'aws-cdk-lib/aws-iam';
 import { CfnStack } from 'aws-cdk-lib';
 import { CfnTable } from 'aws-cdk-lib/aws-dynamodb';
 import { Construct } from 'constructs';
-import { DatasourceType } from '@aws-amplify/graphql-transformer-core';
+import { DataSourceType } from '@aws-amplify/graphql-transformer-core';
 import { ISynthesisSession } from 'aws-cdk-lib';
 import type { NestedStackProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { RDSConnectionSecrets } from '@aws-amplify/graphql-transformer-core';
@@ -138,7 +138,7 @@ export type TestTransformParameters = {
     authConfig?: AppSyncAuthConfiguration;
     userDefinedSlots?: Record<string, UserDefinedSlot[]>;
     stackMapping?: Record<string, string>;
-    modelToDatasourceMap?: Map<string, DatasourceType>;
+    modelToDatasourceMap?: Map<string, DataSourceType>;
     datasourceSecretParameterLocations?: Map<string, RDSConnectionSecrets>;
     customQueries?: Map<string, string>;
     overrideConfig?: OverrideConfig;

--- a/packages/amplify-graphql-transformer-test-utils/src/test-transform.ts
+++ b/packages/amplify-graphql-transformer-test-utils/src/test-transform.ts
@@ -1,7 +1,7 @@
 import { AppSyncAuthConfiguration, TransformerPluginProvider, TransformerLogLevel } from '@aws-amplify/graphql-transformer-interfaces';
 import type { SynthParameters, TransformParameters, VpcConfig } from '@aws-amplify/graphql-transformer-interfaces';
 import {
-  DatasourceType,
+  DataSourceType,
   GraphQLTransform,
   RDSConnectionSecrets,
   ResolverConfig,
@@ -18,7 +18,7 @@ export type TestTransformParameters = {
   authConfig?: AppSyncAuthConfiguration;
   userDefinedSlots?: Record<string, UserDefinedSlot[]>;
   stackMapping?: Record<string, string>;
-  modelToDatasourceMap?: Map<string, DatasourceType>;
+  modelToDatasourceMap?: Map<string, DataSourceType>;
   datasourceSecretParameterLocations?: Map<string, RDSConnectionSecrets>;
   customQueries?: Map<string, string>;
   overrideConfig?: OverrideConfig;

--- a/packages/amplify-graphql-transformer/API.md
+++ b/packages/amplify-graphql-transformer/API.md
@@ -7,7 +7,7 @@
 import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-interfaces';
 import { AssetProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { Construct } from 'constructs';
-import { DatasourceType } from '@aws-amplify/graphql-transformer-core';
+import { DataSourceType } from '@aws-amplify/graphql-transformer-core';
 import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import { IFunction } from 'aws-cdk-lib/aws-lambda';
 import { NestedStackProvider } from '@aws-amplify/graphql-transformer-interfaces';
@@ -34,7 +34,7 @@ export const executeTransform: (config: ExecuteTransformConfig) => void;
 // @public (undocumented)
 export type ExecuteTransformConfig = TransformConfig & {
     schema: string;
-    modelToDatasourceMap?: Map<string, DatasourceType>;
+    modelToDatasourceMap?: Map<string, DataSourceType>;
     customQueries?: Map<string, string>;
     datasourceSecretParameterLocations?: Map<string, RDSConnectionSecrets>;
     printTransformerLog?: (log: TransformerLog) => void;

--- a/packages/amplify-graphql-transformer/src/graphql-transformer.ts
+++ b/packages/amplify-graphql-transformer/src/graphql-transformer.ts
@@ -28,7 +28,7 @@ import {
 } from '@aws-amplify/graphql-transformer-interfaces';
 import type { TransformParameters } from '@aws-amplify/graphql-transformer-interfaces/src';
 import {
-  DatasourceType,
+  DataSourceType,
   GraphQLTransform,
   RDSConnectionSecrets,
   ResolverConfig,
@@ -121,7 +121,7 @@ export const constructTransform = (config: TransformConfig): GraphQLTransform =>
 
 export type ExecuteTransformConfig = TransformConfig & {
   schema: string;
-  modelToDatasourceMap?: Map<string, DatasourceType>;
+  modelToDatasourceMap?: Map<string, DataSourceType>;
   customQueries?: Map<string, string>;
   datasourceSecretParameterLocations?: Map<string, RDSConnectionSecrets>;
   printTransformerLog?: (log: TransformerLog) => void;

--- a/packages/graphql-transformer-core/API.md
+++ b/packages/graphql-transformer-core/API.md
@@ -112,10 +112,10 @@ export const enum ConflictHandlerType {
 }
 
 // @public (undocumented)
-export const constructDataSourceMap: (schema: string, datasourceType: DatasourceType) => Map<string, DatasourceType>;
+export const constructDataSourceMap: (schema: string, datasourceType: DataSourceType) => Map<string, DataSourceType>;
 
 // @public (undocumented)
-export interface DatasourceType {
+export interface DataSourceType {
     // (undocumented)
     dbType: DBType;
     // (undocumented)
@@ -299,7 +299,7 @@ export type ProjectRule = (diffs: Diff[], currentBuild: DiffableProject, nextBui
 // @public (undocumented)
 const readSchema: (projectDirectory: string) => Promise<{
     schema: string;
-    modelToDatasourceMap: Map<string, DatasourceType>;
+    modelToDatasourceMap: Map<string, DataSourceType>;
 }>;
 export { readSchema as readProjectSchema }
 export { readSchema }

--- a/packages/graphql-transformer-core/src/util/transformConfig.ts
+++ b/packages/graphql-transformer-core/src/util/transformConfig.ts
@@ -170,7 +170,7 @@ interface ProjectConfiguration {
     [k: string]: Template;
   };
   config: TransformConfig;
-  modelToDatasourceMap: Map<string, DatasourceType>;
+  modelToDatasourceMap: Map<string, DataSourceType>;
   customQueries: Map<string, string>;
 }
 export const loadProject = async (projectDirectory: string, opts?: ProjectOptions): Promise<ProjectConfiguration> => {
@@ -288,8 +288,8 @@ export const loadProject = async (projectDirectory: string, opts?: ProjectOption
  */
 export const readSchema = async (
   projectDirectory: string,
-): Promise<{ schema: string; modelToDatasourceMap: Map<string, DatasourceType> }> => {
-  let modelToDatasourceMap = new Map<string, DatasourceType>();
+): Promise<{ schema: string; modelToDatasourceMap: Map<string, DataSourceType> }> => {
+  let modelToDatasourceMap = new Map<string, DataSourceType>();
   const schemaFilePaths = [path.join(projectDirectory, 'schema.graphql'), path.join(projectDirectory, 'schema.rds.graphql')];
 
   const existingSchemaFiles = schemaFilePaths.filter((p) => fs.existsSync(p));
@@ -410,12 +410,12 @@ export type DBType = 'DDB' | 'MySQL' | 'Postgres';
  * Configuration for a datasource. Defines the underlying database engine, and instructs the tranformer whether to provision the database
  * storage or whether it already exists.
  */
-export interface DatasourceType {
+export interface DataSourceType {
   dbType: DBType;
   provisionDB: boolean;
 }
 
-function constructDataSourceType(dbType: DBType, provisionDB: boolean = true): DatasourceType {
+function constructDataSourceType(dbType: DBType, provisionDB: boolean = true): DataSourceType {
   return {
     dbType,
     provisionDB,
@@ -429,9 +429,9 @@ function constructDataSourceType(dbType: DBType, provisionDB: boolean = true): D
  * @param datasourceType the datasource type for each model to be associated with
  * @returns a map of model names to datasource types
  */
-export const constructDataSourceMap = (schema: string, datasourceType: DatasourceType): Map<string, DatasourceType> => {
+export const constructDataSourceMap = (schema: string, datasourceType: DataSourceType): Map<string, DataSourceType> => {
   const parsedSchema = parse(schema);
-  const result = new Map<string, DatasourceType>();
+  const result = new Map<string, DataSourceType>();
   parsedSchema.definitions
     .filter((obj) => obj.kind === Kind.OBJECT_TYPE_DEFINITION && obj.directives.some((dir) => dir.name.value === MODEL_DIRECTIVE_NAME))
     .forEach((type) => {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MapsToTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MapsToTransformer.e2e.test.ts
@@ -3,11 +3,11 @@ import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { BelongsToTransformer, HasManyTransformer } from '@aws-amplify/graphql-relational-transformer';
 import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import { getSchemaDeployer, SchemaDeployer } from '../deploySchema';
-import { DDB_DB_TYPE, DatasourceType } from '@aws-amplify/graphql-transformer-core';
+import { DDB_DB_TYPE, DataSourceType } from '@aws-amplify/graphql-transformer-core';
 
 describe('@mapsTo transformer', () => {
   jest.setTimeout(1000 * 60 * 15); // 15 minutes
-  const ddbInfo: DatasourceType = {
+  const ddbInfo: DataSourceType = {
     dbType: DDB_DB_TYPE,
     provisionDB: true,
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8993,10 +8993,15 @@ async@^2.6.4:
   dependencies:
     lodash "^4.17.14"
 
-async@^3.2.0, async@^3.2.3, async@^3.2.4:
+async@^3.2.0, async@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
   integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
+
+async@^3.2.3:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.5.tgz#ebd52a8fdaf7a2289a24df399f8d8485c8a46b66"
+  integrity sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==
 
 asynciterator.prototype@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
#### Description of changes

Rename `DatasourceType` to `DataSourceType` to lay a bit of foundation for merge from main. This was a simple search/replace operation. Build, test, pretty, extract-api all ran & passed.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
