### PR TITLE
chore: update build dependency order

### DIFF
--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -16,6 +16,8 @@ batch:
         type: WINDOWS_SERVER_2019_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
         image: $WINDOWS_IMAGE_2019
+      depend-on:
+        - build_linux
     - identifier: test
       buildspec: codebuild_specs/test.yml
       env:

--- a/codebuild_specs/e2e_workflow_base.yml
+++ b/codebuild_specs/e2e_workflow_base.yml
@@ -16,6 +16,13 @@ batch:
         type: WINDOWS_SERVER_2019_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
         image: $WINDOWS_IMAGE_2019
+      # Declaring a dependency on build_linux allows build_windows to run in
+      # parallel with the other tasks. This means we detect Windows build
+      # failures later in the cycle, but since those are infrequent, and this
+      # step is a long one, we are optimizing for shorter wallclock time in the
+      # average case where there are no Windows build failures.
+      depend-on:
+        - build_linux
     - identifier: test
       buildspec: codebuild_specs/test.yml
       env:

--- a/codebuild_specs/pr_workflow.yml
+++ b/codebuild_specs/pr_workflow.yml
@@ -14,6 +14,13 @@ batch:
         type: WINDOWS_SERVER_2019_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
         image: $WINDOWS_IMAGE_2019
+      # Declaring a dependency on build_linux allows build_windows to run in
+      # parallel with the other tasks. This means we detect Windows build
+      # failures later in the cycle, but since those are infrequent, and this
+      # step is a long one, we are optimizing for shorter wallclock time in the
+      # average case where there are no Windows build failures.
+      depend-on:
+        - build_linux
     - identifier: test
       buildspec: codebuild_specs/test.yml
       depend-on:

--- a/codebuild_specs/release_workflow.yml
+++ b/codebuild_specs/release_workflow.yml
@@ -14,6 +14,13 @@ batch:
         type: WINDOWS_SERVER_2019_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
         image: $WINDOWS_IMAGE_2019
+      # Declaring a dependency on build_linux allows build_windows to run in
+      # parallel with the other tasks. This means we detect Windows build
+      # failures later in the cycle, but since those are infrequent, and this
+      # step is a long one, we are optimizing for shorter wallclock time in the
+      # average case where there are no Windows build failures.
+      depend-on:
+        - build_linux
     - identifier: test
       buildspec: codebuild_specs/test.yml
       depend-on:


### PR DESCRIPTION
#### Description of changes

Updates the `build_windows` step of relevant codebuild specs to depend on `build_linux` rather than making it a top-tier step.

The behavior I observed from manual testing is that any tasks declared with no dependencies must complete before any dependent tasks complete. By moving the long-running `build_windows` task to depend on `build_linux`, we make the tradeoff of decreased wallclock times for codebuild execution (estimated savings: ~20min per build) at the cost of a delay in detecting Windows build failures.

Since Windows build failures are rare (at least in my experience), this seems like a tradeoff worth making for the quality-of-life benefit.

#### Checklist

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
