### PR TITLE
test: add additional multi-auth tests from V1 suite

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
@@ -1,5 +1,5 @@
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
-import { DeploymentResources, testTransform } from '@aws-amplify/graphql-transformer-test-utils';
+import { DeploymentResources, getResourceWithKeyPrefix, testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import { AppSyncAuthConfiguration, AppSyncAuthConfigurationOIDCEntry, AppSyncAuthMode } from '@aws-amplify/graphql-transformer-interfaces';
 import { DocumentNode, ObjectTypeDefinitionNode, Kind, FieldDefinitionNode, parse, InputValueDefinitionNode } from 'graphql';
 import { AuthTransformer } from '../graphql-auth-transformer';
@@ -641,5 +641,88 @@ describe('iam checks', () => {
     expectStashValueLike(out, 'Post', '$util.qr($ctx.stash.put(\\"adminRoles\\", [\\"helloWorldFunction\\",\\"echoMessageFunction\\"]))');
     expect(createResolver).toContain('#foreach( $adminRole in $ctx.stash.adminRoles )');
     expect(createResolver).toMatchSnapshot();
+  });
+
+  test('public with IAM provider adds policy for Unauth role', () => {
+    const schema = getSchema(publicIAMAuthDirective);
+    const authConfig = withAuthModes(userPoolsDefaultConfig, ['AWS_IAM']);
+    const out = transform(authConfig, schema);
+    const unauthPolicy = getResourceWithKeyPrefix('UnauthRolePolicy', out);
+    expect(unauthPolicy).toBeDefined();
+  });
+
+  test('the long Todo type should generate policy statements split amongst resources', () => {
+    const schema = `
+    type TodoWithExtraLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongName @model(subscriptions:null) @auth(rules:[{allow: private, provider: iam}])
+    {
+      id: ID!
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename001: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename002: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename003: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename004: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename005: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename006: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename007: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename008: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename009: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename010: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename011: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename012: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename013: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename014: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename015: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename016: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename017: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename018: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename019: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename020: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename021: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename022: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename023: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename024: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename025: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename026: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename027: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename028: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename029: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename030: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename031: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename032: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename033: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename034: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename035: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename036: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename037: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename038: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename039: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename040: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename041: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename042: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename043: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename044: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename045: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename046: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename047: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename048: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename049: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename050: String! @auth(rules:[{allow: private, provider: iam}])
+      description: String
+    }
+    `;
+    const authConfig = withAuthModes(apiKeyDefaultConfig, ['AMAZON_COGNITO_USER_POOLS', 'AWS_IAM']);
+    const out = transform(authConfig, schema);
+    const authPolicy1 = getResourceWithKeyPrefix('AuthRolePolicy01', out);
+    const authPolicy2 = getResourceWithKeyPrefix('AuthRolePolicy02', out);
+    const authPolicy3 = getResourceWithKeyPrefix('AuthRolePolicy03', out);
+    const unauthPolicy = getResourceWithKeyPrefix('UnauthRolePolicy', out);
+
+    expect(authPolicy1).toBeDefined();
+    expect(authPolicy2).toBeDefined();
+    expect(authPolicy3).toBeDefined();
+    expect(unauthPolicy).toBeUndefined();
+
+    expect(authPolicy1.Properties.PolicyDocument.Statement[0].Resource.length).toEqual(25);
+    expect(authPolicy2.Properties.PolicyDocument.Statement[0].Resource.length).toEqual(26);
+    expect(authPolicy3.Properties.PolicyDocument.Statement[0].Resource.length).toEqual(5);
   });
 });

--- a/packages/amplify-graphql-transformer-test-utils/API.md
+++ b/packages/amplify-graphql-transformer-test-utils/API.md
@@ -74,6 +74,9 @@ export interface DeploymentResources extends ResolversFunctionsAndSchema, Nested
 }
 
 // @public (undocumented)
+export const getResourceWithKeyPrefix: (keyPrefix: string, deploymentResources: DeploymentResources) => any | undefined;
+
+// @public (undocumented)
 export interface MakeSqlDataSourceStrategyOptions {
     // (undocumented)
     customSqlStatements?: Record<string, string>;

--- a/packages/amplify-graphql-transformer-test-utils/src/deployment-resources.ts
+++ b/packages/amplify-graphql-transformer-test-utils/src/deployment-resources.ts
@@ -47,3 +47,16 @@ export interface DeploymentResources extends ResolversFunctionsAndSchema, Nested
   // The full stack mapping for the deployment.
   stackMapping: StackMapping;
 }
+
+export const getResourceWithKeyPrefix = (keyPrefix: string, deploymentResources: DeploymentResources): any | undefined => {
+  const resources = deploymentResources.rootStack.Resources;
+  if (!resources) {
+    return undefined;
+  }
+
+  const matchingKey = Object.keys(resources ?? {}).find((key) => key.startsWith(keyPrefix));
+  if (!matchingKey) {
+    return undefined;
+  }
+  return resources[matchingKey];
+};

--- a/packages/amplify-graphql-transformer-test-utils/src/index.ts
+++ b/packages/amplify-graphql-transformer-test-utils/src/index.ts
@@ -1,5 +1,6 @@
 export { testTransform } from './test-transform';
 export type { TestTransformParameters } from './test-transform';
+export { getResourceWithKeyPrefix } from './deployment-resources';
 export type { Template, StackMapping, ResolversFunctionsAndSchema, NestedStacks, DeploymentResources } from './deployment-resources';
 export type { AmplifyApiGraphQlResourceStackTemplate } from './cdk-compat/amplify-api-resource-stack-types';
 export { TransformManager } from './cdk-compat/transform-manager';


### PR DESCRIPTION
#### Description of changes

Adds a couple of missing multi-auth test cases from the V1 suite.

This change also adds a test utility to retrieve from the root stack, resources by key prefix. Useful for grabbing the policy docs we wanted to assert on. After this is merged I'll port the test in #2164 to use the new util.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
