### PR TITLE
test(api): add rds e2e tests for api key and lambda authorizer field auth

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-field-auth-apikey.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-field-auth-apikey.test.ts
@@ -1,0 +1,15 @@
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { testRdsApiKeyFieldAuth } from '../rds-v2-tests-common/rds-field-auth-apikey';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+describe('RDS MySQL ApiKey field auth rules', () => {
+  const queries = [
+    'CREATE TABLE Person1 (id INT PRIMARY KEY, firstName VARCHAR(255), lastName VARCHAR(255), ssn VARCHAR(20))',
+    'CREATE TABLE Person2 (id INT PRIMARY KEY, firstName VARCHAR(255), lastName VARCHAR(255), ssn VARCHAR(20))',
+    'CREATE TABLE Person3 (id INT PRIMARY KEY, firstName VARCHAR(255), lastName VARCHAR(255), ssn VARCHAR(20))',
+  ];
+
+  testRdsApiKeyFieldAuth(ImportedRDSType.MYSQL, queries);
+});

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-field-auth-lambda.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-field-auth-lambda.test.ts
@@ -1,0 +1,15 @@
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { testRdsLambdaAuthorizerFieldAuth } from '../rds-v2-tests-common/rds-field-auth-lambda';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+describe('RDS MySQL Lambda Authorizer field auth rules', () => {
+  const queries = [
+    'CREATE TABLE Person1 (id INT PRIMARY KEY, firstName VARCHAR(255), lastName VARCHAR(255), ssn VARCHAR(20))',
+    'CREATE TABLE Person2 (id INT PRIMARY KEY, firstName VARCHAR(255), lastName VARCHAR(255), ssn VARCHAR(20))',
+    'CREATE TABLE Person3 (id INT PRIMARY KEY, firstName VARCHAR(255), lastName VARCHAR(255), ssn VARCHAR(20))',
+  ];
+
+  testRdsLambdaAuthorizerFieldAuth(ImportedRDSType.MYSQL, queries);
+});

--- a/packages/amplify-e2e-tests/src/__tests__/rds-pg-field-auth-apikey.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-pg-field-auth-apikey.test.ts
@@ -1,0 +1,15 @@
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { testRdsApiKeyFieldAuth } from '../rds-v2-tests-common/rds-field-auth-apikey';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+describe('RDS Postgres ApiKey field auth rules', () => {
+  const queries = [
+    'CREATE TABLE "Person1" (id INT PRIMARY KEY, "firstName" VARCHAR(255), "lastName" VARCHAR(255), ssn VARCHAR(20))',
+    'CREATE TABLE "Person2" (id INT PRIMARY KEY, "firstName" VARCHAR(255), "lastName" VARCHAR(255), ssn VARCHAR(20))',
+    'CREATE TABLE "Person3" (id INT PRIMARY KEY, "firstName" VARCHAR(255), "lastName" VARCHAR(255), ssn VARCHAR(20))',
+  ];
+
+  testRdsApiKeyFieldAuth(ImportedRDSType.MYSQL, queries);
+});

--- a/packages/amplify-e2e-tests/src/__tests__/rds-pg-field-auth-lambda.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-pg-field-auth-lambda.test.ts
@@ -1,15 +1,15 @@
 import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
-import { testRdsApiKeyFieldAuth } from '../rds-v2-tests-common/rds-field-auth-apikey';
+import { testRdsLambdaAuthorizerFieldAuth } from '../rds-v2-tests-common/rds-field-auth-lambda';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
 
-describe('RDS Postgres ApiKey field auth rules', () => {
+describe('RDS Postgres Lambda Authorizer field auth rules', () => {
   const queries = [
     'CREATE TABLE "Person1" (id INT PRIMARY KEY, "firstName" VARCHAR(255), "lastName" VARCHAR(255), ssn VARCHAR(20))',
     'CREATE TABLE "Person2" (id INT PRIMARY KEY, "firstName" VARCHAR(255), "lastName" VARCHAR(255), ssn VARCHAR(20))',
     'CREATE TABLE "Person3" (id INT PRIMARY KEY, "firstName" VARCHAR(255), "lastName" VARCHAR(255), ssn VARCHAR(20))',
   ];
 
-  testRdsApiKeyFieldAuth(ImportedRDSType.POSTGRESQL, queries);
+  testRdsLambdaAuthorizerFieldAuth(ImportedRDSType.POSTGRESQL, queries);
 });

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-field-auth-apikey.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-field-auth-apikey.ts
@@ -1,0 +1,621 @@
+import {
+  addApiWithAllAuthModes,
+  amplifyPush,
+  createNewProjectDir,
+  deleteDBInstance,
+  deleteProject,
+  deleteProjectDir,
+  enableUserPoolUnauthenticatedAccess,
+  getAppSyncApi,
+  getProjectMeta,
+  importRDSDatabase,
+  initJSProjectWithProfile,
+  setupRDSInstanceAndData,
+  sleep,
+} from 'amplify-category-api-e2e-core';
+import { existsSync, writeFileSync } from 'fs-extra';
+import generator from 'generate-password';
+import path from 'path';
+import { GQLQueryHelper } from '../query-utils/gql-helper';
+import { configureAmplify, getConfiguredAppsyncClientAPIKeyAuth, getConfiguredAppsyncClientIAMAuth } from '../schema-api-directives';
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { SQL_TESTS_USE_BETA } from './sql-e2e-config';
+import { getDefaultDatabasePort } from '../rds-v2-test-utils';
+import { API, Auth } from 'aws-amplify';
+import gql from 'graphql-tag';
+import { withTimeOut } from '../utils/api';
+import { GRAPHQL_AUTH_MODE } from '@aws-amplify/api';
+import { Observable, ZenObservable } from 'zen-observable-ts';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+// delay times
+const SUBSCRIPTION_DELAY = 10000;
+const SUBSCRIPTION_TIMEOUT = 10000;
+
+export const testRdsApiKeyFieldAuth = (engine: ImportedRDSType, queries: string[]): void => {
+  describe('RDS API Key field auth', () => {
+    const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
+
+    // Generate settings for RDS instance
+    const username = db_user;
+    const password = db_password;
+    let region = 'us-east-1'; // This get overwritten in beforeAll
+    let port = getDefaultDatabasePort(engine);
+    const database = 'default_db';
+    let host = 'localhost';
+    const identifier = `integtest${db_identifier}`;
+    const engineSuffix = engine === ImportedRDSType.MYSQL ? 'mysql' : 'pg';
+    const engineName = engine === ImportedRDSType.MYSQL ? 'mysql' : 'postgres';
+    const projName = `${engineSuffix}modelauth2`;
+    const apiName = projName;
+
+    let projRoot;
+    let person1ApiKeyClient, person2ApiKeyClient, person3ApiKeyClient;
+    let person1IAMPublicClient, person2IAMPublicClient, person3IAMPublicClient;
+    let apiEndPoint;
+    
+    beforeAll(async () => {
+      projRoot = await createNewProjectDir(projName);
+      await initProjectAndImportSchema();
+      await amplifyPush(projRoot, false, {
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
+      });
+      await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
+
+      const meta = getProjectMeta(projRoot);
+      const appRegion = meta.providers.awscloudformation.Region;
+      const { output } = meta.api[apiName];
+      const { GraphQLAPIIdOutput, GraphQLAPIEndpointOutput, GraphQLAPIKeyOutput } = output;
+      apiEndPoint = GraphQLAPIEndpointOutput as string;
+
+      const { graphqlApi } = await getAppSyncApi(GraphQLAPIIdOutput, appRegion);
+
+      expect(GraphQLAPIIdOutput).toBeDefined();
+      expect(GraphQLAPIEndpointOutput).toBeDefined();
+      expect(GraphQLAPIKeyOutput).toBeDefined();
+
+      expect(graphqlApi).toBeDefined();
+      expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
+
+      const apiKey = GraphQLAPIKeyOutput as string;
+
+      await createAppSyncClients(apiEndPoint, appRegion, apiKey);
+    });
+
+    const createAppSyncClients = async (apiEndPoint, appRegion, apiKey): Promise<void> => {
+      configureAmplify(projRoot);
+      const unAuthCredentials = await Auth.currentCredentials();
+
+      const unauthAppSyncClient = getConfiguredAppsyncClientIAMAuth(apiEndPoint, appRegion, unAuthCredentials);
+      const apiKeyClient = getConfiguredAppsyncClientAPIKeyAuth(apiEndPoint, appRegion, apiKey);
+      person1ApiKeyClient = constructModelHelper('Person1', apiKeyClient);
+      person2ApiKeyClient = constructModelHelper('Person2', apiKeyClient);
+      person3ApiKeyClient = constructModelHelper('Person3', apiKeyClient);
+      person1IAMPublicClient = constructModelHelper('Person1', unauthAppSyncClient);
+      person2IAMPublicClient = constructModelHelper('Person2', unauthAppSyncClient);
+      person3IAMPublicClient = constructModelHelper('Person3', unauthAppSyncClient);
+    };
+
+    afterAll(async () => {
+      const metaFilePath = path.join(projRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
+      if (existsSync(metaFilePath)) {
+        await deleteProject(projRoot);
+      }
+      deleteProjectDir(projRoot);
+      await cleanupDatabase();
+    });
+
+    const setupDatabase = async (): Promise<void> => {
+      const dbConfig = {
+        identifier,
+        engine,
+        dbname: database,
+        username,
+        password,
+        region,
+      };
+
+      const db = await setupRDSInstanceAndData(dbConfig, queries);
+      port = db.port;
+      host = db.endpoint;
+    };
+
+    const cleanupDatabase = async (): Promise<void> => {
+      await deleteDBInstance(identifier, region);
+    };
+
+    const initProjectAndImportSchema = async (): Promise<void> => {
+      await initJSProjectWithProfile(projRoot, {
+        disableAmplifyAppCreation: false,
+        name: projName,
+      });
+
+      const metaAfterInit = getProjectMeta(projRoot);
+      region = metaAfterInit.providers.awscloudformation.Region;
+      await setupDatabase();
+
+      const rdsSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.sql.graphql');
+
+      await addApiWithAllAuthModes(projRoot, { transformerVersion: 2, apiName });
+
+      await importRDSDatabase(projRoot, {
+        database,
+        engine,
+        host,
+        port,
+        username,
+        password,
+        useVpc: true,
+        apiExists: true,
+      });
+
+      const schema = /* GraphQL */ `
+        input AMPLIFY {
+          engine: String = "${engineName}"
+        }
+
+        # Api Key can't delete a record
+        # Api key can't update SSN field
+        # Api Key can't read SSN field 
+        # Api Key can create a record with all fields, but can't read SSN response
+        # Api Key subscription can't read SSN field
+        type Person1 @model @auth(rules: [{allow: public, provider: apiKey}, {allow: public, provider: iam}]) {
+          id: Int! @primaryKey
+          firstName: String
+          lastName: String
+          ssn: String @auth(rules: [{allow: public, provider: iam}, {allow: public, provider: apiKey, operations: [create]}])
+        }
+
+        # Api Key can't create a record with SSN value
+        # Api Key can create a record without a SSN value
+        # Api Key can't update a record with SSN value
+        # Api Key can't delete a record
+        type Person2 @model @auth(rules: [{allow: public, provider: apiKey}, {allow: public, provider: iam}]) {
+          id: Int! @primaryKey
+          firstName: String
+          lastName: String
+          ssn: String @auth(rules: [{allow: public, provider: iam}, {allow: public, provider: apiKey, operations: [read]}])
+        }
+
+        # Api Key can't create a record with SSN value
+        # Api Key can delete a record
+        type Person3 @model @auth(rules: [{allow: public, provider: apiKey}, {allow: public, provider: iam}]) {
+          id: Int! @primaryKey
+          firstName: String
+          lastName: String
+          ssn: String @auth(rules: [{allow: public, provider: iam}, {allow: public, provider: apiKey, operations: [delete]}])
+        }
+      `;
+      writeFileSync(rdsSchemaFilePath, schema, 'utf8');
+
+      // Enable unauthenticated access to the Cognito resource and push again
+      await enableUserPoolUnauthenticatedAccess(projRoot);
+    };
+
+    const selectionSetWithoutSSN = `
+      id
+      firstName
+      lastName
+    `;
+
+    const getQueryWithoutSSN = (name: string): string => /* GraphQL */ `
+      query Get${name}($id: Int!) {
+        get${name}(id: $id) {
+          ${selectionSetWithoutSSN}
+        }
+      }
+    `;
+
+    const listQueryWithoutSSN = (name: string): string => /* GraphQL */ `
+      query List${name}s {
+        list${name}s {
+          items {
+            ${selectionSetWithoutSSN}
+          }
+        }
+      }
+    `;
+
+    test('Model Person1 - Api Key can create a record with all fields, but SSN response is null', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+        ssn: '123-45-6789',
+      };
+      // The API can create the record with all fields. But the API throws unauthorized error for the SSN field.
+      // We will run a get query to verify that the record was created with all the fields including SSN.
+      await expect(
+        person1ApiKeyClient.create('createPerson1', person),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access ssn on type Person1');
+
+      const person1Response = await person1IAMPublicClient.get({ id: person.id });
+      expect(person1Response.data.getPerson1.id).toEqual(person.id);
+      expect(person1Response.data.getPerson1.firstName).toEqual(person.firstName);
+      expect(person1Response.data.getPerson1.lastName).toEqual(person.lastName);
+      expect(person1Response.data.getPerson1.ssn).toEqual(person.ssn);
+    });
+
+    test('Model Person1 - Api Key cannot read SSN field on GET query', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+      };
+      await expect(
+        person1ApiKeyClient.get({ id: person.id }),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access ssn on type Person1');
+
+      const person1Response = await person1ApiKeyClient.get({ id: person.id }, getQueryWithoutSSN('Person1'));
+      expect(person1Response.data.getPerson1.id).toEqual(person.id);
+      expect(person1Response.data.getPerson1.firstName).toEqual(person.firstName);
+      expect(person1Response.data.getPerson1.lastName).toEqual(person.lastName);
+    });
+
+    test('Model Person1 - Api Key cannot read SSN field on LIST query', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+      };
+      await expect(
+        person1ApiKeyClient.list(),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access ssn on type Person1');
+
+      const listPerson1Response = await person1ApiKeyClient.list(undefined, listQueryWithoutSSN('Person1'));
+      expect(listPerson1Response.data.listPerson1s).toBeDefined();
+      expect(listPerson1Response.data.listPerson1s.items).toBeDefined();
+      expect(listPerson1Response.data.listPerson1s.items).toHaveLength(1);
+      expect(listPerson1Response.data.listPerson1s.items[0].id).toEqual(person.id);
+      expect(listPerson1Response.data.listPerson1s.items[0].firstName).toEqual(person.firstName);
+      expect(listPerson1Response.data.listPerson1s.items[0].lastName).toEqual(person.lastName);
+    });
+
+    test('Model Person1 - Api Key cannot update SSN', async () => {
+      const currentSSN = '123-45-6789';
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+        ssn: '999-99-9999',
+      };
+      await expect(
+        person1ApiKeyClient.update('updatePerson1', person),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access updatePerson1 on type Mutation');
+
+      const person1Response = await person1IAMPublicClient.get({ id: person.id });
+      expect(person1Response.data.getPerson1.id).toEqual(person.id);
+      expect(person1Response.data.getPerson1.firstName).toEqual(person.firstName);
+      expect(person1Response.data.getPerson1.lastName).toEqual(person.lastName);
+      expect(person1Response.data.getPerson1.ssn).toEqual(currentSSN);
+    });
+
+    test('Model Person1 - Api Key can update without SSN', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1-Updated',
+        lastName: 'Person1-Updated',
+      };
+      
+      const person1UpdateResponse = await person1ApiKeyClient.update('updatePerson1', person, selectionSetWithoutSSN);
+      expect(person1UpdateResponse.data.updatePerson1.id).toEqual(person.id);
+      expect(person1UpdateResponse.data.updatePerson1.firstName).toEqual(person.firstName);
+      expect(person1UpdateResponse.data.updatePerson1.lastName).toEqual(person.lastName);
+      
+      const person1Response = await person1IAMPublicClient.get({ id: person.id });
+      expect(person1Response.data.getPerson1.id).toEqual(person.id);
+      expect(person1Response.data.getPerson1.firstName).toEqual(person.firstName);
+      expect(person1Response.data.getPerson1.lastName).toEqual(person.lastName);
+    });
+
+    test('Model Person1 - Api Key cannot delete a record', async () => {
+      const person = {
+        id: 1,
+      };
+      await expect(
+        person1ApiKeyClient.delete('deletePerson1', person),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access deletePerson1 on type Mutation');
+    });
+
+    test('Model Person1 - SSN field must be redacted on subscriptions', async () => {
+      const personRecord = {
+        id: 2,
+        firstName: 'Person2',
+        lastName: 'Person2',
+        ssn: '111-11-1111',
+      };
+
+      // Check onCreate subscription
+      const observer = API.graphql({
+        query: gql`
+          subscription OnCreatePerson1 {
+            onCreatePerson1 {
+              id
+              firstName
+              lastName
+              ssn
+            }
+          }
+        `,
+        authMode: GRAPHQL_AUTH_MODE.API_KEY,
+      }) as unknown as Observable<any>;
+
+      let subscription: ZenObservable.Subscription;
+      const subscriptionPromise = new Promise((resolve, _) => {
+        subscription = observer.subscribe(
+          (event: any) => {
+            const person = event.value.data.onCreatePerson1;
+            subscription.unsubscribe();
+            expect(person).toBeDefined();
+            expect(person).toEqual(
+              expect.objectContaining({
+                id: personRecord.id,
+                firstName: personRecord.firstName,
+                lastName: personRecord.lastName,
+                ssn: null,
+              }),
+            );
+            resolve(undefined);
+          },
+          (err) => {
+            console.log(JSON.stringify(err.error.errors, null, 4));
+            throw new Error('ApiKey client should be able to subscribe on Person1');
+          },
+        );
+      });
+
+      await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
+
+      await person1IAMPublicClient.create('createPerson1', personRecord);
+
+      return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'onCreatePerson1 Subscription timed out', () => {
+        subscription?.unsubscribe();
+      });
+    });
+
+    test('Model Person2 - Api Key cannot create a record with SSN value', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+        ssn: '123-45-6789',
+      };
+      await expect(
+        person2ApiKeyClient.create('createPerson2', person),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access createPerson2 on type Mutation');
+
+      const personResponse = await person2IAMPublicClient.get({ id: person.id });
+      expect(personResponse.data.getPerson2).toBeNull();
+    });
+
+    test('Model Person2 - Api Key can create a record without SSN value', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+      };
+      const personCreateResponse = await person2ApiKeyClient.create('createPerson2', person, selectionSetWithoutSSN);
+      expect(personCreateResponse.data.createPerson2.id).toEqual(person.id);
+      expect(personCreateResponse.data.createPerson2.firstName).toEqual(person.firstName);
+      expect(personCreateResponse.data.createPerson2.lastName).toEqual(person.lastName);
+    });
+
+    test('Model Person2 - Api Key cannot update a record including SSN', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+        ssn: '999-99-9999',
+      };
+      await expect(
+        person2ApiKeyClient.update('updatePerson2', person),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access updatePerson2 on type Mutation');
+    });
+
+    test('Model Person2 - Api Key cannot delete a record', async () => {
+      const person = {
+        id: 1,
+      };
+      await expect(
+        person2ApiKeyClient.delete('deletePerson2', person),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access deletePerson2 on type Mutation');
+    });
+
+    test('Model Person2 - SSN field must be readable on subscriptions', async () => {
+      const personRecord = {
+        id: 2,
+        firstName: 'Person2',
+        lastName: 'Person2',
+        ssn: '111-11-1111',
+      };
+
+      // Check onCreate subscription
+      const observer = API.graphql({
+        query: gql`
+          subscription OnCreatePerson2 {
+            onCreatePerson2 {
+              id
+              firstName
+              lastName
+              ssn
+            }
+          }
+        `,
+        authMode: GRAPHQL_AUTH_MODE.API_KEY,
+      }) as unknown as Observable<any>;
+
+      let subscription: ZenObservable.Subscription;
+      const subscriptionPromise = new Promise((resolve, _) => {
+        subscription = observer.subscribe(
+          (event: any) => {
+            const person = event.value.data.onCreatePerson2;
+            subscription.unsubscribe();
+            expect(person).toBeDefined();
+            expect(person).toEqual(
+              expect.objectContaining({
+                id: personRecord.id,
+                firstName: personRecord.firstName,
+                lastName: personRecord.lastName,
+                ssn: personRecord.ssn,
+              }),
+            );
+            resolve(undefined);
+          },
+          (err) => {
+            console.log(JSON.stringify(err.error.errors, null, 4));
+            throw new Error('ApiKey client should be able to subscribe on Person2');
+          },
+        );
+      });
+
+      await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
+
+      await person2IAMPublicClient.create('createPerson2', personRecord);
+
+      return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'onCreatePerson2 Subscription timed out', () => {
+        subscription?.unsubscribe();
+      });
+    });
+
+    test('Model Person3 - Api Key cannot create a record with SSN value', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+        ssn: '123-45-6789',
+      };
+      await expect(
+        person3ApiKeyClient.create('createPerson3', person),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access createPerson3 on type Mutation');
+
+      const personResponse = await person3IAMPublicClient.get({ id: person.id });
+      expect(personResponse.data.getPerson3).toBeNull();
+    });
+
+    test('Model Person3 - Api Key can delete a record', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+        ssn: '123-45-6789',
+      };
+      const personCreateResponse = await person3IAMPublicClient.create('createPerson3', person);
+      expect(personCreateResponse.data.createPerson3.id).toEqual(person.id);
+      expect(personCreateResponse.data.createPerson3.firstName).toEqual(person.firstName);
+      expect(personCreateResponse.data.createPerson3.lastName).toEqual(person.lastName);
+      expect(personCreateResponse.data.createPerson3.ssn).toBeNull(); // SSN is null because of subscription field redactions
+
+      // Api Key can delete a record. It will throw unauthorized error for SSN field. The record will still be deleted.
+      await expect(
+        person3ApiKeyClient.delete('deletePerson3', { id: person.id }),
+      ).rejects.toThrow('GraphQL error: Not Authorized to access ssn on type Person3');
+
+      const person3GetResponse = await person3IAMPublicClient.get({ id: person.id });
+      expect(person3GetResponse.data.getPerson3).toBeNull();
+    });
+
+    test('Model Person3 - SSN field must be redacted on subscriptions', async () => {
+      const personRecord = {
+        id: 2,
+        firstName: 'Person2',
+        lastName: 'Person2',
+        ssn: '111-11-1111',
+      };
+
+      // Check onCreate subscription
+      const observer = API.graphql({
+        query: gql`
+          subscription OnCreatePerson3 {
+            onCreatePerson3 {
+              id
+              firstName
+              lastName
+              ssn
+            }
+          }
+        `,
+        authMode: GRAPHQL_AUTH_MODE.API_KEY,
+      }) as unknown as Observable<any>;
+
+      let subscription: ZenObservable.Subscription;
+      const subscriptionPromise = new Promise((resolve, _) => {
+        subscription = observer.subscribe(
+          (event: any) => {
+            const person = event.value.data.onCreatePerson3;
+            subscription.unsubscribe();
+            expect(person).toBeDefined();
+            expect(person).toEqual(
+              expect.objectContaining({
+                id: personRecord.id,
+                firstName: personRecord.firstName,
+                lastName: personRecord.lastName,
+                ssn: null,
+              }),
+            );
+            resolve(undefined);
+          },
+          (err) => {
+            console.log(JSON.stringify(err.error.errors, null, 4));
+            throw new Error('ApiKey client should be able to subscribe on Person3');
+          },
+        );
+      });
+
+      await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
+
+      await person3IAMPublicClient.create('createPerson3', personRecord);
+
+      return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'onCreatePerson3 Subscription timed out', () => {
+        subscription?.unsubscribe();
+      });
+    });
+
+    const constructModelHelper = (name: string, client): GQLQueryHelper => {
+      const createSelectionSet = /* GraphQL */ `
+        id
+        firstName
+        lastName
+        ssn
+      `;
+      const updateSelectionSet = createSelectionSet;
+      const deleteSelectionSet = createSelectionSet;
+      const getSelectionSet = /* GraphQL */ `
+        query Get${name}($id: Int!) {
+          get${name}(id: $id) {
+            id
+            firstName
+            lastName
+            ssn
+          }
+        }
+      `;
+      const listSelectionSet = /* GraphQL */ `
+        query List${name}s {
+          list${name}s {
+            items {
+              id
+              firstName
+              lastName
+              ssn
+            }
+          }
+        }
+      `;
+      const helper = new GQLQueryHelper(client, name, {
+        mutation: {
+          create: createSelectionSet,
+          update: updateSelectionSet,
+          delete: deleteSelectionSet,
+        },
+        query: {
+          get: getSelectionSet,
+          list: listSelectionSet,
+        },
+      });
+
+      return helper;
+    };
+  });
+};

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-field-auth-apikey.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-field-auth-apikey.ts
@@ -55,7 +55,7 @@ export const testRdsApiKeyFieldAuth = (engine: ImportedRDSType, queries: string[
     let person1ApiKeyClient, person2ApiKeyClient, person3ApiKeyClient;
     let person1IAMPublicClient, person2IAMPublicClient, person3IAMPublicClient;
     let apiEndPoint;
-    
+
     beforeAll(async () => {
       projRoot = await createNewProjectDir(projName);
       await initProjectAndImportSchema();
@@ -227,9 +227,9 @@ export const testRdsApiKeyFieldAuth = (engine: ImportedRDSType, queries: string[
       };
       // The API can create the record with all fields. But the API throws unauthorized error for the SSN field.
       // We will run a get query to verify that the record was created with all the fields including SSN.
-      await expect(
-        person1ApiKeyClient.create('createPerson1', person),
-      ).rejects.toThrow('GraphQL error: Not Authorized to access ssn on type Person1');
+      await expect(person1ApiKeyClient.create('createPerson1', person)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access ssn on type Person1',
+      );
 
       const person1Response = await person1IAMPublicClient.get({ id: person.id });
       expect(person1Response.data.getPerson1.id).toEqual(person.id);
@@ -244,9 +244,9 @@ export const testRdsApiKeyFieldAuth = (engine: ImportedRDSType, queries: string[
         firstName: 'Person1',
         lastName: 'Person1',
       };
-      await expect(
-        person1ApiKeyClient.get({ id: person.id }),
-      ).rejects.toThrow('GraphQL error: Not Authorized to access ssn on type Person1');
+      await expect(person1ApiKeyClient.get({ id: person.id })).rejects.toThrow(
+        'GraphQL error: Not Authorized to access ssn on type Person1',
+      );
 
       const person1Response = await person1ApiKeyClient.get({ id: person.id }, getQueryWithoutSSN('Person1'));
       expect(person1Response.data.getPerson1.id).toEqual(person.id);
@@ -260,9 +260,7 @@ export const testRdsApiKeyFieldAuth = (engine: ImportedRDSType, queries: string[
         firstName: 'Person1',
         lastName: 'Person1',
       };
-      await expect(
-        person1ApiKeyClient.list(),
-      ).rejects.toThrow('GraphQL error: Not Authorized to access ssn on type Person1');
+      await expect(person1ApiKeyClient.list()).rejects.toThrow('GraphQL error: Not Authorized to access ssn on type Person1');
 
       const listPerson1Response = await person1ApiKeyClient.list(undefined, listQueryWithoutSSN('Person1'));
       expect(listPerson1Response.data.listPerson1s).toBeDefined();
@@ -281,9 +279,9 @@ export const testRdsApiKeyFieldAuth = (engine: ImportedRDSType, queries: string[
         lastName: 'Person1',
         ssn: '999-99-9999',
       };
-      await expect(
-        person1ApiKeyClient.update('updatePerson1', person),
-      ).rejects.toThrow('GraphQL error: Not Authorized to access updatePerson1 on type Mutation');
+      await expect(person1ApiKeyClient.update('updatePerson1', person)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access updatePerson1 on type Mutation',
+      );
 
       const person1Response = await person1IAMPublicClient.get({ id: person.id });
       expect(person1Response.data.getPerson1.id).toEqual(person.id);
@@ -298,12 +296,12 @@ export const testRdsApiKeyFieldAuth = (engine: ImportedRDSType, queries: string[
         firstName: 'Person1-Updated',
         lastName: 'Person1-Updated',
       };
-      
+
       const person1UpdateResponse = await person1ApiKeyClient.update('updatePerson1', person, selectionSetWithoutSSN);
       expect(person1UpdateResponse.data.updatePerson1.id).toEqual(person.id);
       expect(person1UpdateResponse.data.updatePerson1.firstName).toEqual(person.firstName);
       expect(person1UpdateResponse.data.updatePerson1.lastName).toEqual(person.lastName);
-      
+
       const person1Response = await person1IAMPublicClient.get({ id: person.id });
       expect(person1Response.data.getPerson1.id).toEqual(person.id);
       expect(person1Response.data.getPerson1.firstName).toEqual(person.firstName);
@@ -314,9 +312,9 @@ export const testRdsApiKeyFieldAuth = (engine: ImportedRDSType, queries: string[
       const person = {
         id: 1,
       };
-      await expect(
-        person1ApiKeyClient.delete('deletePerson1', person),
-      ).rejects.toThrow('GraphQL error: Not Authorized to access deletePerson1 on type Mutation');
+      await expect(person1ApiKeyClient.delete('deletePerson1', person)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access deletePerson1 on type Mutation',
+      );
     });
 
     test('Model Person1 - SSN field must be redacted on subscriptions', async () => {
@@ -382,9 +380,9 @@ export const testRdsApiKeyFieldAuth = (engine: ImportedRDSType, queries: string[
         lastName: 'Person1',
         ssn: '123-45-6789',
       };
-      await expect(
-        person2ApiKeyClient.create('createPerson2', person),
-      ).rejects.toThrow('GraphQL error: Not Authorized to access createPerson2 on type Mutation');
+      await expect(person2ApiKeyClient.create('createPerson2', person)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access createPerson2 on type Mutation',
+      );
 
       const personResponse = await person2IAMPublicClient.get({ id: person.id });
       expect(personResponse.data.getPerson2).toBeNull();
@@ -409,18 +407,18 @@ export const testRdsApiKeyFieldAuth = (engine: ImportedRDSType, queries: string[
         lastName: 'Person1',
         ssn: '999-99-9999',
       };
-      await expect(
-        person2ApiKeyClient.update('updatePerson2', person),
-      ).rejects.toThrow('GraphQL error: Not Authorized to access updatePerson2 on type Mutation');
+      await expect(person2ApiKeyClient.update('updatePerson2', person)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access updatePerson2 on type Mutation',
+      );
     });
 
     test('Model Person2 - Api Key cannot delete a record', async () => {
       const person = {
         id: 1,
       };
-      await expect(
-        person2ApiKeyClient.delete('deletePerson2', person),
-      ).rejects.toThrow('GraphQL error: Not Authorized to access deletePerson2 on type Mutation');
+      await expect(person2ApiKeyClient.delete('deletePerson2', person)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access deletePerson2 on type Mutation',
+      );
     });
 
     test('Model Person2 - SSN field must be readable on subscriptions', async () => {
@@ -486,9 +484,9 @@ export const testRdsApiKeyFieldAuth = (engine: ImportedRDSType, queries: string[
         lastName: 'Person1',
         ssn: '123-45-6789',
       };
-      await expect(
-        person3ApiKeyClient.create('createPerson3', person),
-      ).rejects.toThrow('GraphQL error: Not Authorized to access createPerson3 on type Mutation');
+      await expect(person3ApiKeyClient.create('createPerson3', person)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access createPerson3 on type Mutation',
+      );
 
       const personResponse = await person3IAMPublicClient.get({ id: person.id });
       expect(personResponse.data.getPerson3).toBeNull();
@@ -508,9 +506,9 @@ export const testRdsApiKeyFieldAuth = (engine: ImportedRDSType, queries: string[
       expect(personCreateResponse.data.createPerson3.ssn).toBeNull(); // SSN is null because of subscription field redactions
 
       // Api Key can delete a record. It will throw unauthorized error for SSN field. The record will still be deleted.
-      await expect(
-        person3ApiKeyClient.delete('deletePerson3', { id: person.id }),
-      ).rejects.toThrow('GraphQL error: Not Authorized to access ssn on type Person3');
+      await expect(person3ApiKeyClient.delete('deletePerson3', { id: person.id })).rejects.toThrow(
+        'GraphQL error: Not Authorized to access ssn on type Person3',
+      );
 
       const person3GetResponse = await person3IAMPublicClient.get({ id: person.id });
       expect(person3GetResponse.data.getPerson3).toBeNull();

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-field-auth-lambda.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-field-auth-lambda.ts
@@ -1,0 +1,620 @@
+import {
+  addApiWithAllAuthModes,
+  amplifyPush,
+  createNewProjectDir,
+  deleteDBInstance,
+  deleteProject,
+  deleteProjectDir,
+  enableUserPoolUnauthenticatedAccess,
+  getAppSyncApi,
+  getProjectMeta,
+  importRDSDatabase,
+  initJSProjectWithProfile,
+  setupRDSInstanceAndData,
+  sleep,
+} from 'amplify-category-api-e2e-core';
+import { existsSync, writeFileSync } from 'fs-extra';
+import generator from 'generate-password';
+import path from 'path';
+import { GQLQueryHelper } from '../query-utils/gql-helper';
+import { configureAmplify, getConfiguredAppsyncClientIAMAuth, getConfiguredAppsyncClientLambdaAuth } from '../schema-api-directives';
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { SQL_TESTS_USE_BETA } from './sql-e2e-config';
+import { getDefaultDatabasePort } from '../rds-v2-test-utils';
+import { API, Auth } from 'aws-amplify';
+import gql from 'graphql-tag';
+import { withTimeOut } from '../utils/api';
+import { GRAPHQL_AUTH_MODE } from '@aws-amplify/api';
+import { Observable, ZenObservable } from 'zen-observable-ts';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+// delay times
+const SUBSCRIPTION_DELAY = 10000;
+const SUBSCRIPTION_TIMEOUT = 10000;
+
+export const testRdsLambdaAuthorizerFieldAuth = (engine: ImportedRDSType, queries: string[]): void => {
+  describe('RDS Lambda Authorizer field auth', () => {
+    const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
+
+    // Generate settings for RDS instance
+    const username = db_user;
+    const password = db_password;
+    let region = 'us-east-1'; // This get overwritten in beforeAll
+    let port = getDefaultDatabasePort(engine);
+    const database = 'default_db';
+    let host = 'localhost';
+    const identifier = `integtest${db_identifier}`;
+    const engineSuffix = engine === ImportedRDSType.MYSQL ? 'mysql' : 'pg';
+    const engineName = engine === ImportedRDSType.MYSQL ? 'mysql' : 'postgres';
+    const projName = `${engineSuffix}modelauth2`;
+    const apiName = projName;
+
+    let projRoot;
+    let person1LambdaAuthClient, person2LambdaAuthClient, person3LambdaAuthClient;
+    let person1IAMPublicClient, person2IAMPublicClient, person3IAMPublicClient;
+    let apiEndPoint;
+
+    beforeAll(async () => {
+      projRoot = await createNewProjectDir(projName);
+      await initProjectAndImportSchema();
+      await amplifyPush(projRoot, false, {
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
+      });
+      await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
+
+      const meta = getProjectMeta(projRoot);
+      const appRegion = meta.providers.awscloudformation.Region;
+      const { output } = meta.api[apiName];
+      const { GraphQLAPIIdOutput, GraphQLAPIEndpointOutput, GraphQLAPIKeyOutput } = output;
+      apiEndPoint = GraphQLAPIEndpointOutput as string;
+
+      const { graphqlApi } = await getAppSyncApi(GraphQLAPIIdOutput, appRegion);
+
+      expect(GraphQLAPIIdOutput).toBeDefined();
+      expect(GraphQLAPIEndpointOutput).toBeDefined();
+      expect(GraphQLAPIKeyOutput).toBeDefined();
+
+      expect(graphqlApi).toBeDefined();
+      expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
+
+      await createAppSyncClients(apiEndPoint, appRegion);
+    });
+
+    const createAppSyncClients = async (apiEndPoint, appRegion): Promise<void> => {
+      configureAmplify(projRoot);
+      const unAuthCredentials = await Auth.currentCredentials();
+
+      const unauthAppSyncClient = getConfiguredAppsyncClientIAMAuth(apiEndPoint, appRegion, unAuthCredentials);
+      const lambdaAuthClient = getConfiguredAppsyncClientLambdaAuth(apiEndPoint, appRegion, 'custom-authorized');
+      person1LambdaAuthClient = constructModelHelper('Person1', lambdaAuthClient);
+      person2LambdaAuthClient = constructModelHelper('Person2', lambdaAuthClient);
+      person3LambdaAuthClient = constructModelHelper('Person3', lambdaAuthClient);
+      person1IAMPublicClient = constructModelHelper('Person1', unauthAppSyncClient);
+      person2IAMPublicClient = constructModelHelper('Person2', unauthAppSyncClient);
+      person3IAMPublicClient = constructModelHelper('Person3', unauthAppSyncClient);
+    };
+
+    afterAll(async () => {
+      const metaFilePath = path.join(projRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
+      if (existsSync(metaFilePath)) {
+        await deleteProject(projRoot);
+      }
+      deleteProjectDir(projRoot);
+      await cleanupDatabase();
+    });
+
+    const setupDatabase = async (): Promise<void> => {
+      const dbConfig = {
+        identifier,
+        engine,
+        dbname: database,
+        username,
+        password,
+        region,
+      };
+
+      const db = await setupRDSInstanceAndData(dbConfig, queries);
+      port = db.port;
+      host = db.endpoint;
+    };
+
+    const cleanupDatabase = async (): Promise<void> => {
+      await deleteDBInstance(identifier, region);
+    };
+
+    const initProjectAndImportSchema = async (): Promise<void> => {
+      await initJSProjectWithProfile(projRoot, {
+        disableAmplifyAppCreation: false,
+        name: projName,
+      });
+
+      const metaAfterInit = getProjectMeta(projRoot);
+      region = metaAfterInit.providers.awscloudformation.Region;
+      await setupDatabase();
+
+      const rdsSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.sql.graphql');
+
+      await addApiWithAllAuthModes(projRoot, { transformerVersion: 2, apiName });
+
+      await importRDSDatabase(projRoot, {
+        database,
+        engine,
+        host,
+        port,
+        username,
+        password,
+        useVpc: true,
+        apiExists: true,
+      });
+
+      const schema = /* GraphQL */ `
+        input AMPLIFY {
+          engine: String = "${engineName}"
+        }
+
+        # Lambda Authorizer can't delete a record
+        # Lambda Authorizer can't update SSN field
+        # Lambda Authorizer can't read SSN field 
+        # Lambda Authorizer can create a record with all fields, but can't read SSN response
+        # Lambda Authorizer subscription can't read SSN field
+        type Person1 @model @auth(rules: [{allow: custom, provider: function}, {allow: public, provider: iam}]) {
+          id: Int! @primaryKey
+          firstName: String
+          lastName: String
+          ssn: String @auth(rules: [{allow: public, provider: iam}, {allow: custom, provider: function, operations: [create]}])
+        }
+
+        # Lambda Authorizer can't create a record with SSN value
+        # Lambda Authorizer can create a record without a SSN value
+        # Lambda Authorizer can't update a record with SSN value
+        # Lambda Authorizer can't delete a record
+        type Person2 @model @auth(rules: [{allow: custom, provider: function}, {allow: public, provider: iam}]) {
+          id: Int! @primaryKey
+          firstName: String
+          lastName: String
+          ssn: String @auth(rules: [{allow: public, provider: iam}, {allow: custom, provider: function, operations: [read]}])
+        }
+
+        # Lambda Authorizer can't create a record with SSN value
+        # Lambda Authorizer can delete a record
+        type Person3 @model @auth(rules: [{allow: custom, provider: function}, {allow: public, provider: iam}]) {
+          id: Int! @primaryKey
+          firstName: String
+          lastName: String
+          ssn: String @auth(rules: [{allow: public, provider: iam}, {allow: custom, provider: function, operations: [delete]}])
+        }
+      `;
+      writeFileSync(rdsSchemaFilePath, schema, 'utf8');
+
+      // Enable unauthenticated access to the Cognito resource and push again
+      await enableUserPoolUnauthenticatedAccess(projRoot);
+    };
+
+    const selectionSetWithoutSSN = `
+      id
+      firstName
+      lastName
+    `;
+
+    const getQueryWithoutSSN = (name: string): string => /* GraphQL */ `
+      query Get${name}($id: Int!) {
+        get${name}(id: $id) {
+          ${selectionSetWithoutSSN}
+        }
+      }
+    `;
+
+    const listQueryWithoutSSN = (name: string): string => /* GraphQL */ `
+      query List${name}s {
+        list${name}s {
+          items {
+            ${selectionSetWithoutSSN}
+          }
+        }
+      }
+    `;
+
+    test('Model Person1 - Lambda Authorizer can create a record with all fields, but SSN response is null', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+        ssn: '123-45-6789',
+      };
+      // Lambda Authorizer can create the record with all fields. But the API throws unauthorized error for the SSN field.
+      // We will run a get query to verify that the record was created with all the fields including SSN.
+      await expect(person1LambdaAuthClient.create('createPerson1', person)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access ssn on type Person1',
+      );
+
+      const person1Response = await person1IAMPublicClient.get({ id: person.id });
+      expect(person1Response.data.getPerson1.id).toEqual(person.id);
+      expect(person1Response.data.getPerson1.firstName).toEqual(person.firstName);
+      expect(person1Response.data.getPerson1.lastName).toEqual(person.lastName);
+      expect(person1Response.data.getPerson1.ssn).toEqual(person.ssn);
+    });
+
+    test('Model Person1 - Lambda Authorizer cannot read SSN field on GET query', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+      };
+      await expect(person1LambdaAuthClient.get({ id: person.id })).rejects.toThrow(
+        'GraphQL error: Not Authorized to access ssn on type Person1',
+      );
+
+      const person1Response = await person1LambdaAuthClient.get({ id: person.id }, getQueryWithoutSSN('Person1'));
+      expect(person1Response.data.getPerson1.id).toEqual(person.id);
+      expect(person1Response.data.getPerson1.firstName).toEqual(person.firstName);
+      expect(person1Response.data.getPerson1.lastName).toEqual(person.lastName);
+    });
+
+    test('Model Person1 - Lambda Authorizer cannot read SSN field on LIST query', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+      };
+      await expect(person1LambdaAuthClient.list()).rejects.toThrow('GraphQL error: Not Authorized to access ssn on type Person1');
+
+      const listPerson1Response = await person1LambdaAuthClient.list(undefined, listQueryWithoutSSN('Person1'));
+      expect(listPerson1Response.data.listPerson1s).toBeDefined();
+      expect(listPerson1Response.data.listPerson1s.items).toBeDefined();
+      expect(listPerson1Response.data.listPerson1s.items).toHaveLength(1);
+      expect(listPerson1Response.data.listPerson1s.items[0].id).toEqual(person.id);
+      expect(listPerson1Response.data.listPerson1s.items[0].firstName).toEqual(person.firstName);
+      expect(listPerson1Response.data.listPerson1s.items[0].lastName).toEqual(person.lastName);
+    });
+
+    test('Model Person1 - Lambda Authorizer cannot update SSN', async () => {
+      const currentSSN = '123-45-6789';
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+        ssn: '999-99-9999',
+      };
+      await expect(person1LambdaAuthClient.update('updatePerson1', person)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access updatePerson1 on type Mutation',
+      );
+
+      const person1Response = await person1IAMPublicClient.get({ id: person.id });
+      expect(person1Response.data.getPerson1.id).toEqual(person.id);
+      expect(person1Response.data.getPerson1.firstName).toEqual(person.firstName);
+      expect(person1Response.data.getPerson1.lastName).toEqual(person.lastName);
+      expect(person1Response.data.getPerson1.ssn).toEqual(currentSSN);
+    });
+
+    test('Model Person1 - Lambda Authorizer can update without SSN', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1-Updated',
+        lastName: 'Person1-Updated',
+      };
+
+      const person1UpdateResponse = await person1LambdaAuthClient.update('updatePerson1', person, selectionSetWithoutSSN);
+      expect(person1UpdateResponse.data.updatePerson1.id).toEqual(person.id);
+      expect(person1UpdateResponse.data.updatePerson1.firstName).toEqual(person.firstName);
+      expect(person1UpdateResponse.data.updatePerson1.lastName).toEqual(person.lastName);
+
+      const person1Response = await person1IAMPublicClient.get({ id: person.id });
+      expect(person1Response.data.getPerson1.id).toEqual(person.id);
+      expect(person1Response.data.getPerson1.firstName).toEqual(person.firstName);
+      expect(person1Response.data.getPerson1.lastName).toEqual(person.lastName);
+    });
+
+    test('Model Person1 - Lambda Authorizer cannot delete a record', async () => {
+      const person = {
+        id: 1,
+      };
+      await expect(person1LambdaAuthClient.delete('deletePerson1', person)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access deletePerson1 on type Mutation',
+      );
+    });
+
+    test('Model Person1 - SSN field must be redacted on subscriptions', async () => {
+      const personRecord = {
+        id: 2,
+        firstName: 'Person2',
+        lastName: 'Person2',
+        ssn: '111-11-1111',
+      };
+
+      // Check onCreate subscription
+      const observer = API.graphql({
+        query: gql`
+          subscription OnCreatePerson1 {
+            onCreatePerson1 {
+              id
+              firstName
+              lastName
+              ssn
+            }
+          }
+        `,
+        authMode: GRAPHQL_AUTH_MODE.AWS_LAMBDA,
+        authToken: 'custom-authorized',
+      }) as unknown as Observable<any>;
+
+      let subscription: ZenObservable.Subscription;
+      const subscriptionPromise = new Promise((resolve, _) => {
+        subscription = observer.subscribe(
+          (event: any) => {
+            const person = event.value.data.onCreatePerson1;
+            subscription.unsubscribe();
+            expect(person).toBeDefined();
+            expect(person).toEqual(
+              expect.objectContaining({
+                id: personRecord.id,
+                firstName: personRecord.firstName,
+                lastName: personRecord.lastName,
+                ssn: null,
+              }),
+            );
+            resolve(undefined);
+          },
+          (err) => {
+            console.log(JSON.stringify(err.error.errors, null, 4));
+            throw new Error('Lambda Authorizer client should be able to subscribe on Person1');
+          },
+        );
+      });
+
+      await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
+
+      await person1IAMPublicClient.create('createPerson1', personRecord);
+
+      return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'onCreatePerson1 Subscription timed out', () => {
+        subscription?.unsubscribe();
+      });
+    });
+
+    test('Model Person2 - Lambda Authorizer cannot create a record with SSN value', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+        ssn: '123-45-6789',
+      };
+      await expect(person2LambdaAuthClient.create('createPerson2', person)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access createPerson2 on type Mutation',
+      );
+
+      const personResponse = await person2IAMPublicClient.get({ id: person.id });
+      expect(personResponse.data.getPerson2).toBeNull();
+    });
+
+    test('Model Person2 - Lambda Authorizer can create a record without SSN value', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+      };
+      const personCreateResponse = await person2LambdaAuthClient.create('createPerson2', person, selectionSetWithoutSSN);
+      expect(personCreateResponse.data.createPerson2.id).toEqual(person.id);
+      expect(personCreateResponse.data.createPerson2.firstName).toEqual(person.firstName);
+      expect(personCreateResponse.data.createPerson2.lastName).toEqual(person.lastName);
+    });
+
+    test('Model Person2 - Lambda Authorizer cannot update a record including SSN', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+        ssn: '999-99-9999',
+      };
+      await expect(person2LambdaAuthClient.update('updatePerson2', person)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access updatePerson2 on type Mutation',
+      );
+    });
+
+    test('Model Person2 - Lambda Authorizer cannot delete a record', async () => {
+      const person = {
+        id: 1,
+      };
+      await expect(person2LambdaAuthClient.delete('deletePerson2', person)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access deletePerson2 on type Mutation',
+      );
+    });
+
+    test('Model Person2 - SSN field must be readable on subscriptions', async () => {
+      const personRecord = {
+        id: 2,
+        firstName: 'Person2',
+        lastName: 'Person2',
+        ssn: '111-11-1111',
+      };
+
+      // Check onCreate subscription
+      const observer = API.graphql({
+        query: gql`
+          subscription OnCreatePerson2 {
+            onCreatePerson2 {
+              id
+              firstName
+              lastName
+              ssn
+            }
+          }
+        `,
+        authMode: GRAPHQL_AUTH_MODE.AWS_LAMBDA,
+        authToken: 'custom-authorized',
+      }) as unknown as Observable<any>;
+
+      let subscription: ZenObservable.Subscription;
+      const subscriptionPromise = new Promise((resolve, _) => {
+        subscription = observer.subscribe(
+          (event: any) => {
+            const person = event.value.data.onCreatePerson2;
+            subscription.unsubscribe();
+            expect(person).toBeDefined();
+            expect(person).toEqual(
+              expect.objectContaining({
+                id: personRecord.id,
+                firstName: personRecord.firstName,
+                lastName: personRecord.lastName,
+                ssn: personRecord.ssn,
+              }),
+            );
+            resolve(undefined);
+          },
+          (err) => {
+            console.log(JSON.stringify(err.error.errors, null, 4));
+            throw new Error('Lambda Authorizer client should be able to subscribe on Person2');
+          },
+        );
+      });
+
+      await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
+
+      await person2IAMPublicClient.create('createPerson2', personRecord);
+
+      return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'onCreatePerson2 Subscription timed out', () => {
+        subscription?.unsubscribe();
+      });
+    });
+
+    test('Model Person3 - Lambda Authorizer cannot create a record with SSN value', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+        ssn: '123-45-6789',
+      };
+      await expect(person3LambdaAuthClient.create('createPerson3', person)).rejects.toThrow(
+        'GraphQL error: Not Authorized to access createPerson3 on type Mutation',
+      );
+
+      const personResponse = await person3IAMPublicClient.get({ id: person.id });
+      expect(personResponse.data.getPerson3).toBeNull();
+    });
+
+    test('Model Person3 - Lambda Authorizer can delete a record', async () => {
+      const person = {
+        id: 1,
+        firstName: 'Person1',
+        lastName: 'Person1',
+        ssn: '123-45-6789',
+      };
+      const personCreateResponse = await person3IAMPublicClient.create('createPerson3', person);
+      expect(personCreateResponse.data.createPerson3.id).toEqual(person.id);
+      expect(personCreateResponse.data.createPerson3.firstName).toEqual(person.firstName);
+      expect(personCreateResponse.data.createPerson3.lastName).toEqual(person.lastName);
+      expect(personCreateResponse.data.createPerson3.ssn).toBeNull(); // SSN is null because of subscription field redactions
+
+      // Lambda Authorizer can delete a record. It will throw unauthorized error for SSN field. The record will still be deleted.
+      await expect(person3LambdaAuthClient.delete('deletePerson3', { id: person.id })).rejects.toThrow(
+        'GraphQL error: Not Authorized to access ssn on type Person3',
+      );
+
+      const person3GetResponse = await person3IAMPublicClient.get({ id: person.id });
+      expect(person3GetResponse.data.getPerson3).toBeNull();
+    });
+
+    test('Model Person3 - SSN field must be redacted on subscriptions', async () => {
+      const personRecord = {
+        id: 2,
+        firstName: 'Person2',
+        lastName: 'Person2',
+        ssn: '111-11-1111',
+      };
+
+      // Check onCreate subscription
+      const observer = API.graphql({
+        query: gql`
+          subscription OnCreatePerson3 {
+            onCreatePerson3 {
+              id
+              firstName
+              lastName
+              ssn
+            }
+          }
+        `,
+        authMode: GRAPHQL_AUTH_MODE.AWS_LAMBDA,
+        authToken: 'custom-authorized',
+      }) as unknown as Observable<any>;
+
+      let subscription: ZenObservable.Subscription;
+      const subscriptionPromise = new Promise((resolve, _) => {
+        subscription = observer.subscribe(
+          (event: any) => {
+            const person = event.value.data.onCreatePerson3;
+            subscription.unsubscribe();
+            expect(person).toBeDefined();
+            expect(person).toEqual(
+              expect.objectContaining({
+                id: personRecord.id,
+                firstName: personRecord.firstName,
+                lastName: personRecord.lastName,
+                ssn: null,
+              }),
+            );
+            resolve(undefined);
+          },
+          (err) => {
+            console.log(JSON.stringify(err.error.errors, null, 4));
+            throw new Error('Lambda Authorizer client should be able to subscribe on Person3');
+          },
+        );
+      });
+
+      await new Promise((res) => setTimeout(res, SUBSCRIPTION_DELAY));
+
+      await person3IAMPublicClient.create('createPerson3', personRecord);
+
+      return withTimeOut(subscriptionPromise, SUBSCRIPTION_TIMEOUT, 'onCreatePerson3 Subscription timed out', () => {
+        subscription?.unsubscribe();
+      });
+    });
+
+    const constructModelHelper = (name: string, client): GQLQueryHelper => {
+      const createSelectionSet = /* GraphQL */ `
+        id
+        firstName
+        lastName
+        ssn
+      `;
+      const updateSelectionSet = createSelectionSet;
+      const deleteSelectionSet = createSelectionSet;
+      const getSelectionSet = /* GraphQL */ `
+        query Get${name}($id: Int!) {
+          get${name}(id: $id) {
+            id
+            firstName
+            lastName
+            ssn
+          }
+        }
+      `;
+      const listSelectionSet = /* GraphQL */ `
+        query List${name}s {
+          list${name}s {
+            items {
+              id
+              firstName
+              lastName
+              ssn
+            }
+          }
+        }
+      `;
+      const helper = new GQLQueryHelper(client, name, {
+        mutation: {
+          create: createSelectionSet,
+          update: updateSelectionSet,
+          delete: deleteSelectionSet,
+        },
+        query: {
+          get: getSelectionSet,
+          list: listSelectionSet,
+        },
+      });
+
+      return helper;
+    };
+  });
+};

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/multi-auth.test.ts
@@ -1,5 +1,5 @@
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
-import { DeploymentResources, testTransform } from '@aws-amplify/graphql-transformer-test-utils';
+import { DeploymentResources, getResourceWithKeyPrefix, testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import { AppSyncAuthConfiguration, AppSyncAuthConfigurationOIDCEntry, AppSyncAuthMode } from '@aws-amplify/graphql-transformer-interfaces';
 import { DocumentNode, ObjectTypeDefinitionNode, Kind, FieldDefinitionNode, parse, InputValueDefinitionNode } from 'graphql';
 import { AuthTransformer } from '../graphql-auth-transformer';
@@ -641,5 +641,88 @@ describe('iam checks', () => {
     expectStashValueLike(out, 'Post', '$util.qr($ctx.stash.put(\\"adminRoles\\", [\\"helloWorldFunction\\",\\"echoMessageFunction\\"]))');
     expect(createResolver).toContain('#foreach( $adminRole in $ctx.stash.adminRoles )');
     expect(createResolver).toMatchSnapshot();
+  });
+
+  test('public with IAM provider adds policy for Unauth role', () => {
+    const schema = getSchema(publicIAMAuthDirective);
+    const authConfig = withAuthModes(userPoolsDefaultConfig, ['AWS_IAM']);
+    const out = transform(authConfig, schema);
+    const unauthPolicy = getResourceWithKeyPrefix('UnauthRolePolicy', out);
+    expect(unauthPolicy).toBeDefined();
+  });
+
+  test('the long Todo type should generate policy statements split amongst resources', () => {
+    const schema = `
+    type TodoWithExtraLongLongLongLongLongLongLongLongLongLongLongLongLongLongLongName @model(subscriptions:null) @auth(rules:[{allow: private, provider: iam}])
+    {
+      id: ID!
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename001: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename002: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename003: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename004: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename005: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename006: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename007: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename008: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename009: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename010: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename011: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename012: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename013: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename014: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename015: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename016: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename017: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename018: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename019: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename020: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename021: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename022: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename023: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename024: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename025: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename026: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename027: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename028: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename029: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename030: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename031: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename032: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename033: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename034: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename035: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename036: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename037: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename038: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename039: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename040: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename041: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename042: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename043: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename044: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename045: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename046: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename047: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename048: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename049: String! @auth(rules:[{allow: private, provider: iam}])
+      namenamenamenamenamenamenamenamenamenamenamenamenamenamename050: String! @auth(rules:[{allow: private, provider: iam}])
+      description: String
+    }
+    `;
+    const authConfig = withAuthModes(apiKeyDefaultConfig, ['AMAZON_COGNITO_USER_POOLS', 'AWS_IAM']);
+    const out = transform(authConfig, schema);
+    const authPolicy1 = getResourceWithKeyPrefix('AuthRolePolicy01', out);
+    const authPolicy2 = getResourceWithKeyPrefix('AuthRolePolicy02', out);
+    const authPolicy3 = getResourceWithKeyPrefix('AuthRolePolicy03', out);
+    const unauthPolicy = getResourceWithKeyPrefix('UnauthRolePolicy', out);
+
+    expect(authPolicy1).toBeDefined();
+    expect(authPolicy2).toBeDefined();
+    expect(authPolicy3).toBeDefined();
+    expect(unauthPolicy).toBeUndefined();
+
+    expect(authPolicy1.Properties.PolicyDocument.Statement[0].Resource.length).toEqual(25);
+    expect(authPolicy2.Properties.PolicyDocument.Statement[0].Resource.length).toEqual(26);
+    expect(authPolicy3.Properties.PolicyDocument.Statement[0].Resource.length).toEqual(5);
   });
 });

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
@@ -361,6 +361,7 @@ enum SearchableAggregateType {
   min
   max
   sum
+  cardinality
 }
 
 enum SearchableEmployeeAggregateField {
@@ -726,6 +727,7 @@ enum SearchableAggregateType {
   min
   max
   sum
+  cardinality
 }
 
 enum SearchablePostAggregateField {
@@ -2077,6 +2079,7 @@ enum SearchableAggregateType {
   min
   max
   sum
+  cardinality
 }
 
 enum SearchablePostAggregateField {
@@ -2460,6 +2463,7 @@ enum SearchableAggregateType {
   min
   max
   sum
+  cardinality
 }
 
 enum SearchablePostAggregateField {
@@ -2823,6 +2827,7 @@ enum SearchableAggregateType {
   min
   max
   sum
+  cardinality
 }
 
 enum SearchablePostAggregateField {
@@ -3186,6 +3191,7 @@ enum SearchableAggregateType {
   min
   max
   sum
+  cardinality
 }
 
 enum SearchablePostAggregateField {

--- a/packages/amplify-graphql-searchable-transformer/src/definitions.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/definitions.ts
@@ -308,7 +308,7 @@ export const makeSearchableXSortInputObject = (obj: ObjectTypeDefinitionNode): I
 
 export const makeSearchableAggregateTypeEnumObject = (): EnumTypeDefinitionNode => {
   const name = graphqlName('SearchableAggregateType');
-  const values: EnumValueDefinitionNode[] = ['terms', 'avg', 'min', 'max', 'sum'].map((type: string) => ({
+  const values: EnumValueDefinitionNode[] = ['terms', 'avg', 'min', 'max', 'sum', 'cardinality'].map((type: string) => ({
     kind: Kind.ENUM_VALUE_DEFINITION,
     name: { kind: 'Name', value: type },
     directives: [],

--- a/packages/amplify-graphql-transformer-test-utils/API.md
+++ b/packages/amplify-graphql-transformer-test-utils/API.md
@@ -74,6 +74,9 @@ export interface DeploymentResources extends ResolversFunctionsAndSchema, Nested
 }
 
 // @public (undocumented)
+export const getResourceWithKeyPrefix: (keyPrefix: string, deploymentResources: DeploymentResources) => any | undefined;
+
+// @public (undocumented)
 export interface MakeSqlDataSourceStrategyOptions {
     // (undocumented)
     customSqlStatements?: Record<string, string>;

--- a/packages/amplify-graphql-transformer-test-utils/src/deployment-resources.ts
+++ b/packages/amplify-graphql-transformer-test-utils/src/deployment-resources.ts
@@ -47,3 +47,16 @@ export interface DeploymentResources extends ResolversFunctionsAndSchema, Nested
   // The full stack mapping for the deployment.
   stackMapping: StackMapping;
 }
+
+export const getResourceWithKeyPrefix = (keyPrefix: string, deploymentResources: DeploymentResources): any | undefined => {
+  const resources = deploymentResources.rootStack.Resources;
+  if (!resources) {
+    return undefined;
+  }
+
+  const matchingKey = Object.keys(resources ?? {}).find((key) => key.startsWith(keyPrefix));
+  if (!matchingKey) {
+    return undefined;
+  }
+  return resources[matchingKey];
+};

--- a/packages/amplify-graphql-transformer-test-utils/src/index.ts
+++ b/packages/amplify-graphql-transformer-test-utils/src/index.ts
@@ -1,5 +1,6 @@
 export { testTransform } from './test-transform';
 export type { TestTransformParameters } from './test-transform';
+export { getResourceWithKeyPrefix } from './deployment-resources';
 export type { Template, StackMapping, ResolversFunctionsAndSchema, NestedStacks, DeploymentResources } from './deployment-resources';
 export type { AmplifyApiGraphQlResourceStackTemplate } from './cdk-compat/amplify-api-resource-stack-types';
 export { TransformManager } from './cdk-compat/transform-manager';

--- a/packages/amplify-schema-validator/jest.config.js
+++ b/packages/amplify-schema-validator/jest.config.js
@@ -1,14 +1,16 @@
 module.exports = {
   preset: 'ts-jest',
   collectCoverage: true,
+  coverageProvider: 'v8',
   collectCoverageFrom: ['<rootDir>/src/**/*.{ts,js}'],
-  coverageReporters: ['cobertura', 'lcov', 'text'],
+  coverageReporters: ['cobertura', 'lcov', 'text', 'clover'],
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/dist/', '<rootDir>/src/__tests__/helpers/'],
   testEnvironment: 'jsdom',
   coverageThreshold: {
     global: {
-      lines: 100,
-      statements: 100,
+      lines: 90,
+      functions: 90,
+      branches: 65,
     },
   },
 };

--- a/packages/amplify-schema-validator/package.json
+++ b/packages/amplify-schema-validator/package.json
@@ -38,20 +38,5 @@
         "graphql"
       ]
     }
-  ],
-  "jest": {
-    "collectCoverage": true,
-    "coverageProvider": "v8",
-    "coverageThreshold": {
-      "global": {
-        "branches": 77,
-        "functions": 90,
-        "lines": 90
-      }
-    },
-    "coverageReporters": [
-      "clover",
-      "text"
-    ]
-  }
+  ]
 }

--- a/packages/graphql-connection-transformer/src/__tests__/ModelConnectionTransformer.test.ts
+++ b/packages/graphql-connection-transformer/src/__tests__/ModelConnectionTransformer.test.ts
@@ -65,7 +65,7 @@ test('ModelConnectionTransformer simple one to many happy case', () => {
   expect(connectionUpdateId).toBeTruthy();
 });
 
-test('ModelConnectionTransformer simple one to many happy case with custom keyField', () => {
+test('ModelConnectionTransformer simple one to many happy case with custom keyField and implicit connection name', () => {
   const validSchema = `
     type Post @model {
         id: ID!
@@ -132,7 +132,7 @@ test('that ModelConnection Transformer throws error when the field in connection
   }
 });
 
-test('ModelConnectionTransformer simple one to many happy case with custom keyField', () => {
+test('ModelConnectionTransformer simple one to many happy case with custom keyField and explicit connection name', () => {
   const validSchema = `
     type Post @model {
         id: ID!
@@ -283,7 +283,7 @@ test('ModelConnectionTransformer many to many should fail due to missing other "
   }
 });
 
-test('ModelConnectionTransformer many to many should fail due to missing other "name"', () => {
+test('ModelConnectionTransformer many to many should fail due to missing other connection', () => {
   const validSchema = `
     type Post @model {
         id: ID!


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Add E2E tests for API Key and Lambda Authorizer field rules.

(The change also includes the commits from main)

##### CDK / CloudFormation Parameters Changed

No.

#### Issue #, if available

NA

#### Description of how you validated changes
- Manual testing
- New E2E tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
