### PR TITLE
test(api): use beta layer for e2e tests

### DIFF
--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/transform-graphql-schema-v2.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/transform-graphql-schema-v2.test.ts
@@ -42,6 +42,13 @@ describe('transformGraphQLSchemaV2', () => {
           resourcesToBeUpdated: [],
           allResources: [],
         })),
+        getProjectMeta: jest.fn(() => ({
+          providers: {
+            awscloudformation: {
+              Region: 'us-east-1',
+            },
+          },
+        })),
       },
       parameters: {
         options: { resourcesDir: 'resourceDir', projectDirectory: __dirname },

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -50,7 +50,6 @@ const PARAMETERS_FILENAME = 'parameters.json';
 const SCHEMA_FILENAME = 'schema.graphql';
 const SCHEMA_DIR_NAME = 'schema';
 const PROVIDER_NAME = 'awscloudformation';
-const LAYER_MAPPING_S3_BUCKET = 'amplify-rds-layer-resources';
 const USE_BETA_SQL_LAYER = 'use-beta-sql-layer';
 
 /**
@@ -396,9 +395,9 @@ export const getUserOverridenSlots = (userDefinedSlots: Record<string, UserDefin
     .filter((slotName) => slotName !== undefined);
 
 const getRDSLayerMapping = async (context: $TSContext, useBetaSqlLayer = false): Promise<RDSLayerMapping> => {
-  const bucket = `${LAYER_MAPPING_S3_BUCKET}${useBetaSqlLayer ? '-beta' : ''}`;
+  const bucket = `${ResourceConstants.RESOURCES.SQLLayerVersionManifestBucket}${useBetaSqlLayer ? '-beta' : ''}`;
   const region = context.amplify.getProjectMeta().providers.awscloudformation.Region;
-  const url = `https://${bucket}.s3.amazonaws.com/sql-layer-versions/${region}`;
+  const url = `https://${bucket}.s3.amazonaws.com/${ResourceConstants.RESOURCES.SQLLayerVersionManifestKeyPrefix}${region}`;
   const response = await fetch(url);
   if (response.status === 200) {
     const result = await response.text();

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -406,7 +406,7 @@ const getRDSLayerMapping = async (context: $TSContext, useBetaSqlLayer = false):
       [region]: {
         layerRegion: result,
       },
-    }
+    };
     return mapping as RDSLayerMapping;
   } else {
     throw new Error(`Unable to retrieve layer mapping from ${url} with status code ${response.status}.`);

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -398,7 +398,7 @@ export const getUserOverridenSlots = (userDefinedSlots: Record<string, UserDefin
 const getRDSLayerMapping = async (context: $TSContext, useBetaSqlLayer = false): Promise<RDSLayerMapping> => {
   const bucket = `${LAYER_MAPPING_S3_BUCKET}${useBetaSqlLayer ? '-beta' : ''}`;
   const region = context.amplify.getProjectMeta().providers.awscloudformation.Region;
-  const url = `https://${bucket}.s3.${region}.amazonaws.com/sql-layer-versions/${region}`;
+  const url = `https://${bucket}.s3.amazonaws.com/sql-layer-versions/${region}`;
   const response = await fetch(url);
   if (response.status === 200) {
     const result = await response.text();

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -51,6 +51,8 @@ const SCHEMA_FILENAME = 'schema.graphql';
 const SCHEMA_DIR_NAME = 'schema';
 const PROVIDER_NAME = 'awscloudformation';
 const LAYER_MAPPING_URL = 'https://amplify-rds-layer-resources.s3.amazonaws.com/rds-layer-mapping.json';
+const LAYER_MAPPING_URL_BETA = 'https://amplify-rds-layer-resources-beta.s3.amazonaws.com/rds-layer-mapping.json';
+const USE_BETA_SQL_LAYER = 'use-beta-sql-layer';
 
 /**
  * Transform GraphQL Schema
@@ -339,8 +341,8 @@ const buildAPIProject = async (context: $TSContext, opts: TransformerProjectOpti
 
   checkForUnsupportedDirectives(schema, { dataSourceStrategies });
 
-  const rdsLayerMapping = await getRDSLayerMapping();
-
+  const useBetaSqlLayer = context?.input?.options?.[USE_BETA_SQL_LAYER] ?? false;
+  const rdsLayerMapping = await getRDSLayerMapping(useBetaSqlLayer);
   const transformManager = new TransformManager(
     opts.overrideConfig,
     hasIamAuth(opts.authConfig),
@@ -394,8 +396,9 @@ export const getUserOverridenSlots = (userDefinedSlots: Record<string, UserDefin
     .flat()
     .filter((slotName) => slotName !== undefined);
 
-const getRDSLayerMapping = async (): Promise<RDSLayerMapping> => {
-  const response = await fetch(LAYER_MAPPING_URL);
+const getRDSLayerMapping = async (useBetaSqlLayer = false): Promise<RDSLayerMapping> => {
+  const url = useBetaSqlLayer ? LAYER_MAPPING_URL_BETA : LAYER_MAPPING_URL;
+  const response = await fetch(url);
   if (response.status === 200) {
     const result = await response.json();
     return result as RDSLayerMapping;

--- a/packages/amplify-e2e-core/src/init/amplifyPush.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPush.ts
@@ -54,7 +54,11 @@ export function amplifyPush(
     if (settings?.useBetaSqlLayer) {
       pushOptions.push('--use-beta-sql-layer');
     }
-    const pushCommands = spawn(getCLIPath(testingWithLatestCodebase), pushOptions, { cwd, stripColors: true, noOutputTimeout: pushTimeoutMS })
+    const pushCommands = spawn(getCLIPath(testingWithLatestCodebase), pushOptions, {
+      cwd,
+      stripColors: true,
+      noOutputTimeout: pushTimeoutMS,
+    })
       .wait('Are you sure you want to continue?')
       .sendConfirmYes();
 

--- a/packages/amplify-e2e-core/src/init/amplifyPush.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPush.ts
@@ -37,6 +37,7 @@ export function amplifyPush(
   testingWithLatestCodebase = false,
   settings?: {
     skipCodegen?: boolean;
+    useBetaSqlLayer?: boolean;
   },
 ): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -49,7 +50,11 @@ export function amplifyPush(
         }
       });
     // Test amplify push
-    const pushCommands = spawn(getCLIPath(testingWithLatestCodebase), ['push'], { cwd, stripColors: true, noOutputTimeout: pushTimeoutMS })
+    const pushOptions = ['push'];
+    if (settings?.useBetaSqlLayer) {
+      pushOptions.push('--use-beta-sql-layer');
+    }
+    const pushCommands = spawn(getCLIPath(testingWithLatestCodebase), pushOptions, { cwd, stripColors: true, noOutputTimeout: pushTimeoutMS })
       .wait('Are you sure you want to continue?')
       .sendConfirmYes();
 

--- a/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-import-vpc.test.ts
@@ -25,6 +25,7 @@ import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
 import { ResourceConstants } from 'graphql-transformer-common';
 import { getDefaultStrategyNameForDbType, getResourceNamesForStrategyName, normalizeDbType } from '@aws-amplify/graphql-transformer-core';
 import { ModelDataSourceStrategySqlDbType } from '@aws-amplify/graphql-transformer-interfaces';
+import { SQL_TESTS_USE_BETA } from '../rds-v2-tests-common/sql-e2e-config';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -198,7 +199,9 @@ describe('RDS Tests', () => {
     expect(rdsPatchingSubscription.Properties.FilterPolicy).toBeDefined();
     expect(rdsPatchingSubscription.Properties.FilterPolicy.Region).toBeDefined();
 
-    await amplifyPush(projRoot);
+    await amplifyPush(projRoot, false, {
+      useBetaSqlLayer: SQL_TESTS_USE_BETA,
+    });
     await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
 
     // Get the AppSync API details after deployment

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-multi-auth-1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-multi-auth-1.test.ts
@@ -26,6 +26,7 @@ import {
 import { setupUser, getUserPoolId, signInUser, configureAmplify } from '../schema-api-directives';
 import { GQLQueryHelper } from '../query-utils/gql-helper';
 import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { SQL_TESTS_USE_BETA } from '../rds-v2-tests-common/sql-e2e-config';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -123,7 +124,9 @@ describe('RDS Cognito userpool provider Auth tests', () => {
     writeFileSync(rdsSchemaFilePath, appendAmplifyInput(schema, ImportedRDSType.MYSQL), 'utf8');
 
     await updateAuthAddUserGroups(projRoot, [adminGroupName, devGroupName, moderatorGroupName]);
-    await amplifyPush(projRoot);
+    await amplifyPush(projRoot, false, {
+      useBetaSqlLayer: SQL_TESTS_USE_BETA,
+    });
     await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
 
     const userPoolId = getUserPoolId(projRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-oidc-auth.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-oidc-auth.test.ts
@@ -11,7 +11,6 @@ import {
   setupRDSInstanceAndData,
   sleep,
   updateAuthAddUserGroups,
-  amplifyPushWithoutCodegen,
   getProjectMeta,
 } from 'amplify-category-api-e2e-core';
 import { existsSync, writeFileSync, removeSync } from 'fs-extra';
@@ -38,6 +37,7 @@ import {
 } from '../schema-api-directives';
 import { gql } from 'graphql-tag';
 import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { SQL_TESTS_USE_BETA } from '../rds-v2-tests-common/sql-e2e-config';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -125,7 +125,10 @@ describe('RDS OIDC provider Auth tests', () => {
 
     await addAuthWithPreTokenGenerationTrigger(projRoot);
     updatePreAuthTrigger(projRoot, 'user_id');
-    await amplifyPushWithoutCodegen(projRoot);
+    await amplifyPush(projRoot, false, {
+      skipCodegen: true,
+      useBetaSqlLayer: SQL_TESTS_USE_BETA,
+    })
 
     await addApi(projRoot, {
       'OpenID Connect': {
@@ -156,7 +159,9 @@ describe('RDS OIDC provider Auth tests', () => {
     writeFileSync(rdsSchemaFilePath, appendAmplifyInput(schema, ImportedRDSType.MYSQL), 'utf8');
 
     await updateAuthAddUserGroups(projRoot, [adminGroupName, devGroupName]);
-    await amplifyPush(projRoot);
+    await amplifyPush(projRoot, false, {
+      useBetaSqlLayer: SQL_TESTS_USE_BETA,
+    });
     await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
 
     const userPoolId = getUserPoolId(projRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-oidc-auth.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-oidc-auth.test.ts
@@ -128,7 +128,7 @@ describe('RDS OIDC provider Auth tests', () => {
     await amplifyPush(projRoot, false, {
       skipCodegen: true,
       useBetaSqlLayer: SQL_TESTS_USE_BETA,
-    })
+    });
 
     await addApi(projRoot, {
       'OpenID Connect': {

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-userpool-auth.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-userpool-auth.test.ts
@@ -27,6 +27,7 @@ import {
 import { setupUser, getUserPoolId, signInUser, configureAmplify, getConfiguredAppsyncClientCognitoAuth } from '../schema-api-directives';
 import { gql } from 'graphql-tag';
 import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { SQL_TESTS_USE_BETA } from '../rds-v2-tests-common/sql-e2e-config';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -135,7 +136,9 @@ describe('RDS Cognito userpool provider Auth tests', () => {
     writeFileSync(rdsSchemaFilePath, appendAmplifyInput(schema, ImportedRDSType.MYSQL), 'utf8');
 
     await updateAuthAddUserGroups(projRoot, [adminGroupName, devGroupName]);
-    await amplifyPush(projRoot);
+    await amplifyPush(projRoot, false, {
+      useBetaSqlLayer: SQL_TESTS_USE_BETA,
+    });
     await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
 
     const userPoolId = getUserPoolId(projRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/rds-pg-array-objects.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-pg-array-objects.test.ts
@@ -22,6 +22,7 @@ import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
 import gql from 'graphql-tag';
 import { getDefaultStrategyNameForDbType, getResourceNamesForStrategyName, normalizeDbType } from '@aws-amplify/graphql-transformer-core';
 import { ModelDataSourceStrategySqlDbType } from '@aws-amplify/graphql-transformer-interfaces';
+import { SQL_TESTS_USE_BETA } from '../rds-v2-tests-common/sql-e2e-config';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -54,7 +55,9 @@ describe('RDS Model Directive', () => {
     projRoot = await createNewProjectDir('rdsmodelapi');
     await initProjectAndImportSchema();
     modifySchema();
-    await amplifyPush(projRoot);
+    await amplifyPush(projRoot, false, {
+      useBetaSqlLayer: SQL_TESTS_USE_BETA,
+    });
     await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
 
     await verifyApiEndpointAndCreateClient();

--- a/packages/amplify-e2e-tests/src/__tests__/rds-pg-relational-directives.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-pg-relational-directives.test.ts
@@ -20,6 +20,7 @@ import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
 import { gql } from 'graphql-tag';
 import { ObjectTypeDefinitionNode, parse } from 'graphql';
 import { GQLQueryHelper } from '../query-utils/gql-helper';
+import { SQL_TESTS_USE_BETA } from '../rds-v2-tests-common/sql-e2e-config';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -43,7 +44,9 @@ describe('RDS Relational Directives', () => {
   beforeAll(async () => {
     projRoot = await createNewProjectDir('rdsmodelapi');
     await initProjectAndImportSchema();
-    await amplifyPush(projRoot);
+    await amplifyPush(projRoot, false, {
+      useBetaSqlLayer: SQL_TESTS_USE_BETA,
+    });
     await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
 
     const meta = getProjectMeta(projRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/rds-relational-directives.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-relational-directives.test.ts
@@ -20,6 +20,7 @@ import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
 import { GQLQueryHelper } from '../query-utils/gql-helper';
 import { gql } from 'graphql-transformer-core';
 import { ObjectTypeDefinitionNode, parse } from 'graphql';
+import { SQL_TESTS_USE_BETA } from '../rds-v2-tests-common/sql-e2e-config';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -43,7 +44,9 @@ describe('RDS Relational Directives', () => {
   beforeAll(async () => {
     projRoot = await createNewProjectDir('rdsmodelapi');
     await initProjectAndImportSchema();
-    await amplifyPush(projRoot);
+    await amplifyPush(projRoot, false, {
+      useBetaSqlLayer: SQL_TESTS_USE_BETA,
+    });
     await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
 
     const meta = getProjectMeta(projRoot);

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-apikey-lambda-iam-subscription.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-apikey-lambda-iam-subscription.ts
@@ -33,6 +33,7 @@ import { Auth, API } from 'aws-amplify';
 import { getUserPoolId } from '../schema-api-directives/authHelper';
 import { reconfigureAmplifyAPI, withTimeOut } from '../utils/api';
 import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { SQL_TESTS_USE_BETA } from './sql-e2e-config';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -70,13 +71,16 @@ export const testApiKeyLambdaIamAuthSubscription = (engine: ImportedRDSType, que
     beforeAll(async () => {
       projRoot = await createNewProjectDir(projName);
       await initProjectAndImportSchema();
-      await amplifyPush(projRoot);
+      await amplifyPush(projRoot, false, {
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
+      });
 
       await apiGqlCompile(projRoot, false, {
         forceCompile: true,
       });
       await amplifyPush(projRoot, false, {
         skipCodegen: true,
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
       });
       await sleep(2 * 60 * 1000); // Wait for a minute for the VPC endpoints to be live.
 

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-apikey-lambda.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-apikey-lambda.ts
@@ -18,6 +18,7 @@ import path from 'path';
 import { GQLQueryHelper } from '../query-utils/gql-helper';
 import { getConfiguredAppsyncClientAPIKeyAuth, getConfiguredAppsyncClientLambdaAuth } from '../schema-api-directives';
 import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { SQL_TESTS_USE_BETA } from './sql-e2e-config';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -46,7 +47,9 @@ export const testRdsApiKeyAndLambdaAuth = (engine: ImportedRDSType, queries: str
     beforeAll(async () => {
       projRoot = await createNewProjectDir(projName);
       await initProjectAndImportSchema();
-      await amplifyPush(projRoot);
+      await amplifyPush(projRoot, false, {
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
+      });
       await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
 
       const meta = getProjectMeta(projRoot);

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-custom-claims-refersto-auth.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-custom-claims-refersto-auth.ts
@@ -28,6 +28,7 @@ import {
 } from '../rds-v2-test-utils';
 import { setupUser, getUserPoolId, signInUser, configureAmplify } from '../schema-api-directives';
 import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { SQL_TESTS_USE_BETA } from './sql-e2e-config';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -129,7 +130,9 @@ export const testCustomClaimsRefersTo = (engine: ImportedRDSType): void => {
       writeFileSync(rdsSchemaFilePath, appendAmplifyInput(schema, engine), 'utf8');
 
       await updateAuthAddUserGroups(projRoot, [adminGroupName, devGroupName]);
-      await amplifyPush(projRoot);
+      await amplifyPush(projRoot, false, {
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
+      });
       await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
 
       const userPoolId = getUserPoolId(projRoot);

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-iam.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-iam.ts
@@ -28,6 +28,7 @@ import {
   getConfiguredAppsyncClientLambdaAuth,
 } from '../schema-api-directives';
 import { getUserPoolId } from '../schema-api-directives/authHelper';
+import { SQL_TESTS_USE_BETA } from './sql-e2e-config';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -158,7 +159,9 @@ export const testRdsIamAuth = (engine: ImportedRDSType, queries: string[]): void
         useVpc: true,
         apiExists: true,
       });
-      await amplifyPush(projRoot);
+      await amplifyPush(projRoot, false, {
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
+      });
 
       const schema = /* GraphQL */ `
         input AMPLIFY {
@@ -194,6 +197,7 @@ export const testRdsIamAuth = (engine: ImportedRDSType, queries: string[]): void
       await enableUserPoolUnauthenticatedAccess(projRoot);
       await amplifyPush(projRoot, false, {
         skipCodegen: true,
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
       });
     };
 

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-oidc.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-oidc.ts
@@ -11,7 +11,6 @@ import {
   setupRDSInstanceAndData,
   sleep,
   updateAuthAddUserGroups,
-  amplifyPushWithoutCodegen,
   getProjectMeta,
 } from 'amplify-category-api-e2e-core';
 import { existsSync, writeFileSync, removeSync } from 'fs-extra';
@@ -39,6 +38,7 @@ import {
 } from '../schema-api-directives';
 import { gql } from 'graphql-tag';
 import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { SQL_TESTS_USE_BETA } from './sql-e2e-config';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -129,7 +129,10 @@ export const testOIDCAuth = (engine: ImportedRDSType): void => {
 
       await addAuthWithPreTokenGenerationTrigger(projRoot);
       updatePreAuthTrigger(projRoot, 'user_id');
-      await amplifyPushWithoutCodegen(projRoot);
+      await amplifyPush(projRoot, false, {
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
+        skipCodegen: true,
+      });
 
       await addApi(projRoot, {
         'OpenID Connect': {
@@ -161,7 +164,9 @@ export const testOIDCAuth = (engine: ImportedRDSType): void => {
       writeFileSync(rdsSchemaFilePath, appendAmplifyInput(schema, engine), 'utf8');
 
       await updateAuthAddUserGroups(projRoot, [adminGroupName, devGroupName]);
-      await amplifyPush(projRoot);
+      await amplifyPush(projRoot, false, {
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
+      });
       await sleep(1 * 60 * 1000); // Wait for a minute for the VPC endpoints to be live.
     };
 

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool.ts
@@ -28,6 +28,7 @@ import {
 import { setupUser, getUserPoolId, signInUser, configureAmplify, getConfiguredAppsyncClientCognitoAuth } from '../schema-api-directives';
 import { gql } from 'graphql-tag';
 import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { SQL_TESTS_USE_BETA } from './sql-e2e-config';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -139,7 +140,9 @@ export const testUserPoolAuth = (engine: ImportedRDSType): void => {
       writeFileSync(rdsSchemaFilePath, appendAmplifyInput(schema, engine), 'utf8');
 
       await updateAuthAddUserGroups(projRoot, [adminGroupName, devGroupName]);
-      await amplifyPush(projRoot);
+      await amplifyPush(projRoot, false, {
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
+      });
       await sleep(30 * 1000); // Wait for 30 seconds for the VPC endpoints to be live.
 
       const userPoolId = getUserPoolId(projRoot);

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-model-v2.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-model-v2.ts
@@ -26,6 +26,7 @@ import {
   normalizeDbType,
 } from '@aws-amplify/graphql-transformer-core';
 import { ModelDataSourceStrategySqlDbType } from '@aws-amplify/graphql-transformer-interfaces';
+import { SQL_TESTS_USE_BETA } from './sql-e2e-config';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -58,7 +59,9 @@ export const testRDSModel = (engine: ImportedRDSType, queries: string[]): void =
     beforeAll(async () => {
       projRoot = await createNewProjectDir(projName);
       await initProjectAndImportSchema();
-      await amplifyPush(projRoot);
+      await amplifyPush(projRoot, false, {
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
+      });
       await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
 
       await verifyApiEndpointAndCreateClient();

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-refers-to-fields.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-refers-to-fields.ts
@@ -18,6 +18,7 @@ import path from 'path';
 import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
 import { GQLQueryHelper } from '../query-utils/gql-helper';
 import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { SQL_TESTS_USE_BETA } from './sql-e2e-config';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -45,7 +46,9 @@ export const testRDSRefersToFields = (engine: ImportedRDSType, queries: string[]
     beforeAll(async () => {
       projRoot = await createNewProjectDir(projName);
       await initProjectAndImportSchema();
-      await amplifyPush(projRoot);
+      await amplifyPush(projRoot, false, {
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
+      });
       await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
 
       const meta = getProjectMeta(projRoot);

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-refers-to.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-refers-to.ts
@@ -18,6 +18,7 @@ import path from 'path';
 import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
 import { GQLQueryHelper } from '../query-utils/gql-helper';
 import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { SQL_TESTS_USE_BETA } from './sql-e2e-config';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -45,7 +46,9 @@ export const testRDSRefersTo = (engine: ImportedRDSType, queries: string[]) => {
     beforeAll(async () => {
       projRoot = await createNewProjectDir(projName);
       await initProjectAndImportSchema();
-      await amplifyPush(projRoot);
+      await amplifyPush(projRoot, false, {
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
+      });
       await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
 
       const meta = getProjectMeta(projRoot);

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/sql-e2e-config.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/sql-e2e-config.ts
@@ -1,3 +1,3 @@
-// Setting SQL_TESTS_USE_BETA flag to 'true' withh test the CLI Gen1 tests with RDS Beta Layers.
+// Setting SQL_TESTS_USE_BETA flag to 'true' with test the CLI Gen1 tests with RDS Beta Layers.
 // Change it to 'false' to test with the PROD layers.
 export const SQL_TESTS_USE_BETA = true;

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/sql-e2e-config.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/sql-e2e-config.ts
@@ -1,0 +1,3 @@
+// Setting SQL_TESTS_USE_BETA flag to 'true' withh test the CLI Gen1 tests with RDS Beta Layers.
+// Change it to 'false' to test with the PROD layers.
+export const SQL_TESTS_USE_BETA = true;


### PR DESCRIPTION
Use the published beta layer versions to run all the E2E tests. This allows us to publish the layer version to PROD after full E2E testing.