### PR TITLE
test: fix subscription prefix in rds-import-vpc.test.ts

### DIFF
--- a/packages/amplify-e2e-core/src/index.ts
+++ b/packages/amplify-e2e-core/src/index.ts
@@ -118,7 +118,7 @@ export const createNewProjectDir = async (
     // Especially for nexpect output waiting
     // This makes it a perfect candidate for staggering test start times
     const initialDelay = Math.floor(Math.random() * 180 * 1000); // between 0 to 3 min
-    console.log(`Waiting for ${initialDelay}s`);
+    console.log(`Waiting for ${initialDelay} ms`);
     await sleep(initialDelay);
   }
 


### PR DESCRIPTION
#### Description of changes

Fix e2e test that broke because of the patching lambda regionalization

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
