### PR TITLE
test: add remaining postgres Auth E2Es

### DIFF
--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -336,15 +336,6 @@ batch:
           CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_key
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/schema-key.test.ts
-          CLI_REGION: ap-southeast-2
-      depend-on:
-        - publish_to_local_registry
     - identifier: containers_api_1
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -436,6 +427,15 @@ batch:
           CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
+    - identifier: rds_mysql_custom_claims_refersto_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-custom-claims-refersto-auth.test.ts
+          CLI_REGION: eu-west-2
+      depend-on:
+        - publish_to_local_registry
     - identifier: rds_mysql_multi_auth_1
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -463,6 +463,33 @@ batch:
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
+    - identifier: rds_pg_auth_apikey_lambda
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-auth-apikey-lambda.test.ts
+          CLI_REGION: us-east-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_auth_iam_apikey_lambda_subscription
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-auth-iam-apikey-lambda-subscription.test.ts
+          CLI_REGION: us-east-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_auth_iam
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-auth-iam.test.ts
+          CLI_REGION: us-west-2
+      depend-on:
+        - publish_to_local_registry
     - identifier: rds_pg_custom_claims_refersto_auth
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -488,15 +515,6 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/rds-pg-userpool-auth.test.ts
           CLI_REGION: ap-southeast-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: schema_model
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/schema-model.test.ts
-          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: apigw
@@ -572,16 +590,6 @@ batch:
           CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_searchable
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/schema-searchable.test.ts
-          CLI_REGION: us-west-2
-          USE_PARENT_ACCOUNT: 1
-      depend-on:
-        - publish_to_local_registry
     - identifier: schema_auth_6
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -589,15 +597,6 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-6.test.ts
           CLI_REGION: eu-west-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: schema_connection
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/schema-connection.test.ts
-          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_had_node_to_node
@@ -912,15 +911,6 @@ batch:
           TEST_SUITE: src/__tests__/FunctionTransformerTestsV2.e2e.test.ts
           CLI_REGION: us-west-2
           USE_PARENT_ACCOUNT: 1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: HttpTransformer
-      buildspec: codebuild_specs/graphql_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/HttpTransformer.e2e.test.ts
-          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: HttpTransformerV2

--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -158,43 +158,44 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        rds_pg_model_v2_rds_pg_refers_to_fields_rds_pg_refers_to_rds_pg_relational_directives
+        rds_pg_model_v2_rds_pg_oidc_auth_rds_pg_refers_to_fields_rds_pg_refers_to
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/rds-pg-model-v2.test.ts|src/__tests__/rds-pg-refers-to-fields.test.ts|src/__tests__/rds-pg-refers-to.test.ts|src/__tests__/rds-pg-relational-directives.test.ts
+            src/__tests__/rds-pg-model-v2.test.ts|src/__tests__/rds-pg-oidc-auth.test.ts|src/__tests__/rds-pg-refers-to-fields.test.ts|src/__tests__/rds-pg-refers-to.test.ts
           CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        rds_pg_v2_generate_schema_rds_relational_directives_rds_v2_test_utils_api_1
+        rds_pg_relational_directives_rds_pg_userpool_auth_rds_pg_v2_generate_schema_rds_relational_directives
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/rds-pg-v2-generate-schema.test.ts|src/__tests__/rds-relational-directives.test.ts|src/__tests__/rds-v2-test-utils.test.ts|src/__tests__/api_1.test.ts
+            src/__tests__/rds-pg-relational-directives.test.ts|src/__tests__/rds-pg-userpool-auth.test.ts|src/__tests__/rds-pg-v2-generate-schema.test.ts|src/__tests__/rds-relational-directives.test.ts
           CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
-    - identifier: resolvers_sync_query_datastore_api_6_api_lambda_auth
+    - identifier: rds_v2_test_utils_api_1_resolvers_sync_query_datastore
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts|src/__tests__/api_6.test.ts|src/__tests__/graphql-v2/api_lambda_auth.test.ts
-          CLI_REGION: eu-west-2
+            src/__tests__/rds-v2-test-utils.test.ts|src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: api_9
+    - identifier: api_6_api_lambda_auth_api_9
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
-          TEST_SUITE: src/__tests__/api_9.test.ts
+          TEST_SUITE: >-
+            src/__tests__/api_6.test.ts|src/__tests__/graphql-v2/api_lambda_auth.test.ts|src/__tests__/api_9.test.ts
           CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
@@ -469,7 +470,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-model.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: apigw
@@ -478,7 +479,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/apigw.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: containers_api_2
@@ -496,7 +497,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-14.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_7
@@ -505,7 +506,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-7.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_9
@@ -514,7 +515,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-9.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_5
@@ -523,7 +524,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-5.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_datastore
@@ -532,7 +533,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-southeast-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -542,7 +543,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_searchable
@@ -551,7 +552,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-searchable.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: us-east-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -561,7 +562,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-6.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_connection
@@ -570,7 +571,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-connection.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_had_node_to_node
@@ -580,7 +581,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-had-node-to-node.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_no_node_to_node
@@ -590,7 +591,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-no-node-to-node.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: api_2

--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -158,45 +158,44 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        rds_pg_model_v2_rds_pg_oidc_auth_rds_pg_refers_to_fields_rds_pg_refers_to
+        rds_pg_model_v2_rds_pg_refers_to_fields_rds_pg_refers_to_rds_pg_relational_directives
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/rds-pg-model-v2.test.ts|src/__tests__/rds-pg-oidc-auth.test.ts|src/__tests__/rds-pg-refers-to-fields.test.ts|src/__tests__/rds-pg-refers-to.test.ts
-          CLI_REGION: eu-west-2
+            src/__tests__/rds-pg-model-v2.test.ts|src/__tests__/rds-pg-refers-to-fields.test.ts|src/__tests__/rds-pg-refers-to.test.ts|src/__tests__/rds-pg-relational-directives.test.ts
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        rds_pg_relational_directives_rds_pg_userpool_auth_rds_pg_v2_generate_schema_rds_relational_directives
+        rds_pg_v2_generate_schema_rds_relational_directives_rds_v2_test_utils_api_1
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/rds-pg-relational-directives.test.ts|src/__tests__/rds-pg-userpool-auth.test.ts|src/__tests__/rds-pg-v2-generate-schema.test.ts|src/__tests__/rds-relational-directives.test.ts
-          CLI_REGION: eu-central-1
+            src/__tests__/rds-pg-v2-generate-schema.test.ts|src/__tests__/rds-relational-directives.test.ts|src/__tests__/rds-v2-test-utils.test.ts|src/__tests__/api_1.test.ts
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: rds_v2_test_utils_api_1_resolvers_sync_query_datastore
+    - identifier: resolvers_sync_query_datastore_api_6_api_lambda_auth
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/rds-v2-test-utils.test.ts|src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts
-          CLI_REGION: ap-northeast-1
+            src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts|src/__tests__/api_6.test.ts|src/__tests__/graphql-v2/api_lambda_auth.test.ts
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: api_6_api_lambda_auth_api_9
+    - identifier: api_9
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
-          TEST_SUITE: >-
-            src/__tests__/api_6.test.ts|src/__tests__/graphql-v2/api_lambda_auth.test.ts|src/__tests__/api_9.test.ts
-          CLI_REGION: eu-central-1
+          TEST_SUITE: src/__tests__/api_9.test.ts
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: function_migration
@@ -464,13 +463,40 @@ batch:
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
+    - identifier: rds_pg_custom_claims_refersto_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-custom-claims-refersto-auth.test.ts
+          CLI_REGION: eu-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_oidc_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-oidc-auth.test.ts
+          CLI_REGION: ap-northeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_userpool_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-userpool-auth.test.ts
+          CLI_REGION: ap-southeast-2
+      depend-on:
+        - publish_to_local_registry
     - identifier: schema_model
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-model.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: apigw
@@ -479,7 +505,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/apigw.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: containers_api_2
@@ -497,7 +523,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-14.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_7
@@ -506,7 +532,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-7.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_9
@@ -515,7 +541,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-9.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_5
@@ -524,7 +550,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-5.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_datastore
@@ -533,7 +559,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: us-east-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -543,7 +569,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_searchable
@@ -552,7 +578,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-searchable.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-west-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -562,7 +588,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-6.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_connection
@@ -571,7 +597,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-connection.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_had_node_to_node
@@ -581,7 +607,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-had-node-to-node.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_no_node_to_node
@@ -591,7 +617,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-no-node-to-node.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: api_2
@@ -600,7 +626,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/api_2.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_migration
@@ -609,7 +635,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/searchable-migration.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: us-east-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry

--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/sandbox-mode-helpers.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/sandbox-mode-helpers.test.ts
@@ -83,16 +83,6 @@ sandbox mode disabled, do not create an API Key.
     });
 
     describe('input AMPLIFY has incorrect values', () => {
-      it('checks for "globalAuthRule"', () => {
-        const schema = `
-          input AMPLIFY { auth_rule: AuthenticationRule = { allow: public } }
-        `;
-
-        expect(() => schemaHasSandboxModeEnabled(schema, 'mockLink')).toThrow(
-          Error('input AMPLIFY requires "globalAuthRule" field. Learn more here: mockLink'),
-        );
-      });
-
       it('allows "global_auth_rule"', () => {
         const schema = `
           input AMPLIFY { global_auth_rule: AuthRule = { allow: public } }

--- a/packages/amplify-category-api/src/graphql-transformer/sandbox-mode-helpers.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/sandbox-mode-helpers.ts
@@ -51,7 +51,7 @@ export function schemaHasSandboxModeEnabled(schema: string, docLink: string): bo
   const authRuleField = amplifyInputType.fields.find(matchesGlobalAuth);
 
   if (!authRuleField) {
-    throw Error(`input AMPLIFY requires "globalAuthRule" field. Learn more here: ${docLink}`);
+    return false;
   }
 
   const typeName = authRuleField.type.name.value;

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -732,6 +732,8 @@ const allAuthTypes = ['API key', 'Amazon Cognito User Pool', 'IAM', 'OpenID Conn
 export function addApi(projectDir: string, settings?: any) {
   const transformerVersion = settings?.transformerVersion ?? 2;
   delete settings?.transformerVersion;
+  const authTypesToSkipSetup = settings?.authTypesToSkipSetup ?? [];
+  delete settings?.authTypesToSkipSetup;
 
   let authTypesToSelectFrom = allAuthTypes.slice();
   return new Promise<void>((resolve, reject) => {
@@ -749,7 +751,7 @@ export function addApi(projectDir: string, settings?: any) {
         .sendCarriageReturn();
 
       singleSelect(chain.wait('Choose the default authorization type for the API'), defaultType, authTypesToSelectFrom);
-      setupAuthType(defaultType, chain, settings);
+      setupAuthType(defaultType, chain, { ...settings, authTypesToSkipSetup });
 
       if (authTypesToAdd.length > 1) {
         authTypesToAdd.shift();
@@ -765,7 +767,7 @@ export function addApi(projectDir: string, settings?: any) {
         );
 
         authTypesToAdd.forEach((authType) => {
-          setupAuthType(authType, chain, settings);
+          setupAuthType(authType, chain, { ...settings, authTypesToSkipSetup });
         });
       } else {
         chain.wait('Configure additional auth types?').sendLine('n');
@@ -816,6 +818,9 @@ export function addV1RDSDataSource(projectDir: string) {
 }
 
 function setupAuthType(authType: string, chain: any, settings?: any) {
+  if (settings?.authTypesToSkipSetup?.includes(authType)) {
+    return;
+  }
   switch (authType) {
     case 'API key':
       setupAPIKey(chain);

--- a/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/custom-claims-userpool.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/custom-claims-userpool.ts
@@ -1,3 +1,4 @@
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
 import { generateDDL } from '../../rds-v2-test-utils';
 
 export const schema = `
@@ -37,4 +38,4 @@ export const schema = `
   }
 `;
 
-export const sqlCreateStatements = generateDDL(schema);
+export const sqlCreateStatements = (engine: ImportedRDSType): string[] => generateDDL(schema, engine);

--- a/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/userpool-provider.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/userpool-provider.ts
@@ -1,6 +1,7 @@
-import { generateDDL } from '../../rds-v2-test-utils';
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { convertToDBSpecificGraphQLString, generateDDL } from '../../rds-v2-test-utils';
 
-export const schema = `
+export const schema = (engine: ImportedRDSType): string => `
   type TodoPrivate @model @auth(rules: [{ allow: private }]) {
     id: ID! @primaryKey
     content: String
@@ -47,14 +48,26 @@ export const schema = `
   }
 
   type Query {
-    customGetTodoPrivate(id: ID!): [TodoNonModel] @sql(statement: "SELECT * FROM TodoPrivate WHERE id = :id") @auth(rules: [{ allow: private }])
-    customGetTodoStaticGroup(id: ID!): [TodoNonModel] @sql(statement: "SELECT * FROM TodoStaticGroup WHERE id = :id") @auth(rules: [{ allow: groups, groups: ["Admin"] }])
+    customGetTodoPrivate(id: ID!): [TodoNonModel] @sql(statement: "SELECT * FROM ${convertToDBSpecificGraphQLString(
+      'TodoPrivate',
+      engine,
+    )} WHERE id = :id") @auth(rules: [{ allow: private }])
+    customGetTodoStaticGroup(id: ID!): [TodoNonModel] @sql(statement: "SELECT * FROM ${convertToDBSpecificGraphQLString(
+      'TodoStaticGroup',
+      engine,
+    )} WHERE id = :id") @auth(rules: [{ allow: groups, groups: ["Admin"] }])
   }
 
   type Mutation {
-    addTodoPrivate(id: ID!, content: String): TodoNonModel @sql(statement: "INSERT INTO TodoPrivate VALUES(:id, :content)") @auth(rules: [{ allow: private }])
-    addTodoStaticGroup(id: ID!, content: String): TodoNonModel @sql(statement: "INSERT INTO TodoStaticGroup VALUES(:id, :content)") @auth(rules: [{ allow: groups, groups: ["Admin"] }])
+    addTodoPrivate(id: ID!, content: String): TodoNonModel @sql(statement: "INSERT INTO ${convertToDBSpecificGraphQLString(
+      'TodoPrivate',
+      engine,
+    )} VALUES(:id, :content)") @auth(rules: [{ allow: private }])
+    addTodoStaticGroup(id: ID!, content: String): TodoNonModel @sql(statement: "INSERT INTO ${convertToDBSpecificGraphQLString(
+      'TodoStaticGroup',
+      engine,
+    )} VALUES(:id, :content)") @auth(rules: [{ allow: groups, groups: ["Admin"] }])
   }
 `;
 
-export const sqlCreateStatements = generateDDL(schema);
+export const sqlCreateStatements = (engine: ImportedRDSType): string[] => generateDDL(schema(engine), engine);

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-multi-auth-1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-multi-auth-1.test.ts
@@ -25,6 +25,7 @@ import {
 } from '../rds-v2-test-utils';
 import { setupUser, getUserPoolId, signInUser, configureAmplify } from '../schema-api-directives';
 import { GQLQueryHelper } from '../query-utils/gql-helper';
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -119,7 +120,7 @@ describe('RDS Cognito userpool provider Auth tests', () => {
       useVpc: true,
       apiExists: true,
     });
-    writeFileSync(rdsSchemaFilePath, appendAmplifyInput(schema, 'mysql'), 'utf8');
+    writeFileSync(rdsSchemaFilePath, appendAmplifyInput(schema, ImportedRDSType.MYSQL), 'utf8');
 
     await updateAuthAddUserGroups(projRoot, [adminGroupName, devGroupName, moderatorGroupName]);
     await amplifyPush(projRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-oidc-auth.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-oidc-auth.test.ts
@@ -17,7 +17,7 @@ import {
 import { existsSync, writeFileSync, removeSync } from 'fs-extra';
 import generator from 'generate-password';
 import path from 'path';
-import { schema, sqlCreateStatements } from './auth-test-schemas/oidc-provider';
+import { schema as generateSchema, sqlCreateStatements } from './auth-test-schemas/oidc-provider';
 import {
   createModelOperationHelpers,
   configureAppSyncClients,
@@ -37,13 +37,14 @@ import {
   getConfiguredAppsyncClientOIDCAuth,
 } from '../schema-api-directives';
 import { gql } from 'graphql-tag';
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
 
 describe('RDS OIDC provider Auth tests', () => {
   const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
-
+  const schema = generateSchema(ImportedRDSType.MYSQL);
   // Generate settings for RDS instance
   const username = db_user;
   const password = db_password;
@@ -64,9 +65,10 @@ describe('RDS OIDC provider Auth tests', () => {
   let projRoot;
   let appSyncClients = {};
   const userMap = {};
+  const engine = ImportedRDSType.MYSQL;
 
   beforeAll(async () => {
-    console.log(sqlCreateStatements);
+    console.log(sqlCreateStatements(engine));
     projRoot = await createNewProjectDir(projName);
     await setupAmplifyProject();
   });
@@ -90,7 +92,7 @@ describe('RDS OIDC provider Auth tests', () => {
       region,
     };
 
-    const db = await setupRDSInstanceAndData(dbConfig, sqlCreateStatements);
+    const db = await setupRDSInstanceAndData(dbConfig, sqlCreateStatements(engine));
     port = db.port;
     host = db.endpoint;
   };
@@ -151,7 +153,7 @@ describe('RDS OIDC provider Auth tests', () => {
       useVpc: true,
       apiExists: true,
     });
-    writeFileSync(rdsSchemaFilePath, appendAmplifyInput(schema, 'mysql'), 'utf8');
+    writeFileSync(rdsSchemaFilePath, appendAmplifyInput(schema, ImportedRDSType.MYSQL), 'utf8');
 
     await updateAuthAddUserGroups(projRoot, [adminGroupName, devGroupName]);
     await amplifyPush(projRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-userpool-auth.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-userpool-auth.test.ts
@@ -15,7 +15,7 @@ import {
 import { existsSync, writeFileSync, removeSync } from 'fs-extra';
 import generator from 'generate-password';
 import path from 'path';
-import { schema, sqlCreateStatements } from './auth-test-schemas/userpool-provider';
+import { schema as generateSchema, sqlCreateStatements } from './auth-test-schemas/userpool-provider';
 import {
   createModelOperationHelpers,
   configureAppSyncClients,
@@ -26,11 +26,13 @@ import {
 } from '../rds-v2-test-utils';
 import { setupUser, getUserPoolId, signInUser, configureAmplify, getConfiguredAppsyncClientCognitoAuth } from '../schema-api-directives';
 import { gql } from 'graphql-tag';
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
 
 describe('RDS Cognito userpool provider Auth tests', () => {
+  const schema = generateSchema(ImportedRDSType.MYSQL);
   const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
 
   // Generate settings for RDS instance
@@ -55,7 +57,7 @@ describe('RDS Cognito userpool provider Auth tests', () => {
   const userMap = {};
 
   beforeAll(async () => {
-    console.log(sqlCreateStatements);
+    console.log(sqlCreateStatements(ImportedRDSType.MYSQL));
     projRoot = await createNewProjectDir(projName);
     await setupAmplifyProject();
   });
@@ -79,7 +81,7 @@ describe('RDS Cognito userpool provider Auth tests', () => {
       region,
     };
 
-    const db = await setupRDSInstanceAndData(dbConfig, sqlCreateStatements);
+    const db = await setupRDSInstanceAndData(dbConfig, sqlCreateStatements(ImportedRDSType.MYSQL));
     port = db.port;
     host = db.endpoint;
   };
@@ -130,7 +132,7 @@ describe('RDS Cognito userpool provider Auth tests', () => {
       apiExists: true,
     });
 
-    writeFileSync(rdsSchemaFilePath, appendAmplifyInput(schema, 'mysql'), 'utf8');
+    writeFileSync(rdsSchemaFilePath, appendAmplifyInput(schema, ImportedRDSType.MYSQL), 'utf8');
 
     await updateAuthAddUserGroups(projRoot, [adminGroupName, devGroupName]);
     await amplifyPush(projRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/rds-pg-custom-claims-refersto-auth.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-pg-custom-claims-refersto-auth.test.ts
@@ -4,6 +4,6 @@ import { testCustomClaimsRefersTo } from '../rds-v2-tests-common/rds-auth-custom
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
 
-describe('RDS MySQL Custom Claims Auth With RefersTo', () => {
-  testCustomClaimsRefersTo(ImportedRDSType.MYSQL);
+describe('RDS Postgres Custom Claims Auth With RefersTo', () => {
+  testCustomClaimsRefersTo(ImportedRDSType.POSTGRESQL);
 });

--- a/packages/amplify-e2e-tests/src/__tests__/rds-pg-oidc-auth.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-pg-oidc-auth.test.ts
@@ -1,0 +1,9 @@
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { testOIDCAuth } from '../rds-v2-tests-common/rds-auth-oidc';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+describe('RDS Postgres OIDC Auth', () => {
+  testOIDCAuth(ImportedRDSType.POSTGRESQL);
+});

--- a/packages/amplify-e2e-tests/src/__tests__/rds-pg-userpool-auth.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-pg-userpool-auth.test.ts
@@ -1,0 +1,9 @@
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { testUserPoolAuth } from '../rds-v2-tests-common/rds-auth-userpool';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+describe('RDS Postgres UserPool Auth', () => {
+  testUserPoolAuth(ImportedRDSType.POSTGRESQL);
+});

--- a/packages/amplify-e2e-tests/src/__tests__/rds-v2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-v2.test.ts
@@ -128,61 +128,61 @@ describe('RDS Tests', () => {
     expect(rdsMappingFile.data).toBeDefined();
     expect(rdsMappingFile.data).toMatchObject({
       'ap-northeast-1': {
-        layerRegion: 'arn:aws:lambda:ap-northeast-1:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:ap-northeast-1:582037449441:layer:AmplifyRDSLayer:24',
       },
       'us-east-1': {
-        layerRegion: 'arn:aws:lambda:us-east-1:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:us-east-1:582037449441:layer:AmplifyRDSLayer:24',
       },
       'ap-southeast-1': {
-        layerRegion: 'arn:aws:lambda:ap-southeast-1:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:ap-southeast-1:582037449441:layer:AmplifyRDSLayer:24',
       },
       'eu-west-1': {
-        layerRegion: 'arn:aws:lambda:eu-west-1:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:eu-west-1:582037449441:layer:AmplifyRDSLayer:24',
       },
       'us-west-1': {
-        layerRegion: 'arn:aws:lambda:us-west-1:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:us-west-1:582037449441:layer:AmplifyRDSLayer:24',
       },
       'ap-east-1': {
-        layerRegion: 'arn:aws:lambda:ap-east-1:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:ap-east-1:582037449441:layer:AmplifyRDSLayer:24',
       },
       'ap-northeast-2': {
-        layerRegion: 'arn:aws:lambda:ap-northeast-2:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:ap-northeast-2:582037449441:layer:AmplifyRDSLayer:24',
       },
       'ap-northeast-3': {
-        layerRegion: 'arn:aws:lambda:ap-northeast-3:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:ap-northeast-3:582037449441:layer:AmplifyRDSLayer:24',
       },
       'ap-south-1': {
-        layerRegion: 'arn:aws:lambda:ap-south-1:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:ap-south-1:582037449441:layer:AmplifyRDSLayer:24',
       },
       'ap-southeast-2': {
-        layerRegion: 'arn:aws:lambda:ap-southeast-2:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:ap-southeast-2:582037449441:layer:AmplifyRDSLayer:24',
       },
       'ca-central-1': {
-        layerRegion: 'arn:aws:lambda:ca-central-1:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:ca-central-1:582037449441:layer:AmplifyRDSLayer:24',
       },
       'eu-central-1': {
-        layerRegion: 'arn:aws:lambda:eu-central-1:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:eu-central-1:582037449441:layer:AmplifyRDSLayer:24',
       },
       'eu-north-1': {
-        layerRegion: 'arn:aws:lambda:eu-north-1:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:eu-north-1:582037449441:layer:AmplifyRDSLayer:24',
       },
       'eu-west-2': {
-        layerRegion: 'arn:aws:lambda:eu-west-2:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:eu-west-2:582037449441:layer:AmplifyRDSLayer:24',
       },
       'eu-west-3': {
-        layerRegion: 'arn:aws:lambda:eu-west-3:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:eu-west-3:582037449441:layer:AmplifyRDSLayer:24',
       },
       'sa-east-1': {
-        layerRegion: 'arn:aws:lambda:sa-east-1:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:sa-east-1:582037449441:layer:AmplifyRDSLayer:24',
       },
       'us-east-2': {
-        layerRegion: 'arn:aws:lambda:us-east-2:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:us-east-2:582037449441:layer:AmplifyRDSLayer:24',
       },
       'us-west-2': {
-        layerRegion: 'arn:aws:lambda:us-west-2:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:us-west-2:582037449441:layer:AmplifyRDSLayer:24',
       },
       'me-south-1': {
-        layerRegion: 'arn:aws:lambda:me-south-1:582037449441:layer:AmplifyRDSLayer:22',
+        layerRegion: 'arn:aws:lambda:me-south-1:582037449441:layer:AmplifyRDSLayer:24',
       },
     });
   });

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-custom-claims-refersto-auth.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-custom-claims-refersto-auth.ts
@@ -1,0 +1,712 @@
+import {
+  addApi,
+  amplifyPush,
+  createNewProjectDir,
+  deleteDBInstance,
+  deleteProject,
+  deleteProjectDir,
+  addAuthWithPreTokenGenerationTrigger,
+  importRDSDatabase,
+  initJSProjectWithProfile,
+  setupRDSInstanceAndData,
+  sleep,
+  updateAuthAddUserGroups,
+  getProjectMeta,
+} from 'amplify-category-api-e2e-core';
+import { existsSync, writeFileSync, removeSync } from 'fs-extra';
+import generator from 'generate-password';
+import path from 'path';
+import { schema, sqlCreateStatements } from '../__tests__/auth-test-schemas/custom-claims-userpool';
+import {
+  createModelOperationHelpers,
+  configureAppSyncClients,
+  checkOperationResult,
+  checkListItemExistence,
+  updatePreAuthTrigger,
+  getDefaultDatabasePort,
+  appendAmplifyInput,
+} from '../rds-v2-test-utils';
+import { setupUser, getUserPoolId, signInUser, configureAmplify } from '../schema-api-directives';
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+export const testCustomClaimsRefersTo = (engine: ImportedRDSType): void => {
+  describe(`RDS userpool provider with custom Auth claims and RefersTo tests - ${engine}`, () => {
+    const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
+
+    // Generate settings for RDS instance
+    const username = db_user;
+    const password = db_password;
+    let region = 'us-east-1';
+    let port = getDefaultDatabasePort(engine);
+    const database = 'default_db';
+    let host = 'localhost';
+    const identifier = `integtest${db_identifier}`;
+    const engineSuffix = engine === ImportedRDSType.MYSQL ? 'mysql' : 'pg';
+    const projName = `${engineSuffix}claims`;
+    const apiName = projName;
+    const userName1 = 'user1';
+    const userName2 = 'user2';
+    const adminGroupName = 'Admin';
+    const devGroupName = 'Dev';
+    const userPassword = 'user@Password';
+    const userpoolsProvider = 'userPools';
+
+    let projRoot;
+    let appSyncClients = {};
+    const userMap = {};
+
+    beforeAll(async () => {
+      console.log(sqlCreateStatements(engine));
+      projRoot = await createNewProjectDir(projName);
+      await setupAmplifyProject();
+    });
+
+    afterAll(async () => {
+      const metaFilePath = path.join(projRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
+      if (existsSync(metaFilePath)) {
+        await deleteProject(projRoot);
+      }
+      deleteProjectDir(projRoot);
+      await cleanupDatabase();
+    });
+
+    const setupDatabase = async (): Promise<void> => {
+      const dbConfig = {
+        identifier,
+        engine,
+        dbname: database,
+        username,
+        password,
+        region,
+        port,
+      };
+
+      const db = await setupRDSInstanceAndData(dbConfig, sqlCreateStatements(engine));
+      port = db.port;
+      host = db.endpoint;
+    };
+
+    const cleanupDatabase = async (): Promise<void> => {
+      await deleteDBInstance(identifier, region);
+    };
+
+    const setupAmplifyProject = async (): Promise<void> => {
+      await initJSProjectWithProfile(projRoot, {
+        disableAmplifyAppCreation: false,
+        name: projName,
+      });
+
+      const metaAfterInit = getProjectMeta(projRoot);
+      region = metaAfterInit.providers.awscloudformation.Region;
+
+      await addAuthWithPreTokenGenerationTrigger(projRoot);
+      updatePreAuthTrigger(projRoot, 'user_id');
+
+      await addApi(projRoot, {
+        'Amazon Cognito User Pool': {},
+        'API key': {},
+        transformerVersion: 2,
+        authTypesToSkipSetup: ['Amazon Cognito User Pool'],
+      });
+      const rdsSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.rds.graphql');
+      const ddbSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.graphql');
+      removeSync(ddbSchemaFilePath);
+
+      await setupDatabase();
+      await importRDSDatabase(projRoot, {
+        database,
+        engine,
+        host,
+        port,
+        username,
+        password,
+        useVpc: true,
+        apiExists: true,
+      });
+      writeFileSync(rdsSchemaFilePath, appendAmplifyInput(schema, engine), 'utf8');
+
+      await updateAuthAddUserGroups(projRoot, [adminGroupName, devGroupName]);
+      await amplifyPush(projRoot);
+      await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
+
+      const userPoolId = getUserPoolId(projRoot);
+      configureAmplify(projRoot);
+      await setupUser(userPoolId, userName1, userPassword, adminGroupName);
+      await setupUser(userPoolId, userName2, userPassword, devGroupName);
+      const user1 = await signInUser(userName1, userPassword);
+      userMap[userName1] = user1;
+      const user2 = await signInUser(userName2, userPassword);
+      userMap[userName2] = user2;
+      appSyncClients = await configureAppSyncClients(projRoot, apiName, [userpoolsProvider], userMap);
+    };
+
+    test('owner of a record can perform CRUD operations using default owner field', async () => {
+      const modelName = 'TodoOwner';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+      expect(createResult.data[resultSetName].owner).toBeDefined();
+
+      const todoWithOwner = {
+        ...todo,
+        owner: createResult.data[resultSetName].owner,
+      };
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        owner: todoWithOwner.owner,
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+    });
+
+    test('non-owner of a record cannot access it using default owner field', async () => {
+      const modelName = 'TodoOwner';
+      const modelOperationHelpersOwner = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName1], schema);
+      const modelOperationHelpersNonOwner = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName2], schema);
+      const todoHelperOwner = modelOperationHelpersOwner[modelName];
+      const todoHelperNonOwner = modelOperationHelpersNonOwner[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperOwner.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        owner: userName2,
+      };
+      await expect(async () => {
+        await todoHelperNonOwner.update(`update${modelName}`, todoUpdated);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access updateTodoOwner on type Mutation"`);
+
+      const getResult = await todoHelperNonOwner.get({
+        id: todo['id'],
+      });
+      expect(getResult.data[`get${modelName}`]).toBeNull();
+
+      const listTodosResult = await todoHelperNonOwner.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id']);
+
+      await expect(async () => {
+        await todoHelperNonOwner.delete(`delete${modelName}`, {
+          id: todo['id'],
+        });
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access deleteTodoOwner on type Mutation"`);
+    });
+
+    test('custom owner field used to store owner information', async () => {
+      const modelName = 'TodoOwnerFieldString';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+      expect(createResult.data[resultSetName].author).toEqual(userName1);
+
+      const todoWithOwner = {
+        ...todo,
+        author: userName1,
+      };
+
+      const todo1Updated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        author: todoWithOwner.author,
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todo1Updated);
+      checkOperationResult(updateResult, todo1Updated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todo1Updated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todo1Updated, `delete${modelName}`);
+    });
+
+    test('non-owner of a record cannot pretend to be an owner and gain access', async () => {
+      const modelName = 'TodoOwnerFieldString';
+      const modelOperationHelpersOwner = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName1], schema);
+      const modelOperationHelpersNonOwner = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName2], schema);
+      const todoHelperOwner = modelOperationHelpersOwner[modelName];
+      const todoHelperNonOwner = modelOperationHelpersNonOwner[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperOwner.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        author: userName1,
+      };
+      await expect(async () => {
+        await todoHelperNonOwner.update(`update${modelName}`, todoUpdated);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"GraphQL error: Not Authorized to access updateTodoOwnerFieldString on type Mutation"`,
+      );
+
+      const getResult = await todoHelperNonOwner.get({
+        id: todo['id'],
+      });
+      expect(getResult.data[`get${modelName}`]).toBeNull();
+
+      const listTodosResult = await todoHelperNonOwner.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id']);
+
+      await expect(async () => {
+        await todoHelperNonOwner.delete(`delete${modelName}`, {
+          id: todo['id'],
+        });
+      }).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"GraphQL error: Not Authorized to access deleteTodoOwnerFieldString on type Mutation"`,
+      );
+    });
+
+    test('member in list of owners can perform CRUD operations', async () => {
+      const modelName = 'TodoOwnerFieldList';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+        authors: [userName1],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+      expect(createResult.data[resultSetName].authors).toEqual([userName1]);
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        authors: [userName1],
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+    });
+
+    test('non-owner of a record cannot add themself to owner list', async () => {
+      const modelName = 'TodoOwnerFieldList';
+      const modelOperationHelpersOwner = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName1], schema);
+      const modelOperationHelpersNonOwner = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName2], schema);
+      const todoHelperOwner = modelOperationHelpersOwner[modelName];
+      const todoHelperNonOwner = modelOperationHelpersNonOwner[modelName];
+
+      const todo = {
+        content: 'Todo',
+        authors: [userName1],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperOwner.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        authors: [userName1, userName2],
+      };
+      await expect(async () => {
+        await todoHelperNonOwner.update(`update${modelName}`, todoUpdated);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access updateTodoOwnerFieldList on type Mutation"`);
+
+      const getResult = await todoHelperNonOwner.get({
+        id: todo['id'],
+      });
+      expect(getResult.data[`get${modelName}`]).toBeNull();
+
+      const listTodosResult = await todoHelperNonOwner.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id']);
+
+      await expect(async () => {
+        await todoHelperNonOwner.delete(`delete${modelName}`, {
+          id: todo['id'],
+        });
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access deleteTodoOwnerFieldList on type Mutation"`);
+    });
+
+    test('owner can add another user to the owner list', async () => {
+      const modelName = 'TodoOwnerFieldList';
+      const modelOperationHelpersOwner = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName1], schema);
+      const modelOperationHelpersNonOwner = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName2], schema);
+      const todoHelperOwner = modelOperationHelpersOwner[modelName];
+      const todoHelperAnotherOwner = modelOperationHelpersNonOwner[modelName];
+
+      const todo = {
+        content: 'Todo',
+        authors: [userName1, userName2],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperOwner.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        authors: [userName1, userName2],
+      };
+      const updateResult = await todoHelperAnotherOwner.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelperAnotherOwner.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelperAnotherOwner.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelperAnotherOwner.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+    });
+
+    test('users in static group can perform CRUD operations', async () => {
+      const modelName = 'TodoStaticGroup';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+    });
+
+    test('users not in static group cannot perform CRUD operations', async () => {
+      const modelName = 'TodoStaticGroup';
+      const modelOperationHelpersAdmin = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName1], schema);
+      const modelOperationHelpersNonAdmin = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName2], schema);
+      const todoHelperAdmin = modelOperationHelpersAdmin[modelName];
+      const todoHelperNonAdmin = modelOperationHelpersNonAdmin[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperAdmin.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      await expect(async () => {
+        await todoHelperNonAdmin.create(`create${modelName}`, todo);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access createTodoStaticGroup on type Mutation"`);
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+      };
+      await expect(async () => {
+        await todoHelperNonAdmin.update(`update${modelName}`, todoUpdated);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access updateTodoStaticGroup on type Mutation"`);
+
+      expect(
+        async () =>
+          await todoHelperNonAdmin.get({
+            id: todo['id'],
+          }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access getTodoStaticGroup on type Query"`);
+
+      await expect(async () => {
+        await todoHelperNonAdmin.list();
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access listTodoStaticGroups on type Query"`);
+
+      await expect(async () => {
+        await todoHelperNonAdmin.delete(`delete${modelName}`, {
+          id: todo['id'],
+        });
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access deleteTodoStaticGroup on type Mutation"`);
+    });
+
+    test('users in group stored as string can perform CRUD operations', async () => {
+      const modelName = 'TodoGroupFieldString';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+        groupField: adminGroupName,
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+      expect(createResult.data[resultSetName].groupField).toEqual(adminGroupName);
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        groupField: adminGroupName,
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+    });
+
+    test('users cannot spoof their group membership and gain access', async () => {
+      const modelName = 'TodoGroupFieldString';
+      const modelOperationHelpersAdmin = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName1], schema);
+      const modelOperationHelpersNonAdmin = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName2], schema);
+      const todoHelperAdmin = modelOperationHelpersAdmin[modelName];
+      const todoHelperNonAdmin = modelOperationHelpersNonAdmin[modelName];
+
+      const todo = {
+        content: 'Todo',
+        groupField: adminGroupName,
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperAdmin.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      await expect(async () => {
+        await todoHelperNonAdmin.create(resultSetName, todo);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"GraphQL error: Not Authorized to access createTodoGroupFieldString on type Mutation"`,
+      );
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        groupField: devGroupName,
+      };
+      await expect(async () => {
+        await todoHelperNonAdmin.update(`update${modelName}`, todoUpdated);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"GraphQL error: Not Authorized to access updateTodoGroupFieldString on type Mutation"`,
+      );
+
+      const getResult = await todoHelperNonAdmin.get({
+        id: todo['id'],
+      });
+      expect(getResult.data[`get${modelName}`]).toBeNull();
+
+      const listTodosResult = await todoHelperNonAdmin.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id']);
+
+      await expect(async () => {
+        await todoHelperNonAdmin.delete(`delete${modelName}`, {
+          id: todo['id'],
+        });
+      }).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"GraphQL error: Not Authorized to access deleteTodoGroupFieldString on type Mutation"`,
+      );
+    });
+
+    test('users in groups stored as list can perform CRUD operations', async () => {
+      const modelName = 'TodoGroupFieldList';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+        groupsField: [adminGroupName],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+      expect(createResult.data[resultSetName].groupsField).toEqual([adminGroupName]);
+
+      const todo1Updated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        groupsField: [adminGroupName],
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todo1Updated);
+      checkOperationResult(updateResult, todo1Updated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todo1Updated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todo1Updated, `delete${modelName}`);
+    });
+
+    test('users not part of allowed groups cannot access the records or modify allowed groups', async () => {
+      const modelName = 'TodoGroupFieldList';
+      const modelOperationHelpersAdmin = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName1], schema);
+      const modelOperationHelpersNonAdmin = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName2], schema);
+      const todoHelperAdmin = modelOperationHelpersAdmin[modelName];
+      const todoHelperNonAdmin = modelOperationHelpersNonAdmin[modelName];
+
+      const todo = {
+        content: 'Todo',
+        groupsField: [adminGroupName],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperAdmin.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        groupsField: [adminGroupName, devGroupName],
+      };
+      await expect(async () => {
+        await todoHelperNonAdmin.update(`update${modelName}`, todoUpdated);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access updateTodoGroupFieldList on type Mutation"`);
+
+      const getResult = await todoHelperNonAdmin.get({
+        id: todo['id'],
+      });
+      expect(getResult.data[`get${modelName}`]).toBeNull();
+
+      const listTodosResult = await todoHelperNonAdmin.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id']);
+
+      await expect(async () => {
+        await todoHelperNonAdmin.delete(`delete${modelName}`, {
+          id: todo['id'],
+        });
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access deleteTodoGroupFieldList on type Mutation"`);
+    });
+
+    test('Admin user can give access to another group of users', async () => {
+      const modelName = 'TodoGroupFieldList';
+      const modelOperationHelpersAdmin = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName1], schema);
+      const modelOperationHelpersNonAdmin = createModelOperationHelpers(appSyncClients[userpoolsProvider][userName2], schema);
+      const todoHelperAdmin = modelOperationHelpersAdmin[modelName];
+      const todoHelperNonAdmin = modelOperationHelpersNonAdmin[modelName];
+
+      const todo = {
+        content: 'Todo',
+        groupsField: [adminGroupName, devGroupName],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperAdmin.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        groupsField: [adminGroupName, devGroupName],
+      };
+      const updateResult = await todoHelperNonAdmin.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelperNonAdmin.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelperNonAdmin.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelperNonAdmin.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+    });
+  });
+};

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-oidc.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-oidc.ts
@@ -1,0 +1,1343 @@
+import {
+  addApi,
+  amplifyPush,
+  createNewProjectDir,
+  deleteDBInstance,
+  deleteProject,
+  deleteProjectDir,
+  addAuthWithPreTokenGenerationTrigger,
+  importRDSDatabase,
+  initJSProjectWithProfile,
+  setupRDSInstanceAndData,
+  sleep,
+  updateAuthAddUserGroups,
+  amplifyPushWithoutCodegen,
+  getProjectMeta,
+} from 'amplify-category-api-e2e-core';
+import { existsSync, writeFileSync, removeSync } from 'fs-extra';
+import generator from 'generate-password';
+import path from 'path';
+import { schema as generateSchema, sqlCreateStatements } from '../__tests__/auth-test-schemas/oidc-provider';
+import {
+  createModelOperationHelpers,
+  configureAppSyncClients,
+  checkOperationResult,
+  checkListItemExistence,
+  appendAmplifyInput,
+  getAppSyncEndpoint,
+  updatePreAuthTrigger,
+  getDefaultDatabasePort,
+} from '../rds-v2-test-utils';
+import {
+  setupUser,
+  getUserPoolId,
+  signInUser,
+  getUserPoolIssUrl,
+  getAppClientIDWeb,
+  configureAmplify,
+  getConfiguredAppsyncClientOIDCAuth,
+} from '../schema-api-directives';
+import { gql } from 'graphql-tag';
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+export const testOIDCAuth = (engine: ImportedRDSType): void => {
+  const schema = generateSchema(engine);
+  describe('RDS OIDC provider Auth tests', () => {
+    const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
+
+    // Generate settings for RDS instance
+    const username = db_user;
+    const password = db_password;
+    let region = 'us-east-1';
+    let port = getDefaultDatabasePort(engine);
+    const database = 'default_db';
+    let host = 'localhost';
+    const identifier = `integtest${db_identifier}`;
+    const projName = 'rdsoidcauth';
+    const userName1 = 'user1';
+    const userName2 = 'user2';
+    const adminGroupName = 'Admin';
+    const devGroupName = 'Dev';
+    const userPassword = 'user@Password';
+    const oidcProvider = 'oidc';
+    let graphQlEndpoint = 'localhost';
+
+    let projRoot;
+    let appSyncClients = {};
+    const userMap = {};
+    const apiName = projName;
+
+    beforeAll(async () => {
+      console.log(sqlCreateStatements(engine));
+      projRoot = await createNewProjectDir(projName);
+      await setupAmplifyProject();
+      await createAppSyncClients();
+    });
+
+    afterAll(async () => {
+      const metaFilePath = path.join(projRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
+      if (existsSync(metaFilePath)) {
+        await deleteProject(projRoot);
+      }
+      deleteProjectDir(projRoot);
+      await cleanupDatabase();
+    });
+
+    const setupDatabase = async (): Promise<void> => {
+      const dbConfig = {
+        identifier,
+        engine,
+        dbname: database,
+        username,
+        password,
+        region,
+        port,
+      };
+
+      const db = await setupRDSInstanceAndData(dbConfig, sqlCreateStatements(engine));
+      port = db.port;
+      host = db.endpoint;
+    };
+
+    const cleanupDatabase = async (): Promise<void> => {
+      await deleteDBInstance(identifier, region);
+    };
+
+    const subscriptionWithOwner = (name: string, ownerField: string = 'owner'): string => {
+      return /* GraphQL */ `
+          subscription On${name}($${ownerField}: String) {
+            on${name}(${ownerField}: $${ownerField}) {
+              id
+              content
+              ${ownerField}
+            }
+          }
+        `;
+    };
+
+    const setupAmplifyProject = async (): Promise<void> => {
+      await initJSProjectWithProfile(projRoot, {
+        disableAmplifyAppCreation: false,
+        name: projName,
+      });
+
+      const metaAfterInit = getProjectMeta(projRoot);
+      region = metaAfterInit.providers.awscloudformation.Region;
+
+      await addAuthWithPreTokenGenerationTrigger(projRoot);
+      updatePreAuthTrigger(projRoot, 'user_id');
+      await amplifyPushWithoutCodegen(projRoot);
+
+      await addApi(projRoot, {
+        'OpenID Connect': {
+          oidcProviderName: 'awscognitouserpool',
+          oidcProviderDomain: getUserPoolIssUrl(projRoot),
+          oidcClientId: getAppClientIDWeb(projRoot),
+          ttlaIssueInMillisecond: '3600000',
+          ttlaAuthInMillisecond: '3600000',
+        },
+        'API key': {},
+        transformerVersion: 2,
+      });
+
+      const rdsSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.rds.graphql');
+      const ddbSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.graphql');
+      removeSync(ddbSchemaFilePath);
+
+      await setupDatabase();
+      await importRDSDatabase(projRoot, {
+        database,
+        engine,
+        host,
+        port,
+        username,
+        password,
+        useVpc: true,
+        apiExists: true,
+      });
+      writeFileSync(rdsSchemaFilePath, appendAmplifyInput(schema, engine), 'utf8');
+
+      await updateAuthAddUserGroups(projRoot, [adminGroupName, devGroupName]);
+      await amplifyPush(projRoot);
+      await sleep(1 * 60 * 1000); // Wait for a minute for the VPC endpoints to be live.
+    };
+
+    const createAppSyncClients = async (): Promise<void> => {
+      const userPoolId = getUserPoolId(projRoot);
+      configureAmplify(projRoot);
+      await setupUser(userPoolId, userName1, userPassword, adminGroupName);
+      await setupUser(userPoolId, userName2, userPassword, devGroupName);
+      graphQlEndpoint = getAppSyncEndpoint(projRoot, apiName);
+      const user1 = await signInUser(userName1, userPassword);
+      userMap[userName1] = user1;
+      const user2 = await signInUser(userName2, userPassword);
+      userMap[userName2] = user2;
+      appSyncClients = await configureAppSyncClients(projRoot, apiName, [oidcProvider], userMap);
+    };
+
+    test('logged in user can perform CRUD and subscription operations', async () => {
+      const modelName = 'TodoPrivate';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[oidcProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      checkOperationResult(createResult, todo, resultSetName);
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
+        async () => {
+          await subTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await subTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [
+        async () => {
+          await subTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('owner of a record can perform CRUD and subscription operations using default owner field', async () => {
+      const modelName = 'TodoOwner';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[oidcProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+      expect(createResult.data[resultSetName].owner).toBeDefined();
+
+      const todoWithOwner = {
+        ...todo,
+        owner: createResult.data[resultSetName].owner,
+      };
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        owner: todoWithOwner.owner,
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        owner: userName1,
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
+        async () => {
+          await subTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await subTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [
+        async () => {
+          await subTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('non-owner of a record cannot access or subscribe to it using default owner field', async () => {
+      const modelName = 'TodoOwner';
+      const modelOperationHelpersOwner = createModelOperationHelpers(appSyncClients[oidcProvider][userName1], schema);
+      const modelOperationHelpersNonOwner = createModelOperationHelpers(appSyncClients[oidcProvider][userName2], schema);
+      const todoHelperOwner = modelOperationHelpersOwner[modelName];
+      const todoHelperNonOwner = modelOperationHelpersNonOwner[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperOwner.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        owner: userName2,
+      };
+      await expect(todoHelperNonOwner.update(`update${modelName}`, todoUpdated)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access updateTodoOwner on type Mutation',
+      );
+
+      const getResult = await todoHelperNonOwner.get({
+        id: todo['id'],
+      });
+      expect(getResult.data[`get${modelName}`]).toBeNull();
+
+      const listTodosResult = await todoHelperNonOwner.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id']);
+
+      await expect(
+        todoHelperNonOwner.delete(`delete${modelName}`, {
+          id: todo['id'],
+        }),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access deleteTodoOwner on type Mutation');
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        owner: userName1,
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName1]);
+      const observerClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName2]);
+      const actorTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const observerTodoHelper = createModelOperationHelpers(observerClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await observerTodoHelper.subscribe('onCreate', [
+        async () => {
+          await actorTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(0);
+      const onUpdateSubscriptionResult = await observerTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await actorTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(0);
+      const onDeleteSubscriptionResult = await observerTodoHelper.subscribe('onDelete', [
+        async () => {
+          await actorTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(0);
+    });
+
+    test('custom owner field used to store owner information', async () => {
+      const modelName = 'TodoOwnerFieldString';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[oidcProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+      expect(createResult.data[resultSetName].author).toEqual(userName1);
+
+      const todoWithOwner = {
+        ...todo,
+        author: userName1,
+      };
+
+      const todo1Updated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        author: todoWithOwner.author,
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todo1Updated);
+      checkOperationResult(updateResult, todo1Updated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todo1Updated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todo1Updated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        author: userName1,
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe(
+        'onCreate',
+        [
+          async () => {
+            await subTodoHelper.create(`create${modelName}`, todoRandom);
+          },
+        ],
+        { author: userName1 },
+        subscriptionWithOwner(`Create${modelName}`, 'author'),
+      );
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await subTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [
+        async () => {
+          await subTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('non-owner of a record cannot pretend to be an owner and gain access', async () => {
+      const modelName = 'TodoOwnerFieldString';
+      const modelOperationHelpersOwner = createModelOperationHelpers(appSyncClients[oidcProvider][userName1], schema);
+      const modelOperationHelpersNonOwner = createModelOperationHelpers(appSyncClients[oidcProvider][userName2], schema);
+      const todoHelperOwner = modelOperationHelpersOwner[modelName];
+      const todoHelperNonOwner = modelOperationHelpersNonOwner[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperOwner.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        author: userName1,
+      };
+      await expect(todoHelperNonOwner.update(`update${modelName}`, todoUpdated)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access updateTodoOwnerFieldString on type Mutation',
+      );
+
+      const getResult = await todoHelperNonOwner.get({
+        id: todo['id'],
+      });
+      expect(getResult.data[`get${modelName}`]).toBeNull();
+
+      const listTodosResult = await todoHelperNonOwner.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id']);
+
+      await expect(
+        todoHelperNonOwner.delete(`delete${modelName}`, {
+          id: todo['id'],
+        }),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access deleteTodoOwnerFieldString on type Mutation');
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        author: userName1,
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+
+      const actorClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName1]);
+      const observerClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName2]);
+      const actorTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const observerTodoHelper = createModelOperationHelpers(observerClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await observerTodoHelper.subscribe(
+        'onCreate',
+        [
+          async () => {
+            await actorTodoHelper.create(`create${modelName}`, todoRandom);
+          },
+        ],
+        { author: userName1 },
+        subscriptionWithOwner(`Create${modelName}`, 'author'),
+      );
+      expect(onCreateSubscriptionResult).toHaveLength(0);
+      const onUpdateSubscriptionResult = await observerTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await actorTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(0);
+      const onDeleteSubscriptionResult = await observerTodoHelper.subscribe('onDelete', [
+        async () => {
+          await actorTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(0);
+    });
+
+    test('member in list of owners can perform CRUD and subscription operations', async () => {
+      const modelName = 'TodoOwnerFieldList';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[oidcProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+        authors: [userName1],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+      expect(createResult.data[resultSetName].authors).toEqual([userName1]);
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        authors: [userName1],
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        authors: [userName1],
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
+        async () => {
+          await subTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await subTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [
+        async () => {
+          await subTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('non-owner of a record cannot add themself to owner list', async () => {
+      const modelName = 'TodoOwnerFieldList';
+      const modelOperationHelpersOwner = createModelOperationHelpers(appSyncClients[oidcProvider][userName1], schema);
+      const modelOperationHelpersNonOwner = createModelOperationHelpers(appSyncClients[oidcProvider][userName2], schema);
+      const todoHelperOwner = modelOperationHelpersOwner[modelName];
+      const todoHelperNonOwner = modelOperationHelpersNonOwner[modelName];
+
+      const todo = {
+        content: 'Todo',
+        authors: [userName1],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperOwner.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        authors: [userName1, userName2],
+      };
+      await expect(todoHelperNonOwner.update(`update${modelName}`, todoUpdated)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access updateTodoOwnerFieldList on type Mutation',
+      );
+
+      const getResult = await todoHelperNonOwner.get({
+        id: todo['id'],
+      });
+      expect(getResult.data[`get${modelName}`]).toBeNull();
+
+      const listTodosResult = await todoHelperNonOwner.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id']);
+
+      await expect(
+        todoHelperNonOwner.delete(`delete${modelName}`, {
+          id: todo['id'],
+        }),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access deleteTodoOwnerFieldList on type Mutation');
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        authors: [userName1],
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName1]);
+      const observerClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName2]);
+      const actorTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const observerTodoHelper = createModelOperationHelpers(observerClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await observerTodoHelper.subscribe('onCreate', [
+        async () => {
+          await actorTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(0);
+      const onUpdateSubscriptionResult = await observerTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await actorTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(0);
+      const onDeleteSubscriptionResult = await observerTodoHelper.subscribe('onDelete', [
+        async () => {
+          await actorTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(0);
+    });
+
+    test('owner can add another user to the owner list', async () => {
+      const modelName = 'TodoOwnerFieldList';
+      const modelOperationHelpersOwner = createModelOperationHelpers(appSyncClients[oidcProvider][userName1], schema);
+      const modelOperationHelpersNonOwner = createModelOperationHelpers(appSyncClients[oidcProvider][userName2], schema);
+      const todoHelperOwner = modelOperationHelpersOwner[modelName];
+      const todoHelperAnotherOwner = modelOperationHelpersNonOwner[modelName];
+
+      const todo = {
+        content: 'Todo',
+        authors: [userName1, userName2],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperOwner.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        authors: [userName1, userName2],
+      };
+      const updateResult = await todoHelperAnotherOwner.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelperAnotherOwner.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelperAnotherOwner.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelperAnotherOwner.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        authors: [userName1, userName2],
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName1]);
+      const observerClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName2]);
+      const actorTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const observerTodoHelper = createModelOperationHelpers(observerClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await observerTodoHelper.subscribe('onCreate', [
+        async () => {
+          await actorTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await observerTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await actorTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await observerTodoHelper.subscribe('onDelete', [
+        async () => {
+          await actorTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('users in static group can perform CRUD and subscription operations', async () => {
+      const modelName = 'TodoStaticGroup';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[oidcProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
+        async () => {
+          await subTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await subTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [
+        async () => {
+          await subTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('users not in static group cannot perform CRUD operations', async () => {
+      const modelName = 'TodoStaticGroup';
+      const modelOperationHelpersAdmin = createModelOperationHelpers(appSyncClients[oidcProvider][userName1], schema);
+      const modelOperationHelpersNonAdmin = createModelOperationHelpers(appSyncClients[oidcProvider][userName2], schema);
+      const todoHelperAdmin = modelOperationHelpersAdmin[modelName];
+      const todoHelperNonAdmin = modelOperationHelpersNonAdmin[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperAdmin.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      await expect(todoHelperNonAdmin.create(`create${modelName}`, todo)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access createTodoStaticGroup on type Mutation',
+      );
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+      };
+      await expect(todoHelperNonAdmin.update(`update${modelName}`, todoUpdated)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access updateTodoStaticGroup on type Mutation',
+      );
+
+      expect(
+        todoHelperNonAdmin.get({
+          id: todo['id'],
+        }),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access getTodoStaticGroup on type Query');
+
+      await expect(todoHelperNonAdmin.list()).rejects.toThrow('GraphQL error: Not Authorized to access listTodoStaticGroups on type Query');
+
+      await expect(
+        todoHelperNonAdmin.delete(`delete${modelName}`, {
+          id: todo['id'],
+        }),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access deleteTodoStaticGroup on type Mutation');
+    });
+
+    test('users in group stored as string can perform CRUD and subscription operations', async () => {
+      const modelName = 'TodoGroupFieldString';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[oidcProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+        groupField: adminGroupName,
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+      expect(createResult.data[resultSetName].groupField).toEqual(adminGroupName);
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        groupField: adminGroupName,
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        groupField: adminGroupName,
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
+        async () => {
+          await subTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await subTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [
+        async () => {
+          await subTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('users cannot spoof their group membership and gain access', async () => {
+      const modelName = 'TodoGroupFieldString';
+      const modelOperationHelpersAdmin = createModelOperationHelpers(appSyncClients[oidcProvider][userName1], schema);
+      const modelOperationHelpersNonAdmin = createModelOperationHelpers(appSyncClients[oidcProvider][userName2], schema);
+      const todoHelperAdmin = modelOperationHelpersAdmin[modelName];
+      const todoHelperNonAdmin = modelOperationHelpersNonAdmin[modelName];
+
+      const todo = {
+        content: 'Todo',
+        groupField: adminGroupName,
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperAdmin.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      await expect(todoHelperNonAdmin.create(resultSetName, todo)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access createTodoGroupFieldString on type Mutation',
+      );
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        groupField: devGroupName,
+      };
+      await expect(todoHelperNonAdmin.update(`update${modelName}`, todoUpdated)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access updateTodoGroupFieldString on type Mutation',
+      );
+
+      const getResult = await todoHelperNonAdmin.get({
+        id: todo['id'],
+      });
+      expect(getResult.data[`get${modelName}`]).toBeNull();
+
+      const listTodosResult = await todoHelperNonAdmin.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id']);
+
+      await expect(
+        todoHelperNonAdmin.delete(`delete${modelName}`, {
+          id: todo['id'],
+        }),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access deleteTodoGroupFieldString on type Mutation');
+    });
+
+    test('users in groups stored as list can perform CRUD and subscription operations', async () => {
+      const modelName = 'TodoGroupFieldList';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[oidcProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+        groupsField: [adminGroupName],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+      expect(createResult.data[resultSetName].groupsField).toEqual([adminGroupName]);
+
+      const todo1Updated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        groupsField: [adminGroupName],
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todo1Updated);
+      checkOperationResult(updateResult, todo1Updated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todo1Updated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todo1Updated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        groupsField: [adminGroupName],
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
+        async () => {
+          await subTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await subTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [
+        async () => {
+          await subTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('users not part of allowed groups cannot access the records or modify allowed groups', async () => {
+      const modelName = 'TodoGroupFieldList';
+      const modelOperationHelpersAdmin = createModelOperationHelpers(appSyncClients[oidcProvider][userName1], schema);
+      const modelOperationHelpersNonAdmin = createModelOperationHelpers(appSyncClients[oidcProvider][userName2], schema);
+      const todoHelperAdmin = modelOperationHelpersAdmin[modelName];
+      const todoHelperNonAdmin = modelOperationHelpersNonAdmin[modelName];
+
+      const todo = {
+        content: 'Todo',
+        groupsField: [adminGroupName],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperAdmin.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        groupsField: [adminGroupName, devGroupName],
+      };
+      await expect(todoHelperNonAdmin.update(`update${modelName}`, todoUpdated)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access updateTodoGroupFieldList on type Mutation',
+      );
+
+      const getResult = await todoHelperNonAdmin.get({
+        id: todo['id'],
+      });
+      expect(getResult.data[`get${modelName}`]).toBeNull();
+
+      const listTodosResult = await todoHelperNonAdmin.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id']);
+
+      await expect(
+        todoHelperNonAdmin.delete(`delete${modelName}`, {
+          id: todo['id'],
+        }),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access deleteTodoGroupFieldList on type Mutation');
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        groupsField: [adminGroupName],
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName1]);
+      const observerClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName2]);
+      const actorTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const observerTodoHelper = createModelOperationHelpers(observerClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await observerTodoHelper.subscribe('onCreate', [
+        async () => {
+          await actorTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(0);
+      const onUpdateSubscriptionResult = await observerTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await actorTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(0);
+      const onDeleteSubscriptionResult = await observerTodoHelper.subscribe('onDelete', [
+        async () => {
+          await actorTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(0);
+    });
+
+    test('Admin user can give access to another group of users', async () => {
+      const modelName = 'TodoGroupFieldList';
+      const modelOperationHelpersAdmin = createModelOperationHelpers(appSyncClients[oidcProvider][userName1], schema);
+      const modelOperationHelpersNonAdmin = createModelOperationHelpers(appSyncClients[oidcProvider][userName2], schema);
+      const todoHelperAdmin = modelOperationHelpersAdmin[modelName];
+      const todoHelperNonAdmin = modelOperationHelpersNonAdmin[modelName];
+
+      const todo = {
+        content: 'Todo',
+        groupsField: [adminGroupName, devGroupName],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperAdmin.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        groupsField: [adminGroupName, devGroupName],
+      };
+      const updateResult = await todoHelperNonAdmin.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelperNonAdmin.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelperNonAdmin.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelperNonAdmin.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        groupsField: [adminGroupName, devGroupName],
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName1]);
+      const observerClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName2]);
+      const actorTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const observerTodoHelper = createModelOperationHelpers(observerClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await observerTodoHelper.subscribe('onCreate', [
+        async () => {
+          await actorTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await observerTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await actorTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await observerTodoHelper.subscribe('onDelete', [
+        async () => {
+          await actorTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('logged in user can perform custom operations', async () => {
+      const appSyncClient = appSyncClients[oidcProvider][userName2];
+      const todo = {
+        id: Date.now().toString(),
+        content: 'Todo',
+      };
+      const createTodoCustom = /* GraphQL */ `
+        mutation CreateTodoCustom($id: ID!, $content: String) {
+          addTodoPrivate(id: $id, content: $content) {
+            id
+            content
+          }
+        }
+      `;
+      const createResult = await appSyncClient.mutate({
+        mutation: gql(createTodoCustom),
+        fetchPolicy: 'no-cache',
+        variables: todo,
+      });
+      expect(createResult.data.addTodoPrivate).toBeDefined();
+
+      const getTodoCustom = /* GraphQL */ `
+        query GetTodoCustom($id: ID!) {
+          customGetTodoPrivate(id: $id) {
+            id
+            content
+          }
+        }
+      `;
+      const getResult = await appSyncClient.query({
+        query: gql(getTodoCustom),
+        fetchPolicy: 'no-cache',
+        variables: {
+          id: todo.id,
+        },
+      });
+      expect(getResult.data.customGetTodoPrivate).toHaveLength(1);
+      expect(getResult.data.customGetTodoPrivate[0].id).toEqual(todo.id);
+      expect(getResult.data.customGetTodoPrivate[0].content).toEqual(todo.content);
+    });
+
+    test('users in static group can perform custom operations', async () => {
+      const appSyncClient = appSyncClients[oidcProvider][userName1];
+      const todo = {
+        id: Date.now().toString(),
+        content: 'Todo',
+      };
+      const createTodoCustom = /* GraphQL */ `
+        mutation CreateTodoCustom($id: ID!, $content: String) {
+          addTodoStaticGroup(id: $id, content: $content) {
+            id
+            content
+          }
+        }
+      `;
+      const createResult = await appSyncClient.mutate({
+        mutation: gql(createTodoCustom),
+        fetchPolicy: 'no-cache',
+        variables: todo,
+      });
+      expect(createResult.data.addTodoStaticGroup).toBeDefined();
+
+      const getTodoCustom = /* GraphQL */ `
+        query GetTodoCustom($id: ID!) {
+          customGetTodoStaticGroup(id: $id) {
+            id
+            content
+          }
+        }
+      `;
+      const getResult = await appSyncClient.query({
+        query: gql(getTodoCustom),
+        fetchPolicy: 'no-cache',
+        variables: {
+          id: todo.id,
+        },
+      });
+      expect(getResult.data.customGetTodoStaticGroup).toHaveLength(1);
+      expect(getResult.data.customGetTodoStaticGroup[0].id).toEqual(todo.id);
+      expect(getResult.data.customGetTodoStaticGroup[0].content).toEqual(todo.content);
+    });
+
+    test('users not in static group cannot perform custom operations', async () => {
+      const appSyncClient = appSyncClients[oidcProvider][userName2];
+      const todo = {
+        id: Date.now().toString(),
+        content: 'Todo',
+      };
+      const createTodoCustom = /* GraphQL */ `
+        mutation CreateTodoCustom($id: ID!, $content: String) {
+          addTodoStaticGroup(id: $id, content: $content) {
+            id
+            content
+          }
+        }
+      `;
+      await expect(
+        appSyncClient.mutate({
+          mutation: gql(createTodoCustom),
+          fetchPolicy: 'no-cache',
+          variables: todo,
+        }),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access addTodoStaticGroup on type Mutation');
+
+      const getTodoCustom = /* GraphQL */ `
+        query GetTodoCustom($id: ID!) {
+          customGetTodoStaticGroup(id: $id) {
+            id
+            content
+          }
+        }
+      `;
+      await expect(
+        appSyncClient.query({
+          query: gql(getTodoCustom),
+          fetchPolicy: 'no-cache',
+          variables: {
+            id: todo.id,
+          },
+        }),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access customGetTodoStaticGroup on type Query');
+    });
+  });
+};

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool.ts
@@ -1,0 +1,1332 @@
+import {
+  addApi,
+  amplifyPush,
+  createNewProjectDir,
+  deleteDBInstance,
+  deleteProject,
+  deleteProjectDir,
+  importRDSDatabase,
+  initJSProjectWithProfile,
+  setupRDSInstanceAndData,
+  sleep,
+  updateAuthAddUserGroups,
+  getProjectMeta,
+} from 'amplify-category-api-e2e-core';
+import { existsSync, writeFileSync, removeSync } from 'fs-extra';
+import generator from 'generate-password';
+import path from 'path';
+import { schema as generateSchema, sqlCreateStatements } from '../__tests__/auth-test-schemas/userpool-provider';
+import {
+  createModelOperationHelpers,
+  configureAppSyncClients,
+  checkOperationResult,
+  checkListItemExistence,
+  appendAmplifyInput,
+  getAppSyncEndpoint,
+  getDefaultDatabasePort,
+} from '../rds-v2-test-utils';
+import { setupUser, getUserPoolId, signInUser, configureAmplify, getConfiguredAppsyncClientCognitoAuth } from '../schema-api-directives';
+import { gql } from 'graphql-tag';
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+export const testUserPoolAuth = (engine: ImportedRDSType): void => {
+  const schema = generateSchema(engine);
+  describe('RDS Cognito userpool provider Auth tests', () => {
+    const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
+
+    // Generate settings for RDS instance
+    const username = db_user;
+    const password = db_password;
+    let region = 'us-east-1';
+    let port = getDefaultDatabasePort(engine);
+    const database = 'default_db';
+    let host = 'localhost';
+    const identifier = `integtest${db_identifier}`;
+    const projName = 'rdsuserpoolauth';
+    const userName1 = 'user1';
+    const userName2 = 'user2';
+    const adminGroupName = 'Admin';
+    const devGroupName = 'Dev';
+    const userPassword = 'user@Password';
+    const userPoolProvider = 'userPools';
+    let graphQlEndpoint = 'localhost';
+
+    let projRoot;
+    let appSyncClients = {};
+    const userMap = {};
+
+    beforeAll(async () => {
+      console.log(sqlCreateStatements(engine));
+      projRoot = await createNewProjectDir(projName);
+      await setupAmplifyProject();
+    });
+
+    afterAll(async () => {
+      const metaFilePath = path.join(projRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
+      if (existsSync(metaFilePath)) {
+        await deleteProject(projRoot);
+      }
+      deleteProjectDir(projRoot);
+      await cleanupDatabase();
+    });
+
+    const setupDatabase = async (): Promise<void> => {
+      const dbConfig = {
+        identifier,
+        engine,
+        dbname: database,
+        username,
+        password,
+        region,
+        port,
+      };
+
+      const db = await setupRDSInstanceAndData(dbConfig, sqlCreateStatements(engine));
+      port = db.port;
+      host = db.endpoint;
+    };
+
+    const cleanupDatabase = async (): Promise<void> => {
+      await deleteDBInstance(identifier, region);
+    };
+
+    const subscriptionWithOwner = (name: string, ownerField: string = 'owner'): string => {
+      return /* GraphQL */ `
+          subscription On${name}($${ownerField}: String) {
+            on${name}(${ownerField}: $${ownerField}) {
+              id
+              content
+              ${ownerField}
+            }
+          }
+        `;
+    };
+
+    const setupAmplifyProject = async (): Promise<void> => {
+      const apiName = projName;
+      await initJSProjectWithProfile(projRoot, {
+        disableAmplifyAppCreation: false,
+        name: projName,
+      });
+
+      const metaAfterInit = getProjectMeta(projRoot);
+      region = metaAfterInit.providers.awscloudformation.Region;
+
+      await addApi(projRoot, {
+        transformerVersion: 2,
+        'Amazon Cognito User Pool': {},
+        'API key': {},
+      });
+      const rdsSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.rds.graphql');
+      const ddbSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.graphql');
+      removeSync(ddbSchemaFilePath);
+
+      await setupDatabase();
+      await importRDSDatabase(projRoot, {
+        database,
+        engine,
+        host,
+        port,
+        username,
+        password,
+        useVpc: true,
+        apiExists: true,
+      });
+
+      writeFileSync(rdsSchemaFilePath, appendAmplifyInput(schema, engine), 'utf8');
+
+      await updateAuthAddUserGroups(projRoot, [adminGroupName, devGroupName]);
+      await amplifyPush(projRoot);
+      await sleep(30 * 1000); // Wait for 30 seconds for the VPC endpoints to be live.
+
+      const userPoolId = getUserPoolId(projRoot);
+      configureAmplify(projRoot);
+      await setupUser(userPoolId, userName1, userPassword, adminGroupName);
+      await setupUser(userPoolId, userName2, userPassword, devGroupName);
+      graphQlEndpoint = getAppSyncEndpoint(projRoot, apiName);
+      const user1 = await signInUser(userName1, userPassword);
+      userMap[userName1] = user1;
+      const user2 = await signInUser(userName2, userPassword);
+      userMap[userName2] = user2;
+      appSyncClients = await configureAppSyncClients(projRoot, apiName, [userPoolProvider], userMap);
+    };
+
+    test('logged in user can perform CRUD and subscription operations', async () => {
+      const modelName = 'TodoPrivate';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(`create${modelName}`, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      checkOperationResult(createResult, todo, `create${modelName}`);
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
+        async () => {
+          await subTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await subTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [
+        async () => {
+          await subTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('owner of a record can perform CRUD operations using default owner field', async () => {
+      const modelName = 'TodoOwner';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+      expect(createResult.data[resultSetName].owner).toBeDefined();
+
+      const todoWithOwner = {
+        ...todo,
+        owner: createResult.data[resultSetName]?.owner,
+      };
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        owner: todoWithOwner.owner,
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        owner: userName1,
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
+        async () => {
+          await subTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await subTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [
+        async () => {
+          await subTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('non-owner of a record cannot access it using default owner field', async () => {
+      const modelName = 'TodoOwner';
+      const modelOperationHelpersOwner = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
+      const modelOperationHelpersNonOwner = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
+      const todoHelperOwner = modelOperationHelpersOwner[modelName];
+      const todoHelperNonOwner = modelOperationHelpersNonOwner[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperOwner.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        owner: userName2,
+      };
+      await expect(async () => {
+        await todoHelperNonOwner.update(`update${modelName}`, todoUpdated);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access updateTodoOwner on type Mutation"`);
+
+      const getResult = await todoHelperNonOwner.get({
+        id: todo['id'],
+      });
+      expect(getResult.data[`get${modelName}`]).toBeNull();
+
+      const listTodosResult = await todoHelperNonOwner.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id']);
+
+      await expect(async () => {
+        await todoHelperNonOwner.delete(`delete${modelName}`, {
+          id: todo['id'],
+        });
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access deleteTodoOwner on type Mutation"`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        owner: userName1,
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName1]);
+      const observerClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName2]);
+      const actorTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const observerTodoHelper = createModelOperationHelpers(observerClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await observerTodoHelper.subscribe('onCreate', [
+        async () => {
+          await actorTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(0);
+      const onUpdateSubscriptionResult = await observerTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await actorTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(0);
+      const onDeleteSubscriptionResult = await observerTodoHelper.subscribe('onDelete', [
+        async () => {
+          await actorTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(0);
+    });
+
+    test('custom owner field used to store owner information', async () => {
+      const modelName = 'TodoOwnerFieldString';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+      expect(createResult.data[resultSetName].author).toEqual(userName1);
+
+      const todoWithOwner = {
+        ...todo,
+        author: userName1,
+      };
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        author: todoWithOwner.author,
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        author: userName1,
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe(
+        'onCreate',
+        [
+          async () => {
+            await subTodoHelper.create(`create${modelName}`, todoRandom);
+          },
+        ],
+        { author: userName1 },
+        subscriptionWithOwner(`Create${modelName}`, 'author'),
+      );
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await subTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [
+        async () => {
+          await subTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('non-owner of a record cannot pretend to be an owner and gain access', async () => {
+      const modelName = 'TodoOwnerFieldString';
+      const modelOperationHelpersOwner = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
+      const modelOperationHelpersNonOwner = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
+      const todoHelperOwner = modelOperationHelpersOwner[modelName];
+      const todoHelperNonOwner = modelOperationHelpersNonOwner[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperOwner.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        author: userName1,
+      };
+      await expect(async () => {
+        await todoHelperNonOwner.update(`update${modelName}`, todoUpdated);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"GraphQL error: Not Authorized to access updateTodoOwnerFieldString on type Mutation"`,
+      );
+
+      const getResult = await todoHelperNonOwner.get({
+        id: todo['id'],
+      });
+      expect(getResult.data[`get${modelName}`]).toBeNull();
+
+      const listTodosResult = await todoHelperNonOwner.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id']);
+
+      await expect(async () => {
+        await todoHelperNonOwner.delete(`delete${modelName}`, {
+          id: todo['id'],
+        });
+      }).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"GraphQL error: Not Authorized to access deleteTodoOwnerFieldString on type Mutation"`,
+      );
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        author: userName1,
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+
+      const actorClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName1]);
+      const observerClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName2]);
+      const actorTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const observerTodoHelper = createModelOperationHelpers(observerClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await observerTodoHelper.subscribe(
+        'onCreate',
+        [
+          async () => {
+            await actorTodoHelper.create(`create${modelName}`, todoRandom);
+          },
+        ],
+        { author: userName1 },
+        subscriptionWithOwner(`Create${modelName}`, 'author'),
+      );
+      expect(onCreateSubscriptionResult).toHaveLength(0);
+      const onUpdateSubscriptionResult = await observerTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await actorTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(0);
+      const onDeleteSubscriptionResult = await observerTodoHelper.subscribe('onDelete', [
+        async () => {
+          await actorTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(0);
+    });
+
+    test('member in list of owners can perform CRUD and subscription operations', async () => {
+      const modelName = 'TodoOwnerFieldList';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+        authors: [userName1],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+      expect(createResult.data[resultSetName].authors).toEqual([userName1]);
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        authors: [userName1],
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        authors: [userName1],
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
+        async () => {
+          await subTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await subTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [
+        async () => {
+          await subTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('non-owner of a record cannot add themself to owner list', async () => {
+      const modelName = 'TodoOwnerFieldList';
+      const modelOperationHelpersOwner = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
+      const modelOperationHelpersNonOwner = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
+      const todoHelperOwner = modelOperationHelpersOwner[modelName];
+      const todoHelperNonOwner = modelOperationHelpersNonOwner[modelName];
+
+      const todo = {
+        content: 'Todo',
+        authors: [userName1],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperOwner.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        authors: [userName1, userName2],
+      };
+      await expect(async () => {
+        await todoHelperNonOwner.update(`update${modelName}`, todoUpdated);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access updateTodoOwnerFieldList on type Mutation"`);
+
+      const getResult = await todoHelperNonOwner.get({
+        id: todo['id'],
+      });
+      expect(getResult.data[`get${modelName}`]).toBeNull();
+
+      const listTodosResult = await todoHelperNonOwner.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id']);
+
+      await expect(async () => {
+        await todoHelperNonOwner.delete(`delete${modelName}`, {
+          id: todo['id'],
+        });
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access deleteTodoOwnerFieldList on type Mutation"`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        authors: [userName1],
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName1]);
+      const observerClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName2]);
+      const actorTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const observerTodoHelper = createModelOperationHelpers(observerClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await observerTodoHelper.subscribe('onCreate', [
+        async () => {
+          await actorTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(0);
+      const onUpdateSubscriptionResult = await observerTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await actorTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(0);
+      const onDeleteSubscriptionResult = await observerTodoHelper.subscribe('onDelete', [
+        async () => {
+          await actorTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(0);
+    });
+
+    test('owner can add another user to the owner list', async () => {
+      const modelName = 'TodoOwnerFieldList';
+      const modelOperationHelpersOwner = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
+      const modelOperationHelpersNonOwner = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
+      const todoHelperOwner = modelOperationHelpersOwner[modelName];
+      const todoHelperAnotherOwner = modelOperationHelpersNonOwner[modelName];
+
+      const todo = {
+        content: 'Todo',
+        authors: [userName1, userName2],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperOwner.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        authors: [userName1, userName2],
+      };
+      const updateResult = await todoHelperAnotherOwner.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelperAnotherOwner.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelperAnotherOwner.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelperAnotherOwner.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        authors: [userName1, userName2],
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName1]);
+      const observerClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName2]);
+      const actorTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const observerTodoHelper = createModelOperationHelpers(observerClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await observerTodoHelper.subscribe('onCreate', [
+        async () => {
+          await actorTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await observerTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await actorTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await observerTodoHelper.subscribe('onDelete', [
+        async () => {
+          await actorTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('users in static group can perform CRUD and subscription operations', async () => {
+      const modelName = 'TodoStaticGroup';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
+        async () => {
+          await subTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await subTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [
+        async () => {
+          await subTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('users not in static group cannot perform CRUD operations', async () => {
+      const modelName = 'TodoStaticGroup';
+      const modelOperationHelpersAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
+      const modelOperationHelpersNonAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
+      const todoHelperAdmin = modelOperationHelpersAdmin[modelName];
+      const todoHelperNonAdmin = modelOperationHelpersNonAdmin[modelName];
+
+      const todo = {
+        content: 'Todo',
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperAdmin.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      await expect(async () => {
+        await todoHelperNonAdmin.create(`create${modelName}`, todo);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access createTodoStaticGroup on type Mutation"`);
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+      };
+      await expect(async () => {
+        await todoHelperNonAdmin.update(`update${modelName}`, todoUpdated);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access updateTodoStaticGroup on type Mutation"`);
+
+      expect(
+        async () =>
+          await todoHelperNonAdmin.get({
+            id: todo['id'],
+          }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access getTodoStaticGroup on type Query"`);
+
+      await expect(async () => {
+        await todoHelperNonAdmin.list();
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access listTodoStaticGroups on type Query"`);
+
+      await expect(async () => {
+        await todoHelperNonAdmin.delete(`delete${modelName}`, {
+          id: todo['id'],
+        });
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access deleteTodoStaticGroup on type Mutation"`);
+    });
+
+    test('users in group stored as string can perform CRUD operations', async () => {
+      const modelName = 'TodoGroupFieldString';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+        groupField: adminGroupName,
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+      expect(createResult.data[resultSetName].groupField).toEqual(adminGroupName);
+
+      const todo1Updated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        groupField: adminGroupName,
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todo1Updated);
+      checkOperationResult(updateResult, todo1Updated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todo1Updated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todo1Updated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        groupField: adminGroupName,
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
+        async () => {
+          await subTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await subTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [
+        async () => {
+          await subTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('users cannot spoof their group membership and gain access', async () => {
+      const modelName = 'TodoGroupFieldString';
+      const modelOperationHelpersAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
+      const modelOperationHelpersNonAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
+      const todoHelperAdmin = modelOperationHelpersAdmin[modelName];
+      const todoHelperNonAdmin = modelOperationHelpersNonAdmin[modelName];
+
+      const todo = {
+        content: 'Todo',
+        groupField: adminGroupName,
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperAdmin.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      await expect(async () => {
+        await todoHelperNonAdmin.create(resultSetName, todo);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"GraphQL error: Not Authorized to access createTodoGroupFieldString on type Mutation"`,
+      );
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        groupField: devGroupName,
+      };
+      await expect(async () => {
+        await todoHelperNonAdmin.update(`update${modelName}`, todoUpdated);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"GraphQL error: Not Authorized to access updateTodoGroupFieldString on type Mutation"`,
+      );
+
+      const getResult = await todoHelperNonAdmin.get({
+        id: todo['id'],
+      });
+      expect(getResult.data[`get${modelName}`]).toBeNull();
+
+      const listTodosResult = await todoHelperNonAdmin.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id']);
+
+      await expect(async () => {
+        await todoHelperNonAdmin.delete(`delete${modelName}`, {
+          id: todo['id'],
+        });
+      }).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"GraphQL error: Not Authorized to access deleteTodoGroupFieldString on type Mutation"`,
+      );
+    });
+
+    test('users in groups stored as list can perform CRUD operations', async () => {
+      const modelName = 'TodoGroupFieldList';
+      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
+      const todoHelper = modelOperationHelpers[modelName];
+
+      const todo = {
+        content: 'Todo',
+        groupsField: [adminGroupName],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelper.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+      expect(createResult.data[resultSetName].content).toEqual(todo.content);
+      expect(createResult.data[resultSetName].groupsField).toEqual([adminGroupName]);
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        groupsField: [adminGroupName],
+      };
+      const updateResult = await todoHelper.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelper.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelper.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelper.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        groupsField: [adminGroupName],
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
+        async () => {
+          await subTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await subTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [
+        async () => {
+          await subTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('users not part of allowed groups cannot access the records or modify allowed groups', async () => {
+      const modelName = 'TodoGroupFieldList';
+      const modelOperationHelpersAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
+      const modelOperationHelpersNonAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
+      const todoHelperAdmin = modelOperationHelpersAdmin[modelName];
+      const todoHelperNonAdmin = modelOperationHelpersNonAdmin[modelName];
+
+      const todo = {
+        content: 'Todo',
+        groupsField: [adminGroupName],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperAdmin.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        groupsField: [adminGroupName, devGroupName],
+      };
+      await expect(async () => {
+        await todoHelperNonAdmin.update(`update${modelName}`, todoUpdated);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access updateTodoGroupFieldList on type Mutation"`);
+
+      const getResult = await todoHelperNonAdmin.get({
+        id: todo['id'],
+      });
+      expect(getResult.data[`get${modelName}`]).toBeNull();
+
+      const listTodosResult = await todoHelperNonAdmin.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id']);
+
+      await expect(async () => {
+        await todoHelperNonAdmin.delete(`delete${modelName}`, {
+          id: todo['id'],
+        });
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access deleteTodoGroupFieldList on type Mutation"`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        groupsField: [adminGroupName],
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName1]);
+      const observerClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName2]);
+      const actorTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const observerTodoHelper = createModelOperationHelpers(observerClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await observerTodoHelper.subscribe('onCreate', [
+        async () => {
+          await actorTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(0);
+      const onUpdateSubscriptionResult = await observerTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await actorTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(0);
+      const onDeleteSubscriptionResult = await observerTodoHelper.subscribe('onDelete', [
+        async () => {
+          await actorTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(0);
+    });
+
+    test('Admin user can give access to another group of users', async () => {
+      const modelName = 'TodoGroupFieldList';
+      const modelOperationHelpersAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
+      const modelOperationHelpersNonAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
+      const todoHelperAdmin = modelOperationHelpersAdmin[modelName];
+      const todoHelperNonAdmin = modelOperationHelpersNonAdmin[modelName];
+
+      const todo = {
+        content: 'Todo',
+        groupsField: [adminGroupName, devGroupName],
+      };
+      const resultSetName = `create${modelName}`;
+      const createResult = await todoHelperAdmin.create(resultSetName, todo);
+      expect(createResult.data[resultSetName].id).toBeDefined();
+      todo['id'] = createResult.data[resultSetName].id;
+
+      const todoUpdated = {
+        id: todo['id'],
+        content: 'Todo updated',
+        groupsField: [adminGroupName, devGroupName],
+      };
+      const updateResult = await todoHelperNonAdmin.update(`update${modelName}`, todoUpdated);
+      checkOperationResult(updateResult, todoUpdated, `update${modelName}`);
+
+      const getResult = await todoHelperNonAdmin.get({
+        id: todo['id'],
+      });
+      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+
+      const listTodosResult = await todoHelperNonAdmin.list();
+      checkListItemExistence(listTodosResult, `list${modelName}s`, todo['id'], true);
+
+      const deleteResult = await todoHelperNonAdmin.delete(`delete${modelName}`, {
+        id: todo['id'],
+      });
+      checkOperationResult(deleteResult, todoUpdated, `delete${modelName}`);
+
+      const todoRandom = {
+        id: Date.now().toString(),
+        content: 'Todo',
+        groupsField: [adminGroupName, devGroupName],
+      };
+      const todoRandomUpdated = {
+        ...todoRandom,
+        content: 'Todo updated',
+      };
+      const actorClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName1]);
+      const observerClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName2]);
+      const actorTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const observerTodoHelper = createModelOperationHelpers(observerClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await observerTodoHelper.subscribe('onCreate', [
+        async () => {
+          await actorTodoHelper.create(`create${modelName}`, todoRandom);
+        },
+      ]);
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onCreateSubscriptionResult[0], todoRandom, `onCreate${modelName}`);
+      const onUpdateSubscriptionResult = await observerTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await actorTodoHelper.update(`update${modelName}`, todoRandomUpdated);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onUpdateSubscriptionResult[0], todoRandomUpdated, `onUpdate${modelName}`);
+      const onDeleteSubscriptionResult = await observerTodoHelper.subscribe('onDelete', [
+        async () => {
+          await actorTodoHelper.delete(`delete${modelName}`, { id: todoRandom.id });
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
+    });
+
+    test('logged in user can perform custom operations', async () => {
+      const appSyncClient = appSyncClients[userPoolProvider][userName2];
+      const todo = {
+        id: Date.now().toString(),
+        content: 'Todo',
+      };
+      const createTodoCustom = /* GraphQL */ `
+        mutation CreateTodoCustom($id: ID!, $content: String) {
+          addTodoPrivate(id: $id, content: $content) {
+            id
+            content
+          }
+        }
+      `;
+      const createResult = await appSyncClient.mutate({
+        mutation: gql(createTodoCustom),
+        fetchPolicy: 'no-cache',
+        variables: todo,
+      });
+      expect(createResult.data.addTodoPrivate).toBeDefined();
+
+      const getTodoCustom = /* GraphQL */ `
+        query GetTodoCustom($id: ID!) {
+          customGetTodoPrivate(id: $id) {
+            id
+            content
+          }
+        }
+      `;
+      const getResult = await appSyncClient.query({
+        query: gql(getTodoCustom),
+        fetchPolicy: 'no-cache',
+        variables: {
+          id: todo.id,
+        },
+      });
+      expect(getResult.data.customGetTodoPrivate).toHaveLength(1);
+      expect(getResult.data.customGetTodoPrivate[0].id).toEqual(todo.id);
+      expect(getResult.data.customGetTodoPrivate[0].content).toEqual(todo.content);
+    });
+
+    test('users in static group can perform custom operations', async () => {
+      const appSyncClient = appSyncClients[userPoolProvider][userName1];
+      const todo = {
+        id: Date.now().toString(),
+        content: 'Todo',
+      };
+      const createTodoCustom = /* GraphQL */ `
+        mutation CreateTodoCustom($id: ID!, $content: String) {
+          addTodoStaticGroup(id: $id, content: $content) {
+            id
+            content
+          }
+        }
+      `;
+      const createResult = await appSyncClient.mutate({
+        mutation: gql(createTodoCustom),
+        fetchPolicy: 'no-cache',
+        variables: todo,
+      });
+      expect(createResult.data.addTodoStaticGroup).toBeDefined();
+
+      const getTodoCustom = /* GraphQL */ `
+        query GetTodoCustom($id: ID!) {
+          customGetTodoStaticGroup(id: $id) {
+            id
+            content
+          }
+        }
+      `;
+      const getResult = await appSyncClient.query({
+        query: gql(getTodoCustom),
+        fetchPolicy: 'no-cache',
+        variables: {
+          id: todo.id,
+        },
+      });
+      expect(getResult.data.customGetTodoStaticGroup).toHaveLength(1);
+      expect(getResult.data.customGetTodoStaticGroup[0].id).toEqual(todo.id);
+      expect(getResult.data.customGetTodoStaticGroup[0].content).toEqual(todo.content);
+    });
+
+    test('users not in static group cannot perform custom operations', async () => {
+      const appSyncClient = appSyncClients[userPoolProvider][userName2];
+      const todo = {
+        id: Date.now().toString(),
+        content: 'Todo',
+      };
+      const createTodoCustom = /* GraphQL */ `
+        mutation CreateTodoCustom($id: ID!, $content: String) {
+          addTodoStaticGroup(id: $id, content: $content) {
+            id
+            content
+          }
+        }
+      `;
+      await expect(async () => {
+        await appSyncClient.mutate({
+          mutation: gql(createTodoCustom),
+          fetchPolicy: 'no-cache',
+          variables: todo,
+        });
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access addTodoStaticGroup on type Mutation"`);
+
+      const getTodoCustom = /* GraphQL */ `
+        query GetTodoCustom($id: ID!) {
+          customGetTodoStaticGroup(id: $id) {
+            id
+            content
+          }
+        }
+      `;
+      await expect(async () => {
+        await appSyncClient.query({
+          query: gql(getTodoCustom),
+          fetchPolicy: 'no-cache',
+          variables: {
+            id: todo.id,
+          },
+        });
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access customGetTodoStaticGroup on type Query"`);
+    });
+  });
+};

--- a/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
@@ -62,73 +62,73 @@ const getLatestLayers = (latestLayers?: RDSLayerMapping): RDSLayerMapping => {
 // For prod use account '582037449441', layer name 'AmplifyRDSLayer' and layer version '3' as of 2023-06-20
 const getDefaultLayerMapping = (): RDSLayerMapping => ({
   'ap-northeast-1': {
-    layerRegion: 'arn:aws:lambda:ap-northeast-1:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:ap-northeast-1:582037449441:layer:AmplifyRDSLayer:24',
   },
   'us-east-1': {
-    layerRegion: 'arn:aws:lambda:us-east-1:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:us-east-1:582037449441:layer:AmplifyRDSLayer:24',
   },
   'ap-southeast-1': {
-    layerRegion: 'arn:aws:lambda:ap-southeast-1:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:ap-southeast-1:582037449441:layer:AmplifyRDSLayer:24',
   },
   'eu-west-1': {
-    layerRegion: 'arn:aws:lambda:eu-west-1:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:eu-west-1:582037449441:layer:AmplifyRDSLayer:24',
   },
   'us-west-1': {
-    layerRegion: 'arn:aws:lambda:us-west-1:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:us-west-1:582037449441:layer:AmplifyRDSLayer:24',
   },
   'ap-east-1': {
-    layerRegion: 'arn:aws:lambda:ap-east-1:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:ap-east-1:582037449441:layer:AmplifyRDSLayer:24',
   },
   'ap-northeast-2': {
-    layerRegion: 'arn:aws:lambda:ap-northeast-2:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:ap-northeast-2:582037449441:layer:AmplifyRDSLayer:24',
   },
   'ap-northeast-3': {
-    layerRegion: 'arn:aws:lambda:ap-northeast-3:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:ap-northeast-3:582037449441:layer:AmplifyRDSLayer:24',
   },
   'ap-south-1': {
-    layerRegion: 'arn:aws:lambda:ap-south-1:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:ap-south-1:582037449441:layer:AmplifyRDSLayer:24',
   },
   'ap-southeast-2': {
-    layerRegion: 'arn:aws:lambda:ap-southeast-2:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:ap-southeast-2:582037449441:layer:AmplifyRDSLayer:24',
   },
   'ca-central-1': {
-    layerRegion: 'arn:aws:lambda:ca-central-1:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:ca-central-1:582037449441:layer:AmplifyRDSLayer:24',
   },
   'eu-central-1': {
-    layerRegion: 'arn:aws:lambda:eu-central-1:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:eu-central-1:582037449441:layer:AmplifyRDSLayer:24',
   },
   'eu-north-1': {
-    layerRegion: 'arn:aws:lambda:eu-north-1:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:eu-north-1:582037449441:layer:AmplifyRDSLayer:24',
   },
   'eu-west-2': {
-    layerRegion: 'arn:aws:lambda:eu-west-2:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:eu-west-2:582037449441:layer:AmplifyRDSLayer:24',
   },
   'eu-west-3': {
-    layerRegion: 'arn:aws:lambda:eu-west-3:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:eu-west-3:582037449441:layer:AmplifyRDSLayer:24',
   },
   'sa-east-1': {
-    layerRegion: 'arn:aws:lambda:sa-east-1:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:sa-east-1:582037449441:layer:AmplifyRDSLayer:24',
   },
   'us-east-2': {
-    layerRegion: 'arn:aws:lambda:us-east-2:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:us-east-2:582037449441:layer:AmplifyRDSLayer:24',
   },
   'us-west-2': {
-    layerRegion: 'arn:aws:lambda:us-west-2:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:us-west-2:582037449441:layer:AmplifyRDSLayer:24',
   },
   'cn-north-1': {
-    layerRegion: 'arn:aws:lambda:cn-north-1:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:cn-north-1:582037449441:layer:AmplifyRDSLayer:24',
   },
   'cn-northwest-1': {
-    layerRegion: 'arn:aws:lambda:cn-northwest-1:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:cn-northwest-1:582037449441:layer:AmplifyRDSLayer:24',
   },
   'us-gov-west-1': {
-    layerRegion: 'arn:aws:lambda:us-gov-west-1:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:us-gov-west-1:582037449441:layer:AmplifyRDSLayer:24',
   },
   'us-gov-east-1': {
-    layerRegion: 'arn:aws:lambda:us-gov-east-1:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:us-gov-east-1:582037449441:layer:AmplifyRDSLayer:24',
   },
   'me-south-1': {
-    layerRegion: 'arn:aws:lambda:me-south-1:582037449441:layer:AmplifyRDSLayer:22',
+    layerRegion: 'arn:aws:lambda:me-south-1:582037449441:layer:AmplifyRDSLayer:24',
   },
 });
 

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -141,12 +141,7 @@ const RUN_SOLO: (string | RegExp)[] = [
 
 const DEBUG_FLAG = '--debug';
 
-const EXCLUDE_TEST_IDS = [
-  'rds_mysql_custom_claims_refersto_auth',
-  'rds_pg_auth_apikey_lambda',
-  'rds_pg_auth_iam_apikey_lambda_subscription',
-  'rds_pg_auth_iam',
-];
+const EXCLUDE_TEST_IDS = ['HttpTransformer', 'schema_model', 'schema_key', 'schema_connection', 'schema_searchable'];
 
 const MAX_WORKERS = 4;
 

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -128,6 +128,9 @@ const RUN_SOLO: (string | RegExp)[] = [
   'src/__tests__/rds-pg-auth-apikey-lambda.test.ts',
   'src/__tests__/rds-pg-auth-iam-apikey-lambda-subscription.test.ts',
   'src/__tests__/rds-pg-auth-iam.test.ts',
+  'src/__tests__/rds-pg-custom-claims-refersto-auth.test.ts',
+  'src/__tests__/rds-pg-oidc-auth.test.ts',
+  'src/__tests__/rds-pg-userpool-auth.test.ts',
   // GraphQL E2E tests
   'src/__tests__/FunctionTransformerTestsV2.e2e.test.ts',
   'src/__tests__/HttpTransformer.e2e.test.ts',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- Do not throw error when global Auth rule is not present. Moved from https://github.com/aws-amplify/amplify-category-api/pull/2034
- Update the SQL lambda layer version after latest release of layer
- Add Postgres Auth E2E tests
- Excludes a small subset of V1 transformer E2Es to make room for new tests. These will be added back once CI account is scaled.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
CI checks

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
