### PR TITLE
test: add additional non-model auth tests from V1 suite

### DIFF
--- a/packages/graphql-connection-transformer/src/__tests__/ModelConnectionTransformer.test.ts
+++ b/packages/graphql-connection-transformer/src/__tests__/ModelConnectionTransformer.test.ts
@@ -65,7 +65,7 @@ test('ModelConnectionTransformer simple one to many happy case', () => {
   expect(connectionUpdateId).toBeTruthy();
 });
 
-test('ModelConnectionTransformer simple one to many happy case with custom keyField', () => {
+test('ModelConnectionTransformer simple one to many happy case with custom keyField and implicit connection name', () => {
   const validSchema = `
     type Post @model {
         id: ID!
@@ -132,7 +132,7 @@ test('that ModelConnection Transformer throws error when the field in connection
   }
 });
 
-test('ModelConnectionTransformer simple one to many happy case with custom keyField', () => {
+test('ModelConnectionTransformer simple one to many happy case with custom keyField and explicit connection name', () => {
   const validSchema = `
     type Post @model {
         id: ID!
@@ -283,7 +283,7 @@ test('ModelConnectionTransformer many to many should fail due to missing other "
   }
 });
 
-test('ModelConnectionTransformer many to many should fail due to missing other "name"', () => {
+test('ModelConnectionTransformer many to many should fail due to missing other connection', () => {
   const validSchema = `
     type Post @model {
         id: ID!


### PR DESCRIPTION
#### Description of changes

Adding to V2 policy verification tests from V1 NonModelAuthTransformer.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
