### PR TITLE
chore: bump timeout for api table test, since it's inconsistently completing in time

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/amplify-table-1.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/amplify-table-1.test.ts
@@ -37,7 +37,7 @@ describe('CDK amplify table 1', () => {
     expect(table.Table.StreamSpecification.StreamViewType).toBe('NEW_AND_OLD_IMAGES');
     const updateTemplatePath = path.resolve(path.join(__dirname, 'backends', 'amplify-table', '1', 'updateIndex'));
     updateCDKAppWithTemplate(projRoot, updateTemplatePath);
-    await cdkDeploy(projRoot, '--all');
+    await cdkDeploy(projRoot, '--all', { timeoutMs: 10 * 60 * 1000 /* 10m */ });
     const updatedTable = await getDDBTable(tableName, region);
     expect(updatedTable).toBeDefined();
     expect(updatedTable.Table.BillingModeSummary.BillingMode).toBe('PROVISIONED');


### PR DESCRIPTION
#### Description of changes
Increase test timeout for iterative deploy step.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
E2E Test passes

#### Checklist
- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
