### PR TITLE
test: Add EnforceHTTPS assertions to OpenSearch transformer

### DIFF
--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/override/amplify-graphql-searchable-transformer-override.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/override/amplify-graphql-searchable-transformer-override.test.ts
@@ -76,6 +76,9 @@ test('it overrides expected resources', () => {
       Enabled: true,
       KmsKeyId: '1a2a3a4-1a2a-3a4a-5a6a-1a2a3a4a5a6a',
     },
+    DomainEndpointOptions: {
+      EnforceHTTPS: true,
+    },
   });
   Template.fromJSON(searchableStack).hasResourceProperties('AWS::AppSync::Resolver', {
     ApiId: {

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
@@ -230,6 +230,9 @@ test('it generates expected resources', () => {
     EBSOptions: Match.anyValue(),
     ElasticsearchClusterConfig: Match.anyValue(),
     ElasticsearchVersion: '7.10',
+    DomainEndpointOptions: {
+      EnforceHTTPS: true,
+    },
   });
   Template.fromJSON(searchableStack).hasResource('AWS::Elasticsearch::Domain', {
     UpdateReplacePolicy: 'Delete',


### PR DESCRIPTION
#### Description of changes

Minor change to assert `EnforceHTTPS` flag in searchable transformer tests.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
