### PR TITLE
fix: bump jest-dev-server, and update test harness accordingly

### DIFF
--- a/client-test-apps/js/api-model-relationship-app/package.json
+++ b/client-test-apps/js/api-model-relationship-app/package.json
@@ -19,7 +19,7 @@
     "cypress": "^10.4.0",
     "hjson": "^3.2.2",
     "ini": "^3.0.1",
-    "jest-dev-server": "~7.0.1",
+    "jest-dev-server": "~9.0.1",
     "jest-junit": "^14.0.1",
     "lodash": "^4.17.21",
     "node-pty": "^0.10.1",


### PR DESCRIPTION
#### Description of changes
"It works on my machine!"

Trying to figure out how to get around some timeout issues w/ jest-dev-server, I bumped to the latest version and explicitly set the `host` now. There's an additional `path` param, which I'd prefer to set to `auth-modes` so that first test suite has a better chance of success, but that's not working for me so left it out.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
Canaries are failing intermittently right now due to many classes of timeouts.

#### Description of how you validated changes
Ran locally

#### Checklist
- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
