### PR TITLE
fix: Make VPC configuration optional

### DIFF
--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -3726,7 +3726,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 326
+            "line": 327
           },
           "name": "addDynamoDbDataSource",
           "parameters": [
@@ -3775,7 +3775,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 338
+            "line": 339
           },
           "name": "addElasticsearchDataSource",
           "parameters": [
@@ -3822,7 +3822,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 348
+            "line": 349
           },
           "name": "addEventBridgeDataSource",
           "parameters": [
@@ -3869,7 +3869,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 430
+            "line": 431
           },
           "name": "addFunction",
           "parameters": [
@@ -3904,7 +3904,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 359
+            "line": 360
           },
           "name": "addHttpDataSource",
           "parameters": [
@@ -3952,7 +3952,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 370
+            "line": 371
           },
           "name": "addLambdaDataSource",
           "parameters": [
@@ -4000,7 +4000,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 381
+            "line": 382
           },
           "name": "addNoneDataSource",
           "parameters": [
@@ -4039,7 +4039,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 392
+            "line": 393
           },
           "name": "addOpenSearchDataSource",
           "parameters": [
@@ -4087,7 +4087,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 405
+            "line": 406
           },
           "name": "addRdsDataSource",
           "parameters": [
@@ -4154,7 +4154,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 421
+            "line": 422
           },
           "name": "addResolver",
           "parameters": [
@@ -6459,22 +6459,6 @@
         {
           "abstract": true,
           "docs": {
-            "stability": "experimental",
-            "summary": "The configuration of the VPC into which to install the Lambda."
-          },
-          "immutable": true,
-          "locationInModule": {
-            "filename": "src/types.ts",
-            "line": 795
-          },
-          "name": "vpcConfiguration",
-          "type": {
-            "fqn": "@aws-amplify/graphql-api-construct.SqlModelDataSourceBindingVpcConfig"
-          }
-        },
-        {
-          "abstract": true,
-          "docs": {
             "remarks": "The key is the value of the `references` attribute of the `@sql` directive in the `schema`; the value is the SQL\nto be executed.",
             "stability": "experimental",
             "summary": "Custom SQL statements."
@@ -6493,6 +6477,23 @@
               },
               "kind": "map"
             }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental",
+            "summary": "The configuration of the VPC into which to install the Lambda."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/types.ts",
+            "line": 795
+          },
+          "name": "vpcConfiguration",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-amplify/graphql-api-construct.SqlModelDataSourceBindingVpcConfig"
           }
         }
       ],
@@ -7034,5 +7035,5 @@
     }
   },
   "version": "1.2.1",
-  "fingerprint": "Ah8EjlOl+q0ncPnkEi6hXjMpxAlStvrx+2MWR2pEeOM="
+  "fingerprint": "d8bSmCAInJFCQG3mfiB0d73UflgRXwTg2PRkuafPJgQ="
 }

--- a/packages/amplify-graphql-api-construct/API.md
+++ b/packages/amplify-graphql-api-construct/API.md
@@ -272,7 +272,7 @@ export interface SqlModelDataSourceBinding {
     readonly bindingType: SQLDBType;
     readonly customSqlStatements?: Record<string, string>;
     readonly dbConnectionConfig: SqlModelDataSourceBindingDbConnectionConfig;
-    readonly vpcConfiguration: SqlModelDataSourceBindingVpcConfig;
+    readonly vpcConfiguration?: SqlModelDataSourceBindingVpcConfig;
 }
 
 // @public

--- a/packages/amplify-graphql-api-construct/src/__tests__/__functional__/props.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/__functional__/props.test.ts
@@ -135,7 +135,7 @@ describe('supports different props configurations', () => {
     });
   });
 
-  it('supports a definition with a SQLModelDataSourceBinding', () => {
+  it('supports a definition with a SQLModelDataSourceBinding with a VPC configuration', () => {
     verifySynth((stack) => {
       new AmplifyGraphqlApi(stack, 'TestApi', {
         definition: AmplifyGraphqlDefinition.fromString(
@@ -163,6 +163,34 @@ describe('supports different props configurations', () => {
                   availabilityZone: 'us-east-1a',
                 },
               ],
+            },
+          },
+        ),
+        authorizationModes: {
+          apiKeyConfig: { expires: cdk.Duration.days(7) },
+        },
+      });
+    });
+  });
+
+  it('supports a definition with a SQLModelDataSourceBinding without a VPC configuration', () => {
+    verifySynth((stack) => {
+      new AmplifyGraphqlApi(stack, 'TestApi', {
+        definition: AmplifyGraphqlDefinition.fromString(
+          /* GraphQL */ `
+            type Todo @model @auth(rules: [{ allow: public }]) {
+              id: ID! @primaryKey
+              description: String!
+            }
+          `,
+          {
+            bindingType: 'MySQL',
+            dbConnectionConfig: {
+              hostnameSsmPath: '/path/to/hostname',
+              usernameSsmPath: '/path/to/username',
+              passwordSsmPath: '/path/to/password',
+              portSsmPath: '/path/to/port',
+              databaseNameSsmPath: '/path/to/databaseName',
             },
           },
         ),

--- a/packages/amplify-graphql-api-construct/src/__tests__/amplify-graphql-definition.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/amplify-graphql-definition.test.ts
@@ -119,7 +119,7 @@ describe('AmplifyGraphqlDefinition', () => {
       expect(definition.modelDataSourceBinding).toEqual(defaultBinding);
     });
 
-    it('binds to a sql data source', () => {
+    it('binds to a sql data source with a VPC configuration', () => {
       const schemaFilePath = path.join(tmpDir, 'schema.graphql');
       const binding: SqlModelDataSourceBinding = {
         bindingType: 'MySQL',
@@ -128,6 +128,23 @@ describe('AmplifyGraphqlDefinition', () => {
           securityGroupIds: ['sg-123'],
           subnetAvailabilityZones: [{ subnetId: 'subnet-123', availabilityZone: 'us-east-1a' }],
         },
+        dbConnectionConfig: {
+          hostnameSsmPath: '/ssm/path/hostnameSsmPath',
+          portSsmPath: '/ssm/path/portSsmPath',
+          usernameSsmPath: '/ssm/path/usernameSsmPath',
+          passwordSsmPath: '/ssm/path/passwordSsmPath',
+          databaseNameSsmPath: '/ssm/path/databaseNameSsmPath',
+        },
+      };
+      fs.writeFileSync(schemaFilePath, TEST_SCHEMA);
+      const definition = AmplifyGraphqlDefinition.fromFilesAndBinding([schemaFilePath], binding);
+      expect(definition.modelDataSourceBinding).toEqual(binding);
+    });
+
+    it('binds to a sql data source with no VPC configuration', () => {
+      const schemaFilePath = path.join(tmpDir, 'schema.graphql');
+      const binding: SqlModelDataSourceBinding = {
+        bindingType: 'MySQL',
         dbConnectionConfig: {
           hostnameSsmPath: '/ssm/path/hostnameSsmPath',
           portSsmPath: '/ssm/path/portSsmPath',

--- a/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
+++ b/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
@@ -252,12 +252,19 @@ export class AmplifyGraphqlApi extends Construct {
     });
     extendedConfig.datasourceSecretParameterLocations = dbSecrets;
 
-    const subnetAvailabilityZoneConfig = modelDataSourceBinding.vpcConfiguration.subnetAvailabilityZones.map(
-      (saz): { SubnetId: string; AvailabilityZone: string } => ({
-        SubnetId: saz.subnetId,
-        AvailabilityZone: saz.availabilityZone,
-      }),
-    );
+    if (modelDataSourceBinding.vpcConfiguration) {
+      const subnetAvailabilityZoneConfig = modelDataSourceBinding.vpcConfiguration.subnetAvailabilityZones.map(
+        (saz): { SubnetId: string; AvailabilityZone: string } => ({
+          SubnetId: saz.subnetId,
+          AvailabilityZone: saz.availabilityZone,
+        }),
+      );
+      extendedConfig.sqlLambdaVpcConfig = {
+        vpcId: modelDataSourceBinding.vpcConfiguration.vpcId,
+        securityGroupIds: modelDataSourceBinding.vpcConfiguration.securityGroupIds,
+        subnetAvailabilityZoneConfig,
+      };
+    }
 
     if (!extendedConfig.modelToDatasourceMap || extendedConfig.modelToDatasourceMap.size === 0) {
       const defaultDataSourceType = {
@@ -266,12 +273,6 @@ export class AmplifyGraphqlApi extends Construct {
       };
       extendedConfig.modelToDatasourceMap = constructDataSourceMap(extendedConfig.schema, defaultDataSourceType);
     }
-
-    extendedConfig.sqlLambdaVpcConfig = {
-      vpcId: modelDataSourceBinding.vpcConfiguration.vpcId,
-      securityGroupIds: modelDataSourceBinding.vpcConfiguration.securityGroupIds,
-      subnetAvailabilityZoneConfig,
-    };
 
     return extendedConfig;
   }

--- a/packages/amplify-graphql-api-construct/src/types.ts
+++ b/packages/amplify-graphql-api-construct/src/types.ts
@@ -792,7 +792,7 @@ export interface SqlModelDataSourceBinding {
   /**
    * The configuration of the VPC into which to install the Lambda.
    */
-  readonly vpcConfiguration: SqlModelDataSourceBindingVpcConfig;
+  readonly vpcConfiguration?: SqlModelDataSourceBindingVpcConfig;
 
   /**
    * Custom SQL statements. The key is the value of the `references` attribute of the `@sql` directive in the `schema`; the value is the SQL


### PR DESCRIPTION
#### Description of changes

Make VPC configuration optional in CDK construct.

Unit tests and manual tests. No good way to do e2e tests on this since it requires a publicly available database, which RDS doesn't like to do.

##### CDK / CloudFormation Parameters Changed

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
