### PR TITLE
fix: convert deepClone to structuredClone in directive-wrapper

### DIFF
--- a/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
@@ -55,7 +55,7 @@ export class DirectiveWrapper {
       {},
     );
     if (options?.deepMergeArguments) {
-      return _.merge(_.cloneDeep(defaultValue), argValues);
+      return _.merge(structuredClone(defaultValue), argValues);
     }
     return Object.assign(defaultValue, argValues);
   };


### PR DESCRIPTION
#### Description of changes

Convert usage of deepClone into structuredClone. 

Using deepClone is giving error: ```RangeError: Maximum call stack size exceeded``` when compiling large schema files with `cdk synth`. the structuredClone achieves the same result as deepClone but without a call stack size error.

##### CDK / CloudFormation Parameters Changed

none

#### Issue #, if available

#1978 


#### Description of how you validated changes

Ran locally to compile large schema file giving an error on `deepClone`, verified `cdk synth` ran correctly and deployed correctly.

#### Checklist


- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
