### PR TITLE
fix(api): download rds layer only if required

### DIFF
--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/rds-utils.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/rds-utils.test.ts
@@ -1,6 +1,9 @@
 import { DataSourceStrategiesProvider, ModelDataSourceStrategy } from '@aws-amplify/graphql-transformer-interfaces';
 import { DDB_DEFAULT_DATASOURCE_STRATEGY, MYSQL_DB_TYPE } from '@aws-amplify/graphql-transformer-core';
-import { checkForUnsupportedDirectives } from '../../../../provider-utils/awscloudformation/utils/rds-resources/utils';
+import {
+  checkForUnsupportedDirectives,
+  containsSqlModelOrDirective,
+} from '../../../../provider-utils/awscloudformation/utils/rds-resources/utils';
 
 describe('check for unsupported RDS directives', () => {
   const dataSourceStrategies: Record<string, ModelDataSourceStrategy> = {
@@ -15,6 +18,11 @@ describe('check for unsupported RDS directives', () => {
         passwordSsmPath: '/passwordSsmPath',
       },
     },
+    Tag: DDB_DEFAULT_DATASOURCE_STRATEGY,
+  };
+
+  const ddbDataSourceStrategies: Record<string, ModelDataSourceStrategy> = {
+    Post: DDB_DEFAULT_DATASOURCE_STRATEGY,
     Tag: DDB_DEFAULT_DATASOURCE_STRATEGY,
   };
 
@@ -143,5 +151,16 @@ describe('check for unsupported RDS directives', () => {
   it('early return if schema is empty or undefined', () => {
     const schema = '';
     expect(() => checkForUnsupportedDirectives(schema, dataSourceStrategiesProvider)).not.toThrowError();
+  });
+
+  it('containsSqlModelOrDirective should return true if there are sql models', () => {
+    expect(containsSqlModelOrDirective(dataSourceStrategies)).toBeTruthy();
+    expect(containsSqlModelOrDirective(dataSourceStrategies)).toBeTruthy();
+  });
+
+  it('containsSqlModelOrDirective should return false if there are no sql models', () => {
+    expect(containsSqlModelOrDirective(ddbDataSourceStrategies)).toBeFalsy();
+    expect(containsSqlModelOrDirective(ddbDataSourceStrategies)).toBeFalsy();
+    expect(containsSqlModelOrDirective(emptyProvider.dataSourceStrategies)).toBeFalsy();
   });
 });

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -343,7 +343,7 @@ const buildAPIProject = async (context: $TSContext, opts: TransformerProjectOpti
 
   // Read the RDS Mapping S3 Manifest only if the schema contains SQL models or @sql directives.
   let rdsLayerMapping: RDSLayerMapping | undefined = undefined;
-  if (containsSqlModelOrDirective(dataSourceStrategies)) {
+  if (containsSqlModelOrDirective(dataSourceStrategies, sqlDirectiveDataSourceStrategies)) {
     rdsLayerMapping = await getRDSLayerMapping(context, useBetaSqlLayer);
   }
 

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -343,7 +343,7 @@ const buildAPIProject = async (context: $TSContext, opts: TransformerProjectOpti
 
   // Read the RDS Mapping S3 Manifest only if the schema contains SQL models or @sql directives.
   let rdsLayerMapping: RDSLayerMapping | undefined = undefined;
-  if (containsSqlModelOrDirective(dataSourceStrategies, sqlDirectiveDataSourceStrategies)) {
+  if (containsSqlModelOrDirective(dataSourceStrategies)) {
     rdsLayerMapping = await getRDSLayerMapping(context, useBetaSqlLayer);
   }
 

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
@@ -1,7 +1,7 @@
 import { parse, FieldDefinitionNode, ObjectTypeDefinitionNode, visit } from 'graphql';
 import _ from 'lodash';
 import { isSqlStrategy } from '@aws-amplify/graphql-transformer-core';
-import { DataSourceStrategiesProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { DataSourceStrategiesProvider, ModelDataSourceStrategy, SqlDirectiveDataSourceStrategy } from '@aws-amplify/graphql-transformer-interfaces';
 
 export const checkForUnsupportedDirectives = (schema: string, context: DataSourceStrategiesProvider): void => {
   const unsupportedRDSDirectives = ['searchable', 'predictions', 'function', 'manyToMany', 'http', 'mapsTo'];
@@ -48,6 +48,19 @@ export const checkForUnsupportedDirectives = (schema: string, context: DataSourc
   };
 
   visit(document, schemaVisitor);
+};
+
+export const containsSqlModelOrDirective = (
+  dataSourceStrategies: Record<string, ModelDataSourceStrategy>,
+  sqlDirectiveDataSourceStrategies: SqlDirectiveDataSourceStrategy[],
+): boolean => {
+  if (sqlDirectiveDataSourceStrategies && sqlDirectiveDataSourceStrategies?.length > 0) {
+    return true;
+  }
+  if (dataSourceStrategies && Object.keys(dataSourceStrategies).length > 0) {
+    return Object.values(dataSourceStrategies).some((strategy) => isSqlStrategy(strategy));
+  }
+  return false;
 };
 
 const unsupportedDirectiveError = (

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
@@ -1,7 +1,11 @@
 import { parse, FieldDefinitionNode, ObjectTypeDefinitionNode, visit } from 'graphql';
 import _ from 'lodash';
 import { isSqlStrategy } from '@aws-amplify/graphql-transformer-core';
-import { DataSourceStrategiesProvider, ModelDataSourceStrategy, SqlDirectiveDataSourceStrategy } from '@aws-amplify/graphql-transformer-interfaces';
+import {
+  DataSourceStrategiesProvider,
+  ModelDataSourceStrategy,
+  SqlDirectiveDataSourceStrategy,
+} from '@aws-amplify/graphql-transformer-interfaces';
 
 export const checkForUnsupportedDirectives = (schema: string, context: DataSourceStrategiesProvider): void => {
   const unsupportedRDSDirectives = ['searchable', 'predictions', 'function', 'manyToMany', 'http', 'mapsTo'];

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
@@ -54,11 +54,14 @@ export const checkForUnsupportedDirectives = (schema: string, context: DataSourc
   visit(document, schemaVisitor);
 };
 
-export const containsSqlModelOrDirective = (dataSourceStrategies: Record<string, ModelDataSourceStrategy>): boolean => {
-  if (dataSourceStrategies && Object.keys(dataSourceStrategies).length > 0) {
-    return Object.values(dataSourceStrategies).some((strategy) => isSqlStrategy(strategy));
+export const containsSqlModelOrDirective = (
+  dataSourceStrategies: Record<string, ModelDataSourceStrategy>,
+  sqlDirectiveDataSourceStrategies?: SqlDirectiveDataSourceStrategy[],
+): boolean => {
+  if (sqlDirectiveDataSourceStrategies && sqlDirectiveDataSourceStrategies?.length > 0) {
+    return true;
   }
-  return false;
+  return Object.values(dataSourceStrategies).some((strategy) => isSqlStrategy(strategy));
 };
 
 const unsupportedDirectiveError = (

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rds-resources/utils.ts
@@ -54,13 +54,7 @@ export const checkForUnsupportedDirectives = (schema: string, context: DataSourc
   visit(document, schemaVisitor);
 };
 
-export const containsSqlModelOrDirective = (
-  dataSourceStrategies: Record<string, ModelDataSourceStrategy>,
-  sqlDirectiveDataSourceStrategies: SqlDirectiveDataSourceStrategy[],
-): boolean => {
-  if (sqlDirectiveDataSourceStrategies && sqlDirectiveDataSourceStrategies?.length > 0) {
-    return true;
-  }
+export const containsSqlModelOrDirective = (dataSourceStrategies: Record<string, ModelDataSourceStrategy>): boolean => {
   if (dataSourceStrategies && Object.keys(dataSourceStrategies).length > 0) {
     return Object.values(dataSourceStrategies).some((strategy) => isSqlStrategy(strategy));
   }


### PR DESCRIPTION
#### Description of changes

Download the RDS Mapping S3 manifest only if the project contains SQL datasource strategy.

##### CDK / CloudFormation Parameters Changed

No
<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Manually tested and made sure that the S3 file is downloaded only if the project contains SQL datasource strategy.
- E2E tests to make sure all the scenarios are working fine.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
