### PR TITLE
fix: Fix manyToMany relationships with Amplify managed table strategies

### DIFF
--- a/packages/amplify-graphql-api-construct/src/__tests__/__functional__/relationships.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/__functional__/relationships.test.ts
@@ -1,5 +1,8 @@
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
+import { ModelDataSourceStrategy } from '@aws-amplify/graphql-transformer-interfaces';
+import { DDB_AMPLIFY_MANAGED_DATASOURCE_STRATEGY, DDB_DEFAULT_DATASOURCE_STRATEGY } from '@aws-amplify/graphql-transformer-core';
+import { mockSqlDataSourceStrategy } from '@aws-amplify/graphql-transformer-test-utils';
 import { AmplifyGraphqlApi } from '../../amplify-graphql-api';
 import { AmplifyGraphqlDefinition } from '../../amplify-graphql-definition';
 
@@ -7,10 +10,10 @@ import { AmplifyGraphqlDefinition } from '../../amplify-graphql-definition';
  * Utility to wrap construct creation a basic synth step to smoke test
  * @param schema schema to synthesize
  */
-const verifySchema = (schema: string): void => {
+const verifySchema = (schema: string, datasourceStrategy: ModelDataSourceStrategy = DDB_DEFAULT_DATASOURCE_STRATEGY): void => {
   const stack = new cdk.Stack();
   new AmplifyGraphqlApi(stack, 'TestApi', {
-    definition: AmplifyGraphqlDefinition.fromString(schema),
+    definition: AmplifyGraphqlDefinition.fromString(schema, datasourceStrategy),
     authorizationModes: {
       apiKeyConfig: { expires: cdk.Duration.days(7) },
     },
@@ -73,7 +76,7 @@ describe('relationships', () => {
     `);
   });
 
-  it('synths with manyToMany', () => {
+  it('synths with manyToMany with default DynamoDB provisioning strategy', () => {
     verifySchema(/* GraphQL */ `
       type Blog @model {
         description: String!
@@ -85,5 +88,111 @@ describe('relationships', () => {
         blog: [Blog] @manyToMany(relationName: "blogPosts")
       }
     `);
+  });
+
+  it('synths with manyToMany and AMPLIFY_TABLE strategy', () => {
+    verifySchema(
+      /* GraphQL */ `
+        type Blog @model {
+          description: String!
+          posts: [Post] @manyToMany(relationName: "blogPosts")
+        }
+
+        type Post @model {
+          description: String!
+          blog: [Blog] @manyToMany(relationName: "blogPosts")
+        }
+      `,
+      DDB_AMPLIFY_MANAGED_DATASOURCE_STRATEGY,
+    );
+  });
+
+  it('fails with manyToMany where one side is default strategy and the other is AMPLIFY_TABLE strategy', () => {
+    const defaultStrategyDef = AmplifyGraphqlDefinition.fromString(/* GraphQL */ `
+      type Blog @model {
+        description: String!
+        posts: [Post] @manyToMany(relationName: "blogPosts")
+      }
+    `);
+    const amplifyManagedStrategyDef = AmplifyGraphqlDefinition.fromString(
+      /* GraphQL */ `
+        type Post @model {
+          description: String!
+          blog: [Blog] @manyToMany(relationName: "blogPosts")
+        }
+      `,
+      DDB_AMPLIFY_MANAGED_DATASOURCE_STRATEGY,
+    );
+
+    const stack = new cdk.Stack();
+    const opts = {
+      definition: AmplifyGraphqlDefinition.combine([defaultStrategyDef, amplifyManagedStrategyDef]),
+      authorizationModes: {
+        apiKeyConfig: { expires: cdk.Duration.days(7) },
+      },
+    };
+
+    expect(() => new AmplifyGraphqlApi(stack, 'TestApi', opts)).toThrowError(
+      '@manyToMany directive cannot be used to relate models with a different DynamoDB-based strategies.',
+    );
+  });
+
+  it('fails with manyToMany with an explicitly defined relationship type', () => {
+    const schema = /* GraphQL */ `
+      type Blog @model {
+        description: String!
+        posts: [Post] @manyToMany(relationName: "blogPosts")
+      }
+
+      type Post @model {
+        description: String!
+        blog: [Blog] @manyToMany(relationName: "blogPosts")
+      }
+
+      type BlogPost @model {
+        id: ID!
+        blogId: ID!
+        blog: Blog @belongsTo
+        postId: ID!
+        post: Post @belongsTo
+      }
+    `;
+    const stack = new cdk.Stack();
+    const opts = {
+      definition: AmplifyGraphqlDefinition.fromString(schema),
+      authorizationModes: {
+        apiKeyConfig: { expires: cdk.Duration.days(7) },
+      },
+    };
+
+    expect(() => new AmplifyGraphqlApi(stack, 'TestApi', opts)).toThrowError(
+      'Blog must have a relationship with BlogPost in order to use @belongsTo.',
+    );
+  });
+
+  it('fail with manyToMany with a SQL-based strategy', () => {
+    const sqlStrategy = mockSqlDataSourceStrategy();
+    const schema = /* GraphQL */ `
+      type Blog @model {
+        id: ID! @primaryKey
+        description: String!
+        posts: [Post] @manyToMany(relationName: "blogPosts")
+      }
+
+      type Post @model {
+        id: ID! @primaryKey
+        description: String!
+        blog: [Blog] @manyToMany(relationName: "blogPosts")
+      }
+    `;
+    const stack = new cdk.Stack();
+    const opts = {
+      definition: AmplifyGraphqlDefinition.fromString(schema, sqlStrategy),
+      authorizationModes: {
+        apiKeyConfig: { expires: cdk.Duration.days(7) },
+      },
+    };
+
+    expect(() => new AmplifyGraphqlApi(stack, 'TestApi', opts)).toThrowError('@manyToMany directive cannot be used on a SQL model.');
   });
 });

--- a/packages/amplify-graphql-api-construct/src/__tests__/__functional__/test-utils.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/__functional__/test-utils.ts
@@ -1,0 +1,35 @@
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { DDB_DEFAULT_DATASOURCE_STRATEGY } from '@aws-amplify/graphql-transformer-core';
+import { ModelDataSourceStrategy } from '@aws-amplify/graphql-transformer-interfaces';
+import { AmplifyGraphqlApi } from '../../amplify-graphql-api';
+import { AmplifyGraphqlDefinition } from '../../amplify-graphql-definition';
+import { IAmplifyGraphqlDefinition } from '../../types';
+
+/** Helper for combining definitions into a test stack with API Key Config */
+export const makeApiByCombining = (...definitions: IAmplifyGraphqlDefinition[]): AmplifyGraphqlApi => {
+  const combinedDefinition = AmplifyGraphqlDefinition.combine(definitions);
+  const stack = new cdk.Stack();
+  const api = new AmplifyGraphqlApi(stack, 'TestSqlBoundApi', {
+    definition: combinedDefinition,
+    authorizationModes: {
+      apiKeyConfig: { expires: cdk.Duration.days(7) },
+    },
+  });
+  return api;
+};
+
+/**
+ * Utility to wrap construct creation a basic synth step to smoke test
+ * @param schema schema to synthesize
+ */
+export const verifySchema = (schema: string, datasourceStrategy: ModelDataSourceStrategy = DDB_DEFAULT_DATASOURCE_STRATEGY): void => {
+  const stack = new cdk.Stack();
+  new AmplifyGraphqlApi(stack, 'TestApi', {
+    definition: AmplifyGraphqlDefinition.fromString(schema, datasourceStrategy),
+    authorizationModes: {
+      apiKeyConfig: { expires: cdk.Duration.days(7) },
+    },
+  });
+  Template.fromStack(stack);
+};


### PR DESCRIPTION
#### Description of changes

Fixes Gen2/CDK Construct regression in manyToMany relationships with Amplify-managed table strategies.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
