### PR TITLE
fix: validate SSM paths in sql db connection config

### DIFF
--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -5197,7 +5197,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-definition.ts",
-            "line": 85
+            "line": 86
           },
           "name": "combine",
           "parameters": [
@@ -5231,7 +5231,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-definition.ts",
-            "line": 47
+            "line": 48
           },
           "name": "fromFiles",
           "parameters": [
@@ -5263,7 +5263,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-definition.ts",
-            "line": 66
+            "line": 67
           },
           "name": "fromFilesAndStrategy",
           "parameters": [
@@ -7964,5 +7964,5 @@
     }
   },
   "version": "1.4.3",
-  "fingerprint": "ON4KYU1vkXL4M9Og9Gybxa88Eja46xJO4YFIDl7jlbs="
+  "fingerprint": "mAciHS/pWYqhXWyt6wEJoOKPayZA5Zdrvb+sn5vJ6vU="
 }

--- a/packages/amplify-graphql-api-construct/src/__tests__/amplify-graphql-definition.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/amplify-graphql-definition.test.ts
@@ -50,7 +50,7 @@ describe('AmplifyGraphqlDefinition', () => {
         },
       };
       expect(() => AmplifyGraphqlDefinition.fromString(TEST_SCHEMA, strategy)).toThrowErrorMatchingInlineSnapshot(
-        `"Invalid SSM paths in dbConnectionConfig: ssm/invalid/hostnameSsmPath, ssm/invalid/portSsmPath, ssm/invalid/usernameSsmPath. SSM paths must start with '/'."`,
+        `"Invalid data source strategy \\"MySqlLambda\\". Following SSM paths must start with '/' in dbConnectionConfig: ssm/invalid/hostnameSsmPath, ssm/invalid/portSsmPath, ssm/invalid/usernameSsmPath."`,
       );
     });
   });
@@ -214,7 +214,7 @@ describe('AmplifyGraphqlDefinition', () => {
       };
       fs.writeFileSync(schemaFilePath, TEST_SCHEMA);
       expect(() => AmplifyGraphqlDefinition.fromFilesAndStrategy([schemaFilePath], strategy)).toThrowErrorMatchingInlineSnapshot(
-        `"Invalid SSM paths in dbConnectionConfig: ssm/invalid/hostnameSsmPath, ssm/invalid/portSsmPath. SSM paths must start with '/'."`,
+        `"Invalid data source strategy \\"MySqlLambda\\". Following SSM paths must start with '/' in dbConnectionConfig: ssm/invalid/hostnameSsmPath, ssm/invalid/portSsmPath."`,
       );
     });
   });

--- a/packages/amplify-graphql-api-construct/src/__tests__/amplify-graphql-definition.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/amplify-graphql-definition.test.ts
@@ -36,6 +36,23 @@ describe('AmplifyGraphqlDefinition', () => {
       const definition = AmplifyGraphqlDefinition.fromString(TEST_SCHEMA, AMPLIFY_TABLE_DS_DEFINITION);
       expect(definition.dataSourceStrategies).toEqual({ Todo: AMPLIFY_TABLE_DS_DEFINITION });
     });
+
+    it('validates the SSM paths in SQL db connection config', () => {
+      const strategy: SQLLambdaModelDataSourceStrategy = {
+        name: 'MySqlLambda',
+        dbType: 'MYSQL',
+        dbConnectionConfig: {
+          hostnameSsmPath: 'ssm/invalid/hostnameSsmPath',
+          portSsmPath: 'ssm/invalid/portSsmPath',
+          usernameSsmPath: 'ssm/invalid/usernameSsmPath',
+          passwordSsmPath: '/ssm/valid/passwordSsmPath',
+          databaseNameSsmPath: '/ssm/valid/databaseNameSsmPath',
+        },
+      };
+      expect(() => AmplifyGraphqlDefinition.fromString(TEST_SCHEMA, strategy)).toThrowErrorMatchingInlineSnapshot(
+        `"Invalid SSM paths in dbConnectionConfig: ssm/invalid/hostnameSsmPath, ssm/invalid/portSsmPath, ssm/invalid/usernameSsmPath. SSM paths must start with '/'."`,
+      );
+    });
   });
 
   describe('fromFiles', () => {
@@ -180,6 +197,25 @@ describe('AmplifyGraphqlDefinition', () => {
       fs.writeFileSync(schemaFilePath, TEST_SCHEMA);
       const definition = AmplifyGraphqlDefinition.fromFilesAndStrategy([schemaFilePath], strategy);
       expect(definition.dataSourceStrategies).toEqual({ Todo: strategy });
+    });
+
+    it('validates the SSM paths in SQL db connection config', () => {
+      const schemaFilePath = path.join(tmpDir, 'schema.graphql');
+      const strategy: SQLLambdaModelDataSourceStrategy = {
+        name: 'MySqlLambda',
+        dbType: 'MYSQL',
+        dbConnectionConfig: {
+          hostnameSsmPath: 'ssm/invalid/hostnameSsmPath',
+          portSsmPath: 'ssm/invalid/portSsmPath',
+          usernameSsmPath: '/ssm/valid/usernameSsmPath',
+          passwordSsmPath: '/ssm/valid/passwordSsmPath',
+          databaseNameSsmPath: '/ssm/valid/databaseNameSsmPath',
+        },
+      };
+      fs.writeFileSync(schemaFilePath, TEST_SCHEMA);
+      expect(() => AmplifyGraphqlDefinition.fromFilesAndStrategy([schemaFilePath], strategy)).toThrowErrorMatchingInlineSnapshot(
+        `"Invalid SSM paths in dbConnectionConfig: ssm/invalid/hostnameSsmPath, ssm/invalid/portSsmPath. SSM paths must start with '/'."`,
+      );
     });
   });
 

--- a/packages/amplify-graphql-api-construct/src/amplify-graphql-definition.ts
+++ b/packages/amplify-graphql-api-construct/src/amplify-graphql-definition.ts
@@ -4,7 +4,7 @@ import { isSqlStrategy } from '@aws-amplify/graphql-transformer-core';
 import { IAmplifyGraphqlDefinition } from './types';
 import { constructDataSourceStrategies } from './internal';
 import { CustomSqlDataSourceStrategy, ModelDataSourceStrategy } from './model-datasource-strategy-types';
-import { constructCustomSqlDataSourceStrategies } from './internal/data-source-config';
+import { constructCustomSqlDataSourceStrategies, validateDataSourceStrategy } from './internal/data-source-config';
 
 export const DEFAULT_MODEL_DATA_SOURCE_STRATEGY: ModelDataSourceStrategy = {
   dbType: 'DYNAMODB',
@@ -30,6 +30,7 @@ export class AmplifyGraphqlDefinition {
     schema: string,
     dataSourceStrategy: ModelDataSourceStrategy = DEFAULT_MODEL_DATA_SOURCE_STRATEGY,
   ): IAmplifyGraphqlDefinition {
+    validateDataSourceStrategy(dataSourceStrategy);
     return {
       schema,
       functionSlots: [],

--- a/packages/amplify-graphql-api-construct/src/internal/data-source-config.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/data-source-config.ts
@@ -107,7 +107,11 @@ export const validateDataSourceStrategy = (strategy: ConstructModelDataSourceStr
   const dbConnectionConfig = strategy.dbConnectionConfig;
   const invalidSSMPaths = Object.values(dbConnectionConfig).filter((value) => typeof value === 'string' && !isValidSSMPath(value));
   if (invalidSSMPaths.length > 0) {
-    throw new Error(`Invalid SSM paths in dbConnectionConfig: ${invalidSSMPaths.join(', ')}. SSM paths must start with '/'.`);
+    throw new Error(
+      `Invalid data source strategy "${
+        strategy.name
+      }". Following SSM paths must start with '/' in dbConnectionConfig: ${invalidSSMPaths.join(', ')}.`,
+    );
   }
 };
 

--- a/packages/amplify-graphql-api-construct/src/internal/data-source-config.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/data-source-config.ts
@@ -93,3 +93,24 @@ export const getDataSourceStrategiesProvider = (definition: IAmplifyGraphqlDefin
 
   return provider;
 };
+
+/**
+ * Validates the user input for the dataSourceStrategy. This is a no-op for DynamoDB strategies for now.
+ * @param strategy user provided model data source strategy
+ * @returns validates and throws an error if the strategy is invalid
+ */
+export const validateDataSourceStrategy = (strategy: ConstructModelDataSourceStrategy) => {
+  if (!isSqlStrategy(strategy)) {
+    return;
+  }
+
+  const dbConnectionConfig = strategy.dbConnectionConfig;
+  const invalidSSMPaths = Object.values(dbConnectionConfig).filter((value) => typeof value === 'string' && !isValidSSMPath(value));
+  if (invalidSSMPaths.length > 0) {
+    throw new Error(`Invalid SSM paths in dbConnectionConfig: ${invalidSSMPaths.join(', ')}. SSM paths must start with '/'.`);
+  }
+};
+
+const isValidSSMPath = (path: string): boolean => {
+  return path.startsWith('/');
+};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Validates the user provided DataSource Strategy for SQL backend to ensure that the input SSM paths have a prefix of `/`.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Added unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
