### PR TITLE
chore(api): improve overall test coverage report accuracy

### DIFF
--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -100,11 +100,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 27,
-        "functions": 36,
-        "lines": 44
+        "branches": 70,
+        "functions": 45,
+        "lines": 50
       }
     },
     "coverageReporters": [

--- a/packages/amplify-data-construct/package.json
+++ b/packages/amplify-data-construct/package.json
@@ -158,9 +158,9 @@
     "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 100,
-        "functions": 100,
-        "lines": 100
+        "branches": 90,
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/amplify-data-construct/package.json
+++ b/packages/amplify-data-construct/package.json
@@ -155,6 +155,14 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
+    "coverageThreshold": {
+      "global": {
+        "branches": 100,
+        "functions": 100,
+        "lines": 100
+      }
+    },
     "coverageReporters": [
       "clover",
       "text"

--- a/packages/amplify-graphql-api-construct/package.json
+++ b/packages/amplify-graphql-api-construct/package.json
@@ -160,8 +160,8 @@
     "coverageThreshold": {
       "global": {
         "branches": 90,
-        "functions": 95,
-        "lines": 95
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-api-construct/package.json
+++ b/packages/amplify-graphql-api-construct/package.json
@@ -156,11 +156,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80
+        "branches": 90,
+        "functions": 95,
+        "lines": 95
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -69,7 +69,7 @@
       "global": {
         "branches": 88,
         "functions": 90,
-        "lines": 94
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -64,11 +64,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80
+        "branches": 88,
+        "functions": 90,
+        "lines": 94
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-default-value-transformer/package.json
+++ b/packages/amplify-graphql-default-value-transformer/package.json
@@ -58,9 +58,9 @@
     "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 91,
-        "functions": 100,
-        "lines": 98
+        "branches": 90,
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-default-value-transformer/package.json
+++ b/packages/amplify-graphql-default-value-transformer/package.json
@@ -55,11 +55,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80
+        "branches": 91,
+        "functions": 100,
+        "lines": 98
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-function-transformer/package.json
+++ b/packages/amplify-graphql-function-transformer/package.json
@@ -59,8 +59,8 @@
     "coverageThreshold": {
       "global": {
         "branches": 70,
-        "functions": 100,
-        "lines": 99
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-function-transformer/package.json
+++ b/packages/amplify-graphql-function-transformer/package.json
@@ -55,11 +55,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 66,
-        "functions": 80,
-        "lines": 80
+        "branches": 70,
+        "functions": 100,
+        "lines": 99
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-http-transformer/package.json
+++ b/packages/amplify-graphql-http-transformer/package.json
@@ -59,8 +59,8 @@
     "coverageThreshold": {
       "global": {
         "branches": 86,
-        "functions": 100,
-        "lines": 96
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-http-transformer/package.json
+++ b/packages/amplify-graphql-http-transformer/package.json
@@ -55,11 +55,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80
+        "branches": 86,
+        "functions": 100,
+        "lines": 96
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-index-transformer/package.json
+++ b/packages/amplify-graphql-index-transformer/package.json
@@ -60,8 +60,8 @@
     "coverageThreshold": {
       "global": {
         "branches": 87,
-        "functions": 96,
-        "lines": 97
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-index-transformer/package.json
+++ b/packages/amplify-graphql-index-transformer/package.json
@@ -56,11 +56,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80
+        "branches": 87,
+        "functions": 96,
+        "lines": 97
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-migration-tests/package.json
+++ b/packages/amplify-graphql-migration-tests/package.json
@@ -27,7 +27,7 @@
       "global": {
         "branches": 81,
         "functions": 84,
-        "lines": 98
+        "lines": 90
       }
     },
     "transform": {

--- a/packages/amplify-graphql-migration-tests/package.json
+++ b/packages/amplify-graphql-migration-tests/package.json
@@ -22,6 +22,14 @@
   "license": "Apache-2.0",
   "jest": {
     "collectCoverage": true,
+    "coverageProvider": "v8",
+    "coverageThreshold": {
+      "global": {
+        "branches": 81,
+        "functions": 84,
+        "lines": 98
+      }
+    },
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/packages/amplify-graphql-name-mapping-transformer/package.json
+++ b/packages/amplify-graphql-name-mapping-transformer/package.json
@@ -69,8 +69,8 @@
     "coverageThreshold": {
       "global": {
         "branches": 66,
-        "functions": 96,
-        "lines": 98
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-name-mapping-transformer/package.json
+++ b/packages/amplify-graphql-name-mapping-transformer/package.json
@@ -61,15 +61,16 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "collectCoverageFrom": [
       "src/**",
       "!src/__tests__/**"
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 71,
-        "functions": 80,
-        "lines": 80
+        "branches": 66,
+        "functions": 96,
+        "lines": 98
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-predictions-transformer/package.json
+++ b/packages/amplify-graphql-predictions-transformer/package.json
@@ -59,9 +59,9 @@
     "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 91,
-        "functions": 100,
-        "lines": 100
+        "branches": 90,
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-predictions-transformer/package.json
+++ b/packages/amplify-graphql-predictions-transformer/package.json
@@ -56,11 +56,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80
+        "branches": 91,
+        "functions": 100,
+        "lines": 100
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-relational-transformer/package.json
+++ b/packages/amplify-graphql-relational-transformer/package.json
@@ -62,8 +62,8 @@
     "coverageThreshold": {
       "global": {
         "branches": 77,
-        "functions": 98,
-        "lines": 95
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-relational-transformer/package.json
+++ b/packages/amplify-graphql-relational-transformer/package.json
@@ -58,11 +58,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 38,
-        "functions": 50,
-        "lines": 55
+        "branches": 77,
+        "functions": 98,
+        "lines": 95
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-schema-generator/package.json
+++ b/packages/amplify-graphql-schema-generator/package.json
@@ -70,11 +70,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 30,
-        "functions": 40,
-        "lines": 50
+        "branches": 76,
+        "functions": 74,
+        "lines": 83
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-schema-test-library/package.json
+++ b/packages/amplify-graphql-schema-test-library/package.json
@@ -58,9 +58,9 @@
     "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 100,
-        "functions": 100,
-        "lines": 100
+        "branches": 90,
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-schema-test-library/package.json
+++ b/packages/amplify-graphql-schema-test-library/package.json
@@ -55,6 +55,14 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
+    "coverageThreshold": {
+      "global": {
+        "branches": 100,
+        "functions": 100,
+        "lines": 100
+      }
+    },
     "coverageReporters": [
       "clover",
       "text"

--- a/packages/amplify-graphql-searchable-transformer/package.json
+++ b/packages/amplify-graphql-searchable-transformer/package.json
@@ -62,8 +62,8 @@
     "coverageThreshold": {
       "global": {
         "branches": 74,
-        "functions": 93,
-        "lines": 94
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-searchable-transformer/package.json
+++ b/packages/amplify-graphql-searchable-transformer/package.json
@@ -58,11 +58,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 61,
-        "functions": 80,
-        "lines": 80
+        "branches": 74,
+        "functions": 93,
+        "lines": 94
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-sql-transformer/package.json
+++ b/packages/amplify-graphql-sql-transformer/package.json
@@ -60,8 +60,8 @@
     "coverageThreshold": {
       "global": {
         "branches": 75,
-        "functions": 100,
-        "lines": 95
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-sql-transformer/package.json
+++ b/packages/amplify-graphql-sql-transformer/package.json
@@ -56,11 +56,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 70,
-        "functions": 90,
-        "lines": 90
+        "branches": 75,
+        "functions": 100,
+        "lines": 95
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -65,11 +65,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 14,
-        "functions": 22,
-        "lines": 29
+        "branches": 69,
+        "functions": 32,
+        "lines": 56
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-transformer-interfaces/package.json
+++ b/packages/amplify-graphql-transformer-interfaces/package.json
@@ -48,6 +48,7 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageReporters": [
       "clover",
       "text"

--- a/packages/amplify-graphql-transformer-migrator/package.json
+++ b/packages/amplify-graphql-transformer-migrator/package.json
@@ -62,8 +62,8 @@
     "coverageThreshold": {
       "global": {
         "branches": 82,
-        "functions": 98,
-        "lines": 93
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-transformer-migrator/package.json
+++ b/packages/amplify-graphql-transformer-migrator/package.json
@@ -58,11 +58,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 77,
-        "functions": 80,
-        "lines": 80
+        "branches": 82,
+        "functions": 98,
+        "lines": 93
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-transformer-test-utils/package.json
+++ b/packages/amplify-graphql-transformer-test-utils/package.json
@@ -56,11 +56,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 0,
-        "functions": 0,
-        "lines": 0
+        "branches": 64,
+        "functions": 74,
+        "lines": 78
       }
     },
     "coverageReporters": [

--- a/packages/amplify-graphql-transformer/package.json
+++ b/packages/amplify-graphql-transformer/package.json
@@ -67,11 +67,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 74,
-        "functions": 80,
-        "lines": 80
+        "branches": 59,
+        "functions": 55,
+        "lines": 74
       }
     },
     "coverageReporters": [

--- a/packages/amplify-schema-validator/package.json
+++ b/packages/amplify-schema-validator/package.json
@@ -45,8 +45,8 @@
     "coverageThreshold": {
       "global": {
         "branches": 77,
-        "functions": 100,
-        "lines": 100
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/amplify-schema-validator/package.json
+++ b/packages/amplify-schema-validator/package.json
@@ -41,6 +41,14 @@
   ],
   "jest": {
     "collectCoverage": true,
+    "coverageProvider": "v8",
+    "coverageThreshold": {
+      "global": {
+        "branches": 77,
+        "functions": 100,
+        "lines": 100
+      }
+    },
     "coverageReporters": [
       "clover",
       "text"

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -94,6 +94,14 @@
       "^.+\\.tsx?$": "ts-jest"
     },
     "collectCoverage": true,
+    "coverageProvider": "v8",
+    "coverageThreshold": {
+      "global": {
+        "branches": 62,
+        "functions": 37,
+        "lines": 16
+      }
+    },
     "collectCoverageFrom": [
       "src/**/*.ts",
       "!**/node_modules/**",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -95,13 +95,6 @@
     },
     "collectCoverage": true,
     "coverageProvider": "v8",
-    "coverageThreshold": {
-      "global": {
-        "branches": 62,
-        "functions": 37,
-        "lines": 16
-      }
-    },
     "collectCoverageFrom": [
       "src/**/*.ts",
       "!**/node_modules/**",

--- a/packages/graphql-auth-transformer/package.json
+++ b/packages/graphql-auth-transformer/package.json
@@ -57,8 +57,8 @@
     "coverageThreshold": {
       "global": {
         "branches": 89,
-        "functions": 96,
-        "lines": 92
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/graphql-auth-transformer/package.json
+++ b/packages/graphql-auth-transformer/package.json
@@ -53,11 +53,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80
+        "branches": 89,
+        "functions": 96,
+        "lines": 92
       }
     },
     "coverageReporters": [

--- a/packages/graphql-connection-transformer/package.json
+++ b/packages/graphql-connection-transformer/package.json
@@ -50,8 +50,8 @@
     "coverageThreshold": {
       "global": {
         "branches": 88,
-        "functions": 100,
-        "lines": 92
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/graphql-connection-transformer/package.json
+++ b/packages/graphql-connection-transformer/package.json
@@ -46,11 +46,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80
+        "branches": 88,
+        "functions": 100,
+        "lines": 92
       }
     },
     "coverageReporters": [

--- a/packages/graphql-dynamodb-transformer/package.json
+++ b/packages/graphql-dynamodb-transformer/package.json
@@ -51,11 +51,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 75,
-        "functions": 80,
-        "lines": 80
+        "branches": 68,
+        "functions": 77,
+        "lines": 81
       }
     },
     "coverageReporters": [

--- a/packages/graphql-elasticsearch-transformer/package.json
+++ b/packages/graphql-elasticsearch-transformer/package.json
@@ -53,9 +53,9 @@
     "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 91,
-        "functions": 100,
-        "lines": 99
+        "branches": 90,
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/graphql-elasticsearch-transformer/package.json
+++ b/packages/graphql-elasticsearch-transformer/package.json
@@ -50,11 +50,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 76,
-        "functions": 80,
-        "lines": 80
+        "branches": 91,
+        "functions": 100,
+        "lines": 99
       }
     },
     "coverageReporters": [

--- a/packages/graphql-function-transformer/package.json
+++ b/packages/graphql-function-transformer/package.json
@@ -49,8 +49,8 @@
     "coverageThreshold": {
       "global": {
         "branches": 89,
-        "functions": 100,
-        "lines": 99
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/graphql-function-transformer/package.json
+++ b/packages/graphql-function-transformer/package.json
@@ -45,11 +45,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80
+        "branches": 89,
+        "functions": 100,
+        "lines": 99
       }
     },
     "coverageReporters": [

--- a/packages/graphql-http-transformer/package.json
+++ b/packages/graphql-http-transformer/package.json
@@ -47,9 +47,9 @@
     "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 94,
+        "branches": 90,
         "functions": 85,
-        "lines": 98
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/graphql-http-transformer/package.json
+++ b/packages/graphql-http-transformer/package.json
@@ -44,11 +44,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80
+        "branches": 94,
+        "functions": 85,
+        "lines": 98
       }
     },
     "coverageReporters": [

--- a/packages/graphql-key-transformer/package.json
+++ b/packages/graphql-key-transformer/package.json
@@ -49,9 +49,9 @@
     "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 93,
-        "functions": 98,
-        "lines": 95
+        "branches": 90,
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/graphql-key-transformer/package.json
+++ b/packages/graphql-key-transformer/package.json
@@ -46,11 +46,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80
+        "branches": 93,
+        "functions": 98,
+        "lines": 95
       }
     },
     "coverageReporters": [

--- a/packages/graphql-mapping-template/package.json
+++ b/packages/graphql-mapping-template/package.json
@@ -39,11 +39,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 27,
-        "functions": 34,
-        "lines": 47
+        "branches": 63,
+        "functions": 33,
+        "lines": 59
       }
     },
     "coverageReporters": [

--- a/packages/graphql-predictions-transformer/package.json
+++ b/packages/graphql-predictions-transformer/package.json
@@ -52,8 +52,8 @@
     "coverageThreshold": {
       "global": {
         "branches": 87,
-        "functions": 100,
-        "lines": 98
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/graphql-predictions-transformer/package.json
+++ b/packages/graphql-predictions-transformer/package.json
@@ -48,11 +48,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 77,
-        "functions": 80,
-        "lines": 80
+        "branches": 87,
+        "functions": 100,
+        "lines": 98
       }
     },
     "coverageReporters": [

--- a/packages/graphql-relational-schema-transformer/package.json
+++ b/packages/graphql-relational-schema-transformer/package.json
@@ -39,9 +39,9 @@
     "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 97,
-        "functions": 100,
-        "lines": 99
+        "branches": 90,
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/graphql-relational-schema-transformer/package.json
+++ b/packages/graphql-relational-schema-transformer/package.json
@@ -36,11 +36,12 @@
   },
   "jest": {
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80
+        "branches": 97,
+        "functions": 100,
+        "lines": 99
       }
     },
     "coverageReporters": [

--- a/packages/graphql-transformer-common/package.json
+++ b/packages/graphql-transformer-common/package.json
@@ -34,11 +34,12 @@
   },
   "jest": {
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 17,
-        "functions": 17,
-        "lines": 34
+        "branches": 63,
+        "functions": 11,
+        "lines": 27
       }
     },
     "coverageReporters": [

--- a/packages/graphql-transformer-core/package.json
+++ b/packages/graphql-transformer-core/package.json
@@ -52,11 +52,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 20,
-        "functions": 32,
-        "lines": 35
+        "branches": 67,
+        "functions": 33,
+        "lines": 48
       }
     },
     "coverageReporters": [

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -67,6 +67,7 @@
     },
     "testEnvironment": "node",
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "collectCoverageFrom": [
       "src/**/*.ts",
       "!**/node_modules/**",

--- a/packages/graphql-versioned-transformer/package.json
+++ b/packages/graphql-versioned-transformer/package.json
@@ -50,8 +50,8 @@
     "coverageThreshold": {
       "global": {
         "branches": 88,
-        "functions": 100,
-        "lines": 96
+        "functions": 90,
+        "lines": 90
       }
     },
     "coverageReporters": [

--- a/packages/graphql-versioned-transformer/package.json
+++ b/packages/graphql-versioned-transformer/package.json
@@ -46,11 +46,12 @@
       "node"
     ],
     "collectCoverage": true,
+    "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80
+        "branches": 88,
+        "functions": 100,
+        "lines": 96
       }
     },
     "coverageReporters": [


### PR DESCRIPTION
Current jest coverage provider (babel) doesn't provide correct test coverage report. This PR changes the coverage provider to 'v8' which provides more accurate report.

**How did I verify `coverageProvider: v8` is accurate?**
 Default coverage provider (babel) showed some obvious straight forward blocks (such as vtl generation helper) as not covered. However, adding logs and breakpoints confirmed that those lines are covered. Changing the coverage provider to v8 produced more accurate report. I took few uncovered lines from v8 report and confirmed that tests are actually missing for those blocks.