### PR TITLE
chore: disable failing auth e2e tests for RDS

### DIFF
--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -147,54 +147,55 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        rds_mysql_refers_to_rds_mysql_v2_generate_schema_rds_pg_array_objects_rds_pg_import
+        rds_mysql_refers_to_rds_mysql_v2_generate_schema_rds_pg_array_objects_rds_pg_auth_apikey_lambda
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/rds-mysql-refers-to.test.ts|src/__tests__/rds-mysql-v2-generate-schema.test.ts|src/__tests__/rds-pg-array-objects.test.ts|src/__tests__/rds-pg-import.test.ts
+            src/__tests__/rds-mysql-refers-to.test.ts|src/__tests__/rds-mysql-v2-generate-schema.test.ts|src/__tests__/rds-pg-array-objects.test.ts|src/__tests__/rds-pg-auth-apikey-lambda.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        rds_pg_model_v2_rds_pg_refers_to_fields_rds_pg_refers_to_rds_pg_relational_directives
+        rds_pg_auth_iam_apikey_lambda_subscription_rds_pg_auth_iam_rds_pg_import_rds_pg_model_v2
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/rds-pg-model-v2.test.ts|src/__tests__/rds-pg-refers-to-fields.test.ts|src/__tests__/rds-pg-refers-to.test.ts|src/__tests__/rds-pg-relational-directives.test.ts
+            src/__tests__/rds-pg-auth-iam-apikey-lambda-subscription.test.ts|src/__tests__/rds-pg-auth-iam.test.ts|src/__tests__/rds-pg-import.test.ts|src/__tests__/rds-pg-model-v2.test.ts
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        rds_pg_v2_generate_schema_rds_relational_directives_rds_v2_test_utils_api_1
+        rds_pg_refers_to_fields_rds_pg_refers_to_rds_pg_relational_directives_rds_pg_v2_generate_schema
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/rds-pg-v2-generate-schema.test.ts|src/__tests__/rds-relational-directives.test.ts|src/__tests__/rds-v2-test-utils.test.ts|src/__tests__/api_1.test.ts
+            src/__tests__/rds-pg-refers-to-fields.test.ts|src/__tests__/rds-pg-refers-to.test.ts|src/__tests__/rds-pg-relational-directives.test.ts|src/__tests__/rds-pg-v2-generate-schema.test.ts
           CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
-    - identifier: resolvers_sync_query_datastore_api_6_api_lambda_auth
+    - identifier: rds_relational_directives_rds_v2_test_utils_api_1_resolvers
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts|src/__tests__/api_6.test.ts|src/__tests__/graphql-v2/api_lambda_auth.test.ts
-          CLI_REGION: us-east-1
+            src/__tests__/rds-relational-directives.test.ts|src/__tests__/rds-v2-test-utils.test.ts|src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: api_9
+    - identifier: sync_query_datastore_api_6_api_lambda_auth_api_9
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
-          TEST_SUITE: src/__tests__/api_9.test.ts
+          TEST_SUITE: >-
+            src/__tests__/graphql-v2/sync_query_datastore.test.ts|src/__tests__/api_6.test.ts|src/__tests__/graphql-v2/api_lambda_auth.test.ts|src/__tests__/api_9.test.ts
           CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
@@ -409,76 +410,13 @@ batch:
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
-    - identifier: rds_mysql_auth_apikey_lambda
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-auth-apikey-lambda.test.ts
-          CLI_REGION: us-east-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_auth_iam_apikey_lambda_subscription
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts
-          CLI_REGION: us-east-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_auth_iam
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-auth-iam.test.ts
-          CLI_REGION: us-west-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_custom_claims_refersto_auth
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-custom-claims-refersto-auth.test.ts
-          CLI_REGION: eu-west-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_multi_auth_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-multi-auth-1.test.ts
-          CLI_REGION: eu-central-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_oidc_auth
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-oidc-auth.test.ts
-          CLI_REGION: ap-northeast-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_userpool_auth
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-userpool-auth.test.ts
-          CLI_REGION: ap-southeast-2
-      depend-on:
-        - publish_to_local_registry
     - identifier: schema_model
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-model.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: apigw
@@ -487,7 +425,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/apigw.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: containers_api_2
@@ -505,7 +443,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-14.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_7
@@ -514,7 +452,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-7.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_9
@@ -523,7 +461,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-9.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_5
@@ -532,7 +470,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-5.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_datastore
@@ -541,7 +479,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-west-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -551,7 +489,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_searchable
@@ -560,7 +498,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-searchable.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-northeast-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -570,7 +508,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-6.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_connection
@@ -579,7 +517,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-connection.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_had_node_to_node
@@ -589,7 +527,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-had-node-to-node.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_no_node_to_node
@@ -599,7 +537,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-no-node-to-node.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: api_2
@@ -608,7 +546,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/api_2.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_migration
@@ -617,7 +555,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/searchable-migration.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: eu-central-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry

--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -147,56 +147,55 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        rds_mysql_refers_to_rds_mysql_v2_generate_schema_rds_pg_array_objects_rds_pg_auth_apikey_lambda
+        rds_mysql_refers_to_rds_mysql_v2_generate_schema_rds_pg_array_objects_rds_pg_import
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/rds-mysql-refers-to.test.ts|src/__tests__/rds-mysql-v2-generate-schema.test.ts|src/__tests__/rds-pg-array-objects.test.ts|src/__tests__/rds-pg-auth-apikey-lambda.test.ts
+            src/__tests__/rds-mysql-refers-to.test.ts|src/__tests__/rds-mysql-v2-generate-schema.test.ts|src/__tests__/rds-pg-array-objects.test.ts|src/__tests__/rds-pg-import.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        rds_pg_auth_iam_apikey_lambda_subscription_rds_pg_auth_iam_rds_pg_import_rds_pg_model_v2
+        rds_pg_model_v2_rds_pg_refers_to_fields_rds_pg_refers_to_rds_pg_relational_directives
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/rds-pg-auth-iam-apikey-lambda-subscription.test.ts|src/__tests__/rds-pg-auth-iam.test.ts|src/__tests__/rds-pg-import.test.ts|src/__tests__/rds-pg-model-v2.test.ts
-          CLI_REGION: us-east-1
+            src/__tests__/rds-pg-model-v2.test.ts|src/__tests__/rds-pg-refers-to-fields.test.ts|src/__tests__/rds-pg-refers-to.test.ts|src/__tests__/rds-pg-relational-directives.test.ts
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        rds_pg_refers_to_fields_rds_pg_refers_to_rds_pg_relational_directives_rds_pg_v2_generate_schema
+        rds_pg_v2_generate_schema_rds_relational_directives_rds_v2_test_utils_api_1
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/rds-pg-refers-to-fields.test.ts|src/__tests__/rds-pg-refers-to.test.ts|src/__tests__/rds-pg-relational-directives.test.ts|src/__tests__/rds-pg-v2-generate-schema.test.ts
-          CLI_REGION: us-east-2
+            src/__tests__/rds-pg-v2-generate-schema.test.ts|src/__tests__/rds-relational-directives.test.ts|src/__tests__/rds-v2-test-utils.test.ts|src/__tests__/api_1.test.ts
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
-    - identifier: rds_relational_directives_rds_v2_test_utils_api_1_resolvers
+    - identifier: resolvers_sync_query_datastore_api_6_api_lambda_auth
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/rds-relational-directives.test.ts|src/__tests__/rds-v2-test-utils.test.ts|src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
-          CLI_REGION: us-west-2
+            src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts|src/__tests__/api_6.test.ts|src/__tests__/graphql-v2/api_lambda_auth.test.ts
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: sync_query_datastore_api_6_api_lambda_auth_api_9
+    - identifier: api_9
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
-          TEST_SUITE: >-
-            src/__tests__/graphql-v2/sync_query_datastore.test.ts|src/__tests__/api_6.test.ts|src/__tests__/graphql-v2/api_lambda_auth.test.ts|src/__tests__/api_9.test.ts
-          CLI_REGION: us-east-2
+          TEST_SUITE: src/__tests__/api_9.test.ts
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: function_migration
@@ -416,7 +415,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-model.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: apigw
@@ -425,7 +424,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/apigw.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: containers_api_2
@@ -443,7 +442,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-14.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_7
@@ -452,7 +451,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-7.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_9
@@ -461,7 +460,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-9.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_5
@@ -470,7 +469,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-5.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_datastore
@@ -479,7 +478,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: ap-northeast-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -489,7 +488,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_searchable
@@ -498,7 +497,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-searchable.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-southeast-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -508,7 +507,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-6.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_connection
@@ -517,7 +516,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-connection.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_had_node_to_node
@@ -527,7 +526,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-had-node-to-node.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_no_node_to_node
@@ -537,7 +536,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-no-node-to-node.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: api_2
@@ -546,7 +545,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/api_2.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_migration
@@ -555,7 +554,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/searchable-migration.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-southeast-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry

--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -409,6 +409,60 @@ batch:
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
+    - identifier: rds_mysql_auth_apikey_lambda
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-auth-apikey-lambda.test.ts
+          CLI_REGION: ap-northeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_auth_iam_apikey_lambda_subscription
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts
+          CLI_REGION: ap-northeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_auth_iam
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-auth-iam.test.ts
+          CLI_REGION: ap-northeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_multi_auth_1
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-multi-auth-1.test.ts
+          CLI_REGION: ap-northeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_oidc_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-oidc-auth.test.ts
+          CLI_REGION: ap-northeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_userpool_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-userpool-auth.test.ts
+          CLI_REGION: ap-northeast-2
+      depend-on:
+        - publish_to_local_registry
     - identifier: schema_model
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:

--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -80,7 +80,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/transformer-migrations/predictions-migration.test.ts|src/__tests__/api_10.test.ts|src/__tests__/function_10.test.ts|src/__tests__/rds-v2.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_predictions_api_7_http_migration_global_sandbox
@@ -143,7 +143,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/api_3.test.ts|src/__tests__/rds-import-vpc.test.ts|src/__tests__/rds-mysql-model-v2.test.ts|src/__tests__/rds-mysql-refers-to-fields.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -154,7 +154,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/rds-mysql-refers-to.test.ts|src/__tests__/rds-mysql-v2-generate-schema.test.ts|src/__tests__/rds-pg-array-objects.test.ts|src/__tests__/rds-pg-import.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -165,7 +165,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/rds-pg-model-v2.test.ts|src/__tests__/rds-pg-refers-to-fields.test.ts|src/__tests__/rds-pg-refers-to.test.ts|src/__tests__/rds-pg-relational-directives.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -176,7 +176,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/rds-pg-v2-generate-schema.test.ts|src/__tests__/rds-relational-directives.test.ts|src/__tests__/rds-v2-test-utils.test.ts|src/__tests__/api_1.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: resolvers_sync_query_datastore_api_6_api_lambda_auth

--- a/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/oidc-provider.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/oidc-provider.ts
@@ -24,18 +24,18 @@ export const schema = `
     authors: [String]
   }
 
-  type TodoStaticGroup @model @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "user_groups" }]) {
+  type TodoStaticGroup @model @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "cognito:groups" }]) {
     id: ID! @primaryKey
     content: String
   }
 
-  type TodoGroupFieldString @model @auth(rules: [{ allow: groups, groupsField: "groupField", provider: oidc, groupClaim: "user_groups" }]) {
+  type TodoGroupFieldString @model @auth(rules: [{ allow: groups, groupsField: "groupField", provider: oidc, groupClaim: "cognito:groups" }]) {
     id: ID! @primaryKey
     content: String
     groupField: String
   }
 
-  type TodoGroupFieldList @model @auth(rules: [{ allow: groups, groupsField: "groupsField", provider: oidc, groupClaim: "user_groups" }]) {
+  type TodoGroupFieldList @model @auth(rules: [{ allow: groups, groupsField: "groupsField", provider: oidc, groupClaim: "cognito:groups" }]) {
     id: ID! @primaryKey
     content: String
     groupsField: [String]
@@ -48,12 +48,12 @@ export const schema = `
 
   type Query {
     customGetTodoPrivate(id: ID!): [TodoNonModel] @sql(statement: "SELECT * FROM TodoPrivate WHERE id = :id") @auth(rules: [{ allow: private, provider: oidc }])
-    customGetTodoStaticGroup(id: ID!): [TodoNonModel] @sql(statement: "SELECT * FROM TodoStaticGroup WHERE id = :id") @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "user_groups" }])
+    customGetTodoStaticGroup(id: ID!): [TodoNonModel] @sql(statement: "SELECT * FROM TodoStaticGroup WHERE id = :id") @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "cognito:groups" }])
   }
 
   type Mutation {
     addTodoPrivate(id: ID!, content: String): TodoNonModel @sql(statement: "INSERT INTO TodoPrivate VALUES(:id, :content)") @auth(rules: [{ allow: private, provider: oidc }])
-    addTodoStaticGroup(id: ID!, content: String): TodoNonModel @sql(statement: "INSERT INTO TodoStaticGroup VALUES(:id, :content)") @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "user_groups" }])
+    addTodoStaticGroup(id: ID!, content: String): TodoNonModel @sql(statement: "INSERT INTO TodoStaticGroup VALUES(:id, :content)") @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "cognito:groups" }])
   }
 `;
 

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-apikey-lambda.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-apikey-lambda.test.ts
@@ -6,10 +6,10 @@ import { testRdsApiKeyAndLambdaAuth } from '../rds-v2-tests-common/rds-auth-apik
 
 describe('RDS MySQL ApiKey and Lambda directive on Models', () => {
   const queries = [
-    'CREATE TABLE "Blog" (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255))',
-    'CREATE TABLE "Post" (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255), "blogId" VARCHAR(40))',
-    'CREATE TABLE "User" (id VARCHAR(40) PRIMARY KEY, name VARCHAR(255))',
-    'CREATE TABLE "Profile" (id VARCHAR(40) PRIMARY KEY, details VARCHAR(255), "userId" VARCHAR(40))',
+    'CREATE TABLE Blog (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255))',
+    'CREATE TABLE Post (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255), blogId VARCHAR(40))',
+    'CREATE TABLE User (id VARCHAR(40) PRIMARY KEY, name VARCHAR(255))',
+    'CREATE TABLE Profile (id VARCHAR(40) PRIMARY KEY, details VARCHAR(255), userId VARCHAR(40))',
   ];
 
   testRdsApiKeyAndLambdaAuth(ImportedRDSType.MYSQL, queries);

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts
@@ -6,10 +6,10 @@ import { testApiKeyLambdaIamAuthSubscription } from '../rds-v2-tests-common/rds-
 
 describe('MySQL ApiKey, IAM and Lambda Subscription Auth on Models', () => {
   const queries = [
-    'CREATE TABLE "Blog" (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255))',
-    'CREATE TABLE "Post" (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255), "blogId" VARCHAR(40))',
-    'CREATE TABLE "User" (id VARCHAR(40) PRIMARY KEY, name VARCHAR(255))',
-    'CREATE TABLE "Profile" (id VARCHAR(40) PRIMARY KEY, details VARCHAR(255), "userId" VARCHAR(40))',
+    'CREATE TABLE Blog (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255))',
+    'CREATE TABLE Post (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255), blogId VARCHAR(40))',
+    'CREATE TABLE User (id VARCHAR(40) PRIMARY KEY, name VARCHAR(255))',
+    'CREATE TABLE Profile (id VARCHAR(40) PRIMARY KEY, details VARCHAR(255), userId VARCHAR(40))',
   ];
 
   testApiKeyLambdaIamAuthSubscription(ImportedRDSType.MYSQL, queries);

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-iam.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-auth-iam.test.ts
@@ -6,10 +6,10 @@ import { testRdsIamAuth } from '../rds-v2-tests-common/rds-auth-iam';
 
 describe('RDS MySQL IAM Auth directive on Models', () => {
   const queries = [
-    'CREATE TABLE "Blog" (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255))',
-    'CREATE TABLE "Post" (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255), "blogId" VARCHAR(40))',
-    'CREATE TABLE "User" (id VARCHAR(40) PRIMARY KEY, name VARCHAR(255))',
-    'CREATE TABLE "Profile" (id VARCHAR(40) PRIMARY KEY, details VARCHAR(255), "userId" VARCHAR(40))',
+    'CREATE TABLE Blog (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255))',
+    'CREATE TABLE Post (id VARCHAR(40) PRIMARY KEY, content VARCHAR(255), blogId VARCHAR(40))',
+    'CREATE TABLE User (id VARCHAR(40) PRIMARY KEY, name VARCHAR(255))',
+    'CREATE TABLE Profile (id VARCHAR(40) PRIMARY KEY, details VARCHAR(255), userId VARCHAR(40))',
   ];
 
   testRdsIamAuth(ImportedRDSType.MYSQL, queries);

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -87,6 +87,9 @@ const RUN_SOLO = [
   'src/__tests__/rds-mysql-multi-auth-1.test.ts',
   'src/__tests__/rds-mysql-oidc-auth.test.ts',
   'src/__tests__/rds-mysql-userpool-auth.test.ts',
+  'src/__tests__/rds-pg-auth-apikey-lambda.test.ts',
+  'src/__tests__/rds-pg-auth-iam-apikey-lambda-subscription.test.ts',
+  'src/__tests__/rds-pg-auth-iam.test.ts',
 ];
 const DEBUG_FLAG = '--debug';
 

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -95,13 +95,7 @@ const RUN_SOLO = [
 const DEBUG_FLAG = '--debug';
 
 const EXCLUDE_TEST_IDS = [
-  'rds_mysql_auth_apikey_lambda',
-  'rds_mysql_auth_iam_apikey_lambda_subscription',
-  'rds_mysql_auth_iam',
   'rds_mysql_custom_claims_refersto_auth',
-  'rds_mysql_multi_auth_1',
-  'rds_mysql_oidc_auth',
-  'rds_mysql_userpool_auth',
   'rds_pg_auth_apikey_lambda',
   'rds_pg_auth_iam_apikey_lambda_subscription',
   'rds_pg_auth_iam',

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -18,6 +18,7 @@ const AWS_REGIONS_TO_RUN_TESTS = [
 const FORCE_REGION_MAP = {
   interactions: 'us-west-2',
   containers: 'us-east-1',
+  rds: 'ap-northeast-2',
 };
 type FORCE_TESTS = 'interactions' | 'containers';
 // some tests require additional time, the parent account can handle longer tests (up to 90 minutes)
@@ -76,10 +77,6 @@ const RUN_SOLO = [
   'src/__tests__/transformer-migrations/model-migration.test.ts',
   'src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-no-node-to-node.test.ts',
   'src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-had-node-to-node.test.ts',
-  // GrapQL E2E tests
-  'src/__tests__/FunctionTransformerTestsV2.e2e.test.ts',
-  'src/__tests__/HttpTransformer.e2e.test.ts',
-  'src/__tests__/HttpTransformerV2.e2e.test.ts',
   'src/__tests__/rds-mysql-auth-apikey-lambda.test.ts',
   'src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts',
   'src/__tests__/rds-mysql-auth-iam.test.ts',
@@ -90,6 +87,10 @@ const RUN_SOLO = [
   'src/__tests__/rds-pg-auth-apikey-lambda.test.ts',
   'src/__tests__/rds-pg-auth-iam-apikey-lambda-subscription.test.ts',
   'src/__tests__/rds-pg-auth-iam.test.ts',
+  // GrapQL E2E tests
+  'src/__tests__/FunctionTransformerTestsV2.e2e.test.ts',
+  'src/__tests__/HttpTransformer.e2e.test.ts',
+  'src/__tests__/HttpTransformerV2.e2e.test.ts',
 ];
 const DEBUG_FLAG = '--debug';
 

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -90,6 +90,19 @@ const RUN_SOLO = [
 ];
 const DEBUG_FLAG = '--debug';
 
+const EXCLUDE_TEST_IDS = [
+  'rds_mysql_auth_apikey_lambda',
+  'rds_mysql_auth_iam_apikey_lambda_subscription',
+  'rds_mysql_auth_iam',
+  'rds_mysql_custom_claims_refersto_auth',
+  'rds_mysql_multi_auth_1',
+  'rds_mysql_oidc_auth',
+  'rds_mysql_userpool_auth',
+  'rds_pg_auth_apikey_lambda',
+  'rds_pg_auth_iam_apikey_lambda_subscription',
+  'rds_pg_auth_iam',
+];
+
 export function loadConfigBase() {
   return yaml.load(fs.readFileSync(CODEBUILD_CONFIG_BASE_PATH, 'utf8'));
 }
@@ -289,6 +302,9 @@ function main(): void {
       });
       outputPath = CODEBUILD_DEBUG_CONFIG_PATH;
     }
+  }
+  if (EXCLUDE_TEST_IDS.length > 0) {
+    allBuilds = allBuilds.filter((build) => !EXCLUDE_TEST_IDS.includes(build.identifier));
   }
   const cleanupResources = {
     identifier: 'cleanup_e2e_resources',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Disable failing RDS Auth E2E including the `custom-claims` on MySQL and all PostgreSQL tests.
These will be re-enabled once fixed and confirmed in CI.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
[E2E run](https://tiny.amazon.com/gqwp1fg9/IsenLink)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
