### PR TITLE
fix: Rename VPC Endpoint CDK prefix

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,7 @@ CHANGELOG.md
 client-test-apps
 packages/amplify-category-api/resources/
 packages/amplify-category-api/src/__tests__/commands/api/mock-data/invalid_schema.graphql
+packages/amplify-dynamodb-simulator/emulator/dynamodb-local-metadata.json
 packages/amplify-e2e-core/dist/index.html
 packages/amplify-e2e-tests/amplify-e2e-reports
 packages/amplify-graphql-api-construct-tests/amplify-e2e-reports

--- a/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
@@ -155,11 +155,11 @@ describe('RDS Tests', () => {
     expect(rdsLambdaFunction.Properties.VpcConfig.SecurityGroupIds).toBeDefined();
     expect(rdsLambdaFunction.Properties.VpcConfig.SecurityGroupIds.length).toBeGreaterThan(0);
 
-    expect(getResource(resources, 'RDSVpcEndpointssm', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
-    expect(getResource(resources, 'RDSVpcEndpointssmmessages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
-    expect(getResource(resources, 'RDSVpcEndpointkms', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
-    expect(getResource(resources, 'RDSVpcEndpointec2', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
-    expect(getResource(resources, 'RDSVpcEndpointec2messages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'SQLVpcEndpointssm', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'SQLVpcEndpointssmmessages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'SQLVpcEndpointkms', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'SQLVpcEndpointec2', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'SQLVpcEndpointec2messages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
 
     // Validate patching lambda and subscription
     const rdsPatchingLambdaFunction = getResource(resources, 'SQLPatchingLambda', CDK_FUNCTION_TYPE);

--- a/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
@@ -110,6 +110,7 @@ describe('RDS Tests', () => {
       apiExists: true,
     });
 
+    console.log(`Reading schema file at ${rdsSchemaFilePath}`);
     const schemaContent = readFileSync(rdsSchemaFilePath, 'utf8');
     const schema = parse(schemaContent);
 
@@ -161,7 +162,7 @@ describe('RDS Tests', () => {
     expect(getResource(resources, 'RDSVpcEndpointec2messages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
 
     // Validate patching lambda and subscription
-    const rdsPatchingLambdaFunction = getResource(resources, 'SQLPatchingLambdaLogicalID', CDK_FUNCTION_TYPE);
+    const rdsPatchingLambdaFunction = getResource(resources, 'SQLPatchingLambda', CDK_FUNCTION_TYPE);
     expect(rdsPatchingLambdaFunction).toBeDefined();
     expect(rdsPatchingLambdaFunction.Properties).toBeDefined();
     expect(rdsPatchingLambdaFunction.Properties.Environment).toBeDefined();
@@ -173,7 +174,7 @@ describe('RDS Tests', () => {
     );
 
     // Validate subscription
-    const rdsPatchingSubscription = getResource(resources, 'SQLPatchingLambdaLogicalID', CDK_SUBSCRIPTION_TYPE);
+    const rdsPatchingSubscription = getResource(resources, 'SQLPatchingLambda', CDK_SUBSCRIPTION_TYPE);
     expect(rdsPatchingSubscription).toBeDefined();
     expect(rdsPatchingSubscription.Properties).toBeDefined();
     expect(rdsPatchingSubscription.Properties.Protocol).toBeDefined();

--- a/packages/amplify-e2e-tests/src/__tests__/rds-pg-array-objects.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-pg-array-objects.test.ts
@@ -127,11 +127,11 @@ describe('RDS Model Directive', () => {
     expect(rdsLambdaFunction.Properties.VpcConfig.SecurityGroupIds).toBeDefined();
     expect(rdsLambdaFunction.Properties.VpcConfig.SecurityGroupIds.length).toBeGreaterThan(0);
 
-    expect(getResource(resources, 'RDSVpcEndpointssm', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
-    expect(getResource(resources, 'RDSVpcEndpointssmmessages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
-    expect(getResource(resources, 'RDSVpcEndpointkms', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
-    expect(getResource(resources, 'RDSVpcEndpointec2', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
-    expect(getResource(resources, 'RDSVpcEndpointec2messages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'SQLVpcEndpointssm', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'SQLVpcEndpointssmmessages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'SQLVpcEndpointkms', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'SQLVpcEndpointec2', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'SQLVpcEndpointec2messages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
   };
 
   afterAll(async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/rds-pg-import.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-pg-import.test.ts
@@ -104,11 +104,11 @@ describe('RDS Model Directive', () => {
     expect(rdsLambdaFunction.Properties.VpcConfig.SecurityGroupIds).toBeDefined();
     expect(rdsLambdaFunction.Properties.VpcConfig.SecurityGroupIds.length).toBeGreaterThan(0);
 
-    expect(getResource(resources, 'RDSVpcEndpointssm', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
-    expect(getResource(resources, 'RDSVpcEndpointssmmessages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
-    expect(getResource(resources, 'RDSVpcEndpointkms', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
-    expect(getResource(resources, 'RDSVpcEndpointec2', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
-    expect(getResource(resources, 'RDSVpcEndpointec2messages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'SQLVpcEndpointssm', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'SQLVpcEndpointssmmessages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'SQLVpcEndpointkms', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'SQLVpcEndpointec2', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+    expect(getResource(resources, 'SQLVpcEndpointec2messages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
   };
 
   afterAll(async () => {

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-model-v2.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-model-v2.ts
@@ -103,11 +103,11 @@ export const testRDSModel = (engine: ImportedRDSType, queries: string[]): void =
       expect(rdsLambdaFunction.Properties.VpcConfig.SecurityGroupIds).toBeDefined();
       expect(rdsLambdaFunction.Properties.VpcConfig.SecurityGroupIds.length).toBeGreaterThan(0);
 
-      expect(getResource(resources, 'RDSVpcEndpointssm', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
-      expect(getResource(resources, 'RDSVpcEndpointssmmessages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
-      expect(getResource(resources, 'RDSVpcEndpointkms', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
-      expect(getResource(resources, 'RDSVpcEndpointec2', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
-      expect(getResource(resources, 'RDSVpcEndpointec2messages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+      expect(getResource(resources, 'SQLVpcEndpointssm', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+      expect(getResource(resources, 'SQLVpcEndpointssmmessages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+      expect(getResource(resources, 'SQLVpcEndpointkms', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+      expect(getResource(resources, 'SQLVpcEndpointec2', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
+      expect(getResource(resources, 'SQLVpcEndpointec2messages', CDK_VPC_ENDPOINT_TYPE)).toBeDefined();
     };
 
     afterAll(async () => {

--- a/packages/amplify-graphql-model-transformer/rds-lambda/package.json
+++ b/packages/amplify-graphql-model-transformer/rds-lambda/package.json
@@ -2,7 +2,6 @@
   "type": "module",
   "devDependencies": {
     "@types/jest": "^29.1.1",
-    "@types/knex": "0.16.1",
     "typescript": "^4.8.4"
   },
   "dependencies": {

--- a/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
@@ -197,7 +197,7 @@ export const createRdsLambda = (
 
 const addVpcEndpoint = (scope: Construct, sqlLambdaVpcConfig: VpcConfig, serviceSuffix: string): CfnVPCEndpoint => {
   const serviceEndpointPrefix = 'com.amazonaws';
-  const endpoint = new CfnVPCEndpoint(scope, `RDSVpcEndpoint${serviceSuffix}`, {
+  const endpoint = new CfnVPCEndpoint(scope, `${ResourceConstants.RESOURCES.SQLVpcEndpointLogicalIDPrefix}${serviceSuffix}`, {
     serviceName: Fn.join('', [serviceEndpointPrefix, '.', Fn.ref('AWS::Region'), '.', serviceSuffix]), // Sample: com.amazonaws.us-east-1.ssmmessages
     vpcEndpointType: 'Interface',
     vpcId: sqlLambdaVpcConfig.vpcId,

--- a/packages/graphql-transformer-common/API.md
+++ b/packages/graphql-transformer-common/API.md
@@ -419,6 +419,7 @@ export class ResourceConstants {
         SQLLambdaAliasLogicalID: string;
         SQLLambdaLayerVersionLogicalID: string;
         SQLLayerMappingID: string;
+        SQLVpcEndpointLogicalIDPrefix: string;
         NoneDataSource: string;
         AuthCognitoUserPoolLogicalID: string;
         AuthCognitoUserPoolNativeClientLogicalID: string;

--- a/packages/graphql-transformer-common/src/ResourceConstants.ts
+++ b/packages/graphql-transformer-common/src/ResourceConstants.ts
@@ -42,6 +42,7 @@ export class ResourceConstants {
     SQLLambdaAliasLogicalID: 'SQLLambdaAlias',
     SQLLambdaLayerVersionLogicalID: 'SQLLambdaLayerVersion',
     SQLLayerMappingID: 'SQLLayerResourceMapping',
+    SQLVpcEndpointLogicalIDPrefix: 'SQLVpcEndpoint',
 
     // Local. Try not to collide with model data sources.
     NoneDataSource: 'NoneDataSource',


### PR DESCRIPTION
#### Description of changes

Renames the VPC Endpoint prefix from RDS to SQL. This is not a breaking change, since these endpoints are created and consumed by Amplify. 

Additional changes:
- Fixes an e2e test that was looking for an incorrect Lambda Layer CDK resource name after the RDS -> SQL renaming in #2069.
- Add a transient dynamodb simulator file to the prettier ignore, since it is sometimes not removed if a local test is interrupted before cleaning up
- Remove deprecated `@types/knex` dependency per its deprecation message:
    > npm WARN deprecated @types/knex@0.16.1: This is a stub types
    > definition. knex provides its own type definitions, so you do not need
    > this installed.

#### Checklist

- [x] PR description included
- [x] Modified E2e test passes locally with latest codebase

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
