### PR TITLE
test: Re-split E2E tests to remove rds-import-vpc.test.ts

### DIFF
--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -60,96 +60,96 @@ batch:
         compute-type: BUILD_GENERAL1_MEDIUM
       depend-on:
         - build_linux
-    - identifier: auth_2_datastore_modelgen_amplify_app_custom_transformers
+    - identifier: auth_2_datastore_modelgen_mock_api_amplify_app
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/auth_2.test.ts|src/__tests__/datastore-modelgen.test.ts|src/__tests__/amplify-app.test.ts|src/__tests__/graphql-v2/custom-transformers.test.ts
+            src/__tests__/auth_2.test.ts|src/__tests__/datastore-modelgen.test.ts|src/__tests__/mock-api.test.ts|src/__tests__/amplify-app.test.ts
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        mock_api_invalid_input_arguments_schema_versioned_schema_data_access_patterns
+        custom_transformers_schema_versioned_invalid_input_arguments_schema_data_access_patterns
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/mock-api.test.ts|src/__tests__/graphql-v2/invalid-input-arguments.test.ts|src/__tests__/schema-versioned.test.ts|src/__tests__/schema-data-access-patterns.test.ts
+            src/__tests__/graphql-v2/custom-transformers.test.ts|src/__tests__/schema-versioned.test.ts|src/__tests__/graphql-v2/invalid-input-arguments.test.ts|src/__tests__/schema-data-access-patterns.test.ts
           CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
-    - identifier: predictions_migration_api_10_function_10_schema_predictions
+    - identifier: predictions_migration_schema_predictions_function_10_api_10
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/transformer-migrations/predictions-migration.test.ts|src/__tests__/api_10.test.ts|src/__tests__/function_10.test.ts|src/__tests__/schema-predictions.test.ts
+            src/__tests__/transformer-migrations/predictions-migration.test.ts|src/__tests__/schema-predictions.test.ts|src/__tests__/function_10.test.ts|src/__tests__/api_10.test.ts
           CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: api_7_http_migration_global_sandbox_schema_function_2
+    - identifier: api_7_http_migration_schema_function_2_global_sandbox
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/api_7.test.ts|src/__tests__/transformer-migrations/http-migration.test.ts|src/__tests__/global_sandbox.test.ts|src/__tests__/schema-function-2.test.ts
+            src/__tests__/api_7.test.ts|src/__tests__/transformer-migrations/http-migration.test.ts|src/__tests__/schema-function-2.test.ts|src/__tests__/global_sandbox.test.ts
           CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
-    - identifier: api_connection_migration_api_8_schema_iterative_update_3_auth_migration
+    - identifier: api_connection_migration_schema_iterative_update_3_api_8_auth_migration
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/migration/api.connection.migration.test.ts|src/__tests__/api_8.test.ts|src/__tests__/schema-iterative-update-3.test.ts|src/__tests__/transformer-migrations/auth-migration.test.ts
+            src/__tests__/migration/api.connection.migration.test.ts|src/__tests__/schema-iterative-update-3.test.ts|src/__tests__/api_8.test.ts|src/__tests__/transformer-migrations/auth-migration.test.ts
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        lambda_conflict_handler_schema_iterative_update_1_schema_iterative_update_locking_index_with_stack_mappings
+        schema_iterative_update_locking_schema_iterative_update_1_lambda_conflict_handler_index_with_stack_mappings
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/graphql-v2/lambda-conflict-handler.test.ts|src/__tests__/schema-iterative-update-1.test.ts|src/__tests__/schema-iterative-update-locking.test.ts|src/__tests__/graphql-v2/index-with-stack-mappings.test.ts
+            src/__tests__/schema-iterative-update-locking.test.ts|src/__tests__/schema-iterative-update-1.test.ts|src/__tests__/graphql-v2/lambda-conflict-handler.test.ts|src/__tests__/graphql-v2/index-with-stack-mappings.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        api_4_custom_policies_container_schema_iterative_update_2_api_connection_migration2
+        schema_iterative_update_2_custom_policies_container_api_4_api_connection_migration2
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/api_4.test.ts|src/__tests__/custom_policies_container.test.ts|src/__tests__/schema-iterative-update-2.test.ts|src/__tests__/migration/api.connection.migration2.test.ts
-          CLI_REGION: us-east-2
+            src/__tests__/schema-iterative-update-2.test.ts|src/__tests__/custom_policies_container.test.ts|src/__tests__/api_4.test.ts|src/__tests__/migration/api.connection.migration2.test.ts
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: api_5_containers_api_secrets_schema_function_1_api_3
+    - identifier: containers_api_secrets_api_5_schema_function_1_api_3
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/api_5.test.ts|src/__tests__/containers-api-secrets.test.ts|src/__tests__/schema-function-1.test.ts|src/__tests__/api_3.test.ts
+            src/__tests__/containers-api-secrets.test.ts|src/__tests__/api_5.test.ts|src/__tests__/schema-function-1.test.ts|src/__tests__/api_3.test.ts
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: sql_generate_unauth_api_1_resolvers_sync_query_datastore
+    - identifier: sql_generate_unauth_resolvers_api_1_sync_query_datastore
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/sql-generate-unauth.test.ts|src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts
+            src/__tests__/sql-generate-unauth.test.ts|src/__tests__/resolvers.test.ts|src/__tests__/api_1.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
@@ -191,23 +191,23 @@ batch:
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
-    - identifier: api_key_migration5
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/migration/api.key.migration5.test.ts
-          CLI_REGION: ap-southeast-2
-          USE_PARENT_ACCOUNT: 1
-      depend-on:
-        - publish_to_local_registry
     - identifier: schema_iterative_update_5
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-5.test.ts
+          CLI_REGION: ap-southeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_key_migration5
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/migration/api.key.migration5.test.ts
           CLI_REGION: us-east-2
+          USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
     - identifier: model_migration
@@ -219,21 +219,21 @@ batch:
           CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_auth_10
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/schema-auth-10.test.ts
-          CLI_REGION: eu-west-2
-      depend-on:
-        - publish_to_local_registry
     - identifier: schema_auth_2
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-2.test.ts
+          CLI_REGION: eu-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: schema_auth_10
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/schema-auth-10.test.ts
           CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
@@ -246,22 +246,31 @@ batch:
           CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_auth_12
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/schema-auth-12.test.ts
-          CLI_REGION: ap-southeast-2
-      depend-on:
-        - publish_to_local_registry
     - identifier: schema_auth_13
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-13.test.ts
+          CLI_REGION: ap-southeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: schema_auth_12
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/schema-auth-12.test.ts
           CLI_REGION: us-east-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: schema_auth_3
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/schema-auth-3.test.ts
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_15
@@ -273,13 +282,13 @@ batch:
           CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_auth_3
+    - identifier: schema_iterative_rollback_1
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/schema-auth-3.test.ts
-          CLI_REGION: eu-west-2
+          TEST_SUITE: src/__tests__/schema-iterative-rollback-1.test.ts
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: api_key_migration4
@@ -288,17 +297,17 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/migration/api.key.migration4.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-northeast-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_iterative_rollback_1
+    - identifier: schema_key
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/schema-iterative-rollback-1.test.ts
-          CLI_REGION: ap-northeast-1
+          TEST_SUITE: src/__tests__/schema-key.test.ts
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_iterative_rollback_2
@@ -310,22 +319,13 @@ batch:
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_key
+    - identifier: schema_auth_8
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/schema-key.test.ts
-          CLI_REGION: us-east-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: containers_api_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/containers-api-1.test.ts
-          CLI_REGION: us-east-1
+          TEST_SUITE: src/__tests__/schema-auth-8.test.ts
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_4
@@ -337,23 +337,13 @@ batch:
           CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_auth_8
+    - identifier: containers_api_1
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/schema-auth-8.test.ts
-          CLI_REGION: eu-west-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: api_key_migration2
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/migration/api.key.migration2.test.ts
-          CLI_REGION: eu-central-1
-          USE_PARENT_ACCOUNT: 1
+          TEST_SUITE: src/__tests__/containers-api-1.test.ts
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_11
@@ -362,7 +352,17 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-11.test.ts
+          CLI_REGION: eu-central-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_key_migration2
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/migration/api.key.migration2.test.ts
           CLI_REGION: ap-northeast-1
+          USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
     - identifier: api_key_migration1
@@ -374,237 +374,21 @@ batch:
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
-    - identifier: api_11
+    - identifier: schema_model
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/api_11.test.ts
+          TEST_SUITE: src/__tests__/schema-model.test.ts
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: rds_import_vpc
+    - identifier: rds_v2_test_utils
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/rds-import-vpc.test.ts
-          CLI_REGION: us-east-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_auth_apikey_lambda
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-auth-apikey-lambda.test.ts
-          CLI_REGION: us-west-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_auth_iam_apikey_lambda_subscription
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts
-          CLI_REGION: eu-west-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_auth_iam
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-auth-iam.test.ts
-          CLI_REGION: eu-central-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_custom_claims_refersto_auth
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-custom-claims-refersto-auth.test.ts
-          CLI_REGION: ap-northeast-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_model_v2
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-model-v2.test.ts
-          CLI_REGION: ap-southeast-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_multi_auth_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-multi-auth-1.test.ts
-          CLI_REGION: ap-southeast-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_oidc_auth
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-oidc-auth.test.ts
-          CLI_REGION: us-east-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_refers_to_fields
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-refers-to-fields.test.ts
-          CLI_REGION: us-east-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_refers_to
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-refers-to.test.ts
-          CLI_REGION: us-west-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_userpool_auth
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-userpool-auth.test.ts
-          CLI_REGION: eu-west-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_v2_generate_schema
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-v2-generate-schema.test.ts
-          CLI_REGION: eu-central-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_array_objects
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-array-objects.test.ts
-          CLI_REGION: ap-northeast-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_auth_apikey_lambda
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-auth-apikey-lambda.test.ts
-          CLI_REGION: ap-southeast-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_auth_iam_apikey_lambda_subscription
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-auth-iam-apikey-lambda-subscription.test.ts
-          CLI_REGION: ap-southeast-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_auth_iam
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-auth-iam.test.ts
-          CLI_REGION: us-east-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_custom_claims_refersto_auth
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-custom-claims-refersto-auth.test.ts
-          CLI_REGION: us-east-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_import
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-import.test.ts
-          CLI_REGION: us-west-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_model_v2
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-model-v2.test.ts
-          CLI_REGION: eu-west-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_oidc_auth
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-oidc-auth.test.ts
-          CLI_REGION: eu-central-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_refers_to_fields
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-refers-to-fields.test.ts
-          CLI_REGION: ap-northeast-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_refers_to
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-refers-to.test.ts
-          CLI_REGION: ap-southeast-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_relational_directives
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-relational-directives.test.ts
-          CLI_REGION: ap-southeast-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_userpool_auth
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-userpool-auth.test.ts
-          CLI_REGION: us-east-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_v2_generate_schema
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-v2-generate-schema.test.ts
+          TEST_SUITE: src/__tests__/rds-v2-test-utils.test.ts
           CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
@@ -617,22 +401,229 @@ batch:
           CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: rds_v2_test_utils
+    - identifier: rds_pg_v2_generate_schema
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/rds-v2-test-utils.test.ts
+          TEST_SUITE: src/__tests__/rds-pg-v2-generate-schema.test.ts
           CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_model
+    - identifier: rds_pg_userpool_auth
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/schema-model.test.ts
+          TEST_SUITE: src/__tests__/rds-pg-userpool-auth.test.ts
           CLI_REGION: eu-central-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_relational_directives
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-relational-directives.test.ts
+          CLI_REGION: ap-northeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_refers_to
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-refers-to.test.ts
+          CLI_REGION: ap-southeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_refers_to_fields
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-refers-to-fields.test.ts
+          CLI_REGION: ap-southeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_oidc_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-oidc-auth.test.ts
+          CLI_REGION: us-east-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_model_v2
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-model-v2.test.ts
+          CLI_REGION: us-east-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_import
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-import.test.ts
+          CLI_REGION: us-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_custom_claims_refersto_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-custom-claims-refersto-auth.test.ts
+          CLI_REGION: eu-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_auth_iam
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-auth-iam.test.ts
+          CLI_REGION: eu-central-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_auth_iam_apikey_lambda_subscription
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-auth-iam-apikey-lambda-subscription.test.ts
+          CLI_REGION: ap-northeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_auth_apikey_lambda
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-auth-apikey-lambda.test.ts
+          CLI_REGION: ap-southeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_array_objects
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-array-objects.test.ts
+          CLI_REGION: ap-southeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_v2_generate_schema
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-v2-generate-schema.test.ts
+          CLI_REGION: us-east-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_userpool_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-userpool-auth.test.ts
+          CLI_REGION: us-east-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_refers_to
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-refers-to.test.ts
+          CLI_REGION: us-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_refers_to_fields
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-refers-to-fields.test.ts
+          CLI_REGION: eu-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_oidc_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-oidc-auth.test.ts
+          CLI_REGION: eu-central-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_multi_auth_1
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-multi-auth-1.test.ts
+          CLI_REGION: ap-northeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_model_v2
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-model-v2.test.ts
+          CLI_REGION: ap-southeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_custom_claims_refersto_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-custom-claims-refersto-auth.test.ts
+          CLI_REGION: ap-southeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_auth_iam
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-auth-iam.test.ts
+          CLI_REGION: us-east-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_auth_iam_apikey_lambda_subscription
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts
+          CLI_REGION: us-east-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_auth_apikey_lambda
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-auth-apikey-lambda.test.ts
+          CLI_REGION: us-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_11
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/api_11.test.ts
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: apigw
@@ -641,16 +632,25 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/apigw.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
-    - identifier: containers_api_2
+    - identifier: schema_auth_9
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/containers-api-2.test.ts
-          CLI_REGION: us-east-1
+          TEST_SUITE: src/__tests__/schema-auth-9.test.ts
+          CLI_REGION: ap-northeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: schema_auth_7
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/schema-auth-7.test.ts
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_14
@@ -662,22 +662,13 @@ batch:
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_auth_7
+    - identifier: containers_api_2
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/schema-auth-7.test.ts
+          TEST_SUITE: src/__tests__/containers-api-2.test.ts
           CLI_REGION: us-east-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: schema_auth_9
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/schema-auth-9.test.ts
-          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_5
@@ -686,16 +677,16 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-5.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
-    - identifier: searchable_datastore
+    - identifier: schema_searchable
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts
-          CLI_REGION: eu-central-1
+          TEST_SUITE: src/__tests__/schema-searchable.test.ts
+          CLI_REGION: eu-west-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -705,17 +696,26 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_searchable
+    - identifier: searchable_datastore
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/schema-searchable.test.ts
-          CLI_REGION: ap-southeast-1
+          TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts
+          CLI_REGION: ap-northeast-1
           USE_PARENT_ACCOUNT: 1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: schema_connection
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/schema-connection.test.ts
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_6
@@ -727,15 +727,6 @@ batch:
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_connection
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/schema-connection.test.ts
-          CLI_REGION: us-east-1
-      depend-on:
-        - publish_to_local_registry
     - identifier: searchable_previous_deployment_had_node_to_node
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -743,7 +734,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-had-node-to-node.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_no_node_to_node
@@ -753,7 +744,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-no-node-to-node.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: api_2
@@ -762,7 +753,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/api_2.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_migration
@@ -771,99 +762,90 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/searchable-migration.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: eu-west-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
-    - identifier: add_resources_admin_role_all_auth_modes_amplify_table_1
+    - identifier: sql_models_relationships_data_construct_custom_logic
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/add-resources.test.ts|src/__tests__/admin-role.test.ts|src/__tests__/all-auth-modes.test.ts|src/__tests__/amplify-table-1.test.ts
+            src/__tests__/sql-models.test.ts|src/__tests__/relationships.test.ts|src/__tests__/data-construct.test.ts|src/__tests__/custom-logic.test.ts
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: amplify_table_2_base_cdk_custom_logic_data_construct
+    - identifier: base_cdk_amplify_table_2_amplify_table_1_all_auth_modes
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/amplify-table-2.test.ts|src/__tests__/base-cdk.test.ts|src/__tests__/custom-logic.test.ts|src/__tests__/data-construct.test.ts
+            src/__tests__/base-cdk.test.ts|src/__tests__/amplify-table-2.test.ts|src/__tests__/amplify-table-1.test.ts|src/__tests__/all-auth-modes.test.ts
           CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
-    - identifier: >-
-        3_gsis_10k_records_3_gsis_1k_records_3_gsis_empty_table_3_gsis_single_record
+    - identifier: admin_role_add_resources_single_gsi_single_record_single_gsi_empty_table
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-1k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-single-record.test.ts
+            src/__tests__/admin-role.test.ts|src/__tests__/add-resources.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-empty-table.test.ts
           CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        replace_2_gsis_10k_records_replace_2_gsis_1k_records_replace_2_gsis_empty_table_replace_2_gsis_single_record
+        single_gsi_1k_records_single_gsi_10k_records_replace_2_gsis_update_attr_single_record_replace_2_gsis_update_attr_empty_table
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-1k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-single-record.test.ts
+            src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-1k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-empty-table.test.ts
           CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        replace_2_gsis_update_attr_10k_records_replace_2_gsis_update_attr_1k_records_replace_2_gsis_update_attr_empty_table_replace_2_g
+        replace_2_gsis_update_attr_1k_records_replace_2_gsis_update_attr_10k_records_replace_2_gsis_single_record_replace_2_gsis_empty_
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-1k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-single-record.test.ts
+            src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-1k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-empty-table.test.ts
           CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        single_gsi_10k_records_single_gsi_1k_records_single_gsi_empty_table_single_gsi_single_record
+        replace_2_gsis_1k_records_replace_2_gsis_10k_records_3_gsis_single_record_3_gsis_empty_table
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-1k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-single-record.test.ts
+            src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-1k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-empty-table.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: relationships_sql_models
+    - identifier: 3_gsis_1k_records_3_gsis_10k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
-          TEST_SUITE: src/__tests__/relationships.test.ts|src/__tests__/sql-models.test.ts
+          TEST_SUITE: >-
+            src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-1k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-10k-records.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: 3_gsis_100k_records
+    - identifier: single_gsi_100k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/deploy-velocity/3-gsis-100k-records.test.ts
+          TEST_SUITE: src/__tests__/deploy-velocity/single-gsi-100k-records.test.ts
           CLI_REGION: ap-southeast-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: replace_2_gsis_100k_records
-      buildspec: codebuild_specs/run_cdk_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/deploy-velocity/replace-2-gsis-100k-records.test.ts
-          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: replace_2_gsis_update_attr_100k_records
@@ -873,158 +855,167 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/deploy-velocity/replace-2-gsis-update-attr-100k-records.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: single_gsi_100k_records
+    - identifier: replace_2_gsis_100k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/deploy-velocity/single-gsi-100k-records.test.ts
+          TEST_SUITE: src/__tests__/deploy-velocity/replace-2-gsis-100k-records.test.ts
+          CLI_REGION: us-east-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: 3_gsis_100k_records
+      buildspec: codebuild_specs/run_cdk_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/deploy-velocity/3-gsis-100k-records.test.ts
           CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        CustomRoots_KeyTransformerLocal_NestedStacksTest_TestComplexStackMappingsLocal
+        TestComplexStackMappingsLocal_NestedStacksTest_KeyTransformerLocal_CustomRoots
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/CustomRoots.e2e.test.ts|src/__tests__/KeyTransformerLocal.e2e.test.ts|src/__tests__/NestedStacksTest.e2e.test.ts|src/__tests__/TestComplexStackMappingsLocal.e2e.test.ts
+            src/__tests__/TestComplexStackMappingsLocal.e2e.test.ts|src/__tests__/NestedStacksTest.e2e.test.ts|src/__tests__/KeyTransformerLocal.e2e.test.ts|src/__tests__/CustomRoots.e2e.test.ts
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        NonModelAuthV2Function_FunctionTransformerTests_KeyWithAuth_MutationCondition
+        NonModelAuthV2Function_VersionedModelTransformer_TransformerOptionsV2_PredictionsTransformerV2Tests
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/NonModelAuthV2Function.e2e.test.ts|src/__tests__/FunctionTransformerTests.e2e.test.ts|src/__tests__/KeyWithAuth.e2e.test.ts|src/__tests__/MutationCondition.e2e.test.ts
+            src/__tests__/NonModelAuthV2Function.e2e.test.ts|src/__tests__/VersionedModelTransformer.e2e.test.ts|src/__tests__/TransformerOptionsV2.e2e.test.ts|src/__tests__/PredictionsTransformerV2Tests.e2e.test.ts
           CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        NoneEnvFunctionTransformer_NonModelAuthFunction_PerFieldAuthTests_PredictionsTransformerTests
+        PredictionsTransformerTests_PerFieldAuthTests_NoneEnvFunctionTransformer_NonModelAuthFunction
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/NoneEnvFunctionTransformer.e2e.test.ts|src/__tests__/NonModelAuthFunction.e2e.test.ts|src/__tests__/PerFieldAuthTests.e2e.test.ts|src/__tests__/PredictionsTransformerTests.e2e.test.ts
-          CLI_REGION: eu-west-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: >-
-        PredictionsTransformerV2Tests_TransformerOptionsV2_VersionedModelTransformer_ConnectionsWithAuthTests
-      buildspec: codebuild_specs/graphql_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_MEDIUM
-        variables:
-          TEST_SUITE: >-
-            src/__tests__/PredictionsTransformerV2Tests.e2e.test.ts|src/__tests__/TransformerOptionsV2.e2e.test.ts|src/__tests__/VersionedModelTransformer.e2e.test.ts|src/__tests__/ConnectionsWithAuthTests.e2e.test.ts
-          CLI_REGION: eu-central-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: >-
-        DefaultValueTransformer_DynamoDBModelTransformer_ModelConnectionTransformer_NewConnectionTransformer
-      buildspec: codebuild_specs/graphql_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_MEDIUM
-        variables:
-          TEST_SUITE: >-
-            src/__tests__/DefaultValueTransformer.e2e.test.ts|src/__tests__/DynamoDBModelTransformer.e2e.test.ts|src/__tests__/ModelConnectionTransformer.e2e.test.ts|src/__tests__/NewConnectionTransformer.e2e.test.ts
-          CLI_REGION: ap-northeast-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: >-
-        NewConnectionWithAuth_RelationalWithOwnerFieldAsKeySchemaAuth_BelongsToTransformerV2_KeyTransformer
-      buildspec: codebuild_specs/graphql_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_MEDIUM
-        variables:
-          TEST_SUITE: >-
-            src/__tests__/NewConnectionWithAuth.e2e.test.ts|src/__tests__/RelationalWithOwnerFieldAsKeySchemaAuth.e2e.test.ts|src/__tests__/BelongsToTransformerV2.e2e.test.ts|src/__tests__/KeyTransformer.e2e.test.ts
-          CLI_REGION: us-east-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: >-
-        ModelAuthTransformer_PerFieldAuthV2Transformer_PerFieldAuthV2TransformerWithFF_SubscriptionsWithAuthTest
-      buildspec: codebuild_specs/graphql_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_MEDIUM
-        variables:
-          TEST_SUITE: >-
-            src/__tests__/ModelAuthTransformer.e2e.test.ts|src/__tests__/PerFieldAuthV2Transformer.e2e.test.ts|src/__tests__/PerFieldAuthV2TransformerWithFF.e2e.test.ts|src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts
-          CLI_REGION: us-east-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: >-
-        IndexWithAuthV2_ModelConnectionWithKeyTransformer_RelationalWithAuthV2WithFF_IndexWithAuthV2WithFF
-      buildspec: codebuild_specs/graphql_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_MEDIUM
-        variables:
-          TEST_SUITE: >-
-            src/__tests__/IndexWithAuthV2.e2e.test.ts|src/__tests__/ModelConnectionWithKeyTransformer.e2e.test.ts|src/__tests__/RelationalWithAuthV2WithFF.e2e.test.ts|src/__tests__/IndexWithAuthV2WithFF.e2e.test.ts
+            src/__tests__/PredictionsTransformerTests.e2e.test.ts|src/__tests__/PerFieldAuthTests.e2e.test.ts|src/__tests__/NoneEnvFunctionTransformer.e2e.test.ts|src/__tests__/NonModelAuthFunction.e2e.test.ts
           CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        MultiAuthModelAuthTransformer_IndexWithClaimFieldAsSortKeyAuth_ModelTransformer_MultiAuthV2Transformer
+        MutationCondition_KeyWithAuth_FunctionTransformerTests_DynamoDBModelTransformer
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts|src/__tests__/IndexWithClaimFieldAsSortKeyAuth.e2e.test.ts|src/__tests__/ModelTransformer.e2e.test.ts|src/__tests__/MultiAuthV2Transformer.e2e.test.ts
+            src/__tests__/MutationCondition.e2e.test.ts|src/__tests__/KeyWithAuth.e2e.test.ts|src/__tests__/FunctionTransformerTests.e2e.test.ts|src/__tests__/DynamoDBModelTransformer.e2e.test.ts
           CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        SubscriptionsWithAuthV2WithFF_MapsToTransformer_RelationalWithAuthV2_SubscriptionsWithAuthV2
+        DefaultValueTransformer_ConnectionsWithAuthTests_RelationalWithOwnerFieldAsKeySchemaAuth_NewConnectionWithAuth
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/SubscriptionsWithAuthV2WithFF.e2e.test.ts|src/__tests__/MapsToTransformer.e2e.test.ts|src/__tests__/RelationalWithAuthV2.e2e.test.ts|src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts
-          CLI_REGION: eu-central-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: >-
-        IndexTransformer_MultiAuthV2TransformerWithFF_AuthV2Transformer_AuthV2ExhaustiveT1A
-      buildspec: codebuild_specs/graphql_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_MEDIUM
-        variables:
-          TEST_SUITE: >-
-            src/__tests__/IndexTransformer.e2e.test.ts|src/__tests__/MultiAuthV2TransformerWithFF.e2e.test.ts|src/__tests__/AuthV2Transformer.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT1A.test.ts
+            src/__tests__/DefaultValueTransformer.e2e.test.ts|src/__tests__/ConnectionsWithAuthTests.e2e.test.ts|src/__tests__/RelationalWithOwnerFieldAsKeySchemaAuth.e2e.test.ts|src/__tests__/NewConnectionWithAuth.e2e.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        AuthV2ExhaustiveT1B_AuthV2TransformerWithFF_IndexWithAutoQueryField_AuthV2ExhaustiveT1C
+        NewConnectionTransformer_ModelConnectionTransformer_SubscriptionsWithAuthTest_PerFieldAuthV2TransformerWithFF
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/AuthV2ExhaustiveT1B.test.ts|src/__tests__/AuthV2TransformerWithFF.e2e.test.ts|src/__tests__/IndexWithAutoQueryField.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT1C.test.ts
+            src/__tests__/NewConnectionTransformer.e2e.test.ts|src/__tests__/ModelConnectionTransformer.e2e.test.ts|src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts|src/__tests__/PerFieldAuthV2TransformerWithFF.e2e.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        AuthV2ExhaustiveT2A_RelationalTransformers_SubscriptionsRuntimeFiltering_AuthV2ExhaustiveT1D
+        PerFieldAuthV2Transformer_ModelAuthTransformer_KeyTransformer_BelongsToTransformerV2
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/AuthV2ExhaustiveT2A.test.ts|src/__tests__/RelationalTransformers.e2e.test.ts|src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT1D.test.ts
+            src/__tests__/PerFieldAuthV2Transformer.e2e.test.ts|src/__tests__/ModelAuthTransformer.e2e.test.ts|src/__tests__/KeyTransformer.e2e.test.ts|src/__tests__/BelongsToTransformerV2.e2e.test.ts
+          CLI_REGION: us-east-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: >-
+        RelationalWithAuthV2WithFF_ModelConnectionWithKeyTransformer_IndexWithAuthV2_MultiAuthModelAuthTransformer
+      buildspec: codebuild_specs/graphql_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/RelationalWithAuthV2WithFF.e2e.test.ts|src/__tests__/ModelConnectionWithKeyTransformer.e2e.test.ts|src/__tests__/IndexWithAuthV2.e2e.test.ts|src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
+          CLI_REGION: us-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: >-
+        IndexWithAuthV2WithFF_SubscriptionsWithAuthV2WithFF_MultiAuthV2Transformer_ModelTransformer
+      buildspec: codebuild_specs/graphql_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/IndexWithAuthV2WithFF.e2e.test.ts|src/__tests__/SubscriptionsWithAuthV2WithFF.e2e.test.ts|src/__tests__/MultiAuthV2Transformer.e2e.test.ts|src/__tests__/ModelTransformer.e2e.test.ts
+          CLI_REGION: eu-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: >-
+        IndexWithClaimFieldAsSortKeyAuth_SubscriptionsWithAuthV2_RelationalWithAuthV2_MapsToTransformer
+      buildspec: codebuild_specs/graphql_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/IndexWithClaimFieldAsSortKeyAuth.e2e.test.ts|src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts|src/__tests__/RelationalWithAuthV2.e2e.test.ts|src/__tests__/MapsToTransformer.e2e.test.ts
+          CLI_REGION: eu-central-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: >-
+        MultiAuthV2TransformerWithFF_IndexTransformer_AuthV2Transformer_AuthV2ExhaustiveT1B
+      buildspec: codebuild_specs/graphql_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/MultiAuthV2TransformerWithFF.e2e.test.ts|src/__tests__/IndexTransformer.e2e.test.ts|src/__tests__/AuthV2Transformer.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT1B.test.ts
+          CLI_REGION: ap-northeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: >-
+        AuthV2ExhaustiveT1A_IndexWithAutoQueryField_AuthV2TransformerWithFF_SubscriptionsRuntimeFiltering
+      buildspec: codebuild_specs/graphql_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/AuthV2ExhaustiveT1A.test.ts|src/__tests__/IndexWithAutoQueryField.e2e.test.ts|src/__tests__/AuthV2TransformerWithFF.e2e.test.ts|src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts
+          CLI_REGION: ap-southeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: >-
+        RelationalTransformers_AuthV2ExhaustiveT2A_AuthV2ExhaustiveT1C_AuthV2ExhaustiveT1D
+      buildspec: codebuild_specs/graphql_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/RelationalTransformers.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT2A.test.ts|src/__tests__/AuthV2ExhaustiveT1C.test.ts|src/__tests__/AuthV2ExhaustiveT1D.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
@@ -1040,13 +1031,13 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        SearchableWithAuthTests_SearchableModelTransformer_SearchableWithAuthV2_SearchableWithAuthV2WithFF
+        SearchableWithAuthTests_SearchableModelTransformer_SearchableWithAuthV2WithFF_SearchableWithAuthV2
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/SearchableWithAuthTests.e2e.test.ts|src/__tests__/SearchableModelTransformer.e2e.test.ts|src/__tests__/SearchableWithAuthV2.e2e.test.ts|src/__tests__/SearchableWithAuthV2WithFF.e2e.test.ts
+            src/__tests__/SearchableWithAuthTests.e2e.test.ts|src/__tests__/SearchableModelTransformer.e2e.test.ts|src/__tests__/SearchableWithAuthV2WithFF.e2e.test.ts|src/__tests__/SearchableWithAuthV2.e2e.test.ts
           CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
@@ -1056,17 +1047,8 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/FunctionTransformerTestsV2.e2e.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-central-1
           USE_PARENT_ACCOUNT: 1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: HttpTransformer
-      buildspec: codebuild_specs/graphql_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/HttpTransformer.e2e.test.ts
-          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: HttpTransformerV2
@@ -1078,9 +1060,18 @@ batch:
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
+    - identifier: HttpTransformer
+      buildspec: codebuild_specs/graphql_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/HttpTransformer.e2e.test.ts
+          CLI_REGION: us-east-1
+      depend-on:
+        - publish_to_local_registry
     - identifier: cleanup_e2e_resources
       buildspec: codebuild_specs/cleanup_e2e_resources.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
       depend-on:
-        - auth_2_datastore_modelgen_amplify_app_custom_transformers
+        - auth_2_datastore_modelgen_mock_api_amplify_app


### PR DESCRIPTION
#### Description of changes

Ran `yarn split-e2e-tests` to regenerate the CodeBuild workflow manifest without `rds-import-vpc.test.ts`, which was removed in 5921dc825.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
