### PR TITLE
fix: retain custom enums during schema regeneration

### DIFF
--- a/packages/amplify-graphql-schema-generator/src/__tests__/schema-overrides.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/schema-overrides.test.ts
@@ -800,6 +800,50 @@ describe('model auth rules overrides', () => {
   });
 });
 
+describe('schema overrides for Enum types', () => {
+  it('should retain added custom enum types', () => {
+    const document = parse(`
+            type Post @model {
+                id: ID!
+                title: String
+            }
+        `);
+    const editedSchema = `
+            type Post @model {
+                id: ID!
+                title: String
+            }
+            enum Status {
+                ACTIVE
+                INACTIVE
+            }
+        `;
+    const editedDocument = parse(editedSchema);
+    const updatedDocument = applySchemaOverrides(document, editedDocument);
+    stringsMatchWithoutWhitespace(print(updatedDocument), editedSchema);
+  });
+
+  it('should not retain edits to non-custom enum types', () => {
+    const schema = `
+            enum Status {
+                ACTIVE
+                INACTIVE
+            }
+        `;
+    const editedSchema = `
+            enum Status {
+                ACTIVE
+                INACTIVE
+                DELETED
+            }
+        `;
+    const document = parse(schema);
+    const editedDocument = parse(editedSchema);
+    const updatedDocument = applySchemaOverrides(document, editedDocument);
+    stringsMatchWithoutWhitespace(print(updatedDocument), schema);
+  });
+});
+
 const stringsMatchWithoutWhitespace = (actual: string, expected: string) => {
   expect(actual.replace(/\s/g, '')).toEqual(expected.replace(/\s/g, ''));
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
If the customers have enum types in their schema that do not exist in their database but are defined manually to represent either the inputs or outputs of custom GraphQL operations, we will preserve them when they re-generate their schema.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Added unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
