### PR TITLE
test(api): increase model transformer test coverage

### DIFF
--- a/packages/amplify-graphql-model-transformer/package.json
+++ b/packages/amplify-graphql-model-transformer/package.json
@@ -62,11 +62,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 57,
-        "functions": 69,
-        "lines": 74
+        "branches": 75,
+        "functions": 80,
+        "lines": 85
       }
     },
     "coverageReporters": [


### PR DESCRIPTION
Increase model transformer test coverage lines > 80%.

Currently coverage provider is set to babel (default) which produces incorrect coverage report. I have verified the lines showed as uncovered with breakpoints and those lines are definitely covered. Upon further analysis, it is found that coverage provider "v8" provides more accurate report.