### PR TITLE
fix(api): validate imported enum values

### DIFF
--- a/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-schema.test.ts.snap
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-schema.test.ts.snap
@@ -26,6 +26,21 @@ type User @refersTo(name: \\"users\\") @model {
 "
 `;
 
+exports[`enum imports enum values with single character 1`] = `
+"type User @refersTo(name: \\"users\\") @model {
+  id: String! @primaryKey
+  name: String
+  status: UserStatus
+}
+
+enum UserStatus {
+  A
+  D
+  B
+}
+"
+`;
+
 exports[`enum imports generates enum imports 1`] = `
 "type User @refersTo(name: \\"users\\") @model {
   id: String! @primaryKey

--- a/packages/amplify-graphql-schema-generator/src/__tests__/generate-schema.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/generate-schema.test.ts
@@ -88,7 +88,7 @@ describe('enum imports', () => {
     dbschema.addModel(model);
 
     expect(() => generateGraphQLSchema(dbschema)).toThrowError(
-      'Enum "UserStatus" (values: ACTIVE-0,INACTIVE-1) contains one or more invalid values. Enum values can contain A-Z, a-z, 0-9 or underscore(_) and must begin with an alphabet or an underscore(_).',
+      'Enum "UserStatus" (values: ACTIVE-0,INACTIVE-1) contains one or more invalid values. Enum values must match the regex [_A-Za-z][_0-9A-Za-z]*.',
     );
   });
 

--- a/packages/amplify-graphql-schema-generator/src/__tests__/generate-schema.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/generate-schema.test.ts
@@ -75,6 +75,7 @@ describe('enum imports', () => {
     dbschema.addModel(model);
 
     const graphqlSchema = generateGraphQLSchema(dbschema);
+    parse(graphqlSchema); // Parse to make sure that the Schema is valid.
     expect(graphqlSchema).toMatchSnapshot();
   });
 

--- a/packages/amplify-graphql-schema-generator/src/__tests__/generate-schema.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/generate-schema.test.ts
@@ -65,6 +65,19 @@ describe('enum imports', () => {
     expect(graphqlSchema).toMatchSnapshot();
   });
 
+  it('enum values with single character', () => {
+    const dbschema = new Schema(new Engine('Postgres'));
+    const model = new Model('users');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'String' } }));
+    model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('status', { kind: 'Enum', name: 'UserStatus', values: ['A', 'D', 'B'] }));
+    model.setPrimaryKey(['id']);
+    dbschema.addModel(model);
+
+    const graphqlSchema = generateGraphQLSchema(dbschema);
+    expect(graphqlSchema).toMatchSnapshot();
+  });
+
   it('invalid enum value must throw an error', () => {
     const dbschema = new Schema(new Engine('Postgres'));
     const model = new Model('users');

--- a/packages/amplify-graphql-schema-generator/src/__tests__/generate-schema.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/generate-schema.test.ts
@@ -65,6 +65,20 @@ describe('enum imports', () => {
     expect(graphqlSchema).toMatchSnapshot();
   });
 
+  it('invalid enum value must throw an error', () => {
+    const dbschema = new Schema(new Engine('Postgres'));
+    const model = new Model('users');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'String' } }));
+    model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
+    model.addField(new Field('status', { kind: 'Enum', name: 'UserStatus', values: ['ACTIVE-0', 'INACTIVE-1'] }));
+    model.setPrimaryKey(['id']);
+    dbschema.addModel(model);
+
+    expect(() => generateGraphQLSchema(dbschema)).toThrowError(
+      'Enum "UserStatus" (values: ACTIVE-0,INACTIVE-1) contains one or more invalid values. Enum values can contain A-Z, a-z, 0-9 or underscore(_) and must begin with an alphabet or an underscore(_).',
+    );
+  });
+
   it('multiple enum fields of same name must generate one graphql enum type', () => {
     const dbschema = new Schema(new Engine('Postgres'));
     let model = new Model('users');

--- a/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
@@ -189,6 +189,11 @@ const constructObjectType = (model: Model) => {
 };
 
 const constructEnumType = (type: EnumType): EnumWrapper => {
+  // Check if the enum values imported from the database contain any invalid character.
+  // Enum can contain A-Z, a-z, 0-9 or underscore(_) and must begin with an alphabet or an underscore(_).
+  if (!validateEnumValues(type.values)) {
+    throw new Error(`Enum "${type.name}" (values: ${type.values.join(',')}) contains one or more invalid values. Enum values can contain A-Z, a-z, 0-9 or underscore(_) and must begin with an alphabet or an underscore(_).`);
+  }
   const enumValues = type.values.map((t) => {
     return {
       kind: Kind.ENUM_VALUE_DEFINITION,
@@ -208,6 +213,12 @@ const constructEnumType = (type: EnumType): EnumWrapper => {
   });
   return enumType;
 };
+
+const validateEnumValues = (values: string[]): boolean => {
+ const regex = new RegExp(/^[_A-Za-z][_0-9A-Za-z]*$/);
+ const containsValidValues = values.every((value) => regex.test(value));
+ return containsValidValues;
+}
 
 const addIndexes = (type: ObjectDefinitionWrapper, indexes: Index[]): void => {
   indexes.forEach((index) => {

--- a/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
@@ -192,7 +192,11 @@ const constructEnumType = (type: EnumType): EnumWrapper => {
   // Check if the enum values imported from the database contain any invalid character.
   // Enum can contain A-Z, a-z, 0-9 or underscore(_) and must begin with an alphabet or an underscore(_).
   if (!validateEnumValues(type.values)) {
-    throw new Error(`Enum "${type.name}" (values: ${type.values.join(',')}) contains one or more invalid values. Enum values can contain A-Z, a-z, 0-9 or underscore(_) and must begin with an alphabet or an underscore(_).`);
+    throw new Error(
+      `Enum "${type.name}" (values: ${type.values.join(
+        ',',
+      )}) contains one or more invalid values. Enum values can contain A-Z, a-z, 0-9 or underscore(_) and must begin with an alphabet or an underscore(_).`,
+    );
   }
   const enumValues = type.values.map((t) => {
     return {
@@ -215,10 +219,10 @@ const constructEnumType = (type: EnumType): EnumWrapper => {
 };
 
 const validateEnumValues = (values: string[]): boolean => {
- const regex = new RegExp(/^[_A-Za-z][_0-9A-Za-z]*$/);
- const containsValidValues = values.every((value) => regex.test(value));
- return containsValidValues;
-}
+  const regex = new RegExp(/^[_A-Za-z][_0-9A-Za-z]*$/);
+  const containsValidValues = values.every((value) => regex.test(value));
+  return containsValidValues;
+};
 
 const addIndexes = (type: ObjectDefinitionWrapper, indexes: Index[]): void => {
   indexes.forEach((index) => {

--- a/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-generator/generate-schema.ts
@@ -195,7 +195,7 @@ const constructEnumType = (type: EnumType): EnumWrapper => {
     throw new Error(
       `Enum "${type.name}" (values: ${type.values.join(
         ',',
-      )}) contains one or more invalid values. Enum values can contain A-Z, a-z, 0-9 or underscore(_) and must begin with an alphabet or an underscore(_).`,
+      )}) contains one or more invalid values. Enum values must match the regex [_A-Za-z][_0-9A-Za-z]*.`,
     );
   }
   const enumValues = type.values.map((t) => {

--- a/packages/amplify-graphql-transformer-core/package.json
+++ b/packages/amplify-graphql-transformer-core/package.json
@@ -69,7 +69,7 @@
     "coverageThreshold": {
       "global": {
         "branches": 69,
-        "functions": 32,
+        "functions": 31,
         "lines": 56
       }
     },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Add a validation step to make sure that the imported ENUM values are valid GraphQL enum values. Otherwise, throw an error.

##### CDK / CloudFormation Parameters Changed
No.


#### Issue #, if available
NA

#### Description of how you validated changes
- Manual test
- Unit test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
