### PR TITLE
test: Fix beta canary

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": false
+    "source.fixAll.eslint": "never"
   },
   "editor.formatOnSave": false,
   "editor.rulers": [140],

--- a/client-test-apps/js/api-model-relationship-app/.gitignore
+++ b/client-test-apps/js/api-model-relationship-app/.gitignore
@@ -32,12 +32,14 @@ cypress/screenshots
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+yarn.lock
 
 #amplify-do-not-edit-begin
 amplify/\#current-cloud-backend
 amplify/.config/local-*
 amplify/logs
 amplify/mock-data
+amplify/mock-api-resources
 amplify/backend/amplify-meta.json
 amplify/backend/.temp
 build/

--- a/client-test-apps/js/api-model-relationship-app/package.json
+++ b/client-test-apps/js/api-model-relationship-app/package.json
@@ -12,7 +12,7 @@
     "@types/jest": "^27.5.2",
     "@types/jest-dev-server": "^5.0.0",
     "@types/node": "^16.11.56",
-    "@types/react": "^18.0.18",
+    "@types/react": "18.2.42",
     "@types/react-dom": "^18.0.6",
     "aws-amplify": "^4.3.30",
     "cross-env": "^7.0.3",

--- a/client-test-apps/js/api-model-relationship-app/src/__tests__/utils/amplifyCLI.ts
+++ b/client-test-apps/js/api-model-relationship-app/src/__tests__/utils/amplifyCLI.ts
@@ -269,7 +269,10 @@ export class AmplifyCLI {
 
     if (s?.name?.length > 20) console.warn('Project names should not be longer than 20 characters. This may cause tests to break.');
 
-    const chain = spawn(getCLIPath(), cliArgs, { cwd: this.projectRoot, env, disableCIDetection: s.disableCIDetection })
+    const cliPath = getCLIPath();
+    console.log(`Using CLI path '${cliPath}'`);
+    console.log(`Project root: '${this.projectRoot}'`);
+    const chain = spawn(cliPath, cliArgs, { cwd: this.projectRoot, env, disableCIDetection: s.disableCIDetection })
       .wait('Enter a name for the project')
       .sendLine(s.name)
       .wait('Initialize the project with the above configuration?')

--- a/client-test-apps/js/api-model-relationship-app/src/__tests__/utils/execUtils.ts
+++ b/client-test-apps/js/api-model-relationship-app/src/__tests__/utils/execUtils.ts
@@ -1,12 +1,14 @@
 /* eslint-disable testing-library/await-async-utils */
 import { join, parse } from 'path';
-import { EOL } from 'os';
+import * as os from 'os';
 import * as fs from 'fs-extra';
 import { types } from 'util';
 import retimer from 'retimer';
 import * as pty from 'node-pty';
 import chalk from 'chalk';
 import _ from 'lodash';
+import strip from 'strip-ansi';
+
 
 // https://notes.burke.libbey.me/ansi-escape-codes/
 const KEY_UP_ARROW = '\x1b[A';
@@ -21,7 +23,7 @@ const DEFAULT_NO_OUTPUT_TIMEOUT = process.env.AMPLIFY_TEST_TIMEOUT_SEC
 const EXIT_CODE_TIMEOUT = 2;
 const EXIT_CODE_GENERIC_ERROR = 3;
 
-const RETURN = EOL;
+const RETURN = os.EOL;
 
 type RecordingHeader = {
   version: 2;
@@ -173,7 +175,7 @@ class Recorder {
   private renderPrompt(cwd: string, cmd?: string, args?: string[]) {
     const separator = '\u2b80';
     const basePrompt = `${chalk.bgBlack('user@host') + chalk.black(separator)}${chalk.bgBlue(cwd) + chalk.blue(separator)}`;
-    const cmdPrompt = cmd ? `${cmd} ${args.length ? args.join(' ') : ''}` : '';
+    const cmdPrompt = cmd ? `${cmd} ${args?.length ? args?.join(' ') : ''}` : '';
     return `${basePrompt} ${cmdPrompt}\r\n`;
   }
 }
@@ -259,7 +261,7 @@ const chain = (context: Context): ExecutionContext => {
     pauseRecording: (): ExecutionContext => {
       let _pauseRecording: ExecutionStep = {
         fn: () => {
-          context.process.pauseRecording();
+          context.process?.pauseRecording();
           return true;
         },
         name: '_pauseRecording',
@@ -274,7 +276,7 @@ const chain = (context: Context): ExecutionContext => {
     resumeRecording: (): ExecutionContext => {
       let _resumeRecording: ExecutionStep = {
         fn: data => {
-          context.process.resumeRecording();
+          context.process?.resumeRecording();
           return true;
         },
         name: '_resumeRecording',
@@ -323,7 +325,7 @@ const chain = (context: Context): ExecutionContext => {
     sendLine: function (line: string): ExecutionContext {
       let _sendline: ExecutionStep = {
         fn: () => {
-          context.process.write(`${line}${RETURN}`);
+          context.process?.write(`${line}${RETURN}`);
           return true;
         },
         name: '_sendline',
@@ -337,7 +339,7 @@ const chain = (context: Context): ExecutionContext => {
     sendCarriageReturn: function (): ExecutionContext {
       let _sendline: ExecutionStep = {
         fn: () => {
-          context.process.write(RETURN);
+          context.process?.write(RETURN);
           return true;
         },
         name: '_sendline',
@@ -351,7 +353,7 @@ const chain = (context: Context): ExecutionContext => {
     send: function (line: string): ExecutionContext {
       var _send: ExecutionStep = {
         fn: () => {
-          context.process.write(line);
+          context.process?.write(line);
           return true;
         },
         name: '_send',
@@ -367,7 +369,7 @@ const chain = (context: Context): ExecutionContext => {
       var _send: ExecutionStep = {
         fn: () => {
           for (let i = 0; i < repetitions; ++i) {
-            context.process.write(KEY_DOWN_ARROW);
+            context.process?.write(KEY_DOWN_ARROW);
           }
           return true;
         },
@@ -384,7 +386,7 @@ const chain = (context: Context): ExecutionContext => {
       var _send: ExecutionStep = {
         fn: () => {
           for (let i = 0; i < repetitions; ++i) {
-            context.process.write(KEY_UP_ARROW);
+            context.process?.write(KEY_UP_ARROW);
           }
           return true;
         },
@@ -399,7 +401,7 @@ const chain = (context: Context): ExecutionContext => {
     sendConfirmYes: function (): ExecutionContext {
       var _send: ExecutionStep = {
         fn: () => {
-          context.process.write(`Y${RETURN}`);
+          context.process?.write(`Y${RETURN}`);
           return true;
         },
         name: '_send',
@@ -413,7 +415,7 @@ const chain = (context: Context): ExecutionContext => {
     sendYes: function (): ExecutionContext {
       var _send: ExecutionStep = {
         fn: () => {
-          context.process.write(`Y`);
+          context.process?.write(`Y`);
           return true;
         },
         name: '_send',
@@ -427,7 +429,7 @@ const chain = (context: Context): ExecutionContext => {
     sendConfirmNo: function (): ExecutionContext {
       var _send: ExecutionStep = {
         fn: () => {
-          context.process.write(`N${RETURN}`);
+          context.process?.write(`N${RETURN}`);
           return true;
         },
         name: '_send',
@@ -441,7 +443,7 @@ const chain = (context: Context): ExecutionContext => {
     sendNo: function (): ExecutionContext {
       var _send: ExecutionStep = {
         fn: () => {
-          context.process.write(`N`);
+          context.process?.write(`N`);
           return true;
         },
         name: '_send',
@@ -455,7 +457,7 @@ const chain = (context: Context): ExecutionContext => {
     sendCtrlC: function (): ExecutionContext {
       var _send: ExecutionStep = {
         fn: () => {
-          context.process.write(`${CONTROL_C}${RETURN}`);
+          context.process?.write(`${CONTROL_C}${RETURN}`);
           return true;
         },
         name: '_send',
@@ -469,7 +471,7 @@ const chain = (context: Context): ExecutionContext => {
     sendCtrlA: function (): ExecutionContext {
       var _send: ExecutionStep = {
         fn: () => {
-          context.process.write(`${CONTROL_A}`);
+          context.process?.write(`${CONTROL_A}`);
           return true;
         },
         name: '_send',
@@ -483,7 +485,7 @@ const chain = (context: Context): ExecutionContext => {
     sendEof: function (): ExecutionContext {
       var _sendEof: ExecutionStep = {
         fn: () => {
-          context.process.sendEof();
+          context.process?.sendEof();
           return true;
         },
         shift: true,
@@ -532,7 +534,7 @@ const chain = (context: Context): ExecutionContext => {
 
     const exitHandler = (code: number, signal: any) => {
       noOutputTimer.clear();
-      context.process.removeOnExitHandlers(exitHandler);
+      context.process?.removeOnExitHandlers(exitHandler);
       if (logDumpFile) {
         logDumpFile.close();
       }
@@ -590,7 +592,7 @@ const chain = (context: Context): ExecutionContext => {
 
       if (kill) {
         try {
-          context.process.kill();
+          context.process?.kill();
         } catch (ex) {}
       }
 
@@ -693,18 +695,18 @@ const chain = (context: Context): ExecutionContext => {
     // 2. Removing case sensitivity (if necessary)
     // 3. Splitting `data` into multiple lines.
     //
-    function onLine(data: string | Buffer) {
+    function onLine(data: string) {
       noOutputTimer.reschedule(context.noOutputTimeout);
       data = data.toString();
       if (logDumpFile && spinnerRegex.test(data) === false && strip(data).trim().length > 0) {
-        logDumpFile.write(`${data}${EOL}`);
+        logDumpFile.write(`${data}${os.EOL}`);
       }
 
       if (context.stripColors) {
         data = strip(data);
       }
 
-      var lines = data.split(EOL).filter(function (line) {
+      var lines = data.split(os.EOL).filter(function (line) {
         return line.length > 0 && line !== '\r';
       });
       stdout = stdout.concat(lines);


### PR DESCRIPTION
#### Description of changes

`@types/react` released a breaking change in 18.2.43 that made `placeholder` a required attribute in components from our `@aws-amplify/ui-react` dependency.

This change pins `@types/react` to 18.2.42 until they release a new version, to restore canary coverage.

Additional changes:
- Update fixAll.eslint setting (auto-applied by VSCode)
- Opportunistic lint fixes
- Fix missing `strip-ansi` import that was breaking local canary execution

#### Description of how you validated changes

- Local canary execution now succeeds

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
