### PR TITLE
test: Restore custom CLI jest environment

### DIFF
--- a/FixJestEnvironment.js
+++ b/FixJestEnvironment.js
@@ -1,10 +1,13 @@
 const NodeEnvironment = require('jest-environment-node');
 
+/**
+ * NOTE: Any fixes in this file should also be ported to packages/amplify-e2e-core/src/cli-test-environment.js
+ */
 class FixJestEnvironment extends NodeEnvironment {
   constructor(...args) {
     super(...args);
     // https://github.com/jestjs/jest/issues/12628
-    // sturcturedClone is missing in the jest node environment.
+    // structuredClone is missing in the jest node environment.
     // Newer versions of jest have fixed this, but is not possible to upgrade at this time.
     // Newer versions of jest have a performance issue when not used with Node ^20.11.0
     // https://github.com/jestjs/jest/issues/11956

--- a/packages/amplify-e2e-core/src/cli-test-environment.js
+++ b/packages/amplify-e2e-core/src/cli-test-environment.js
@@ -3,6 +3,15 @@ const NodeEnvironment = require('jest-environment-node');
 class CLIEnvironment extends NodeEnvironment {
   constructor(config, context) {
     super(config, context);
+
+    // https://github.com/jestjs/jest/issues/12628
+    // structuredClone is missing in the jest node environment.
+    // Newer versions of jest have fixed this, but is not possible to upgrade at this time.
+    // Newer versions of jest have a performance issue when not used with Node ^20.11.0
+    // https://github.com/jestjs/jest/issues/11956
+    // Our minimum supported version is Node 18.
+    this.global.structuredClone = structuredClone;
+
     this.testPath = context.testPath;
     this.testLogStack = [];
     this.describeBlocks = [];

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -115,8 +115,7 @@
     },
     "moduleNameMapper": {
       "axios": "axios/dist/node/axios.cjs"
-    },
-    "testEnvironment": "../../FixJestEnvironment.js"
+    }
   },
   "jest-junit": {
     "outputDirectory": "reports/junit/",

--- a/packages/amplify-graphql-api-construct-tests/package.json
+++ b/packages/amplify-graphql-api-construct-tests/package.json
@@ -98,8 +98,7 @@
     },
     "moduleNameMapper": {
       "axios": "axios/dist/node/axios.cjs"
-    },
-    "testEnvironment": "../../FixJestEnvironment.js"
+    }
   },
   "jest-junit": {
     "outputDirectory": "reports/junit/",

--- a/packages/amplify-graphql-http-transformer/package.json
+++ b/packages/amplify-graphql-http-transformer/package.json
@@ -67,7 +67,6 @@
       "clover",
       "text"
     ],
-    "testEnvironment": "../../FixJestEnvironment.js",
     "modulePathIgnorePatterns": [
       "overrides"
     ],

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -109,7 +109,6 @@
       "default",
       "jest-junit"
     ],
-    "testEnvironment": "node",
     "testURL": "http://localhost/",
     "testRegex": "(src/(__tests__|__e2e__|__e2e_v2__)/.*.test.ts)$",
     "moduleFileExtensions": [

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -65,7 +65,6 @@
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
-    "testEnvironment": "node",
     "collectCoverage": true,
     "coverageProvider": "v8",
     "collectCoverageFrom": [


### PR DESCRIPTION
#### Description of changes

3351250a9 fixed the Jest environment by adding the `structuredClone` global to the environment. However, that commit overwrote a custom environment declaration used by some E2E tests. This PR restores that custom environment and ports the `structuredClone` fix to it. It also removes some duplicate `testEnvironment` declarations from various **package.json** files.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] [E2E tests running](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:57d26994-49c1-48d6-8e1d-7188925de300?region=us-east-1)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
