### PR TITLE
feat: Adds support for cardinality aggregation type

### DIFF
--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
@@ -361,6 +361,7 @@ enum SearchableAggregateType {
   min
   max
   sum
+  cardinality
 }
 
 enum SearchableEmployeeAggregateField {
@@ -726,6 +727,7 @@ enum SearchableAggregateType {
   min
   max
   sum
+  cardinality
 }
 
 enum SearchablePostAggregateField {
@@ -2077,6 +2079,7 @@ enum SearchableAggregateType {
   min
   max
   sum
+  cardinality
 }
 
 enum SearchablePostAggregateField {
@@ -2460,6 +2463,7 @@ enum SearchableAggregateType {
   min
   max
   sum
+  cardinality
 }
 
 enum SearchablePostAggregateField {
@@ -2823,6 +2827,7 @@ enum SearchableAggregateType {
   min
   max
   sum
+  cardinality
 }
 
 enum SearchablePostAggregateField {
@@ -3186,6 +3191,7 @@ enum SearchableAggregateType {
   min
   max
   sum
+  cardinality
 }
 
 enum SearchablePostAggregateField {

--- a/packages/amplify-graphql-searchable-transformer/src/definitions.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/definitions.ts
@@ -308,7 +308,7 @@ export const makeSearchableXSortInputObject = (obj: ObjectTypeDefinitionNode): I
 
 export const makeSearchableAggregateTypeEnumObject = (): EnumTypeDefinitionNode => {
   const name = graphqlName('SearchableAggregateType');
-  const values: EnumValueDefinitionNode[] = ['terms', 'avg', 'min', 'max', 'sum'].map((type: string) => ({
+  const values: EnumValueDefinitionNode[] = ['terms', 'avg', 'min', 'max', 'sum', 'cardinality'].map((type: string) => ({
     kind: Kind.ENUM_VALUE_DEFINITION,
     name: { kind: 'Name', value: type },
     directives: [],


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

I extended the searchable transformer definitions, so the generated enum includes the cardinality aggregation type. 
The cardinality aggregation works without any other changes with the current resolver templates.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Used the amplify-dev build to do a `amplify-dev codegen` and verfied that the `cardinality` is generated into the API.ts. Then used the cardinality agg to fetch data from opensearch. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
