### PR TITLE
test: add group based field auth e2e tests for SQL sources

### DIFF
--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -461,7 +461,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-oidc-auth-fields.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_oidc_auth
@@ -497,7 +497,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-userpool-auth-fields.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_userpool_auth
@@ -605,7 +605,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-oidc-auth-fields.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_oidc_auth
@@ -650,7 +650,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-userpool-auth-fields.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_userpool_auth

--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -160,7 +160,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/api_6.test.ts|src/__tests__/graphql-v2/api_lambda_auth.test.ts|src/__tests__/api_9.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_v2
@@ -419,13 +419,31 @@ batch:
           CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
+    - identifier: rds_mysql_field_auth_apikey
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-field-auth-apikey.test.ts
+          CLI_REGION: ap-northeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_field_auth_lambda
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-field-auth-lambda.test.ts
+          CLI_REGION: ap-southeast-1
+      depend-on:
+        - publish_to_local_registry
     - identifier: rds_mysql_model_v2
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-model-v2.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_multi_auth_1
@@ -434,7 +452,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-multi-auth-1.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_oidc_auth_fields
@@ -443,7 +461,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-oidc-auth-fields.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_oidc_auth
@@ -452,7 +470,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-oidc-auth.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_refers_to_fields
@@ -461,7 +479,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-refers-to-fields.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_refers_to
@@ -470,7 +488,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-refers-to.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_userpool_auth_fields
@@ -479,7 +497,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-userpool-auth-fields.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_userpool_auth
@@ -488,7 +506,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-userpool-auth.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_v2_generate_schema
@@ -497,7 +515,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-v2-generate-schema.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_array_objects
@@ -506,7 +524,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-array-objects.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_auth_apikey_lambda
@@ -515,7 +533,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-auth-apikey-lambda.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_auth_iam_apikey_lambda_subscription
@@ -524,7 +542,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-auth-iam-apikey-lambda-subscription.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_auth_iam
@@ -533,7 +551,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-auth-iam.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_custom_claims_refersto_auth
@@ -542,7 +560,25 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-custom-claims-refersto-auth.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-central-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_field_auth_apikey
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-field-auth-apikey.test.ts
+          CLI_REGION: ap-northeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_field_auth_lambda
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-field-auth-lambda.test.ts
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_import
@@ -551,7 +587,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-import.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_model_v2
@@ -560,7 +596,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-model-v2.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_oidc_auth_fields
@@ -569,7 +605,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-oidc-auth-fields.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_oidc_auth
@@ -578,7 +614,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-oidc-auth.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_refers_to_fields
@@ -587,7 +623,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-refers-to-fields.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_refers_to
@@ -596,7 +632,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-refers-to.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_relational_directives
@@ -605,7 +641,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-relational-directives.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_userpool_auth_fields
@@ -614,7 +650,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-userpool-auth-fields.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_userpool_auth
@@ -623,7 +659,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-userpool-auth.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_v2_generate_schema
@@ -632,7 +668,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-v2-generate-schema.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_relational_directives
@@ -641,7 +677,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-relational-directives.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_v2_test_utils
@@ -650,7 +686,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-v2-test-utils.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_model
@@ -659,7 +695,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-model.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: apigw
@@ -668,7 +704,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/apigw.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: containers_api_2
@@ -686,7 +722,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-14.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_7
@@ -695,7 +731,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-7.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_9
@@ -704,7 +740,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-9.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_5
@@ -713,7 +749,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-5.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_datastore
@@ -722,7 +758,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: eu-west-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -732,7 +768,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_searchable
@@ -741,7 +777,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-searchable.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: ap-northeast-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -751,7 +787,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-6.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_connection
@@ -760,7 +796,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-connection.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_had_node_to_node
@@ -770,7 +806,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-had-node-to-node.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_no_node_to_node
@@ -780,7 +816,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-no-node-to-node.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: api_2
@@ -789,7 +825,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/api_2.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_migration
@@ -798,7 +834,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/searchable-migration.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: eu-west-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry

--- a/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/oidc-provider-fields.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/oidc-provider-fields.ts
@@ -6,28 +6,38 @@ export const schema = `
     id: ID! @primaryKey @auth(rules: [{ allow: private, provider: oidc }, { allow: public }])
     owner: String
     authors: [String]
+    group: String
+    groups: [String]
     privateContent: String @auth(rules: [{ allow: private, provider: oidc }])
     publicContent: String @auth(rules: [{ allow: public }])
-    ownerContent: String @auth(rules: [{ allow: owner, operations: [create, read], provider: oidc, identityClaim: "user_id" }])
-    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", operations: [update, read], provider: oidc, identityClaim: "user_id" }])
+    ownerContent: String @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id", operations: [create, read] }])
+    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", provider: oidc, identityClaim: "user_id", operations: [update, read] }])
+    adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "cognito:groups" }])
+    groupContent: String @auth(rules: [{ allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [create, read] }])
+    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "groups", provider: oidc, groupClaim: "cognito:groups", operations: [update, read] }])
   }
 
   type TodoOwnerContentVarious @model @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id" }]) {
     id: ID! @primaryKey @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id" }, { allow: private, provider: oidc }, { allow: public }])
     owner: String
     authors: [String]
+    group: String
+    groups: [String]
     privateContent: String @auth(rules: [{ allow: private, provider: oidc, operations: [create, update, read] }])
     publicContent: String @auth(rules: [{ allow: public }])
-    ownerContent: String @auth(rules: [{ allow: owner, operations: [update, delete, read], provider: oidc, identityClaim: "user_id" }])
-    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", operations: [create, read], provider: oidc, identityClaim: "user_id" }])
+    ownerContent: String @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id", operations: [update, delete, read] }])
+    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", provider: oidc, identityClaim: "user_id", operations: [create, read] }])
+    adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "cognito:groups" }])
+    groupContent: String @auth(rules: [{ allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [update, delete, read] }])
+    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "groups", provider: oidc, groupClaim: "cognito:groups", operations: [create, read] }])
   }
 
   type TodoCustomOwnerContentVarious @model @auth(rules: [{ allow: owner, ownerField: "author", provider: oidc, identityClaim: "user_id" }]) {
     customId: ID! @primaryKey @auth(rules: [{ allow: owner, ownerField: "author", provider: oidc, identityClaim: "user_id" }, { allow: private, provider: oidc }, { allow: public }])
     author: String
-    privateContent: String @auth(rules: [{ allow: private, provider: oidc }, { allow: owner, ownerField: "author", operations: [delete], provider: oidc, identityClaim: "user_id" }])
-    publicContent: String @auth(rules: [{ allow: public }, { allow: owner, ownerField: "author", operations: [delete], provider: oidc, identityClaim: "user_id" }])
-    ownerContent: String @auth(rules: [{ allow: owner, ownerField: "author", operations: [create, delete, read], provider: oidc, identityClaim: "user_id" }])
+    privateContent: String @auth(rules: [{ allow: private, provider: oidc }, { allow: owner, ownerField: "author", provider: oidc, identityClaim: "user_id", operations: [delete] }])
+    publicContent: String @auth(rules: [{ allow: public }, { allow: owner, ownerField: "author", provider: oidc, identityClaim: "user_id", operations: [delete] }])
+    ownerContent: String @auth(rules: [{ allow: owner, ownerField: "author", provider: oidc, identityClaim: "user_id", operations: [create, delete, read] }])
   }
 
   type TodoCustomOwnersContentVarious @model @auth(rules: [{ allow: owner, ownerField: "authors", provider: oidc, identityClaim: "user_id" }]) {
@@ -35,41 +45,49 @@ export const schema = `
     authors: [String]
     privateContent: String @auth(rules: [{ allow: private, provider: oidc }])
     publicContent: String @auth(rules: [{ allow: public }])
-    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", operations: [update, read], provider: oidc, identityClaim: "user_id" }])
+    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", provider: oidc, identityClaim: "user_id", operations: [update, read] }])
   }
 
   type TodoAdminContentVarious @model @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "cognito:groups" }]) {
     id: ID! @primaryKey @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "cognito:groups" }, { allow: private, provider: oidc }, { allow: public }])
     owner: String
     authors: [String]
+    group: String
+    groups: [String]
     privateContent: String @auth(rules: [{ allow: private, provider: oidc }])
     publicContent: String @auth(rules: [{ allow: public }])
-    ownerContent: String @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id" }])
-    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", provider: oidc, identityClaim: "user_id" }])
+    ownerContent: String @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id", operations: [update, read] }])
+    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", provider: oidc, identityClaim: "user_id", operations: [create, read] }])
+    groupContent: String @auth(rules: [{ allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [update, delete, read] }])
+    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "groups", provider: oidc, groupClaim: "cognito:groups", operations: [create, read] }])
   }
 
-  type TodoCustomGroupContentVarious @model @auth(rules: [{ allow: groups, groupsField: "customGroup", provider: oidc, groupClaim: "cognito:groups" }]) {
-    customId: ID! @primaryKey @auth(rules: [{ allow: groups, groupsField: "customGroup", provider: oidc, groupClaim: "cognito:groups" }, { allow: private, provider: oidc }, { allow: public }])
+  type TodoCustomGroupContentVarious @model @auth(rules: [{ allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups" }]) {
+    customId: ID! @primaryKey @auth(rules: [{ allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups" }, { allow: private, provider: oidc }, { allow: public }])
     owner: String
     authors: [String]
-    customGroup: String
-    privateContent: String @auth(rules: [{ allow: private, provider: oidc }])
-    publicContent: String @auth(rules: [{ allow: public }])
-    ownerContent: String @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id" }])
-    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", provider: oidc, identityClaim: "user_id" }])
-    adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "cognito:groups" }])
+    group: String
+    groups: [String]
+    privateContent: String @auth(rules: [{ allow: private, provider: oidc }, { allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
+    publicContent: String @auth(rules: [{ allow: public }, { allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
+    ownerContent: String @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id", operations: [update, read] }, { allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
+    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", provider: oidc, identityClaim: "user_id", operations: [create, read] }, { allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
+    adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "cognito:groups" }, { allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
+    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "groups", provider: oidc, groupClaim: "cognito:groups", operations: [create, read] }, { allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
   }
 
-  type TodoCustomGroupsContentVarious @model @auth(rules: [{ allow: groups, groupsField: "customGroups", provider: oidc, groupClaim: "cognito:groups" }]) {
-    customId: ID! @primaryKey @auth(rules: [{ allow: groups, groupsField: "customGroups", provider: oidc, groupClaim: "cognito:groups" }, { allow: private, provider: oidc }, { allow: public }])
+  type TodoCustomGroupsContentVarious @model @auth(rules: [{ allow: groups, groupsField: "groups", provider: oidc, groupClaim: "cognito:groups" }]) {
+    customId: ID! @primaryKey @auth(rules: [{ allow: groups, groupsField: "groups", provider: oidc, groupClaim: "cognito:groups" }, { allow: private, provider: oidc }, { allow: public }])
     owner: String
     authors: [String]
-    customGroups: [String]
+    group: String
+    groups: [String]
     privateContent: String @auth(rules: [{ allow: private, provider: oidc }])
     publicContent: String @auth(rules: [{ allow: public }])
-    ownerContent: String @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id" }])
-    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", provider: oidc, identityClaim: "user_id" }])
+    ownerContent: String @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id", operations: [update, read] }])
+    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", provider: oidc, identityClaim: "user_id", operations: [create, read] }])
     adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "cognito:groups" }])
+    groupContent: String @auth(rules: [{ allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [update, read] }])
   }
 `;
 

--- a/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/oidc-provider-fields.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/oidc-provider-fields.ts
@@ -6,30 +6,30 @@ export const schema = `
     id: ID! @primaryKey @auth(rules: [{ allow: private, provider: oidc }, { allow: public }])
     owner: String
     authors: [String]
-    group: String
-    groups: [String]
+    customGroup: String
+    customGroups: [String]
     privateContent: String @auth(rules: [{ allow: private, provider: oidc }])
     publicContent: String @auth(rules: [{ allow: public }])
     ownerContent: String @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id", operations: [create, read] }])
     ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", provider: oidc, identityClaim: "user_id", operations: [update, read] }])
     adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "cognito:groups" }])
-    groupContent: String @auth(rules: [{ allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [create, read] }])
-    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "groups", provider: oidc, groupClaim: "cognito:groups", operations: [update, read] }])
+    groupContent: String @auth(rules: [{ allow: groups, groupsField: "customGroup", provider: oidc, groupClaim: "cognito:groups", operations: [create, read] }])
+    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "customGroups", provider: oidc, groupClaim: "cognito:groups", operations: [update, read] }])
   }
 
   type TodoOwnerContentVarious @model @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id" }]) {
     id: ID! @primaryKey @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id" }, { allow: private, provider: oidc }, { allow: public }])
     owner: String
     authors: [String]
-    group: String
-    groups: [String]
+    customGroup: String
+    customGroups: [String]
     privateContent: String @auth(rules: [{ allow: private, provider: oidc, operations: [create, update, read] }])
     publicContent: String @auth(rules: [{ allow: public }])
     ownerContent: String @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id", operations: [update, delete, read] }])
     ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", provider: oidc, identityClaim: "user_id", operations: [create, read] }])
     adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "cognito:groups" }])
-    groupContent: String @auth(rules: [{ allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [update, delete, read] }])
-    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "groups", provider: oidc, groupClaim: "cognito:groups", operations: [create, read] }])
+    groupContent: String @auth(rules: [{ allow: groups, groupsField: "customGroup", provider: oidc, groupClaim: "cognito:groups", operations: [update, delete, read] }])
+    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "customGroups", provider: oidc, groupClaim: "cognito:groups", operations: [create, read] }])
   }
 
   type TodoCustomOwnerContentVarious @model @auth(rules: [{ allow: owner, ownerField: "author", provider: oidc, identityClaim: "user_id" }]) {
@@ -52,42 +52,42 @@ export const schema = `
     id: ID! @primaryKey @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "cognito:groups" }, { allow: private, provider: oidc }, { allow: public }])
     owner: String
     authors: [String]
-    group: String
-    groups: [String]
+    customGroup: String
+    customGroups: [String]
     privateContent: String @auth(rules: [{ allow: private, provider: oidc }])
     publicContent: String @auth(rules: [{ allow: public }])
     ownerContent: String @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id", operations: [update, read] }])
     ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", provider: oidc, identityClaim: "user_id", operations: [create, read] }])
-    groupContent: String @auth(rules: [{ allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [update, delete, read] }])
-    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "groups", provider: oidc, groupClaim: "cognito:groups", operations: [create, read] }])
+    groupContent: String @auth(rules: [{ allow: groups, groupsField: "customGroup", provider: oidc, groupClaim: "cognito:groups", operations: [update, delete, read] }])
+    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "customGroups", provider: oidc, groupClaim: "cognito:groups", operations: [create, read] }])
   }
 
-  type TodoCustomGroupContentVarious @model @auth(rules: [{ allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups" }]) {
-    customId: ID! @primaryKey @auth(rules: [{ allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups" }, { allow: private, provider: oidc }, { allow: public }])
+  type TodoCustomGroupContentVarious @model @auth(rules: [{ allow: groups, groupsField: "customGroup", provider: oidc, groupClaim: "cognito:groups" }]) {
+    customId: ID! @primaryKey @auth(rules: [{ allow: groups, groupsField: "customGroup", provider: oidc, groupClaim: "cognito:groups" }, { allow: private, provider: oidc }, { allow: public }])
     owner: String
     authors: [String]
-    group: String
-    groups: [String]
-    privateContent: String @auth(rules: [{ allow: private, provider: oidc }, { allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
-    publicContent: String @auth(rules: [{ allow: public }, { allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
-    ownerContent: String @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id", operations: [update, read] }, { allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
-    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", provider: oidc, identityClaim: "user_id", operations: [create, read] }, { allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
-    adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "cognito:groups" }, { allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
-    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "groups", provider: oidc, groupClaim: "cognito:groups", operations: [create, read] }, { allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
+    customGroup: String
+    customGroups: [String]
+    privateContent: String @auth(rules: [{ allow: private, provider: oidc }, { allow: groups, groupsField: "customGroup", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
+    publicContent: String @auth(rules: [{ allow: public }, { allow: groups, groupsField: "customGroup", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
+    ownerContent: String @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id", operations: [update, read] }, { allow: groups, groupsField: "customGroup", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
+    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", provider: oidc, identityClaim: "user_id", operations: [create, read] }, { allow: groups, groupsField: "customGroup", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
+    adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "cognito:groups" }, { allow: groups, groupsField: "customGroup", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
+    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "customGroups", provider: oidc, groupClaim: "cognito:groups", operations: [create, read] }, { allow: groups, groupsField: "customGroup", provider: oidc, groupClaim: "cognito:groups", operations: [delete] }])
   }
 
-  type TodoCustomGroupsContentVarious @model @auth(rules: [{ allow: groups, groupsField: "groups", provider: oidc, groupClaim: "cognito:groups" }]) {
-    customId: ID! @primaryKey @auth(rules: [{ allow: groups, groupsField: "groups", provider: oidc, groupClaim: "cognito:groups" }, { allow: private, provider: oidc }, { allow: public }])
+  type TodoCustomGroupsContentVarious @model @auth(rules: [{ allow: groups, groupsField: "customGroups", provider: oidc, groupClaim: "cognito:groups" }]) {
+    customId: ID! @primaryKey @auth(rules: [{ allow: groups, groupsField: "customGroups", provider: oidc, groupClaim: "cognito:groups" }, { allow: private, provider: oidc }, { allow: public }])
     owner: String
     authors: [String]
-    group: String
-    groups: [String]
+    customGroup: String
+    customGroups: [String]
     privateContent: String @auth(rules: [{ allow: private, provider: oidc }])
     publicContent: String @auth(rules: [{ allow: public }])
     ownerContent: String @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "user_id", operations: [update, read] }])
     ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", provider: oidc, identityClaim: "user_id", operations: [create, read] }])
     adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"], provider: oidc, groupClaim: "cognito:groups" }])
-    groupContent: String @auth(rules: [{ allow: groups, groupsField: "group", provider: oidc, groupClaim: "cognito:groups", operations: [update, read] }])
+    groupContent: String @auth(rules: [{ allow: groups, groupsField: "customGroup", provider: oidc, groupClaim: "cognito:groups", operations: [update, read] }])
   }
 `;
 

--- a/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/userpool-provider-fields.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/userpool-provider-fields.ts
@@ -6,20 +6,30 @@ export const schema = `
     id: ID! @primaryKey @auth(rules: [{ allow: private }, { allow: public }])
     owner: String
     authors: [String]
+    group: String
+    groups: [String]
     privateContent: String @auth(rules: [{ allow: private }])
     publicContent: String @auth(rules: [{ allow: public }])
     ownerContent: String @auth(rules: [{ allow: owner, operations: [create, read] }])
     ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", operations: [update, read] }])
+    adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"] }])
+    groupContent: String @auth(rules: [{ allow: groups, groupsField: "group", operations: [create, read] }])
+    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "groups", operations: [update, read] }])
   }
 
   type TodoOwnerContentVarious @model @auth(rules: [{ allow: owner }]) {
     id: ID! @primaryKey @auth(rules: [{ allow: owner }, { allow: private }, { allow: public }])
     owner: String
     authors: [String]
+    group: String
+    groups: [String]
     privateContent: String @auth(rules: [{ allow: private, operations: [create, update, read] }])
     publicContent: String @auth(rules: [{ allow: public }])
     ownerContent: String @auth(rules: [{ allow: owner, operations: [update, delete, read] }])
     ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", operations: [create, read] }])
+    adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"] }])
+    groupContent: String @auth(rules: [{ allow: groups, groupsField: "group", operations: [update, delete, read] }])
+    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "groups", operations: [create, read] }])
   }
 
   type TodoCustomOwnerContentVarious @model @auth(rules: [{ allow: owner, ownerField: "author" }]) {
@@ -42,34 +52,42 @@ export const schema = `
     id: ID! @primaryKey @auth(rules: [{ allow: groups, groups: ["Admin"] }, { allow: private }, { allow: public }])
     owner: String
     authors: [String]
+    group: String
+    groups: [String]
     privateContent: String @auth(rules: [{ allow: private }])
     publicContent: String @auth(rules: [{ allow: public }])
-    ownerContent: String @auth(rules: [{ allow: owner }])
-    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors" }])
+    ownerContent: String @auth(rules: [{ allow: owner, operations: [update, read] }])
+    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", operations: [create, read] }])
+    groupContent: String @auth(rules: [{ allow: groups, groupsField: "group", operations: [update, delete, read] }])
+    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "groups", operations: [create, read] }])
   }
 
-  type TodoCustomGroupContentVarious @model @auth(rules: [{ allow: groups, groupsField: "customGroup" }]) {
-    customId: ID! @primaryKey @auth(rules: [{ allow: groups, groupsField: "customGroup" }, { allow: private }, { allow: public }])
+  type TodoCustomGroupContentVarious @model @auth(rules: [{ allow: groups, groupsField: "group" }]) {
+    customId: ID! @primaryKey @auth(rules: [{ allow: groups, groupsField: "group" }, { allow: private }, { allow: public }])
     owner: String
     authors: [String]
-    customGroup: String
-    privateContent: String @auth(rules: [{ allow: private }])
-    publicContent: String @auth(rules: [{ allow: public }])
-    ownerContent: String @auth(rules: [{ allow: owner }])
-    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors" }])
-    adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"] }])
+    group: String
+    groups: [String]
+    privateContent: String @auth(rules: [{ allow: private }, { allow: groups, groupsField: "group", operations: [delete] }])
+    publicContent: String @auth(rules: [{ allow: public }, { allow: groups, groupsField: "group", operations: [delete] }])
+    ownerContent: String @auth(rules: [{ allow: owner, operations: [update, read] }, { allow: groups, groupsField: "group", operations: [delete] }])
+    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", operations: [create, read] }, { allow: groups, groupsField: "group", operations: [delete] }])
+    adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"] }, { allow: groups, groupsField: "group", operations: [delete] }])
+    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "groups", operations: [create, read] }, { allow: groups, groupsField: "group", operations: [delete] }])
   }
 
-  type TodoCustomGroupsContentVarious @model @auth(rules: [{ allow: groups, groupsField: "customGroups" }]) {
-    customId: ID! @primaryKey @auth(rules: [{ allow: groups, groupsField: "customGroups" }, { allow: private }, { allow: public }])
+  type TodoCustomGroupsContentVarious @model @auth(rules: [{ allow: groups, groupsField: "groups" }]) {
+    customId: ID! @primaryKey @auth(rules: [{ allow: groups, groupsField: "groups" }, { allow: private }, { allow: public }])
     owner: String
     authors: [String]
-    customGroups: [String]
+    group: String
+    groups: [String]
     privateContent: String @auth(rules: [{ allow: private }])
     publicContent: String @auth(rules: [{ allow: public }])
-    ownerContent: String @auth(rules: [{ allow: owner }])
-    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors" }])
+    ownerContent: String @auth(rules: [{ allow: owner, operations: [update, read] }])
+    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", operations: [create, read] }])
     adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"] }])
+    groupContent: String @auth(rules: [{ allow: groups, groupsField: "group", operations: [update, read] }])
   }
 `;
 

--- a/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/userpool-provider-fields.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/userpool-provider-fields.ts
@@ -6,30 +6,30 @@ export const schema = `
     id: ID! @primaryKey @auth(rules: [{ allow: private }, { allow: public }])
     owner: String
     authors: [String]
-    group: String
-    groups: [String]
+    customGroup: String
+    customGroups: [String]
     privateContent: String @auth(rules: [{ allow: private }])
     publicContent: String @auth(rules: [{ allow: public }])
     ownerContent: String @auth(rules: [{ allow: owner, operations: [create, read] }])
     ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", operations: [update, read] }])
     adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"] }])
-    groupContent: String @auth(rules: [{ allow: groups, groupsField: "group", operations: [create, read] }])
-    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "groups", operations: [update, read] }])
+    groupContent: String @auth(rules: [{ allow: groups, groupsField: "customGroup", operations: [create, read] }])
+    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "customGroups", operations: [update, read] }])
   }
 
   type TodoOwnerContentVarious @model @auth(rules: [{ allow: owner }]) {
     id: ID! @primaryKey @auth(rules: [{ allow: owner }, { allow: private }, { allow: public }])
     owner: String
     authors: [String]
-    group: String
-    groups: [String]
+    customGroup: String
+    customGroups: [String]
     privateContent: String @auth(rules: [{ allow: private, operations: [create, update, read] }])
     publicContent: String @auth(rules: [{ allow: public }])
     ownerContent: String @auth(rules: [{ allow: owner, operations: [update, delete, read] }])
     ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", operations: [create, read] }])
     adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"] }])
-    groupContent: String @auth(rules: [{ allow: groups, groupsField: "group", operations: [update, delete, read] }])
-    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "groups", operations: [create, read] }])
+    groupContent: String @auth(rules: [{ allow: groups, groupsField: "customGroup", operations: [update, delete, read] }])
+    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "customGroups", operations: [create, read] }])
   }
 
   type TodoCustomOwnerContentVarious @model @auth(rules: [{ allow: owner, ownerField: "author" }]) {
@@ -52,42 +52,42 @@ export const schema = `
     id: ID! @primaryKey @auth(rules: [{ allow: groups, groups: ["Admin"] }, { allow: private }, { allow: public }])
     owner: String
     authors: [String]
-    group: String
-    groups: [String]
+    customGroup: String
+    customGroups: [String]
     privateContent: String @auth(rules: [{ allow: private }])
     publicContent: String @auth(rules: [{ allow: public }])
     ownerContent: String @auth(rules: [{ allow: owner, operations: [update, read] }])
     ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", operations: [create, read] }])
-    groupContent: String @auth(rules: [{ allow: groups, groupsField: "group", operations: [update, delete, read] }])
-    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "groups", operations: [create, read] }])
+    groupContent: String @auth(rules: [{ allow: groups, groupsField: "customGroup", operations: [update, delete, read] }])
+    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "customGroups", operations: [create, read] }])
   }
 
-  type TodoCustomGroupContentVarious @model @auth(rules: [{ allow: groups, groupsField: "group" }]) {
-    customId: ID! @primaryKey @auth(rules: [{ allow: groups, groupsField: "group" }, { allow: private }, { allow: public }])
+  type TodoCustomGroupContentVarious @model @auth(rules: [{ allow: groups, groupsField: "customGroup" }]) {
+    customId: ID! @primaryKey @auth(rules: [{ allow: groups, groupsField: "customGroup" }, { allow: private }, { allow: public }])
     owner: String
     authors: [String]
-    group: String
-    groups: [String]
-    privateContent: String @auth(rules: [{ allow: private }, { allow: groups, groupsField: "group", operations: [delete] }])
-    publicContent: String @auth(rules: [{ allow: public }, { allow: groups, groupsField: "group", operations: [delete] }])
-    ownerContent: String @auth(rules: [{ allow: owner, operations: [update, read] }, { allow: groups, groupsField: "group", operations: [delete] }])
-    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", operations: [create, read] }, { allow: groups, groupsField: "group", operations: [delete] }])
-    adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"] }, { allow: groups, groupsField: "group", operations: [delete] }])
-    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "groups", operations: [create, read] }, { allow: groups, groupsField: "group", operations: [delete] }])
+    customGroup: String
+    customGroups: [String]
+    privateContent: String @auth(rules: [{ allow: private }, { allow: groups, groupsField: "customGroup", operations: [delete] }])
+    publicContent: String @auth(rules: [{ allow: public }, { allow: groups, groupsField: "customGroup", operations: [delete] }])
+    ownerContent: String @auth(rules: [{ allow: owner, operations: [update, read] }, { allow: groups, groupsField: "customGroup", operations: [delete] }])
+    ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", operations: [create, read] }, { allow: groups, groupsField: "customGroup", operations: [delete] }])
+    adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"] }, { allow: groups, groupsField: "customGroup", operations: [delete] }])
+    groupsContent: String @auth(rules: [{ allow: groups, groupsField: "customGroups", operations: [create, read] }, { allow: groups, groupsField: "customGroup", operations: [delete] }])
   }
 
-  type TodoCustomGroupsContentVarious @model @auth(rules: [{ allow: groups, groupsField: "groups" }]) {
-    customId: ID! @primaryKey @auth(rules: [{ allow: groups, groupsField: "groups" }, { allow: private }, { allow: public }])
+  type TodoCustomGroupsContentVarious @model @auth(rules: [{ allow: groups, groupsField: "customGroups" }]) {
+    customId: ID! @primaryKey @auth(rules: [{ allow: groups, groupsField: "customGroups" }, { allow: private }, { allow: public }])
     owner: String
     authors: [String]
-    group: String
-    groups: [String]
+    customGroup: String
+    customGroups: [String]
     privateContent: String @auth(rules: [{ allow: private }])
     publicContent: String @auth(rules: [{ allow: public }])
     ownerContent: String @auth(rules: [{ allow: owner, operations: [update, read] }])
     ownersContent: String @auth(rules: [{ allow: owner, ownerField: "authors", operations: [create, read] }])
     adminContent: String @auth(rules: [{ allow: groups, groups: ["Admin"] }])
-    groupContent: String @auth(rules: [{ allow: groups, groupsField: "group", operations: [update, read] }])
+    groupContent: String @auth(rules: [{ allow: groups, groupsField: "customGroup", operations: [update, read] }])
   }
 `;
 

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-oidc-fields.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-oidc-fields.ts
@@ -184,7 +184,11 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       const todo = {
         privateContent: 'Private Content',
         ownerContent: 'Owner Content',
+        adminContent: 'Admin Content',
+        groupContent: 'Group Content',
         authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
       };
       const createResultSetName = `create${modelName}`;
       const updateResultSetName = `update${modelName}`;
@@ -192,8 +196,12 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           id
           owner
           authors
+          group
+          groups
           privateContent
           ownerContent
+          adminContent
+          groupContent
         `;
 
       // owner(user1) creates a record with only allowed fields
@@ -202,34 +210,66 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       todo['id'] = createResult1.data[createResultSetName].id;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      expectNullFields(createResult1.data[createResultSetName], ['owner', 'authors', 'privateContent', 'ownerContent']);
+      expectNullFields(createResult1.data[createResultSetName], [
+        'owner',
+        'authors',
+        'group',
+        'groups',
+        'privateContent',
+        'ownerContent',
+        'adminContent',
+        'groupContent',
+      ]);
 
       // user1 can update the allowed fields and add user2 to dyamic owners list field
       const todoUpdated1 = {
         id: todo['id'],
         authors: [userName1, userName2],
+        groups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
+        ownersContent: 'Owners Content updated',
+        adminContent: 'Admin Content updated',
+        groupsContent: 'Groups Content updated',
       };
       const user1UpdateAllowedSet = `
           id
           owner
           authors
+          group
+          groups
           privateContent
           ownersContent
+          adminContent
+          groupsContent
         `;
       const updateResult1 = await user1TodoHelper.update(updateResultSetName, todoUpdated1, user1UpdateAllowedSet);
       expect(updateResult1.data[updateResultSetName].id).toEqual(todo['id']);
-      expectNullFields(updateResult1.data[updateResultSetName], ['owner', 'authors', 'privateContent', 'ownersContent']);
+      expectNullFields(updateResult1.data[updateResultSetName], [
+        'owner',
+        'authors',
+        'group',
+        'groups',
+        'privateContent',
+        'ownersContent',
+        'adminContent',
+        'groupsContent',
+      ]);
 
       // user1 can read the allowed fields
-      const user1ReadAllowedSet = `
-          id
-          owner
-          authors
-          privateContent
-          ownerContent
-          ownersContent
-        `;
+      const completeResultSet = `
+        id
+        owner
+        authors
+        group
+        groups
+        privateContent
+        ownerContent
+        ownersContent
+        adminContent
+        groupContent
+        groupsContent
+      `;
+      const user1ReadAllowedSet = completeResultSet;
       const getResult1 = await user1TodoHelper.get(
         {
           id: todo['id'],
@@ -237,7 +277,7 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         user1ReadAllowedSet,
         false,
       );
-      checkOperationResult(getResult1, { ...todo, ...todoUpdated1, ownersContent: null }, `get${modelName}`);
+      checkOperationResult(getResult1, { ...todo, ...todoUpdated1 }, `get${modelName}`);
 
       const listTodosResult1 = await user1TodoHelper.list({}, user1ReadAllowedSet, `list${modelName}`, false, 'all');
       checkListItemExistence(listTodosResult1, `list${modelName}`, todo['id'], true);
@@ -247,19 +287,33 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         id: todo['id'],
         owner: todo['owner'],
         authors: [userName2],
+        group: devGroupName,
+        groups: [devGroupName],
         privateContent: 'Private Content updated 1',
         ownersContent: 'Owners Content updated 1',
+        groupsContent: 'Groups Content updated 1',
       };
       const user2UpdateAllowedSet = `
           id
           owner
           authors
+          group
+          groups
           privateContent
           ownersContent
+          groupsContent
         `;
       const updateResult2 = await user2TodoHelper.update(updateResultSetName, todoUpdated2, user2UpdateAllowedSet);
       expect(updateResult2.data[updateResultSetName].id).toEqual(todo['id']);
-      expectNullFields(updateResult2.data[updateResultSetName], ['owner', 'authors', 'privateContent', 'ownersContent']);
+      expectNullFields(updateResult2.data[updateResultSetName], [
+        'owner',
+        'authors',
+        'group',
+        'groups',
+        'privateContent',
+        'ownersContent',
+        'groupsContent',
+      ]);
 
       // user2 can read the allowed fields
       const user2ReadAllowedSet = user2UpdateAllowedSet;
@@ -290,6 +344,7 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         id: todoRandom.id,
         owner: userName1,
         privateContent: 'Private Content updated',
+        adminContent: 'Admin Content updated',
       };
       const subscriberClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName2]);
       const subTodoHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
@@ -306,11 +361,16 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         false,
       );
       expect(onCreateSubscriptionResult).toHaveLength(1);
-      checkOperationResult(
-        onCreateSubscriptionResult[0],
-        { ...todoRandom, owner: null, authors: null, privateContent: null, ownerContent: null },
-        `onCreate${modelName}`,
-      );
+      expectNullFields(onCreateSubscriptionResult[0].data[`onCreate${modelName}`], [
+        'owner',
+        'authors',
+        'group',
+        'groups',
+        'privateContent',
+        'ownerContent',
+        'adminContent',
+        'groupContent',
+      ]);
 
       const onUpdateSubscriptionResult = await subTodoHelper.subscribe(
         'onUpdate',
@@ -320,15 +380,20 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           },
         ],
         {},
-        user2UpdateAllowedSet,
+        user1UpdateAllowedSet,
         false,
       );
       expect(onUpdateSubscriptionResult).toHaveLength(1);
-      checkOperationResult(
-        onUpdateSubscriptionResult[0],
-        { ...todoRandomUpdated, owner: null, authors: null, privateContent: null, ownersContent: null },
-        `onUpdate${modelName}`,
-      );
+      expectNullFields(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`], [
+        'owner',
+        'authors',
+        'group',
+        'groups',
+        'privateContent',
+        'ownersContent',
+        'adminContent',
+        'groupsContent',
+      ]);
 
       const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [], {}, user1UpdateAllowedSet, false);
       expect(onDeleteSubscriptionResult).toHaveLength(0);
@@ -342,6 +407,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       const todoPrivateFields = {
         owner: userName1,
         authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
         privateContent: 'Private Content',
       };
       const createResultSetName = `create${modelName}`;
@@ -350,6 +417,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           id
           owner
           authors
+          group
+          groups
           privateContent
         `;
 
@@ -363,20 +432,28 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         async () => await user1TodoHelper.create(createResultSetName, { ...todoPrivateFields, ownersContent: 'Owners Content' }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
 
+      // cannot create a record with dynamic groups list protected field that does not allow create operation
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todoPrivateFields, groupsContent: 'Groups Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+
       // Create a record with allowed fields, so we can test the update and delete operations.
       const user1CreateAllowedSet = `
           ${privateResultSet}
           ownerContent
+          adminContent
+          groupContent
         `;
       const createResult1 = await user1TodoHelper.create(
         createResultSetName,
-        { ...todoPrivateFields, ownerContent: 'Owner Content' },
+        { ...todoPrivateFields, ownerContent: 'Owner Content', adminContent: 'Admin Content', groupContent: 'Group Content' },
         user1CreateAllowedSet,
       );
       expect(createResult1.data[createResultSetName].id).toBeDefined();
       todoPrivateFields['id'] = createResult1.data[createResultSetName].id;
       // protected fields are nullified in mutation responses
-      expectNullFields(createResult1.data[createResultSetName], ['owner', 'authors', 'privateContent', 'ownerContent']);
+      const nulledPrivateFields = ['owner', 'authors', 'group', 'groups', 'privateContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledPrivateFields, 'ownerContent', 'adminContent', 'groupContent']);
 
       const privateAndPublicSet = `
           ${privateResultSet}
@@ -398,16 +475,35 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           await user1TodoHelper.update(updateResultSetName, { ...todoPrivateFields, ownerContent: 'Owner Content' }, privateAndOwnerSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
-      /* todo: enable once fixed in auth utils
-        const privateAndOwnersSet = `
+      const privateAndOwnersSet = `
+        ${privateResultSet}
+        ownersContent
+      `;
+      // non-owner cannot update a record with dynamic owner list protected field
+      await expect(
+        async () =>
+          await user2TodoHelper.update(updateResultSetName, { ...todoPrivateFields, ownersContent: 'Owners Content' }, privateAndOwnersSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      const privateAndGroupSet = `
           ${privateResultSet}
-          ownersContent
+          groupContent
         `;
-        // non-owner cannot update a record with dynamic owner list protected field
-        await expect(async () => await user2TodoHelper.update(updateResultSetName, { ...todoPrivateFields, ownersContent: 'Owners Content'}, privateAndOwnersSet)).rejects.toThrowErrorMatchingInlineSnapshot(
-          expectedOperationError(updateResultSetName, 'Mutation'),
-        );
-        */
+      // cannot update a record with group protected field that does not allow update operation
+      await expect(
+        async () =>
+          await user1TodoHelper.update(updateResultSetName, { ...todoPrivateFields, groupContent: 'Group Content' }, privateAndGroupSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      const privateAndGroupsSet = `
+        ${privateResultSet}
+        groupsContent
+      `;
+      // non-owner cannot update a record with dynamic group list protected field
+      await expect(
+        async () =>
+          await user2TodoHelper.update(updateResultSetName, { ...todoPrivateFields, groupsContent: 'Groups Content' }, privateAndGroupsSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // cannot read a record with public protected field
       const getResult1 = await user1TodoHelper.get({ id: todoPrivateFields['id'] }, privateAndPublicSet, false, 'all');
@@ -423,24 +519,24 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       checkListItemExistence(listTodosResult1, `list${modelName}`, todoPrivateFields['id'], true);
       checkListResponseErrors(listTodosResult1, expectedFieldErrors(['publicContent'], modelName, false));
 
-      // non-owner cannot read owner's records
-      const privateAndAllOwnersSet = `
+      // non-owner or user not part of allowed groups cannot read owner, group protected fields
+      const ownerAndGroupFields = ['ownerContent', 'ownersContent', 'adminContent', 'groupContent', 'groupsContent'];
+      const nonPublicSet = `
         ${privateResultSet}
-        ownerContent
-        ownersContent
+        ${ownerAndGroupFields.join('\n')}
       `;
-      const getResult2 = await user2TodoHelper.get({ id: todoPrivateFields['id'] }, privateAndAllOwnersSet, false, 'all');
+      const getResult2 = await user2TodoHelper.get({ id: todoPrivateFields['id'] }, nonPublicSet, false, 'all');
       checkOperationResult(
         getResult2,
-        { ...todoPrivateFields, ownerContent: null, ownersContent: null },
+        { ...todoPrivateFields, ownerContent: null, ownersContent: null, adminContent: null, groupContent: null, groupsContent: null },
         `get${modelName}`,
         false,
-        expectedFieldErrors(['ownerContent', 'ownersContent'], modelName),
+        expectedFieldErrors(ownerAndGroupFields, modelName),
       );
 
-      const listTodosResult2 = await user2TodoHelper.list({}, privateAndAllOwnersSet, `list${modelName}`, false, 'all');
+      const listTodosResult2 = await user2TodoHelper.list({}, nonPublicSet, `list${modelName}`, false, 'all');
       checkListItemExistence(listTodosResult2, `list${modelName}`, todoPrivateFields['id'], true);
-      checkListResponseErrors(listTodosResult2, expectedFieldErrors(['ownerContent', 'ownersContent'], modelName, false));
+      checkListResponseErrors(listTodosResult2, expectedFieldErrors(ownerAndGroupFields, modelName, false));
     });
 
     test('Owner model auth and allowed field operations', async () => {
@@ -450,8 +546,12 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
 
       const todo = {
         authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
+        adminContent: 'Admin Content',
+        groupsContent: 'Groups Content',
       };
       const createResultSetName = `create${modelName}`;
       const updateResultSetName = `update${modelName}`;
@@ -463,51 +563,65 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ${privateResultSet}
           owner
           authors
+          group
+          groups
         `;
-      const setWithOwnerContent = `
+      const adminOwnerResultSet = `
           ${ownerResultSet}
+          adminContent
+        `;
+      const setWithOwnerAndGroupContent = `
+          ${adminOwnerResultSet}
           ownerContent
+          groupContent
         `;
-      const setWithOwnersContent = `
-          ${ownerResultSet}
+      const setWithOwnersAndGroupsContent = `
+          ${adminOwnerResultSet}
           ownersContent
+          groupsContent
         `;
-      const completeOwnerResultSet = `
-          ${ownerResultSet}
+      const completeResultSet = `
+          ${adminOwnerResultSet}
           ownerContent
           ownersContent
+          groupContent
+          groupsContent
         `;
 
       // owner(user1) creates a record with only allowed fields
-      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersContent);
+      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersAndGroupsContent);
       expect(createResult1.data[createResultSetName].id).toBeDefined();
       todo['id'] = createResult1.data[createResultSetName].id;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      expectNullFields(createResult1.data[createResultSetName], ['owner', 'authors', 'privateContent', 'ownersContent']);
+      const nulledOwnerFields = ['owner', 'authors', 'group', 'groups', 'privateContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledOwnerFields, 'ownersContent', 'groupsContent']);
 
       // user1 can update the allowed fields and add user2 to dyamic owners list field
       const todoUpdated1 = {
         id: todo['id'],
         authors: [userName1, userName2],
+        groups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
         ownerContent: 'Owner Content',
+        adminContent: 'Admin Content updated',
+        groupContent: 'Group Content',
       };
-      const updateResult1 = await user1TodoHelper.update(updateResultSetName, todoUpdated1, setWithOwnerContent);
+      const updateResult1 = await user1TodoHelper.update(updateResultSetName, todoUpdated1, setWithOwnerAndGroupContent);
       expect(updateResult1.data[updateResultSetName].id).toEqual(todo['id']);
-      expectNullFields(updateResult1.data[updateResultSetName], ['owner', 'authors', 'privateContent', 'ownerContent']);
+      expectNullFields(updateResult1.data[updateResultSetName], [...nulledOwnerFields, 'ownerContent', 'groupContent']);
 
       // user1 can read the allowed fields
       const getResult1 = await user1TodoHelper.get(
         {
           id: todo['id'],
         },
-        completeOwnerResultSet,
+        completeResultSet,
         false,
       );
       checkOperationResult(getResult1, { ...todo, ...todoUpdated1 }, `get${modelName}`);
 
-      const listTodosResult1 = await user1TodoHelper.list({}, completeOwnerResultSet, `list${modelName}`, false, 'all');
+      const listTodosResult1 = await user1TodoHelper.list({}, completeResultSet, `list${modelName}`, false, 'all');
       checkListItemExistence(listTodosResult1, `list${modelName}`, todo['id'], true);
 
       // unless one has delete access to all fields in the model, delete is expected to fail
@@ -515,22 +629,21 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         async () => await user1TodoHelper.delete(`delete${modelName}`, { id: todo['id'] }, privateResultSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(`delete${modelName}`, 'Mutation'));
 
-      /* todo: enable once fixed in auth utils
-        // user2 can update the private field
-        const todoUpdated2 = {
-          id: todo['id'],
-          privateContent: 'Private Content updated 1',
-        };
-        const updateResult2 = await user2TodoHelper.update(updateResultSetName, todoUpdated2, privateResultSet);
-        expect(updateResult2.data[updateResultSetName].id).toEqual(todo['id']);
-        expectNullFields(updateResult2.data[updateResultSetName], ['privateContent']);
-        */
+      // user2 can update the private field
+      const todoUpdated2 = {
+        id: todo['id'],
+        privateContent: 'Private Content updated 1',
+      };
+      const updateResult2 = await user2TodoHelper.update(updateResultSetName, todoUpdated2, privateResultSet);
+      expect(updateResult2.data[updateResultSetName].id).toEqual(todo['id']);
+      expectNullFields(updateResult2.data[updateResultSetName], ['privateContent']);
 
       // user2 can read the allowed fields
       const user2ReadAllowedSet = `
           id
           privateContent
           ownersContent
+          groupsContent
         `;
       const getResult2 = await user2TodoHelper.get(
         {
@@ -543,8 +656,9 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         getResult2,
         {
           id: todo['id'],
-          privateContent: todoUpdated1['privateContent'],
+          privateContent: todoUpdated2['privateContent'],
           ownersContent: todo['ownersContent'],
+          groupsContent: todo['groupsContent'],
         },
         `get${modelName}`,
       );
@@ -570,17 +684,27 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         'onCreate',
         [
           async () => {
-            await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersContent);
+            await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersAndGroupsContent);
           },
         ],
         {},
-        setWithOwnersContent,
+        setWithOwnersAndGroupsContent,
         false,
       );
       expect(onCreateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
         onCreateSubscriptionResult[0],
-        { ...todoRandom, owner: null, authors: null, privateContent: null, ownersContent: null },
+        {
+          ...todoRandom,
+          owner: null,
+          authors: null,
+          group: null,
+          groups: null,
+          privateContent: null,
+          adminContent: null,
+          ownersContent: null,
+          groupsContent: null,
+        },
         `onCreate${modelName}`,
       );
 
@@ -588,33 +712,47 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         'onUpdate',
         [
           async () => {
-            await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerContent);
+            await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerAndGroupContent);
           },
         ],
         {},
-        setWithOwnerContent,
+        setWithOwnerAndGroupContent,
         false,
       );
       expect(onUpdateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
         onUpdateSubscriptionResult[0],
-        { ...todoRandomUpdated, owner: null, authors: null, privateContent: null, ownerContent: null },
+        {
+          ...todoRandomUpdated,
+          owner: null,
+          authors: null,
+          group: null,
+          groups: null,
+          privateContent: null,
+          adminContent: null,
+          ownerContent: null,
+          groupContent: null,
+        },
         `onUpdate${modelName}`,
       );
 
-      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [], {}, setWithOwnersContent, false);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [], {}, setWithOwnersAndGroupsContent, false);
       expect(onDeleteSubscriptionResult).toHaveLength(0);
     });
 
-    test('Owner model auth with restricted field operations', async () => {
+    test('Owner model auth and restricted field operations', async () => {
       const modelName = 'TodoOwnerContentVarious';
       const user1TodoHelper = user1ModelOperationHelpers[modelName];
       const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
       const todo = {
         authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
+        adminContent: 'Admin Content',
+        groupsContent: 'Groups Content',
       };
       const createResultSetName = `create${modelName}`;
       const updateResultSetName = `update${modelName}`;
@@ -626,40 +764,59 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ${privateResultSet}
           owner
           authors
+          group
+          groups
         `;
-      const setWithOwnerContent = `
+      const adminOwnerResultSet = `
           ${ownerResultSet}
+          adminContent
+        `;
+      const setWithOwnerAndGroupContent = `
+          ${adminOwnerResultSet}
           ownerContent
+          groupContent
         `;
-      const setWithOwnersContent = `
-          ${ownerResultSet}
+      const setWithOwnersAndGroupsContent = `
+          ${adminOwnerResultSet}
           ownersContent
+          groupsContent
+        `;
+      const completeResultSet = `
+          ${adminOwnerResultSet}
+          ownerContent
+          ownersContent
+          groupContent
+          groupsContent
         `;
 
-      /* todo: enable once fixed in auth utils
-        // user1 cannot create a record by specifying user2 as the owner
-        await expect(async () => await user1TodoHelper.create(createResultSetName, { ...todo, owner: 'user2' })).rejects.toThrowErrorMatchingInlineSnapshot(
-          expectedOperationError(createResultSetName, 'Mutation'),
-        );
-        */
+      // user1 cannot create a record by specifying user2 as the owner
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, owner: 'user2' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
 
       // user cannot create a record with public protected field
       await expect(
         async () => await user1TodoHelper.create(createResultSetName, { ...todo, publicContent: 'Public Content' }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
 
-      // user cannot create a record with a field that is protected and does not allow create operation
+      // user cannot create a record with a owner protected field that does not allow create operation
       await expect(
         async () => await user1TodoHelper.create(createResultSetName, { ...todo, ownerContent: 'Owner Content' }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
 
+      // user cannot create a record with a group protected field that does not allow create operation
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, groupContent: 'Group Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+
       // Create a record with allowed fields, so we can test the update and delete operations.
-      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersContent);
+      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersAndGroupsContent);
       expect(createResult1.data[createResultSetName].id).toBeDefined();
       todo['id'] = createResult1.data[createResultSetName].id;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      expectNullFields(createResult1.data[createResultSetName], ['owner', 'authors', 'privateContent', 'ownersContent']);
+      const nulledOwnerFields = ['owner', 'authors', 'group', 'groups', 'privateContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledOwnerFields, 'ownersContent']);
 
       const publicFieldSet = `
           id
@@ -670,9 +827,14 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         async () => await user1TodoHelper.update(updateResultSetName, { id: todo['id'], publicContent: 'Public Content' }, publicFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
-      // owner cannot update a record with a protected field that does not allow update operation
+      // owner cannot update a record with dynamic list of owners protected field that does not allow update operation
       await expect(
         async () => await user1TodoHelper.update(updateResultSetName, { ...todo, ownersContent: 'Owners Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // owner cannot update a record with dynamic list of groups protected field that does not allow update operation
+      await expect(
+        async () => await user1TodoHelper.update(updateResultSetName, { ...todo, groupsContent: 'Groups Content' }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // non-owner cannot update a record to re-assign ownership
@@ -693,6 +855,24 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], authors: ['user2'] }, ownersFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
+      // non-owner cannot update a record to re-assign group membership
+      const groupFieldSet = `
+          id
+          group
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], group: devGroupName }, groupFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // non-owner cannot update a record to re-assign group memberships stored as dynamic list
+      const groupsFieldSet = `
+          id
+          groups
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], groups: [devGroupName] }, groupsFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
       // non-owner cannot update a record with an owner protected field
       const ownerContentFieldSet = `
           id
@@ -700,6 +880,15 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         `;
       await expect(
         async () => await user2TodoHelper.update(updateResultSetName, { ...todo, ownerContent: 'Owner Content' }, ownerContentFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // non-member of group cannot update a record with a group protected field
+      const groupContentFieldSet = `
+          id
+          groupContent
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { ...todo, groupContent: 'Group Content' }, groupContentFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // owner cannot read a record with public protected field
@@ -716,29 +905,51 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       checkListItemExistence(listTodosResult1, `list${modelName}`, todo['id'], true);
       checkListResponseErrors(listTodosResult1, expectedFieldErrors(['publicContent'], modelName, false));
 
-      // non-owner cannot read a record with owner protected fields in the selection set
+      // non-owner cannot read a record with owner and group protected fields in the selection set
       const ownerReadFieldSet = `
         id
         owner
         authors
+        group
+        groups
         ownerContent
         ownersContent
+        adminContent
+        groupContent
+        groupsContent
       `;
       const getResult2 = await user2TodoHelper.get({ id: todo['id'] }, ownerReadFieldSet, false, 'all');
+      const expectedReadErrorFields = [
+        'owner',
+        'authors',
+        'ownerContent',
+        'ownersContent',
+        'adminContent',
+        'groupContent',
+        'groupsContent',
+      ];
       checkOperationResult(
         getResult2,
-        { id: todo['id'], owner: null, authors: null, ownerContent: null, ownersContent: null },
+        {
+          id: todo['id'],
+          owner: null,
+          authors: null,
+          group: null,
+          groups: null,
+          ownerContent: null,
+          ownersContent: null,
+          adminContent: null,
+          groupContent: null,
+          groupsContent: null,
+        },
         `get${modelName}`,
         false,
-        expectedFieldErrors(['owner', 'authors', 'ownerContent', 'ownersContent'], modelName),
+        expectedFieldErrors(expectedReadErrorFields, modelName),
       );
 
       const listTodosResult2 = await user2TodoHelper.list({}, ownerReadFieldSet, `list${modelName}`, false, 'all');
       checkListItemExistence(listTodosResult2, `list${modelName}`, todo['id'], true);
-      checkListResponseErrors(
-        listTodosResult2,
-        expectedFieldErrors(['owner', 'authors', 'ownerContent', 'ownersContent'], modelName, false),
-      );
+      checkListResponseErrors(listTodosResult2, expectedFieldErrors(expectedReadErrorFields, modelName, false));
 
       // non-owner cannot listen to updates on owner protected fields
       const todoRandom = {
@@ -750,41 +961,29 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         owner: userName1,
         privateContent: 'Private Content updated',
         ownerContent: 'Owner Content updated',
+        groupContent: 'Group Content updated',
       };
       const subscriberClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName2]);
       const subTodoHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
 
       const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
         async () => {
-          await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersContent);
+          await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersAndGroupsContent);
         },
       ]);
+      const expectedSubscriptionNullFields = [...expectedReadErrorFields, 'privateContent', 'publicContent'];
       expect(onCreateSubscriptionResult).toHaveLength(1);
       expect(onCreateSubscriptionResult[0].data[`onCreate${modelName}`].id).toEqual(todoRandom.id);
-      expectNullFields(onCreateSubscriptionResult[0].data[`onCreate${modelName}`], [
-        'owner',
-        'authors',
-        'privateContent',
-        'publicContent',
-        'ownerContent',
-        'ownersContent',
-      ]);
+      expectNullFields(onCreateSubscriptionResult[0].data[`onCreate${modelName}`], expectedSubscriptionNullFields);
 
       const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
         async () => {
-          await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerContent);
+          await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerAndGroupContent);
         },
       ]);
       expect(onUpdateSubscriptionResult).toHaveLength(1);
       expect(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`].id).toEqual(todoRandom.id);
-      expectNullFields(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`], [
-        'owner',
-        'authors',
-        'privateContent',
-        'publicContent',
-        'ownerContent',
-        'ownersContent',
-      ]);
+      expectNullFields(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`], expectedSubscriptionNullFields);
 
       const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', []);
       expect(onDeleteSubscriptionResult).toHaveLength(0);
@@ -849,17 +1048,14 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       const listTodosResult1 = await user1TodoHelper.list({}, completeOwnerResultSet, `list${modelName}`, false, 'all');
       checkListItemExistence(listTodosResult1, `list${modelName}`, todo['customId'], true, 'customId');
 
-      /* todo: enable once fixed in auth utils
-  
-        // user2 can update the private field
-        const todoUpdated2 = {
-          customId: todo['customId'],
-          privateContent: 'Private Content updated 1',
-        };
-        const updateResult2 = await user2TodoHelper.update(updateResultSetName, todoUpdated2, privateResultSet);
-        expect(updateResult2.data[updateResultSetName].customId).toEqual(todo['customId']);
-        expectNullFields(updateResult2.data[updateResultSetName], ['privateContent']);
-        */
+      // user2 can update the private field
+      const todoUpdated2 = {
+        customId: todo['customId'],
+        privateContent: 'Private Content updated 1',
+      };
+      const updateResult2 = await user2TodoHelper.update(updateResultSetName, todoUpdated2, privateResultSet);
+      expect(updateResult2.data[updateResultSetName].customId).toEqual(todo['customId']);
+      expectNullFields(updateResult2.data[updateResultSetName], ['privateContent']);
 
       // user2 can read the allowed fields
       const getResult2 = await user2TodoHelper.get(
@@ -875,7 +1071,7 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         getResult2,
         {
           customId: todo['customId'],
-          privateContent: todoUpdated1['privateContent'],
+          privateContent: todoUpdated2['privateContent'],
         },
         `get${modelName}`,
       );
@@ -883,11 +1079,13 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       const listTodosResult2 = await user2TodoHelper.list({}, privateResultSet, `list${modelName}`, false, 'all');
       checkListItemExistence(listTodosResult2, `list${modelName}`, todo['customId'], true, 'customId');
 
-      /* todo: enable once fixed in auth utils
-        // user1 can delete the record
-        const deleteResult1 = await user1TodoHelper.delete(deleteResultSetName, { customId: todo['customId'] }, completeOwnerResultSet);
-        checkOperationResult(deleteResult1, { ...todo, ...todoUpdated1, privateContent: null, ownerContent: null }, deleteResultSetName);
-        */
+      // user1 can delete the record
+      const deleteResult1 = await user1TodoHelper.delete(deleteResultSetName, { customId: todo['customId'] }, completeOwnerResultSet);
+      checkOperationResult(
+        deleteResult1,
+        { ...todo, ...todoUpdated1, privateContent: null, ownerContent: null, author: null },
+        deleteResultSetName,
+      );
 
       // owner(user1) can listen to updates on allowed fields
       const todoRandom = {
@@ -938,21 +1136,23 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         `onUpdate${modelName}`,
       );
 
-      /* todo: enable once fixed in auth utils
-        const onDeleteSubscriptionResult = await subTodoHelper.subscribe(
-          'onDelete', 
-          [
-            async () => {
-              await user1TodoHelper.delete(deleteResultSetName, { customId: todoRandom.customId }, completeOwnerResultSet);
-            },
-          ], 
-          {}, 
-          completeOwnerResultSet,
-          false
-        );
-        expect(onDeleteSubscriptionResult).toHaveLength(1);
-        checkOperationResult(onDeleteSubscriptionResult[0], {...todoRandomUpdated, author: null, privateContent: null, ownerContent: null}, `onDelete${modelName}`);
-        */
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe(
+        'onDelete',
+        [
+          async () => {
+            await user1TodoHelper.delete(deleteResultSetName, { customId: todoRandom.customId }, completeOwnerResultSet);
+          },
+        ],
+        {},
+        completeOwnerResultSet,
+        false,
+      );
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(
+        onDeleteSubscriptionResult[0],
+        { ...todoRandomUpdated, author: null, privateContent: null, ownerContent: null },
+        `onDelete${modelName}`,
+      );
     });
 
     test('Custom owner model auth and restricted field operations', async () => {
@@ -982,12 +1182,10 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ownerContent
         `;
 
-      /* todo: enable once fixed in auth utils
-        // user1 cannot create a record by specifying user2 as the owner
-        await expect(async () => await user1TodoHelper.create(createResultSetName, { ...todo, author: 'user2' }, completeOwnerResultSet)).rejects.toThrowErrorMatchingInlineSnapshot(
-          expectedOperationError(createResultSetName, 'Mutation'),
-        );
-        */
+      // user1 cannot create a record by specifying user2 as the owner
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, author: 'user2' }, completeOwnerResultSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
 
       // user cannot create a record with public protected field
       await expect(
@@ -1304,12 +1502,10 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ownersContent
         `;
 
-      /* todo: enable once fixed in auth utils
-        // user1 cannot create a record by specifying user2 as the only owner
-        await expect(async () => await user1TodoHelper.create(createResultSetName, { ...todo, authors: [userName2] }, completeOwnerResultSet)).rejects.toThrowErrorMatchingInlineSnapshot(
-          expectedOperationError(createResultSetName, 'Mutation'),
-        );
-        */
+      // user1 cannot create a record by specifying user2 as the only owner
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, authors: [userName2] }, completeOwnerResultSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
 
       // user cannot create a record with dynamic owner list protected field that does not allow create operation
       await expect(
@@ -1441,263 +1637,594 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       expectNullFields(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`], ['authors', 'privateContent', 'ownersContent']);
     });
 
-    test.skip('non-admin users can perform CRUD and subscription operations with only private fields in selection set', async () => {
+    test('admin group protected model and allowed field operations', async () => {
       const modelName = 'TodoAdminContentVarious';
-      const todoHelperAdmin = user1ModelOperationHelpers[modelName];
-      const todoHelperNonAdmin = user2ModelOperationHelpers[modelName];
+      const user1TodoHelper = user1ModelOperationHelpers[modelName];
+      const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
-      const todoWithPrivateFields = {
-        privateContent: 'PrivateContent',
+      const todo = {
+        owner: userName1,
+        authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
+        privateContent: 'Private Content',
+        ownersContent: 'Owners Content',
+        groupsContent: 'Groups Content',
       };
+      const createResultSetName = `create${modelName}`;
+      const updateResultSetName = `update${modelName}`;
       const privateResultSet = `
           id
           privateContent
         `;
-      const createResultSetName = `create${modelName}`;
+      const adminResultSet = `
+          ${privateResultSet}
+          owner
+          authors
+          group
+          groups
+        `;
+      const setWithOwnerAndGroupContent = `
+          ${adminResultSet}
+          ownerContent
+          groupContent
+        `;
+      const setWithOwnersAndGroupsContent = `
+          ${adminResultSet}
+          ownersContent
+          groupsContent
+        `;
+      const completeResultSet = `
+          ${adminResultSet}
+          ownerContent
+          ownersContent
+          groupContent
+          groupsContent
+        `;
 
-      // admin is able to create a record with only private fields
-      const createResult = await todoHelperNonAdmin.create(createResultSetName, todoWithPrivateFields, privateResultSet);
-      expect(createResult.data[createResultSetName].id).toBeDefined();
-      todoWithPrivateFields['id'] = createResult.data[createResultSetName].id;
-      expect(createResult.data[createResultSetName].privateContent).toBeNull();
+      // admin(user1) creates a record with only allowed fields
+      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersAndGroupsContent);
+      expect(createResult1.data[createResultSetName].id).toBeDefined();
+      todo['id'] = createResult1.data[createResultSetName].id;
+      todo['owner'] = userName1;
+      // protected fields are nullified in mutation responses
+      const nulledOwnerFields = ['owner', 'authors', 'group', 'groups', 'privateContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledOwnerFields, 'ownersContent', 'groupsContent']);
 
-      const todoUpdated = {
-        id: todoWithPrivateFields['id'],
+      // user1 can update the allowed fields and add user2 to dyamic owners list field
+      const todoUpdated1 = {
+        id: todo['id'],
+        authors: [userName1, userName2],
+        groups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
+        ownerContent: 'Owner Content',
+        groupContent: 'Group Content',
       };
+      const updateResult1 = await user1TodoHelper.update(updateResultSetName, todoUpdated1, setWithOwnerAndGroupContent);
+      expect(updateResult1.data[updateResultSetName].id).toEqual(todo['id']);
+      expectNullFields(updateResult1.data[updateResultSetName], [...nulledOwnerFields, 'ownerContent', 'groupContent']);
 
-      const updateResult = await todoHelperNonAdmin.update(`update${modelName}`, todoUpdated, privateResultSet);
-      expect(updateResult.data[`update${modelName}`].id).toEqual(todoWithPrivateFields['id']);
-      expect(updateResult.data[`update${modelName}`].privateContent).toBeNull();
-
-      const getResult = await todoHelperNonAdmin.get(
+      // user1 can read the allowed fields
+      const getResult1 = await user1TodoHelper.get(
         {
-          id: todoWithPrivateFields['id'],
+          id: todo['id'],
         },
-        privateResultSet,
+        completeResultSet,
         false,
       );
-      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+      checkOperationResult(getResult1, { ...todo, ...todoUpdated1 }, `get${modelName}`);
 
-      const listTodosResult = await todoHelperNonAdmin.list({}, privateResultSet, `list${modelName}`, false);
-      checkListItemExistence(listTodosResult, `list${modelName}`, todoWithPrivateFields['id'], true);
+      const listTodosResult1 = await user1TodoHelper.list({}, completeResultSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult1, `list${modelName}`, todo['id'], true);
 
-      // unless all fields have same Auth rules as the model, delete is expected to fail
+      // unless one has delete access to all fields in the model, delete is expected to fail
       await expect(
-        async () => await todoHelperNonAdmin.delete(`delete${modelName}`, { id: todoWithPrivateFields['id'] }, privateResultSet),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access delete${modelName} on type Mutation"`);
+        async () => await user1TodoHelper.delete(`delete${modelName}`, { id: todo['id'] }, privateResultSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(`delete${modelName}`, 'Mutation'));
 
+      // user2 can update the private field
+      const todoUpdated2 = {
+        id: todo['id'],
+        privateContent: 'Private Content updated 1',
+      };
+      const updateResult2 = await user2TodoHelper.update(updateResultSetName, todoUpdated2, privateResultSet);
+      expect(updateResult2.data[updateResultSetName].id).toEqual(todo['id']);
+      expectNullFields(updateResult2.data[updateResultSetName], ['privateContent']);
+
+      // user2 can read the allowed fields
+      const user2ReadAllowedSet = `
+          id
+          privateContent
+          ownersContent
+          groupsContent
+        `;
+      const getResult2 = await user2TodoHelper.get(
+        {
+          id: todo['id'],
+        },
+        user2ReadAllowedSet,
+        false,
+      );
+      checkOperationResult(
+        getResult2,
+        {
+          id: todo['id'],
+          privateContent: todoUpdated2['privateContent'],
+          ownersContent: todo['ownersContent'],
+          groupsContent: todo['groupsContent'],
+        },
+        `get${modelName}`,
+      );
+
+      const listTodosResult2 = await user2TodoHelper.list({}, user2ReadAllowedSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult2, `list${modelName}`, todo['id'], true);
+
+      // owner can listen to updates on allowed fields
       const todoRandom = {
-        ...todoWithPrivateFields,
+        ...todo,
         id: Date.now().toString(),
       };
       const todoRandomUpdated = {
-        ...todoWithPrivateFields,
+        ...todoUpdated1,
         id: todoRandom.id,
+        owner: userName1,
+        privateContent: 'Private Content updated',
       };
-      const actorClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName2]);
-      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const subscriberClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
 
       const onCreateSubscriptionResult = await subTodoHelper.subscribe(
         'onCreate',
         [
           async () => {
-            await todoHelperAdmin.create(createResultSetName, todoRandom, privateResultSet);
+            await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersAndGroupsContent);
           },
         ],
         {},
-        privateResultSet,
+        setWithOwnersAndGroupsContent,
         false,
       );
       expect(onCreateSubscriptionResult).toHaveLength(1);
-      expect(onCreateSubscriptionResult[0].data[`onCreate${modelName}`].id).toEqual(todoRandom.id);
-      expect(onCreateSubscriptionResult[0].data[`onCreate${modelName}`].privateContent).toBeNull();
+      checkOperationResult(
+        onCreateSubscriptionResult[0],
+        {
+          ...todoRandom,
+          owner: null,
+          authors: null,
+          group: null,
+          groups: null,
+          privateContent: null,
+          ownersContent: null,
+          groupsContent: null,
+        },
+        `onCreate${modelName}`,
+      );
 
       const onUpdateSubscriptionResult = await subTodoHelper.subscribe(
         'onUpdate',
         [
           async () => {
-            await todoHelperAdmin.update(`update${modelName}`, todoRandomUpdated, privateResultSet);
+            await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerAndGroupContent);
           },
         ],
         {},
-        privateResultSet,
+        setWithOwnerAndGroupContent,
         false,
       );
       expect(onUpdateSubscriptionResult).toHaveLength(1);
-      expect(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`].id).toEqual(todoRandom.id);
-      expect(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`].privateContent).toBeNull();
+      checkOperationResult(
+        onUpdateSubscriptionResult[0],
+        {
+          ...todoRandomUpdated,
+          owner: null,
+          authors: null,
+          group: null,
+          groups: null,
+          privateContent: null,
+          ownerContent: null,
+          groupContent: null,
+        },
+        `onUpdate${modelName}`,
+      );
 
-      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [], {}, privateResultSet, false);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [], {}, setWithOwnersAndGroupsContent, false);
       expect(onDeleteSubscriptionResult).toHaveLength(0);
     });
 
-    test.skip('admin users cannot perform CRUD and subscription operations on public protected field', async () => {
+    test('admin group protected model and restricted field operations', async () => {
       const modelName = 'TodoAdminContentVarious';
-      const modelOperationHelpers = user1ModelOperationHelpers;
-      const todoHelper = modelOperationHelpers[modelName];
+      const user1TodoHelper = user1ModelOperationHelpers[modelName];
+      const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
-      const todoWithPrivateFields = {
-        privateContent: 'PrivateContent',
-      };
       const todo = {
-        ...todoWithPrivateFields,
-        publicContent: 'PublicContent',
+        owner: userName1,
+        authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
+        privateContent: 'Private Content',
+        ownersContent: 'Owners Content',
+        groupsContent: 'Groups Content',
       };
-      const completeResultSet = `
-          id
-          privateContent
-          publicContent
-        `;
       const createResultSetName = `create${modelName}`;
-
-      await expect(async () => await todoHelper.create(createResultSetName, todo)).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"GraphQL error: Not Authorized to access create${modelName} on type Mutation"`,
-      );
-
-      // Create a record with only allowed fields, so we can test the update and delete operations.
+      const updateResultSetName = `update${modelName}`;
       const privateResultSet = `
           id
           privateContent
         `;
-      const createResult = await todoHelper.create(createResultSetName, todoWithPrivateFields, privateResultSet);
-      expect(createResult.data[createResultSetName].id).toBeDefined();
-      todo['id'] = createResult.data[createResultSetName].id;
+      const adminResultSet = `
+          ${privateResultSet}
+          owner
+          authors
+          group
+          groups
+        `;
+      const setWithOwnerAndGroupContent = `
+          ${adminResultSet}
+          ownerContent
+          groupContent
+        `;
+      const setWithOwnersAndGroupsContent = `
+          ${adminResultSet}
+          ownersContent
+          groupsContent
+        `;
 
-      const todoUpdated = {
-        id: todo['id'],
-        privateContent: 'Private Content updated',
-        publicContent: 'Public Content updated',
-      };
+      // admin cannot create a record with public protected field
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, publicContent: 'Public Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
 
-      await expect(async () => await todoHelper.update(`update${modelName}`, todoUpdated)).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"GraphQL error: Not Authorized to access update${modelName} on type Mutation"`,
+      // admin owner cannot create a record with a owner protected field that does not allow create operation
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, ownerContent: 'Owner Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+
+      // admin cannot create a record with a group protected field that does not allow create operation
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, groupContent: 'Group Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+
+      // Create a record with allowed fields, so we can test the update and delete operations.
+      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersAndGroupsContent);
+      expect(createResult1.data[createResultSetName].id).toBeDefined();
+      todo['id'] = createResult1.data[createResultSetName].id;
+      todo['owner'] = userName1;
+      // protected fields are nullified in mutation responses
+      const nulledOwnerFields = ['owner', 'authors', 'group', 'groups', 'privateContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledOwnerFields, 'ownersContent']);
+
+      const publicFieldSet = `
+          id
+          publicContent
+        `;
+      // admin cannot update a record with public protected field
+      await expect(
+        async () => await user1TodoHelper.update(updateResultSetName, { id: todo['id'], publicContent: 'Public Content' }, publicFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // admin cannot update a record with dynamic list of owners protected field that does not allow update operation
+      await expect(
+        async () => await user1TodoHelper.update(updateResultSetName, { ...todo, ownersContent: 'Owners Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // admin cannot update a record with dynamic list of groups protected field that does not allow update operation
+      await expect(
+        async () => await user1TodoHelper.update(updateResultSetName, { ...todo, groupsContent: 'Groups Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // non-admin cannot update a record to re-assign ownership
+      const ownerFieldSet = `
+          id
+          owner
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], owner: 'user2' }, ownerFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // non-admin cannot update a record to re-assign owners in dynamic owners list
+      const ownersFieldSet = `
+          id
+          authors
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], authors: ['user2'] }, ownersFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // non-admin cannot update a record to re-assign group membership
+      const groupFieldSet = `
+          id
+          group
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], group: devGroupName }, groupFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // non-admin cannot update a record to re-assign group memberships stored as dynamic list
+      const groupsFieldSet = `
+          id
+          groups
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], groups: [devGroupName] }, groupsFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // non-owner cannot update a record with an owner protected field
+      const ownerContentFieldSet = `
+          id
+          ownerContent
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { ...todo, ownerContent: 'Owner Content' }, ownerContentFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // non-member of group cannot update a record with a group protected field
+      const groupContentFieldSet = `
+          id
+          groupContent
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { ...todo, groupContent: 'Group Content' }, groupContentFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // admin cannot read a record with public protected field
+      const getResult1 = await user1TodoHelper.get({ id: todo['id'] }, publicFieldSet, false, 'all');
+      checkOperationResult(
+        getResult1,
+        { id: todo['id'], publicContent: null },
+        `get${modelName}`,
+        false,
+        expectedFieldErrors(['publicContent'], modelName),
       );
 
-      const expectedFieldError = `"GraphQL error: Not Authorized to access publicContent on type ${modelName}"`;
-      const getResult = await todoHelper.get({ id: todo['id'] }, undefined, true, 'all');
-      checkOperationResult(getResult, { ...todo, publicContent: null }, `get${modelName}`, false, [expectedFieldError]);
+      const listTodosResult1 = await user1TodoHelper.list({}, publicFieldSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult1, `list${modelName}`, todo['id'], true);
+      checkListResponseErrors(listTodosResult1, expectedFieldErrors(['publicContent'], modelName, false));
 
-      const listTodosResult = await todoHelper.list({}, completeResultSet, `list${modelName}`, false, 'all');
-      checkListItemExistence(listTodosResult, `list${modelName}`, todo['id'], true);
-      checkListResponseErrors(listTodosResult, [`Not Authorized to access publicContent on type ${modelName}`]);
+      // non-admin and non-owner cannot read a record with owner and group protected fields in the selection set
+      const ownerReadFieldSet = `
+        id
+        owner
+        authors
+        group
+        groups
+        ownerContent
+        ownersContent
+        groupContent
+        groupsContent
+      `;
+      const getResult2 = await user2TodoHelper.get({ id: todo['id'] }, ownerReadFieldSet, false, 'all');
+      const expectedReadErrorFields = ['owner', 'authors', 'ownerContent', 'ownersContent', 'groupContent', 'groupsContent'];
+      checkOperationResult(
+        getResult2,
+        {
+          id: todo['id'],
+          owner: null,
+          authors: null,
+          group: null,
+          groups: null,
+          ownerContent: null,
+          ownersContent: null,
+          groupContent: null,
+          groupsContent: null,
+        },
+        `get${modelName}`,
+        false,
+        expectedFieldErrors(expectedReadErrorFields, modelName),
+      );
 
+      const listTodosResult2 = await user2TodoHelper.list({}, ownerReadFieldSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult2, `list${modelName}`, todo['id'], true);
+      checkListResponseErrors(listTodosResult2, expectedFieldErrors(expectedReadErrorFields, modelName, false));
+
+      // non-admin/owner cannot listen to updates on owner/group protected fields
       const todoRandom = {
-        ...todoWithPrivateFields,
+        ...todo,
         id: Date.now().toString(),
       };
       const todoRandomUpdated = {
-        ...todoWithPrivateFields,
         id: todoRandom.id,
+        owner: userName1,
+        privateContent: 'Private Content updated',
+        ownerContent: 'Owner Content updated',
+        groupContent: 'Group Content updated',
       };
-      const actorClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName1]);
-      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const subscriberClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName2]);
+      const subTodoHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
 
       const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
         async () => {
-          await subTodoHelper.create(createResultSetName, todoRandom, privateResultSet);
+          await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersAndGroupsContent);
         },
       ]);
+      const expectedSubscriptionNullFields = [...expectedReadErrorFields, 'privateContent', 'publicContent'];
       expect(onCreateSubscriptionResult).toHaveLength(1);
-      checkOperationResult(
-        onCreateSubscriptionResult[0],
-        { ...todoRandom, publicContent: null, privateContent: null },
-        `onCreate${modelName}`,
-      );
+      expect(onCreateSubscriptionResult[0].data[`onCreate${modelName}`].id).toEqual(todoRandom.id);
+      expectNullFields(onCreateSubscriptionResult[0].data[`onCreate${modelName}`], expectedSubscriptionNullFields);
 
       const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
         async () => {
-          await subTodoHelper.update(`update${modelName}`, todoRandomUpdated, privateResultSet);
+          await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerAndGroupContent);
         },
       ]);
       expect(onUpdateSubscriptionResult).toHaveLength(1);
-      checkOperationResult(
-        onUpdateSubscriptionResult[0],
-        { ...todoRandomUpdated, publicContent: null, privateContent: null },
-        `onUpdate${modelName}`,
-      );
+      expect(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`].id).toEqual(todoRandom.id);
+      expectNullFields(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`], expectedSubscriptionNullFields);
 
       const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', []);
       expect(onDeleteSubscriptionResult).toHaveLength(0);
     });
 
-    test.skip('user not part of allowed custom group of a record can perform CRUD and subscription operations with only allowed fields in selection set', async () => {
+    test('custom group field protected model and allowed field operations', async () => {
       const modelName = 'TodoCustomGroupContentVarious';
-      const todoHelperAdmin = user1ModelOperationHelpers[modelName];
-      const todoHelperNonAdmin = user2ModelOperationHelpers[modelName];
+      const user1TodoHelper = user1ModelOperationHelpers[modelName];
+      const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
-      const todoWithAllowedFields = {
-        privateContent: 'PrivateContent',
-        customGroup: adminGroupName,
+      const todo = {
+        customId: Date.now().toString(),
+        owner: userName1,
+        authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
+        privateContent: 'Private Content',
+        ownersContent: 'Owners Content',
+        adminContent: 'Admin Content',
+        groupsContent: 'Groups Content',
       };
-      const allowedResultSet = `
-          id
-          customGroup
-          privateContent
-        `;
       const createResultSetName = `create${modelName}`;
       const updateResultSetName = `update${modelName}`;
+      const deleteResultSetName = `delete${modelName}`;
+      const privateResultSet = `
+          customId
+          privateContent
+        `;
+      const adminResultSet = `
+          ${privateResultSet}
+          owner
+          authors
+          group
+          groups
+          adminContent
+        `;
+      const setWithOwnerContent = `
+          ${adminResultSet}
+          ownerContent
+        `;
+      const setWithOwnersAndGroupsContent = `
+          ${adminResultSet}
+          ownersContent
+          groupsContent
+        `;
+      const completeResultSet = `
+          ${adminResultSet}
+          ownerContent
+          ownersContent
+          groupsContent
+        `;
 
-      // admin is able to create a record with only private fields
-      const createResult = await todoHelperAdmin.create(createResultSetName, todoWithAllowedFields, allowedResultSet);
-      expect(createResult.data[createResultSetName].id).toBeDefined();
-      todoWithAllowedFields['id'] = createResult.data[createResultSetName].id;
-      expect(createResult.data[createResultSetName].privateContent).toBeNull();
-      expect(createResult.data[createResultSetName].customGroup).toBeNull();
+      // admin(user1) creates a record with only allowed fields
+      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersAndGroupsContent);
+      expect(createResult1.data[createResultSetName].customId).toBeDefined();
+      todo['customId'] = createResult1.data[createResultSetName].customId;
+      todo['owner'] = userName1;
+      // protected fields are nullified in mutation responses
+      const nulledMutationFields = ['owner', 'authors', 'group', 'groups', 'privateContent', 'adminContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledMutationFields, 'ownersContent', 'groupsContent']);
 
-      const todoUpdated = {
-        ...todoWithAllowedFields,
+      // user in allowed group can update the allowed fields and add user2 to dyamic owners list field
+      const todoUpdated1 = {
+        customId: todo['customId'],
+        authors: [userName1, userName2],
+        groups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
+        ownerContent: 'Owner Content',
       };
+      const updateResult1 = await user1TodoHelper.update(updateResultSetName, todoUpdated1, setWithOwnerContent);
+      expect(updateResult1.data[updateResultSetName].customId).toEqual(todo['customId']);
+      expectNullFields(updateResult1.data[updateResultSetName], [...nulledMutationFields, 'ownerContent']);
 
-      // non-admin can update the private protected field
-      const updateResult = await todoHelperNonAdmin.update(updateResultSetName, todoUpdated, allowedResultSet);
-      checkOperationResult(updateResult, { ...todoUpdated, customGroup: null, privateContent: null }, updateResultSetName);
-
-      // non-admin can read the private protected field
-      const getResult = await todoHelperNonAdmin.get(
+      // user in allowed group can read the allowed fields
+      const getResult1 = await user1TodoHelper.get(
         {
-          id: todoWithAllowedFields['id'],
+          customId: todo['customId'],
         },
-        allowedResultSet,
+        completeResultSet,
         false,
+        'all',
+        'customId',
       );
-      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+      checkOperationResult(getResult1, { ...todo, ...todoUpdated1 }, `get${modelName}`);
 
-      const listTodosResult = await todoHelperNonAdmin.list({}, allowedResultSet, `list${modelName}`, false);
-      checkListItemExistence(listTodosResult, `list${modelName}`, todoWithAllowedFields['id'], true);
+      const listTodosResult1 = await user1TodoHelper.list({}, completeResultSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult1, `list${modelName}`, todo['customId'], true, 'customId');
 
-      // unless all fields have same Auth rules as the model, delete is expected to fail
-      await expect(
-        async () => await todoHelperNonAdmin.delete(`delete${modelName}`, { id: todoWithAllowedFields['id'] }, allowedResultSet),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access delete${modelName} on type Mutation"`);
+      // user not in allowed group can update the private field
+      const todoUpdated2 = {
+        customId: todo['customId'],
+        privateContent: 'Private Content updated 1',
+      };
+      const updateResult2 = await user2TodoHelper.update(updateResultSetName, todoUpdated2, privateResultSet);
+      expect(updateResult2.data[updateResultSetName].customId).toEqual(todo['customId']);
+      expectNullFields(updateResult2.data[updateResultSetName], ['privateContent']);
 
+      // user2 who is now in allowed group can read the allowed fields
+      const user2ReadAllowedSet = `
+          customId
+          privateContent
+          ownersContent
+          groupsContent
+        `;
+      const getResult2 = await user2TodoHelper.get(
+        {
+          customId: todo['customId'],
+        },
+        user2ReadAllowedSet,
+        false,
+        'all',
+        'customId',
+      );
+      checkOperationResult(
+        getResult2,
+        {
+          customId: todo['customId'],
+          privateContent: todoUpdated2['privateContent'],
+          ownersContent: todo['ownersContent'],
+          groupsContent: todo['groupsContent'],
+        },
+        `get${modelName}`,
+      );
+
+      const listTodosResult2 = await user2TodoHelper.list({}, user2ReadAllowedSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult2, `list${modelName}`, todo['customId'], true, 'customId');
+
+      // user in allowed group can delete the record
+      const deleteResult1 = await user1TodoHelper.delete(deleteResultSetName, { customId: todo.customId }, completeResultSet);
+      expect(deleteResult1.data[deleteResultSetName].customId).toEqual(todo['customId']);
+      expectNullFields(deleteResult1.data[deleteResultSetName], [
+        ...nulledMutationFields,
+        'ownerContent',
+        'ownersContent',
+        'groupsContent',
+      ]);
+
+      // user in allowed group can listen to updates on allowed fields
       const todoRandom = {
-        ...todoWithAllowedFields,
-        id: Date.now().toString(),
+        ...todo,
+        customId: Date.now().toString(),
       };
       const todoRandomUpdated = {
-        ...todoWithAllowedFields,
-        id: todoRandom.id,
+        ...todoUpdated1,
+        customId: todoRandom.customId,
+        owner: userName1,
+        privateContent: 'Private Content updated',
       };
-      const actorClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName2]);
-      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const subscriberClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
 
       const onCreateSubscriptionResult = await subTodoHelper.subscribe(
         'onCreate',
         [
           async () => {
-            await todoHelperAdmin.create(createResultSetName, todoRandom, allowedResultSet);
+            await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersAndGroupsContent);
           },
         ],
         {},
-        allowedResultSet,
+        setWithOwnersAndGroupsContent,
         false,
       );
       expect(onCreateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
         onCreateSubscriptionResult[0],
-        { ...todoRandom, customGroup: null, privateContent: null },
+        {
+          ...todoRandom,
+          owner: null,
+          authors: null,
+          group: null,
+          groups: null,
+          privateContent: null,
+          ownersContent: null,
+          adminContent: null,
+          groupsContent: null,
+        },
         `onCreate${modelName}`,
       );
 
@@ -1705,157 +2232,469 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         'onUpdate',
         [
           async () => {
-            await todoHelperAdmin.update(`update${modelName}`, todoRandomUpdated, allowedResultSet);
+            await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerContent);
           },
         ],
         {},
-        allowedResultSet,
+        setWithOwnerContent,
         false,
       );
       expect(onUpdateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
-        onCreateSubscriptionResult[0],
-        { ...todoRandomUpdated, customGroup: null, privateContent: null },
+        onUpdateSubscriptionResult[0],
+        {
+          ...todoRandomUpdated,
+          owner: null,
+          authors: null,
+          group: null,
+          groups: null,
+          privateContent: null,
+          ownerContent: null,
+          adminContent: null,
+        },
         `onUpdate${modelName}`,
       );
 
-      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [], {}, allowedResultSet, false);
-      expect(onDeleteSubscriptionResult).toHaveLength(0);
-    });
-
-    test.skip('user part of allowed custom group of a record cannot perform CRUD operations on public protected field', async () => {
-      const modelName = 'TodoCustomGroupContentVarious';
-      const todoHelperAdmin = user1ModelOperationHelpers[modelName];
-      const todoHelperNonAdmin = user2ModelOperationHelpers[modelName];
-
-      const todoWithAllowedFields = {
-        privateContent: 'PrivateContent',
-        customGroup: adminGroupName,
-      };
-      const todo = {
-        ...todoWithAllowedFields,
-        publicContent: 'PublicContent',
-      };
-      const completeResultSet = `
-          id
-          customGroup
-          privateContent
-          publicContent
-        `;
-      const createResultSetName = `create${modelName}`;
-
-      await expect(async () => await todoHelperAdmin.create(createResultSetName, todo)).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"GraphQL error: Not Authorized to access create${modelName} on type Mutation"`,
-      );
-
-      // Create a record with allowed fields only, so we can test the update and delete operations.
-      const allowedResultSet = `
-          id
-          customGroup
-          privateContent
-        `;
-      const createResult = await todoHelperAdmin.create(createResultSetName, todoWithAllowedFields, allowedResultSet);
-      expect(createResult.data[createResultSetName].id).toBeDefined();
-      todo['id'] = createResult.data[createResultSetName].id;
-      expect(createResult.data[createResultSetName].privateContent).toBeNull();
-      expect(createResult.data[createResultSetName].customGroup).toBeNull();
-
-      const todoUpdated = {
-        ...todo,
-        privateContent: 'Private Content updated',
-        publicContent: 'Public Content updated',
-      };
-
-      await expect(async () => await todoHelperAdmin.update(`update${modelName}`, todoUpdated)).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"GraphQL error: Not Authorized to access update${modelName} on type Mutation"`,
-      );
-
-      const expectedFieldError = `"GraphQL error: Not Authorized to access publicContent on type ${modelName}"`;
-      const getResult = await todoHelperAdmin.get({ id: todo['id'] }, undefined, true, 'all');
-      checkOperationResult(getResult, { ...todo, publicContent: null }, `get${modelName}`, false, [expectedFieldError]);
-
-      const listTodosResult = await todoHelperAdmin.list({}, completeResultSet, `list${modelName}`, false, 'all');
-      checkListItemExistence(listTodosResult, `list${modelName}`, todo['id'], true);
-      checkListResponseErrors(listTodosResult, [`Not Authorized to access publicContent on type ${modelName}`]);
-    });
-
-    test.skip('user not part of group in allowed custom groups list of a record can perform CRUD and subscription operations with only allowed fields in selection set', async () => {
-      const modelName = 'TodoCustomGroupsContentVarious';
-      const todoHelperAdmin = user1ModelOperationHelpers[modelName];
-      const todoHelperNonAdmin = user2ModelOperationHelpers[modelName];
-
-      const todoWithAllowedFields = {
-        privateContent: 'PrivateContent',
-        customGroups: [adminGroupName],
-      };
-      const allowedResultSet = `
-          id
-          customGroups
-          privateContent
-        `;
-      const createResultSetName = `create${modelName}`;
-      const updateResultSetName = `update${modelName}`;
-
-      // admin is able to create a record with only private fields
-      const createResult = await todoHelperAdmin.create(createResultSetName, todoWithAllowedFields, allowedResultSet);
-      expect(createResult.data[createResultSetName].id).toBeDefined();
-      todoWithAllowedFields['id'] = createResult.data[createResultSetName].id;
-      expect(createResult.data[createResultSetName].privateContent).toBeNull();
-      expect(createResult.data[createResultSetName].customGroups).toBeNull();
-
-      const todoUpdated = {
-        ...todoWithAllowedFields,
-        privateContent: 'Private Content updated',
-      };
-
-      // non-admin can update the private protected field
-      const updateResult = await todoHelperNonAdmin.update(updateResultSetName, todoUpdated, allowedResultSet);
-      checkOperationResult(updateResult, { ...todoUpdated, customGroups: null, privateContent: null }, updateResultSetName);
-
-      // non-admin can read the private protected field
-      const getResult = await todoHelperNonAdmin.get(
-        {
-          id: todoWithAllowedFields['id'],
-        },
-        allowedResultSet,
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe(
+        'onDelete',
+        [
+          async () => {
+            await user1TodoHelper.delete(deleteResultSetName, { customId: todoRandom.customId }, completeResultSet);
+          },
+        ],
+        {},
+        completeResultSet,
         false,
       );
-      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(
+        onDeleteSubscriptionResult[0],
+        {
+          ...todoRandomUpdated,
+          owner: null,
+          authors: null,
+          group: null,
+          groups: null,
+          privateContent: null,
+          ownerContent: null,
+          ownersContent: null,
+          adminContent: null,
+          groupsContent: null,
+        },
+        `onDelete${modelName}`,
+      );
+    });
 
-      const listTodosResult = await todoHelperNonAdmin.list({}, allowedResultSet, `list${modelName}`, false);
-      checkListItemExistence(listTodosResult, `list${modelName}`, todoWithAllowedFields['id'], true);
+    test('custom group field protected model and restricted field operations', async () => {
+      const modelName = 'TodoCustomGroupContentVarious';
+      const user1TodoHelper = user1ModelOperationHelpers[modelName];
+      const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
-      // unless all fields have same Auth rules as the model, delete is expected to fail
+      const todo = {
+        customId: Date.now().toString(),
+        owner: userName1,
+        authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
+        privateContent: 'Private Content',
+        ownersContent: 'Owners Content',
+        adminContent: 'Admin Content',
+        groupsContent: 'Groups Content',
+      };
+      const createResultSetName = `create${modelName}`;
+      const updateResultSetName = `update${modelName}`;
+      const deleteResultSetName = `delete${modelName}`;
+      const privateResultSet = `
+          customId
+          privateContent
+        `;
+      const adminResultSet = `
+          ${privateResultSet}
+          owner
+          authors
+          group
+          groups
+          adminContent
+        `;
+      const setWithOwnerContent = `
+          ${adminResultSet}
+          ownerContent
+        `;
+      const setWithOwnersAndGroupsContent = `
+          ${adminResultSet}
+          ownersContent
+          groupsContent
+        `;
+
+      const completeResultSet = `
+          ${adminResultSet}
+          ownerContent
+          ownersContent
+          groupsContent
+        `;
+
+      // user in allowed group cannot create a record with public protected field
       await expect(
-        async () => await todoHelperNonAdmin.delete(`delete${modelName}`, { id: todoWithAllowedFields['id'] }, allowedResultSet),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access delete${modelName} on type Mutation"`);
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, publicContent: 'Public Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
 
+      // user in allowed group cannot create a record with owner protected field that does not allow create operation
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, ownerContent: 'Owner Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+
+      // Create a record with allowed fields, so we can test the update and delete operations.
+      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersAndGroupsContent);
+      expect(createResult1.data[createResultSetName].customId).toBeDefined();
+      todo['customId'] = createResult1.data[createResultSetName].customId;
+      todo['owner'] = userName1;
+      // protected fields are nullified in mutation responses
+      const nulledAdminFields = ['owner', 'authors', 'group', 'groups', 'privateContent', 'adminContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledAdminFields, 'ownersContent', 'groupsContent']);
+
+      const publicFieldSet = `
+          customId
+          publicContent
+        `;
+      // user in allowed group cannot update a record with public protected field
+      await expect(
+        async () =>
+          await user1TodoHelper.update(
+            updateResultSetName,
+            { customId: todo['customId'], publicContent: 'Public Content' },
+            publicFieldSet,
+          ),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user in allowed group cannot update a record with dynamic list of owners protected field that does not allow update operation
+      await expect(
+        async () => await user1TodoHelper.update(updateResultSetName, { ...todo, ownersContent: 'Owners Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user in allowed group cannot update a record with dynamic list of groups protected field that does not allow update operation
+      await expect(
+        async () => await user1TodoHelper.update(updateResultSetName, { ...todo, groupsContent: 'Groups Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user not in allowed group cannot update a record to re-assign ownership
+      const ownerFieldSet = `
+          customId
+          owner
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], owner: 'user2' }, ownerFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user not in allowed group cannot update a record to re-assign owners in dynamic owners list
+      const ownersFieldSet = `
+          customId
+          authors
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], authors: ['user2'] }, ownersFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user not in allowed group cannot update a record to re-assign group membership
+      const groupFieldSet = `
+          customId
+          group
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], group: devGroupName }, groupFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user not in allowed group cannot update a record to re-assign group memberships stored as dynamic list
+      const groupsFieldSet = `
+          customId
+          groups
+        `;
+      await expect(
+        async () =>
+          await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], groups: [devGroupName] }, groupsFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user not in allowed group cannot update a record with an owner protected field
+      const ownerContentFieldSet = `
+          customId
+          ownerContent
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { ...todo, ownerContent: 'Owner Content' }, ownerContentFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user in allowed group cannot read a record with public protected field
+      const getResult1 = await user1TodoHelper.get({ customId: todo['customId'] }, publicFieldSet, false, 'all', 'customId');
+      checkOperationResult(
+        getResult1,
+        { customId: todo['customId'], publicContent: null },
+        `get${modelName}`,
+        false,
+        expectedFieldErrors(['publicContent'], modelName),
+      );
+
+      const listTodosResult1 = await user1TodoHelper.list({}, publicFieldSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult1, `list${modelName}`, todo['customId'], true, 'customId');
+      checkListResponseErrors(listTodosResult1, expectedFieldErrors(['publicContent'], modelName, false));
+
+      // user not in allowed group and non-owner cannot read a record with owner and group protected fields in the selection set
+      const readFieldSet = `
+        customId
+        owner
+        authors
+        group
+        groups
+        ownerContent
+        ownersContent
+        adminContent
+        groupsContent
+      `;
+      const getResult2 = await user2TodoHelper.get({ customId: todo['customId'] }, readFieldSet, false, 'all', 'customId');
+      const expectedReadErrorFields = [
+        'owner',
+        'authors',
+        'group',
+        'groups',
+        'ownerContent',
+        'ownersContent',
+        'adminContent',
+        'groupsContent',
+      ];
+      checkOperationResult(
+        getResult2,
+        {
+          customId: todo['customId'],
+          owner: null,
+          authors: null,
+          group: null,
+          groups: null,
+          ownerContent: null,
+          ownersContent: null,
+          adminContent: null,
+          groupsContent: null,
+        },
+        `get${modelName}`,
+        false,
+        expectedFieldErrors(expectedReadErrorFields, modelName),
+      );
+
+      const listTodosResult2 = await user2TodoHelper.list({}, readFieldSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult2, `list${modelName}`, todo['customId'], true, 'customId');
+      checkListResponseErrors(listTodosResult2, expectedFieldErrors(expectedReadErrorFields, modelName, false));
+
+      // user not in allowed group cannot listen to updates on owner/group protected fields
       const todoRandom = {
-        ...todoWithAllowedFields,
-        id: Date.now().toString(),
+        ...todo,
+        customId: Date.now().toString(),
       };
       const todoRandomUpdated = {
-        ...todoWithAllowedFields,
-        id: todoRandom.id,
+        customId: todoRandom.customId,
+        owner: userName1,
+        privateContent: 'Private Content updated',
+        ownerContent: 'Owner Content updated',
       };
-      const actorClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName2]);
-      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const subscriberClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName2]);
+      const subTodoHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
+        async () => {
+          await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersAndGroupsContent);
+        },
+      ]);
+      const expectedSubscriptionNullFields = [...expectedReadErrorFields, 'privateContent', 'publicContent'];
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      expect(onCreateSubscriptionResult[0].data[`onCreate${modelName}`].customId).toEqual(todoRandom.customId);
+      expectNullFields(onCreateSubscriptionResult[0].data[`onCreate${modelName}`], [
+        ...expectedSubscriptionNullFields,
+        'ownersContent',
+        'adminContent',
+        'groupsContent',
+      ]);
+
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerContent);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      expect(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`].customId).toEqual(todoRandom.customId);
+      expectNullFields(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`], [
+        ...expectedSubscriptionNullFields,
+        'ownerContent',
+        'adminContent',
+      ]);
+
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [
+        async () => {
+          await user1TodoHelper.delete(deleteResultSetName, { customId: todoRandom.customId }, completeResultSet);
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      expect(onDeleteSubscriptionResult[0].data[`onDelete${modelName}`].customId).toEqual(todoRandom.customId);
+      expectNullFields(onDeleteSubscriptionResult[0].data[`onDelete${modelName}`], [
+        ...expectedSubscriptionNullFields,
+        'ownerContent',
+        'ownersContent',
+        'adminContent',
+        'groupsContent',
+      ]);
+    });
+
+    test('custom list of groups field protected model and allowed field operations', async () => {
+      const modelName = 'TodoCustomGroupsContentVarious';
+      const user1TodoHelper = user1ModelOperationHelpers[modelName];
+      const user2TodoHelper = user2ModelOperationHelpers[modelName];
+
+      const todo = {
+        customId: Date.now().toString(),
+        owner: userName1,
+        authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
+        privateContent: 'Private Content',
+        adminContent: 'Admin Content',
+        ownersContent: 'Owners Content',
+      };
+      const createResultSetName = `create${modelName}`;
+      const updateResultSetName = `update${modelName}`;
+      const privateResultSet = `
+          customId
+          privateContent
+        `;
+      const adminResultSet = `
+          ${privateResultSet}
+          owner
+          authors
+          group
+          groups
+          adminContent
+        `;
+      const setWithOwnerAndGroupContent = `
+          ${adminResultSet}
+          ownerContent
+          groupContent
+        `;
+      const setWithOwnersContent = `
+          ${adminResultSet}
+          ownersContent
+        `;
+      const completeResultSet = `
+          ${adminResultSet}
+          ownerContent
+          ownersContent
+          groupContent
+        `;
+
+      // admin(user1) creates a record with only allowed fields
+      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersContent);
+      expect(createResult1.data[createResultSetName].customId).toBeDefined();
+      todo['customId'] = createResult1.data[createResultSetName].customId;
+      todo['owner'] = userName1;
+      // protected fields are nullified in mutation responses
+      const nulledMutationFields = ['owner', 'authors', 'group', 'groups', 'privateContent', 'adminContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledMutationFields, 'ownersContent']);
+
+      // user part of allowed groups can update the allowed fields and add user2 to dyamic owners list field
+      const todoUpdated1 = {
+        customId: todo['customId'],
+        authors: [userName1, userName2],
+        groups: [adminGroupName, devGroupName],
+        privateContent: 'Private Content updated',
+        ownerContent: 'Owner Content',
+        groupContent: 'Group Content',
+      };
+      const updateResult1 = await user1TodoHelper.update(updateResultSetName, todoUpdated1, setWithOwnerAndGroupContent);
+      expect(updateResult1.data[updateResultSetName].customId).toEqual(todo['customId']);
+      expectNullFields(updateResult1.data[updateResultSetName], [...nulledMutationFields, 'ownerContent', 'groupContent']);
+
+      // user part of allowed groups can read the allowed fields
+      const getResult1 = await user1TodoHelper.get(
+        {
+          customId: todo['customId'],
+        },
+        completeResultSet,
+        false,
+        'all',
+        'customId',
+      );
+      checkOperationResult(getResult1, { ...todo, ...todoUpdated1 }, `get${modelName}`);
+
+      const listTodosResult1 = await user1TodoHelper.list({}, completeResultSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult1, `list${modelName}`, todo['customId'], true, 'customId');
+
+      // user not part of allowed groups can update the private field
+      const todoUpdated2 = {
+        customId: todo['customId'],
+        privateContent: 'Private Content updated 1',
+      };
+      const updateResult2 = await user2TodoHelper.update(updateResultSetName, todoUpdated2, privateResultSet);
+      expect(updateResult2.data[updateResultSetName].customId).toEqual(todo['customId']);
+      expectNullFields(updateResult2.data[updateResultSetName], ['privateContent']);
+
+      // user2 who is now part of allowed groups can read the allowed fields
+      const user2ReadAllowedSet = `
+          customId
+          privateContent
+          ownersContent
+        `;
+      const getResult2 = await user2TodoHelper.get(
+        {
+          customId: todo['customId'],
+        },
+        user2ReadAllowedSet,
+        false,
+        'all',
+        'customId',
+      );
+      checkOperationResult(
+        getResult2,
+        {
+          customId: todo['customId'],
+          privateContent: todoUpdated2['privateContent'],
+          ownersContent: todo['ownersContent'],
+        },
+        `get${modelName}`,
+      );
+
+      const listTodosResult2 = await user2TodoHelper.list({}, user2ReadAllowedSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult2, `list${modelName}`, todo['customId'], true, 'customId');
+
+      // user part of allowed groups can listen to updates on allowed fields
+      const todoRandom = {
+        ...todo,
+        customId: Date.now().toString(),
+      };
+      const todoRandomUpdated = {
+        ...todoUpdated1,
+        customId: todoRandom.customId,
+        owner: userName1,
+      };
+      const subscriberClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
 
       const onCreateSubscriptionResult = await subTodoHelper.subscribe(
         'onCreate',
         [
           async () => {
-            await todoHelperAdmin.create(createResultSetName, todoRandom, allowedResultSet);
+            await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersContent);
           },
         ],
         {},
-        allowedResultSet,
+        setWithOwnersContent,
         false,
       );
       expect(onCreateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
         onCreateSubscriptionResult[0],
-        { ...todoRandom, customGroups: null, privateContent: null },
+        {
+          ...todoRandom,
+          owner: null,
+          authors: null,
+          group: null,
+          groups: null,
+          privateContent: null,
+          ownersContent: null,
+          adminContent: null,
+        },
         `onCreate${modelName}`,
       );
 
@@ -1863,78 +2702,272 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         'onUpdate',
         [
           async () => {
-            await todoHelperAdmin.update(`update${modelName}`, todoRandomUpdated, allowedResultSet);
+            await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerAndGroupContent);
           },
         ],
         {},
-        allowedResultSet,
+        setWithOwnerAndGroupContent,
         false,
       );
       expect(onUpdateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
-        onCreateSubscriptionResult[0],
-        { ...todoRandomUpdated, customGroups: null, privateContent: null },
+        onUpdateSubscriptionResult[0],
+        {
+          ...todoRandomUpdated,
+          owner: null,
+          authors: null,
+          group: null,
+          groups: null,
+          privateContent: null,
+          ownerContent: null,
+          adminContent: null,
+          groupContent: null,
+        },
         `onUpdate${modelName}`,
       );
-
-      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [], {}, allowedResultSet, false);
-      expect(onDeleteSubscriptionResult).toHaveLength(0);
     });
 
-    test.skip('user part of group in allowed custom groups list of a record cannot perform CRUD operations on public protected field', async () => {
+    test('custom list of groups field protected model and restricted field operations', async () => {
       const modelName = 'TodoCustomGroupsContentVarious';
-      const todoHelperAdmin = user1ModelOperationHelpers[modelName];
-      const todoHelperNonAdmin = user2ModelOperationHelpers[modelName];
+      const user1TodoHelper = user1ModelOperationHelpers[modelName];
+      const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
-      const todoWithAllowedFields = {
-        privateContent: 'PrivateContent',
-        customGroups: [adminGroupName],
-      };
       const todo = {
-        ...todoWithAllowedFields,
-        publicContent: 'PublicContent',
+        customId: Date.now().toString(),
+        owner: userName1,
+        authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
+        privateContent: 'Private Content',
+        ownersContent: 'Owners Content',
+        adminContent: 'Admin Content',
       };
-      const completeResultSet = `
-          id
-          customGroups
+      const createResultSetName = `create${modelName}`;
+      const updateResultSetName = `update${modelName}`;
+      const deleteResultSetName = `delete${modelName}`;
+      const privateResultSet = `
+          customId
           privateContent
+        `;
+      const adminResultSet = `
+          ${privateResultSet}
+          owner
+          authors
+          group
+          groups
+          adminContent
+        `;
+      const setWithOwnerAndGroupContent = `
+          ${adminResultSet}
+          ownerContent
+          groupContent
+        `;
+      const setWithOwnersContent = `
+          ${adminResultSet}
+          ownersContent
+        `;
+
+      const completeResultSet = `
+          ${adminResultSet}
+          ownerContent
+          ownersContent
+          groupContent
+        `;
+
+      // user part of allowed groups cannot create a record with public protected field
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, publicContent: 'Public Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+
+      // user part of allowed groups cannot create a record with owner protected field that does not allow create operation
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, ownerContent: 'Owner Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+
+      // user part of allowed groups cannot create a record with list of groups protected field that does not allow create operation
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, groupContent: 'Group Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+
+      // Create a record with allowed fields, so we can test the update and delete operations.
+      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersContent);
+      expect(createResult1.data[createResultSetName].customId).toBeDefined();
+      todo['customId'] = createResult1.data[createResultSetName].customId;
+      todo['owner'] = userName1;
+      // protected fields are nullified in mutation responses
+      const nulledAdminFields = ['owner', 'authors', 'group', 'groups', 'privateContent', 'adminContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledAdminFields, 'ownersContent']);
+
+      const publicFieldSet = `
+          customId
           publicContent
         `;
-      const createResultSetName = `create${modelName}`;
+      // user part of allowed groups cannot update a record with public protected field
+      await expect(
+        async () =>
+          await user1TodoHelper.update(
+            updateResultSetName,
+            { customId: todo['customId'], publicContent: 'Public Content' },
+            publicFieldSet,
+          ),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
-      await expect(async () => await todoHelperAdmin.create(createResultSetName, todo)).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"GraphQL error: Not Authorized to access create${modelName} on type Mutation"`,
-      );
+      // user part of allowed groups cannot update a record with dynamic list of owners protected field that does not allow update operation
+      await expect(
+        async () => await user1TodoHelper.update(updateResultSetName, { ...todo, ownersContent: 'Owners Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
-      // Create a record with allowed fields only, so we can test the update and delete operations.
-      const allowedResultSet = `
-          id
-          customGroups
-          privateContent
+      // user not part of allowed groups cannot update a record to re-assign ownership
+      const ownerFieldSet = `
+          customId
+          owner
         `;
-      const createResult = await todoHelperAdmin.create(createResultSetName, todoWithAllowedFields, allowedResultSet);
-      expect(createResult.data[createResultSetName].id).toBeDefined();
-      todo['id'] = createResult.data[createResultSetName].id;
-      expect(createResult.data[createResultSetName].privateContent).toBeNull();
-      expect(createResult.data[createResultSetName].customGroups).toBeNull();
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], owner: 'user2' }, ownerFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
-      const todoUpdated = {
-        ...todo,
-        privateContent: 'Private Content updated',
-        publicContent: 'Public Content updated',
-      };
+      // user not part of allowed groups cannot update a record to re-assign owners in dynamic owners list
+      const ownersFieldSet = `
+          customId
+          authors
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], authors: ['user2'] }, ownersFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
-      await expect(async () => await todoHelperAdmin.update(`update${modelName}`, todoUpdated)).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"GraphQL error: Not Authorized to access update${modelName} on type Mutation"`,
+      // user not part of allowed groups cannot update a record to re-assign group membership
+      const groupFieldSet = `
+          customId
+          group
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], group: devGroupName }, groupFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user not part of allowed groups cannot update a record to re-assign group memberships stored as dynamic list
+      const groupsFieldSet = `
+          customId
+          groups
+        `;
+      await expect(
+        async () =>
+          await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], groups: [devGroupName] }, groupsFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user not part of allowed groups cannot update a record with an owner protected field
+      const ownerContentFieldSet = `
+          customId
+          ownerContent
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { ...todo, ownerContent: 'Owner Content' }, ownerContentFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user part of allowed groups cannot read a record with public protected field
+      const getResult1 = await user1TodoHelper.get({ customId: todo['customId'] }, publicFieldSet, false, 'all', 'customId');
+      checkOperationResult(
+        getResult1,
+        { customId: todo['customId'], publicContent: null },
+        `get${modelName}`,
+        false,
+        expectedFieldErrors(['publicContent'], modelName),
       );
 
-      const expectedFieldError = `"GraphQL error: Not Authorized to access publicContent on type ${modelName}"`;
-      const getResult = await todoHelperAdmin.get({ id: todo['id'] }, undefined, true, 'all');
-      checkOperationResult(getResult, { ...todo, publicContent: null }, `get${modelName}`, false, [expectedFieldError]);
+      const listTodosResult1 = await user1TodoHelper.list({}, publicFieldSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult1, `list${modelName}`, todo['customId'], true, 'customId');
+      checkListResponseErrors(listTodosResult1, expectedFieldErrors(['publicContent'], modelName, false));
 
-      const listTodosResult = await todoHelperAdmin.list({}, completeResultSet, `list${modelName}`, false, 'all');
-      checkListItemExistence(listTodosResult, `list${modelName}`, todo['id'], true);
-      checkListResponseErrors(listTodosResult, [`Not Authorized to access publicContent on type ${modelName}`]);
+      // user not part of allowed groups and non-owner cannot read a record with owner and group protected fields in the selection set
+      const readFieldSet = `
+        customId
+        owner
+        authors
+        group
+        groups
+        ownerContent
+        ownersContent
+        adminContent
+        groupContent
+      `;
+      const getResult2 = await user2TodoHelper.get({ customId: todo['customId'] }, readFieldSet, false, 'all', 'customId');
+      const expectedReadErrorFields = [
+        'owner',
+        'authors',
+        'group',
+        'groups',
+        'ownerContent',
+        'ownersContent',
+        'adminContent',
+        'groupContent',
+      ];
+      checkOperationResult(
+        getResult2,
+        {
+          customId: todo['customId'],
+          owner: null,
+          authors: null,
+          group: null,
+          groups: null,
+          ownerContent: null,
+          ownersContent: null,
+          adminContent: null,
+          groupContent: null,
+        },
+        `get${modelName}`,
+        false,
+        expectedFieldErrors(expectedReadErrorFields, modelName),
+      );
+
+      const listTodosResult2 = await user2TodoHelper.list({}, readFieldSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult2, `list${modelName}`, todo['customId'], true, 'customId');
+      checkListResponseErrors(listTodosResult2, expectedFieldErrors(expectedReadErrorFields, modelName, false));
+
+      // unless one has delete access to all fields in the model, delete is expected to fail
+      await expect(
+        async () => await user1TodoHelper.delete(`delete${modelName}`, { customId: todo['customId'] }, completeResultSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(`delete${modelName}`, 'Mutation'));
+
+      // user not part of allowed groups cannot listen to updates on owner/group protected fields
+      const todoRandom = {
+        ...todo,
+        customId: Date.now().toString(),
+      };
+      const todoRandomUpdated = {
+        customId: todoRandom.customId,
+        owner: userName1,
+        privateContent: 'Private Content updated',
+        ownerContent: 'Owner Content updated',
+      };
+      const subscriberClient = getConfiguredAppsyncClientOIDCAuth(graphQlEndpoint, region, userMap[userName2]);
+      const subTodoHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
+        async () => {
+          await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersContent);
+        },
+      ]);
+      const expectedSubscriptionNullFields = [...expectedReadErrorFields, 'privateContent', 'publicContent'];
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      expect(onCreateSubscriptionResult[0].data[`onCreate${modelName}`].customId).toEqual(todoRandom.customId);
+      expectNullFields(onCreateSubscriptionResult[0].data[`onCreate${modelName}`], [
+        ...expectedSubscriptionNullFields,
+        'ownersContent',
+        'adminContent',
+      ]);
+
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerAndGroupContent);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      expect(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`].customId).toEqual(todoRandom.customId);
+      expectNullFields(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`], [
+        ...expectedSubscriptionNullFields,
+        'ownerContent',
+        'adminContent',
+        'groupContent',
+      ]);
     });
   });
 };

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-oidc-fields.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-oidc-fields.ts
@@ -187,8 +187,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         adminContent: 'Admin Content',
         groupContent: 'Group Content',
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
       };
       const createResultSetName = `create${modelName}`;
       const updateResultSetName = `update${modelName}`;
@@ -196,8 +196,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           id
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
           privateContent
           ownerContent
           adminContent
@@ -213,8 +213,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       expectNullFields(createResult1.data[createResultSetName], [
         'owner',
         'authors',
-        'group',
-        'groups',
+        'customGroup',
+        'customGroups',
         'privateContent',
         'ownerContent',
         'adminContent',
@@ -225,7 +225,7 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       const todoUpdated1 = {
         id: todo['id'],
         authors: [userName1, userName2],
-        groups: [adminGroupName, devGroupName],
+        customGroups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
         ownersContent: 'Owners Content updated',
         adminContent: 'Admin Content updated',
@@ -235,8 +235,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           id
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
           privateContent
           ownersContent
           adminContent
@@ -247,8 +247,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       expectNullFields(updateResult1.data[updateResultSetName], [
         'owner',
         'authors',
-        'group',
-        'groups',
+        'customGroup',
+        'customGroups',
         'privateContent',
         'ownersContent',
         'adminContent',
@@ -260,8 +260,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         id
         owner
         authors
-        group
-        groups
+        customGroup
+        customGroups
         privateContent
         ownerContent
         ownersContent
@@ -287,8 +287,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         id: todo['id'],
         owner: todo['owner'],
         authors: [userName2],
-        group: devGroupName,
-        groups: [devGroupName],
+        customGroup: devGroupName,
+        customGroups: [devGroupName],
         privateContent: 'Private Content updated 1',
         ownersContent: 'Owners Content updated 1',
         groupsContent: 'Groups Content updated 1',
@@ -297,8 +297,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           id
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
           privateContent
           ownersContent
           groupsContent
@@ -308,8 +308,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       expectNullFields(updateResult2.data[updateResultSetName], [
         'owner',
         'authors',
-        'group',
-        'groups',
+        'customGroup',
+        'customGroups',
         'privateContent',
         'ownersContent',
         'groupsContent',
@@ -364,8 +364,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       expectNullFields(onCreateSubscriptionResult[0].data[`onCreate${modelName}`], [
         'owner',
         'authors',
-        'group',
-        'groups',
+        'customGroup',
+        'customGroups',
         'privateContent',
         'ownerContent',
         'adminContent',
@@ -387,8 +387,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       expectNullFields(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`], [
         'owner',
         'authors',
-        'group',
-        'groups',
+        'customGroup',
+        'customGroups',
         'privateContent',
         'ownersContent',
         'adminContent',
@@ -407,8 +407,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       const todoPrivateFields = {
         owner: userName1,
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
       };
       const createResultSetName = `create${modelName}`;
@@ -417,8 +417,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           id
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
           privateContent
         `;
 
@@ -452,7 +452,7 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       expect(createResult1.data[createResultSetName].id).toBeDefined();
       todoPrivateFields['id'] = createResult1.data[createResultSetName].id;
       // protected fields are nullified in mutation responses
-      const nulledPrivateFields = ['owner', 'authors', 'group', 'groups', 'privateContent'];
+      const nulledPrivateFields = ['owner', 'authors', 'customGroup', 'customGroups', 'privateContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledPrivateFields, 'ownerContent', 'adminContent', 'groupContent']);
 
       const privateAndPublicSet = `
@@ -546,8 +546,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
 
       const todo = {
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
         adminContent: 'Admin Content',
@@ -563,8 +563,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ${privateResultSet}
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
         `;
       const adminOwnerResultSet = `
           ${ownerResultSet}
@@ -594,14 +594,14 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       todo['id'] = createResult1.data[createResultSetName].id;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      const nulledOwnerFields = ['owner', 'authors', 'group', 'groups', 'privateContent'];
+      const nulledOwnerFields = ['owner', 'authors', 'customGroup', 'customGroups', 'privateContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledOwnerFields, 'ownersContent', 'groupsContent']);
 
       // user1 can update the allowed fields and add user2 to dyamic owners list field
       const todoUpdated1 = {
         id: todo['id'],
         authors: [userName1, userName2],
-        groups: [adminGroupName, devGroupName],
+        customGroups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
         ownerContent: 'Owner Content',
         adminContent: 'Admin Content updated',
@@ -698,8 +698,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ...todoRandom,
           owner: null,
           authors: null,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           privateContent: null,
           adminContent: null,
           ownersContent: null,
@@ -726,8 +726,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ...todoRandomUpdated,
           owner: null,
           authors: null,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           privateContent: null,
           adminContent: null,
           ownerContent: null,
@@ -747,8 +747,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
 
       const todo = {
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
         adminContent: 'Admin Content',
@@ -764,8 +764,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ${privateResultSet}
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
         `;
       const adminOwnerResultSet = `
           ${ownerResultSet}
@@ -815,7 +815,7 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       todo['id'] = createResult1.data[createResultSetName].id;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      const nulledOwnerFields = ['owner', 'authors', 'group', 'groups', 'privateContent'];
+      const nulledOwnerFields = ['owner', 'authors', 'customGroup', 'customGroups', 'privateContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledOwnerFields, 'ownersContent']);
 
       const publicFieldSet = `
@@ -858,19 +858,19 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       // non-owner cannot update a record to re-assign group membership
       const groupFieldSet = `
           id
-          group
+          customGroup
         `;
       await expect(
-        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], group: devGroupName }, groupFieldSet),
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], customGroup: devGroupName }, groupFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // non-owner cannot update a record to re-assign group memberships stored as dynamic list
       const groupsFieldSet = `
           id
-          groups
+          customGroups
         `;
       await expect(
-        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], groups: [devGroupName] }, groupsFieldSet),
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], customGroups: [devGroupName] }, groupsFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // non-owner cannot update a record with an owner protected field
@@ -910,8 +910,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         id
         owner
         authors
-        group
-        groups
+        customGroup
+        customGroups
         ownerContent
         ownersContent
         adminContent
@@ -934,8 +934,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           id: todo['id'],
           owner: null,
           authors: null,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           ownerContent: null,
           ownersContent: null,
           adminContent: null,
@@ -1645,8 +1645,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       const todo = {
         owner: userName1,
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
         groupsContent: 'Groups Content',
@@ -1661,8 +1661,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ${privateResultSet}
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
         `;
       const setWithOwnerAndGroupContent = `
           ${adminResultSet}
@@ -1688,14 +1688,14 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       todo['id'] = createResult1.data[createResultSetName].id;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      const nulledOwnerFields = ['owner', 'authors', 'group', 'groups', 'privateContent'];
+      const nulledOwnerFields = ['owner', 'authors', 'customGroup', 'customGroups', 'privateContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledOwnerFields, 'ownersContent', 'groupsContent']);
 
       // user1 can update the allowed fields and add user2 to dyamic owners list field
       const todoUpdated1 = {
         id: todo['id'],
         authors: [userName1, userName2],
-        groups: [adminGroupName, devGroupName],
+        customGroups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
         ownerContent: 'Owner Content',
         groupContent: 'Group Content',
@@ -1791,8 +1791,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ...todoRandom,
           owner: null,
           authors: null,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           privateContent: null,
           ownersContent: null,
           groupsContent: null,
@@ -1818,8 +1818,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ...todoRandomUpdated,
           owner: null,
           authors: null,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           privateContent: null,
           ownerContent: null,
           groupContent: null,
@@ -1839,8 +1839,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       const todo = {
         owner: userName1,
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
         groupsContent: 'Groups Content',
@@ -1855,8 +1855,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ${privateResultSet}
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
         `;
       const setWithOwnerAndGroupContent = `
           ${adminResultSet}
@@ -1890,7 +1890,7 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       todo['id'] = createResult1.data[createResultSetName].id;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      const nulledOwnerFields = ['owner', 'authors', 'group', 'groups', 'privateContent'];
+      const nulledOwnerFields = ['owner', 'authors', 'customGroup', 'customGroups', 'privateContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledOwnerFields, 'ownersContent']);
 
       const publicFieldSet = `
@@ -1933,19 +1933,19 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       // non-admin cannot update a record to re-assign group membership
       const groupFieldSet = `
           id
-          group
+          customGroup
         `;
       await expect(
-        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], group: devGroupName }, groupFieldSet),
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], customGroup: devGroupName }, groupFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // non-admin cannot update a record to re-assign group memberships stored as dynamic list
       const groupsFieldSet = `
           id
-          groups
+          customGroups
         `;
       await expect(
-        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], groups: [devGroupName] }, groupsFieldSet),
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], customGroups: [devGroupName] }, groupsFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // non-owner cannot update a record with an owner protected field
@@ -1985,8 +1985,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         id
         owner
         authors
-        group
-        groups
+        customGroup
+        customGroups
         ownerContent
         ownersContent
         groupContent
@@ -2000,8 +2000,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           id: todo['id'],
           owner: null,
           authors: null,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           ownerContent: null,
           ownersContent: null,
           groupContent: null,
@@ -2063,8 +2063,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         customId: Date.now().toString(),
         owner: userName1,
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
         adminContent: 'Admin Content',
@@ -2081,8 +2081,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ${privateResultSet}
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
           adminContent
         `;
       const setWithOwnerContent = `
@@ -2107,14 +2107,14 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       todo['customId'] = createResult1.data[createResultSetName].customId;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      const nulledMutationFields = ['owner', 'authors', 'group', 'groups', 'privateContent', 'adminContent'];
+      const nulledMutationFields = ['owner', 'authors', 'customGroup', 'customGroups', 'privateContent', 'adminContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledMutationFields, 'ownersContent', 'groupsContent']);
 
       // user in allowed group can update the allowed fields and add user2 to dyamic owners list field
       const todoUpdated1 = {
         customId: todo['customId'],
         authors: [userName1, userName2],
-        groups: [adminGroupName, devGroupName],
+        customGroups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
         ownerContent: 'Owner Content',
       };
@@ -2218,8 +2218,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ...todoRandom,
           owner: null,
           authors: null,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           privateContent: null,
           ownersContent: null,
           adminContent: null,
@@ -2246,8 +2246,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ...todoRandomUpdated,
           owner: null,
           authors: null,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           privateContent: null,
           ownerContent: null,
           adminContent: null,
@@ -2273,8 +2273,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ...todoRandomUpdated,
           owner: null,
           authors: null,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           privateContent: null,
           ownerContent: null,
           ownersContent: null,
@@ -2294,8 +2294,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         customId: Date.now().toString(),
         owner: userName1,
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
         adminContent: 'Admin Content',
@@ -2312,8 +2312,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ${privateResultSet}
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
           adminContent
         `;
       const setWithOwnerContent = `
@@ -2349,7 +2349,7 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       todo['customId'] = createResult1.data[createResultSetName].customId;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      const nulledAdminFields = ['owner', 'authors', 'group', 'groups', 'privateContent', 'adminContent'];
+      const nulledAdminFields = ['owner', 'authors', 'customGroup', 'customGroups', 'privateContent', 'adminContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledAdminFields, 'ownersContent', 'groupsContent']);
 
       const publicFieldSet = `
@@ -2397,20 +2397,21 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       // user not in allowed group cannot update a record to re-assign group membership
       const groupFieldSet = `
           customId
-          group
+          customGroup
         `;
       await expect(
-        async () => await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], group: devGroupName }, groupFieldSet),
+        async () =>
+          await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], customGroup: devGroupName }, groupFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // user not in allowed group cannot update a record to re-assign group memberships stored as dynamic list
       const groupsFieldSet = `
           customId
-          groups
+          customGroups
         `;
       await expect(
         async () =>
-          await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], groups: [devGroupName] }, groupsFieldSet),
+          await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], customGroups: [devGroupName] }, groupsFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // user not in allowed group cannot update a record with an owner protected field
@@ -2441,8 +2442,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         customId
         owner
         authors
-        group
-        groups
+        customGroup
+        customGroups
         ownerContent
         ownersContent
         adminContent
@@ -2452,8 +2453,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       const expectedReadErrorFields = [
         'owner',
         'authors',
-        'group',
-        'groups',
+        'customGroup',
+        'customGroups',
         'ownerContent',
         'ownersContent',
         'adminContent',
@@ -2465,8 +2466,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           customId: todo['customId'],
           owner: null,
           authors: null,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           ownerContent: null,
           ownersContent: null,
           adminContent: null,
@@ -2548,8 +2549,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         customId: Date.now().toString(),
         owner: userName1,
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
         adminContent: 'Admin Content',
         ownersContent: 'Owners Content',
@@ -2564,8 +2565,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ${privateResultSet}
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
           adminContent
         `;
       const setWithOwnerAndGroupContent = `
@@ -2590,14 +2591,14 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       todo['customId'] = createResult1.data[createResultSetName].customId;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      const nulledMutationFields = ['owner', 'authors', 'group', 'groups', 'privateContent', 'adminContent'];
+      const nulledMutationFields = ['owner', 'authors', 'customGroup', 'customGroups', 'privateContent', 'adminContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledMutationFields, 'ownersContent']);
 
       // user part of allowed groups can update the allowed fields and add user2 to dyamic owners list field
       const todoUpdated1 = {
         customId: todo['customId'],
         authors: [userName1, userName2],
-        groups: [adminGroupName, devGroupName],
+        customGroups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
         ownerContent: 'Owner Content',
         groupContent: 'Group Content',
@@ -2689,8 +2690,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ...todoRandom,
           owner: null,
           authors: null,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           privateContent: null,
           ownersContent: null,
           adminContent: null,
@@ -2716,8 +2717,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ...todoRandomUpdated,
           owner: null,
           authors: null,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           privateContent: null,
           ownerContent: null,
           adminContent: null,
@@ -2736,8 +2737,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         customId: Date.now().toString(),
         owner: userName1,
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
         adminContent: 'Admin Content',
@@ -2753,8 +2754,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           ${privateResultSet}
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
           adminContent
         `;
       const setWithOwnerAndGroupContent = `
@@ -2795,7 +2796,7 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       todo['customId'] = createResult1.data[createResultSetName].customId;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      const nulledAdminFields = ['owner', 'authors', 'group', 'groups', 'privateContent', 'adminContent'];
+      const nulledAdminFields = ['owner', 'authors', 'customGroup', 'customGroups', 'privateContent', 'adminContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledAdminFields, 'ownersContent']);
 
       const publicFieldSet = `
@@ -2838,20 +2839,21 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       // user not part of allowed groups cannot update a record to re-assign group membership
       const groupFieldSet = `
           customId
-          group
+          customGroup
         `;
       await expect(
-        async () => await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], group: devGroupName }, groupFieldSet),
+        async () =>
+          await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], customGroup: devGroupName }, groupFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // user not part of allowed groups cannot update a record to re-assign group memberships stored as dynamic list
       const groupsFieldSet = `
           customId
-          groups
+          customGroups
         `;
       await expect(
         async () =>
-          await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], groups: [devGroupName] }, groupsFieldSet),
+          await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], customGroups: [devGroupName] }, groupsFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // user not part of allowed groups cannot update a record with an owner protected field
@@ -2882,8 +2884,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
         customId
         owner
         authors
-        group
-        groups
+        customGroup
+        customGroups
         ownerContent
         ownersContent
         adminContent
@@ -2893,8 +2895,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       const expectedReadErrorFields = [
         'owner',
         'authors',
-        'group',
-        'groups',
+        'customGroup',
+        'customGroups',
         'ownerContent',
         'ownersContent',
         'adminContent',
@@ -2906,8 +2908,8 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
           customId: todo['customId'],
           owner: null,
           authors: null,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           ownerContent: null,
           ownersContent: null,
           adminContent: null,

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool-fields.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool-fields.ts
@@ -163,8 +163,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         adminContent: 'Admin Content',
         groupContent: 'Group Content',
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
       };
       const createResultSetName = `create${modelName}`;
       const updateResultSetName = `update${modelName}`;
@@ -172,8 +172,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         id
         owner
         authors
-        group
-        groups
+        customGroup
+        customGroups
         privateContent
         ownerContent
         adminContent
@@ -189,8 +189,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
       expectNullFields(createResult1.data[createResultSetName], [
-        'group',
-        'groups',
+        'customGroup',
+        'customGroups',
         'privateContent',
         'ownerContent',
         'adminContent',
@@ -201,7 +201,7 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       const todoUpdated1 = {
         id: todo['id'],
         authors: [userName1, userName2],
-        groups: [adminGroupName, devGroupName],
+        customGroups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
         ownersContent: 'Owners Content updated',
         adminContent: 'Admin Content updated',
@@ -211,8 +211,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         id
         owner
         authors
-        group
-        groups
+        customGroup
+        customGroups
         privateContent
         ownersContent
         adminContent
@@ -223,8 +223,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       expect(updateResult1.data[updateResultSetName].owner).toEqual(userName1);
       expect(updateResult1.data[updateResultSetName].authors).toEqual([userName1, userName2]);
       expectNullFields(updateResult1.data[updateResultSetName], [
-        'group',
-        'groups',
+        'customGroup',
+        'customGroups',
         'privateContent',
         'ownersContent',
         'adminContent',
@@ -236,8 +236,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         id
         owner
         authors
-        group
-        groups
+        customGroup
+        customGroups
         privateContent
         ownerContent
         ownersContent
@@ -263,8 +263,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         id: todo['id'],
         owner: todo['owner'],
         authors: [userName2],
-        group: devGroupName,
-        groups: [devGroupName],
+        customGroup: devGroupName,
+        customGroups: [devGroupName],
         privateContent: 'Private Content updated 1',
         ownersContent: 'Owners Content updated 1',
         groupsContent: 'Groups Content updated 1',
@@ -273,8 +273,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         id
         owner
         authors
-        group
-        groups
+        customGroup
+        customGroups
         privateContent
         ownersContent
         groupsContent
@@ -283,7 +283,13 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       expect(updateResult2.data[updateResultSetName].id).toEqual(todo['id']);
       expect(updateResult2.data[updateResultSetName].owner).toEqual(userName1);
       expect(updateResult2.data[updateResultSetName].authors).toEqual([userName2]);
-      expectNullFields(updateResult2.data[updateResultSetName], ['group', 'groups', 'privateContent', 'ownersContent', 'groupsContent']);
+      expectNullFields(updateResult2.data[updateResultSetName], [
+        'customGroup',
+        'customGroups',
+        'privateContent',
+        'ownersContent',
+        'groupsContent',
+      ]);
 
       // user2 can read the allowed fields
       const user2ReadAllowedSet = user2UpdateAllowedSet;
@@ -332,8 +338,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       );
       expect(onCreateSubscriptionResult).toHaveLength(1);
       expectNullFields(onCreateSubscriptionResult[0].data[`onCreate${modelName}`], [
-        'group',
-        'groups',
+        'customGroup',
+        'customGroups',
         'privateContent',
         'ownerContent',
         'adminContent',
@@ -353,8 +359,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       );
       expect(onUpdateSubscriptionResult).toHaveLength(1);
       expectNullFields(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`], [
-        'group',
-        'groups',
+        'customGroup',
+        'customGroups',
         'privateContent',
         'ownersContent',
         'adminContent',
@@ -373,8 +379,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       const todoPrivateFields = {
         owner: userName1,
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
       };
       const createResultSetName = `create${modelName}`;
@@ -383,8 +389,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         id
         owner
         authors
-        group
-        groups
+        customGroup
+        customGroups
         privateContent
       `;
 
@@ -420,7 +426,7 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       expect(createResult1.data[createResultSetName].authors).toEqual([userName1]);
       todoPrivateFields['id'] = createResult1.data[createResultSetName].id;
       // protected fields are nullified in mutation responses
-      const nulledPrivateFields = ['group', 'groups', 'privateContent'];
+      const nulledPrivateFields = ['customGroup', 'customGroups', 'privateContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledPrivateFields, 'ownerContent', 'adminContent', 'groupContent']);
 
       const privateAndPublicSet = `
@@ -514,8 +520,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
 
       const todo = {
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
         adminContent: 'Admin Content',
@@ -531,8 +537,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         ${privateResultSet}
         owner
         authors
-        group
-        groups
+        customGroup
+        customGroups
       `;
       const adminOwnerResultSet = `
           ${ownerResultSet}
@@ -564,14 +570,14 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       todo['id'] = createResult1.data[createResultSetName].id;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      const nulledOwnerFields = ['group', 'groups', 'privateContent'];
+      const nulledOwnerFields = ['customGroup', 'customGroups', 'privateContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledOwnerFields, 'ownersContent', 'groupsContent']);
 
       // user1 can update the allowed fields and add user2 to dyamic owners list field
       const todoUpdated1 = {
         id: todo['id'],
         authors: [userName1, userName2],
-        groups: [adminGroupName, devGroupName],
+        customGroups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
         ownerContent: 'Owner Content',
         adminContent: 'Admin Content updated',
@@ -666,7 +672,15 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       expect(onCreateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
         onCreateSubscriptionResult[0],
-        { ...todoRandom, group: null, groups: null, privateContent: null, adminContent: null, ownersContent: null, groupsContent: null },
+        {
+          ...todoRandom,
+          customGroup: null,
+          customGroups: null,
+          privateContent: null,
+          adminContent: null,
+          ownersContent: null,
+          groupsContent: null,
+        },
         `onCreate${modelName}`,
       );
 
@@ -686,8 +700,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         onUpdateSubscriptionResult[0],
         {
           ...todoRandomUpdated,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           privateContent: null,
           adminContent: null,
           ownerContent: null,
@@ -707,8 +721,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
 
       const todo = {
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
         adminContent: 'Admin Content',
@@ -724,8 +738,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         ${privateResultSet}
         owner
         authors
-        group
-        groups
+        customGroup
+        customGroups
       `;
       const adminOwnerResultSet = `
           ${ownerResultSet}
@@ -777,7 +791,7 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       todo['id'] = createResult1.data[createResultSetName].id;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      const nulledOwnerFields = ['group', 'groups', 'privateContent'];
+      const nulledOwnerFields = ['customGroup', 'customGroups', 'privateContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledOwnerFields, 'ownersContent']);
 
       const publicFieldSet = `
@@ -820,19 +834,19 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       // non-owner cannot update a record to re-assign group membership
       const groupFieldSet = `
           id
-          group
+          customGroup
         `;
       await expect(
-        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], group: devGroupName }, groupFieldSet),
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], customGroup: devGroupName }, groupFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // non-owner cannot update a record to re-assign group memberships stored as dynamic list
       const groupsFieldSet = `
           id
-          groups
+          customGroups
         `;
       await expect(
-        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], groups: [devGroupName] }, groupsFieldSet),
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], customGroups: [devGroupName] }, groupsFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // non-owner cannot update a record with an owner protected field
@@ -872,8 +886,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         id
         owner
         authors
-        group
-        groups
+        customGroup
+        customGroups
         ownerContent
         ownersContent
         adminContent
@@ -896,8 +910,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
           id: todo['id'],
           owner: null,
           authors: null,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           ownerContent: null,
           ownersContent: null,
           adminContent: null,
@@ -1607,8 +1621,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       const todo = {
         owner: userName1,
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
         groupsContent: 'Groups Content',
@@ -1623,8 +1637,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
           ${privateResultSet}
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
         `;
       const setWithOwnerAndGroupContent = `
           ${adminResultSet}
@@ -1652,14 +1666,14 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       todo['id'] = createResult1.data[createResultSetName].id;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      const nulledFields = ['group', 'groups', 'privateContent'];
+      const nulledFields = ['customGroup', 'customGroups', 'privateContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledFields, 'ownersContent', 'groupsContent']);
 
       // user1 can update the allowed fields and add user2 to dyamic owners list field
       const todoUpdated1 = {
         id: todo['id'],
         authors: [userName1, userName2],
-        groups: [adminGroupName, devGroupName],
+        customGroups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
         ownerContent: 'Owner Content',
         groupContent: 'Group Content',
@@ -1751,7 +1765,7 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       expect(onCreateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
         onCreateSubscriptionResult[0],
-        { ...todoRandom, group: null, groups: null, privateContent: null, ownersContent: null, groupsContent: null },
+        { ...todoRandom, customGroup: null, customGroups: null, privateContent: null, ownersContent: null, groupsContent: null },
         `onCreate${modelName}`,
       );
 
@@ -1769,7 +1783,7 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       expect(onUpdateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
         onUpdateSubscriptionResult[0],
-        { ...todoRandomUpdated, group: null, groups: null, privateContent: null, ownerContent: null, groupContent: null },
+        { ...todoRandomUpdated, customGroup: null, customGroups: null, privateContent: null, ownerContent: null, groupContent: null },
         `onUpdate${modelName}`,
       );
 
@@ -1784,8 +1798,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
 
       const todo = {
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
         groupsContent: 'Groups Content',
@@ -1800,8 +1814,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
           ${privateResultSet}
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
         `;
       const setWithOwnerAndGroupContent = `
           ${adminResultSet}
@@ -1835,7 +1849,7 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       todo['id'] = createResult1.data[createResultSetName].id;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      const nulledFields = ['group', 'groups', 'privateContent'];
+      const nulledFields = ['customGroup', 'customGroups', 'privateContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledFields, 'ownersContent']);
 
       const publicFieldSet = `
@@ -1852,7 +1866,7 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         async () => await user1TodoHelper.update(updateResultSetName, { ...todo, ownersContent: 'Owners Content' }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
-      // admin cannot update a record with dynamic list of groups protected field that does not allow update operation
+      // admin cannot update a record with dynamic list of customGroups protected field that does not allow update operation
       await expect(
         async () => await user1TodoHelper.update(updateResultSetName, { ...todo, groupsContent: 'Groups Content' }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
@@ -1878,19 +1892,19 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       // non-admin cannot update a record to re-assign group membership
       const groupFieldSet = `
         id
-        group
+        customGroup
       `;
       await expect(
-        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], group: devGroupName }, groupFieldSet),
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], customGroup: devGroupName }, groupFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // non-admin cannot update a record to re-assign group memberships stored as dynamic list
       const groupsFieldSet = `
           id
-          groups
+          customGroups
         `;
       await expect(
-        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], groups: [devGroupName] }, groupsFieldSet),
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], customGroups: [devGroupName] }, groupsFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // non-owner cannot update a record with an owner protected field
@@ -1930,8 +1944,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         id
         owner
         authors
-        group
-        groups
+        customGroup
+        customGroups
         ownerContent
         ownersContent
         groupContent
@@ -1945,8 +1959,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
           id: todo['id'],
           owner: null,
           authors: null,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           ownerContent: null,
           ownersContent: null,
           groupContent: null,
@@ -2015,8 +2029,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         customId: Date.now().toString(),
         owner: userName1,
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
         adminContent: 'Admin Content',
@@ -2033,8 +2047,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
           ${privateResultSet}
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
           adminContent
         `;
       const setWithOwnerContent = `
@@ -2061,14 +2075,14 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       todo['customId'] = createResult1.data[createResultSetName].customId;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      const nulledMutationFields = ['group', 'groups', 'privateContent', 'adminContent'];
+      const nulledMutationFields = ['customGroup', 'customGroups', 'privateContent', 'adminContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledMutationFields, 'ownersContent', 'groupsContent']);
 
       // user in allowed group can update the allowed fields and add user2 to dyamic owners list field
       const todoUpdated1 = {
         customId: todo['customId'],
         authors: [userName1, userName2],
-        groups: [adminGroupName, devGroupName],
+        customGroups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
         ownerContent: 'Owner Content',
       };
@@ -2170,7 +2184,15 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       expect(onCreateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
         onCreateSubscriptionResult[0],
-        { ...todoRandom, group: null, groups: null, privateContent: null, ownersContent: null, adminContent: null, groupsContent: null },
+        {
+          ...todoRandom,
+          customGroup: null,
+          customGroups: null,
+          privateContent: null,
+          ownersContent: null,
+          adminContent: null,
+          groupsContent: null,
+        },
         `onCreate${modelName}`,
       );
 
@@ -2188,7 +2210,7 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       expect(onUpdateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
         onUpdateSubscriptionResult[0],
-        { ...todoRandomUpdated, group: null, groups: null, privateContent: null, ownerContent: null, adminContent: null },
+        { ...todoRandomUpdated, customGroup: null, customGroups: null, privateContent: null, ownerContent: null, adminContent: null },
         `onUpdate${modelName}`,
       );
 
@@ -2208,8 +2230,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         onDeleteSubscriptionResult[0],
         {
           ...todoRandomUpdated,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           privateContent: null,
           ownerContent: null,
           ownersContent: null,
@@ -2229,8 +2251,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         customId: Date.now().toString(),
         owner: userName1,
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
         adminContent: 'Admin Content',
@@ -2247,8 +2269,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
           ${privateResultSet}
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
           adminContent
         `;
       const setWithOwnerContent = `
@@ -2286,7 +2308,7 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       todo['customId'] = createResult1.data[createResultSetName].customId;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      const nulledAdminFields = ['group', 'groups', 'privateContent', 'adminContent'];
+      const nulledAdminFields = ['customGroup', 'customGroups', 'privateContent', 'adminContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledAdminFields, 'ownersContent', 'groupsContent']);
 
       const publicFieldSet = `
@@ -2334,20 +2356,21 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       // user not in allowed group cannot update a record to re-assign group membership
       const groupFieldSet = `
           customId
-          group
+          customGroup
         `;
       await expect(
-        async () => await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], group: devGroupName }, groupFieldSet),
+        async () =>
+          await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], customGroup: devGroupName }, groupFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // user not in allowed group cannot update a record to re-assign group memberships stored as dynamic list
       const groupsFieldSet = `
           customId
-          groups
+          customGroups
         `;
       await expect(
         async () =>
-          await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], groups: [devGroupName] }, groupsFieldSet),
+          await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], customGroups: [devGroupName] }, groupsFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // user not in allowed group cannot update a record with an owner protected field
@@ -2378,8 +2401,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         customId
         owner
         authors
-        group
-        groups
+        customGroup
+        customGroups
         ownerContent
         ownersContent
         adminContent
@@ -2389,8 +2412,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       const expectedReadErrorFields = [
         'owner',
         'authors',
-        'group',
-        'groups',
+        'customGroup',
+        'customGroups',
         'ownerContent',
         'ownersContent',
         'adminContent',
@@ -2402,8 +2425,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
           customId: todo['customId'],
           owner: null,
           authors: null,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           ownerContent: null,
           ownersContent: null,
           adminContent: null,
@@ -2437,7 +2460,7 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
           await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersAndGroupsContent);
         },
       ]);
-      const expectedSubscriptionNullFields = ['group', 'groups', 'privateContent', 'publicContent'];
+      const expectedSubscriptionNullFields = ['customGroup', 'customGroups', 'privateContent', 'publicContent'];
       expect(onCreateSubscriptionResult).toHaveLength(1);
       expect(onCreateSubscriptionResult[0].data[`onCreate${modelName}`].customId).toEqual(todoRandom.customId);
       expectNullFields(onCreateSubscriptionResult[0].data[`onCreate${modelName}`], [
@@ -2485,8 +2508,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         customId: Date.now().toString(),
         owner: userName1,
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
         adminContent: 'Admin Content',
         ownersContent: 'Owners Content',
@@ -2501,8 +2524,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
           ${privateResultSet}
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
           adminContent
         `;
       const setWithOwnerAndGroupContent = `
@@ -2529,14 +2552,14 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       todo['customId'] = createResult1.data[createResultSetName].customId;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      const nulledMutationFields = ['group', 'groups', 'privateContent', 'adminContent'];
+      const nulledMutationFields = ['customGroup', 'customGroups', 'privateContent', 'adminContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledMutationFields, 'ownersContent']);
 
       // user part of allowed groups can update the allowed fields and add user2 to dyamic owners list field
       const todoUpdated1 = {
         customId: todo['customId'],
         authors: [userName1, userName2],
-        groups: [adminGroupName, devGroupName],
+        customGroups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
         ownerContent: 'Owner Content',
         groupContent: 'Group Content',
@@ -2626,7 +2649,7 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       expect(onCreateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
         onCreateSubscriptionResult[0],
-        { ...todoRandom, group: null, groups: null, privateContent: null, ownersContent: null, adminContent: null },
+        { ...todoRandom, customGroup: null, customGroups: null, privateContent: null, ownersContent: null, adminContent: null },
         `onCreate${modelName}`,
       );
 
@@ -2646,8 +2669,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         onUpdateSubscriptionResult[0],
         {
           ...todoRandomUpdated,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           privateContent: null,
           ownerContent: null,
           adminContent: null,
@@ -2666,8 +2689,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         customId: Date.now().toString(),
         owner: userName1,
         authors: [userName1],
-        group: adminGroupName,
-        groups: [adminGroupName],
+        customGroup: adminGroupName,
+        customGroups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
         adminContent: 'Admin Content',
@@ -2683,8 +2706,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
           ${privateResultSet}
           owner
           authors
-          group
-          groups
+          customGroup
+          customGroups
           adminContent
         `;
       const setWithOwnerAndGroupContent = `
@@ -2727,7 +2750,7 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       todo['customId'] = createResult1.data[createResultSetName].customId;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      const nulledAdminFields = ['group', 'groups', 'privateContent', 'adminContent'];
+      const nulledAdminFields = ['customGroup', 'customGroups', 'privateContent', 'adminContent'];
       expectNullFields(createResult1.data[createResultSetName], [...nulledAdminFields, 'ownersContent']);
 
       const publicFieldSet = `
@@ -2770,20 +2793,21 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       // user not part of allowed groups cannot update a record to re-assign group membership
       const groupFieldSet = `
           customId
-          group
+          customGroup
         `;
       await expect(
-        async () => await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], group: devGroupName }, groupFieldSet),
+        async () =>
+          await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], customGroup: devGroupName }, groupFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // user not part of allowed groups cannot update a record to re-assign group memberships stored as dynamic list
       const groupsFieldSet = `
           customId
-          groups
+          customGroups
         `;
       await expect(
         async () =>
-          await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], groups: [devGroupName] }, groupsFieldSet),
+          await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], customGroups: [devGroupName] }, groupsFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // user not part of allowed groups cannot update a record with an owner protected field
@@ -2814,8 +2838,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         customId
         owner
         authors
-        group
-        groups
+        customGroup
+        customGroups
         ownerContent
         ownersContent
         adminContent
@@ -2825,8 +2849,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       const expectedReadErrorFields = [
         'owner',
         'authors',
-        'group',
-        'groups',
+        'customGroup',
+        'customGroups',
         'ownerContent',
         'ownersContent',
         'adminContent',
@@ -2838,8 +2862,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
           customId: todo['customId'],
           owner: null,
           authors: null,
-          group: null,
-          groups: null,
+          customGroup: null,
+          customGroups: null,
           ownerContent: null,
           ownersContent: null,
           adminContent: null,
@@ -2878,7 +2902,7 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
           await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersContent);
         },
       ]);
-      const expectedSubscriptionNullFields = ['group', 'groups', 'privateContent', 'publicContent'];
+      const expectedSubscriptionNullFields = ['customGroup', 'customGroups', 'privateContent', 'publicContent'];
       expect(onCreateSubscriptionResult).toHaveLength(1);
       expect(onCreateSubscriptionResult[0].data[`onCreate${modelName}`].customId).toEqual(todoRandom.customId);
       expectNullFields(onCreateSubscriptionResult[0].data[`onCreate${modelName}`], [

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool-fields.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool-fields.ts
@@ -32,6 +32,7 @@ import {
 import { setupUser, getUserPoolId, signInUser, configureAmplify, getConfiguredAppsyncClientCognitoAuth } from '../schema-api-directives';
 import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
 import { SQL_TESTS_USE_BETA } from './sql-e2e-config';
+import { GQLQueryHelper } from '../query-utils/gql-helper';
 
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
@@ -59,7 +60,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
     let graphQlEndpoint = 'localhost';
 
     let projRoot;
-    let appSyncClients = {};
+    let user1ModelOperationHelpers: { [key: string]: GQLQueryHelper };
+    let user2ModelOperationHelpers: { [key: string]: GQLQueryHelper };
     const userMap = {};
 
     beforeAll(async () => {
@@ -145,20 +147,24 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       userMap[userName1] = user1;
       const user2 = await signInUser(userName2, userPassword);
       userMap[userName2] = user2;
-      appSyncClients = await configureAppSyncClients(projRoot, apiName, [userPoolProvider, apiKeyProvider], userMap);
+      const appSyncClients = await configureAppSyncClients(projRoot, apiName, [userPoolProvider, apiKeyProvider], userMap);
+      user1ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
+      user2ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
     };
 
     test('Private model auth and allowed field operations', async () => {
       const modelName = 'TodoPrivateContentVarious';
-      const user1ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
-      const user2ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
       const user1TodoHelper = user1ModelOperationHelpers[modelName];
       const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
       const todo = {
         privateContent: 'Private Content',
         ownerContent: 'Owner Content',
+        adminContent: 'Admin Content',
+        groupContent: 'Group Content',
         authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
       };
       const createResultSetName = `create${modelName}`;
       const updateResultSetName = `update${modelName}`;
@@ -166,8 +172,12 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         id
         owner
         authors
+        group
+        groups
         privateContent
         ownerContent
+        adminContent
+        groupContent
       `;
 
       // owner(user1) creates a record with only allowed fields
@@ -178,36 +188,64 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       todo['id'] = createResult1.data[createResultSetName].id;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      expectNullFields(createResult1.data[createResultSetName], ['privateContent', 'ownerContent']);
+      expectNullFields(createResult1.data[createResultSetName], [
+        'group',
+        'groups',
+        'privateContent',
+        'ownerContent',
+        'adminContent',
+        'groupContent',
+      ]);
 
       // user1 can update the allowed fields and add user2 to dyamic owners list field
       const todoUpdated1 = {
         id: todo['id'],
         authors: [userName1, userName2],
+        groups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
+        ownersContent: 'Owners Content updated',
+        adminContent: 'Admin Content updated',
+        groupsContent: 'Groups Content updated',
       };
       const user1UpdateAllowedSet = `
         id
         owner
         authors
+        group
+        groups
         privateContent
         ownersContent
+        adminContent
+        groupsContent
       `;
       const updateResult1 = await user1TodoHelper.update(updateResultSetName, todoUpdated1, user1UpdateAllowedSet);
       expect(updateResult1.data[updateResultSetName].id).toEqual(todo['id']);
       expect(updateResult1.data[updateResultSetName].owner).toEqual(userName1);
       expect(updateResult1.data[updateResultSetName].authors).toEqual([userName1, userName2]);
-      expectNullFields(updateResult1.data[updateResultSetName], ['privateContent', 'ownersContent']);
+      expectNullFields(updateResult1.data[updateResultSetName], [
+        'group',
+        'groups',
+        'privateContent',
+        'ownersContent',
+        'adminContent',
+        'groupsContent',
+      ]);
 
       // user1 can read the allowed fields
-      const user1ReadAllowedSet = `
+      const completeResultSet = `
         id
         owner
         authors
+        group
+        groups
         privateContent
         ownerContent
         ownersContent
+        adminContent
+        groupContent
+        groupsContent
       `;
+      const user1ReadAllowedSet = completeResultSet;
       const getResult1 = await user1TodoHelper.get(
         {
           id: todo['id'],
@@ -215,7 +253,7 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         user1ReadAllowedSet,
         false,
       );
-      checkOperationResult(getResult1, { ...todo, ...todoUpdated1, ownersContent: null }, `get${modelName}`);
+      checkOperationResult(getResult1, { ...todo, ...todoUpdated1 }, `get${modelName}`);
 
       const listTodosResult1 = await user1TodoHelper.list({}, user1ReadAllowedSet, `list${modelName}`, false, 'all');
       checkListItemExistence(listTodosResult1, `list${modelName}`, todo['id'], true);
@@ -225,21 +263,27 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         id: todo['id'],
         owner: todo['owner'],
         authors: [userName2],
+        group: devGroupName,
+        groups: [devGroupName],
         privateContent: 'Private Content updated 1',
         ownersContent: 'Owners Content updated 1',
+        groupsContent: 'Groups Content updated 1',
       };
       const user2UpdateAllowedSet = `
         id
         owner
         authors
+        group
+        groups
         privateContent
         ownersContent
+        groupsContent
       `;
       const updateResult2 = await user2TodoHelper.update(updateResultSetName, todoUpdated2, user2UpdateAllowedSet);
       expect(updateResult2.data[updateResultSetName].id).toEqual(todo['id']);
       expect(updateResult2.data[updateResultSetName].owner).toEqual(userName1);
       expect(updateResult2.data[updateResultSetName].authors).toEqual([userName2]);
-      expectNullFields(updateResult2.data[updateResultSetName], ['privateContent', 'ownersContent']);
+      expectNullFields(updateResult2.data[updateResultSetName], ['group', 'groups', 'privateContent', 'ownersContent', 'groupsContent']);
 
       // user2 can read the allowed fields
       const user2ReadAllowedSet = user2UpdateAllowedSet;
@@ -270,6 +314,7 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         id: todoRandom.id,
         owner: userName1,
         privateContent: 'Private Content updated',
+        adminContent: 'Admin Content updated',
       };
       const subscriberClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName2]);
       const subTodoHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
@@ -286,11 +331,14 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         false,
       );
       expect(onCreateSubscriptionResult).toHaveLength(1);
-      checkOperationResult(
-        onCreateSubscriptionResult[0],
-        { ...todoRandom, privateContent: null, ownerContent: null },
-        `onCreate${modelName}`,
-      );
+      expectNullFields(onCreateSubscriptionResult[0].data[`onCreate${modelName}`], [
+        'group',
+        'groups',
+        'privateContent',
+        'ownerContent',
+        'adminContent',
+        'groupContent',
+      ]);
 
       const onUpdateSubscriptionResult = await subTodoHelper.subscribe(
         'onUpdate',
@@ -300,15 +348,18 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
           },
         ],
         {},
-        user2UpdateAllowedSet,
+        user1UpdateAllowedSet,
         false,
       );
       expect(onUpdateSubscriptionResult).toHaveLength(1);
-      checkOperationResult(
-        onUpdateSubscriptionResult[0],
-        { ...todoRandomUpdated, privateContent: null, ownersContent: null },
-        `onUpdate${modelName}`,
-      );
+      expectNullFields(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`], [
+        'group',
+        'groups',
+        'privateContent',
+        'ownersContent',
+        'adminContent',
+        'groupsContent',
+      ]);
 
       const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [], {}, user1UpdateAllowedSet, false);
       expect(onDeleteSubscriptionResult).toHaveLength(0);
@@ -316,14 +367,14 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
 
     test('Private model auth and restricted field operations', async () => {
       const modelName = 'TodoPrivateContentVarious';
-      const user1ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
-      const user2ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
       const user1TodoHelper = user1ModelOperationHelpers[modelName];
       const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
       const todoPrivateFields = {
         owner: userName1,
         authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
         privateContent: 'Private Content',
       };
       const createResultSetName = `create${modelName}`;
@@ -332,6 +383,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         id
         owner
         authors
+        group
+        groups
         privateContent
       `;
 
@@ -345,14 +398,21 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         async () => await user1TodoHelper.create(createResultSetName, { ...todoPrivateFields, ownersContent: 'Owners Content' }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
 
+      // cannot create a record with dynamic groups list protected field that does not allow create operation
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todoPrivateFields, groupsContent: 'Groups Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+
       // Create a record with allowed fields, so we can test the update and delete operations.
       const user1CreateAllowedSet = `
         ${privateResultSet}
         ownerContent
+        adminContent
+        groupContent
       `;
       const createResult1 = await user1TodoHelper.create(
         createResultSetName,
-        { ...todoPrivateFields, ownerContent: 'Owner Content' },
+        { ...todoPrivateFields, ownerContent: 'Owner Content', adminContent: 'Admin Content', groupContent: 'Group Content' },
         user1CreateAllowedSet,
       );
       expect(createResult1.data[createResultSetName].id).toBeDefined();
@@ -360,7 +420,8 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       expect(createResult1.data[createResultSetName].authors).toEqual([userName1]);
       todoPrivateFields['id'] = createResult1.data[createResultSetName].id;
       // protected fields are nullified in mutation responses
-      expectNullFields(createResult1.data[createResultSetName], ['privateContent', 'ownerContent']);
+      const nulledPrivateFields = ['group', 'groups', 'privateContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledPrivateFields, 'ownerContent', 'adminContent', 'groupContent']);
 
       const privateAndPublicSet = `
         ${privateResultSet}
@@ -382,16 +443,35 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
           await user1TodoHelper.update(updateResultSetName, { ...todoPrivateFields, ownerContent: 'Owner Content' }, privateAndOwnerSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
-      /* todo: enable once fixed in auth utils
       const privateAndOwnersSet = `
         ${privateResultSet}
         ownersContent
       `;
       // non-owner cannot update a record with dynamic owner list protected field
-      await expect(async () => await user2TodoHelper.update(updateResultSetName, { ...todoPrivateFields, ownersContent: 'Owners Content'}, privateAndOwnersSet)).rejects.toThrowErrorMatchingInlineSnapshot(
-        expectedOperationError(updateResultSetName, 'Mutation'),
-      );
-      */
+      await expect(
+        async () =>
+          await user2TodoHelper.update(updateResultSetName, { ...todoPrivateFields, ownersContent: 'Owners Content' }, privateAndOwnersSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      const privateAndGroupSet = `
+          ${privateResultSet}
+          groupContent
+        `;
+      // cannot update a record with group protected field that does not allow update operation
+      await expect(
+        async () =>
+          await user1TodoHelper.update(updateResultSetName, { ...todoPrivateFields, groupContent: 'Group Content' }, privateAndGroupSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      const privateAndGroupsSet = `
+        ${privateResultSet}
+        groupsContent
+      `;
+      // non-owner cannot update a record with dynamic group list protected field
+      await expect(
+        async () =>
+          await user2TodoHelper.update(updateResultSetName, { ...todoPrivateFields, groupsContent: 'Groups Content' }, privateAndGroupsSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // cannot read a record with public protected field
       const getResult1 = await user1TodoHelper.get({ id: todoPrivateFields['id'] }, privateAndPublicSet, false, 'all');
@@ -407,37 +487,39 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       checkListItemExistence(listTodosResult1, `list${modelName}`, todoPrivateFields['id'], true);
       checkListResponseErrors(listTodosResult1, expectedFieldErrors(['publicContent'], modelName, false));
 
-      // non-owner cannot read owner's records
-      const privateAndAllOwnersSet = `
+      // non-owner or user not part of allowed groups cannot read owner, group protected fields
+      const ownerAndGroupFields = ['ownerContent', 'ownersContent', 'adminContent', 'groupContent', 'groupsContent'];
+      const nonPublicSet = `
         ${privateResultSet}
-        ownerContent
-        ownersContent
+        ${ownerAndGroupFields.join('\n')}
       `;
-      const getResult2 = await user2TodoHelper.get({ id: todoPrivateFields['id'] }, privateAndAllOwnersSet, false, 'all');
+      const getResult2 = await user2TodoHelper.get({ id: todoPrivateFields['id'] }, nonPublicSet, false, 'all');
       checkOperationResult(
         getResult2,
-        { ...todoPrivateFields, ownerContent: null, ownersContent: null },
+        { ...todoPrivateFields, ownerContent: null, ownersContent: null, adminContent: null, groupContent: null, groupsContent: null },
         `get${modelName}`,
         false,
-        expectedFieldErrors(['ownerContent', 'ownersContent'], modelName),
+        expectedFieldErrors(ownerAndGroupFields, modelName),
       );
 
-      const listTodosResult2 = await user2TodoHelper.list({}, privateAndAllOwnersSet, `list${modelName}`, false, 'all');
+      const listTodosResult2 = await user2TodoHelper.list({}, nonPublicSet, `list${modelName}`, false, 'all');
       checkListItemExistence(listTodosResult2, `list${modelName}`, todoPrivateFields['id'], true);
-      checkListResponseErrors(listTodosResult2, expectedFieldErrors(['ownerContent', 'ownersContent'], modelName, false));
+      checkListResponseErrors(listTodosResult2, expectedFieldErrors(ownerAndGroupFields, modelName, false));
     });
 
     test('Owner model auth and allowed field operations', async () => {
       const modelName = 'TodoOwnerContentVarious';
-      const user1ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
-      const user2ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
       const user1TodoHelper = user1ModelOperationHelpers[modelName];
       const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
       const todo = {
         authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
+        adminContent: 'Admin Content',
+        groupsContent: 'Groups Content',
       };
       const createResultSetName = `create${modelName}`;
       const updateResultSetName = `update${modelName}`;
@@ -449,55 +531,69 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         ${privateResultSet}
         owner
         authors
+        group
+        groups
       `;
-      const setWithOwnerContent = `
-        ${ownerResultSet}
-        ownerContent
-      `;
-      const setWithOwnersContent = `
-        ${ownerResultSet}
-        ownersContent
-      `;
-      const completeOwnerResultSet = `
-        ${ownerResultSet}
-        ownerContent
-        ownersContent
-      `;
+      const adminOwnerResultSet = `
+          ${ownerResultSet}
+          adminContent
+        `;
+      const setWithOwnerAndGroupContent = `
+          ${adminOwnerResultSet}
+          ownerContent
+          groupContent
+        `;
+      const setWithOwnersAndGroupsContent = `
+          ${adminOwnerResultSet}
+          ownersContent
+          groupsContent
+        `;
+      const completeResultSet = `
+          ${adminOwnerResultSet}
+          ownerContent
+          ownersContent
+          groupContent
+          groupsContent
+        `;
 
       // owner(user1) creates a record with only allowed fields
-      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersContent);
+      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersAndGroupsContent);
       expect(createResult1.data[createResultSetName].id).toBeDefined();
       expect(createResult1.data[createResultSetName].owner).toEqual(userName1);
       expect(createResult1.data[createResultSetName].authors).toEqual([userName1]);
       todo['id'] = createResult1.data[createResultSetName].id;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      expectNullFields(createResult1.data[createResultSetName], ['privateContent', 'ownersContent']);
+      const nulledOwnerFields = ['group', 'groups', 'privateContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledOwnerFields, 'ownersContent', 'groupsContent']);
 
       // user1 can update the allowed fields and add user2 to dyamic owners list field
       const todoUpdated1 = {
         id: todo['id'],
         authors: [userName1, userName2],
+        groups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
         ownerContent: 'Owner Content',
+        adminContent: 'Admin Content updated',
+        groupContent: 'Group Content',
       };
-      const updateResult1 = await user1TodoHelper.update(updateResultSetName, todoUpdated1, setWithOwnerContent);
+      const updateResult1 = await user1TodoHelper.update(updateResultSetName, todoUpdated1, setWithOwnerAndGroupContent);
       expect(updateResult1.data[updateResultSetName].id).toEqual(todo['id']);
       expect(updateResult1.data[updateResultSetName].owner).toEqual(userName1);
       expect(updateResult1.data[updateResultSetName].authors).toEqual([userName1, userName2]);
-      expectNullFields(updateResult1.data[updateResultSetName], ['privateContent', 'ownerContent']);
+      expectNullFields(updateResult1.data[updateResultSetName], [...nulledOwnerFields, 'ownerContent', 'groupContent']);
 
       // user1 can read the allowed fields
       const getResult1 = await user1TodoHelper.get(
         {
           id: todo['id'],
         },
-        completeOwnerResultSet,
+        completeResultSet,
         false,
       );
       checkOperationResult(getResult1, { ...todo, ...todoUpdated1 }, `get${modelName}`);
 
-      const listTodosResult1 = await user1TodoHelper.list({}, completeOwnerResultSet, `list${modelName}`, false, 'all');
+      const listTodosResult1 = await user1TodoHelper.list({}, completeResultSet, `list${modelName}`, false, 'all');
       checkListItemExistence(listTodosResult1, `list${modelName}`, todo['id'], true);
 
       // unless one has delete access to all fields in the model, delete is expected to fail
@@ -505,7 +601,6 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         async () => await user1TodoHelper.delete(`delete${modelName}`, { id: todo['id'] }, privateResultSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(`delete${modelName}`, 'Mutation'));
 
-      /* todo: enable once fixed in auth utils
       // user2 can update the private field
       const todoUpdated2 = {
         id: todo['id'],
@@ -514,13 +609,13 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       const updateResult2 = await user2TodoHelper.update(updateResultSetName, todoUpdated2, privateResultSet);
       expect(updateResult2.data[updateResultSetName].id).toEqual(todo['id']);
       expectNullFields(updateResult2.data[updateResultSetName], ['privateContent']);
-      */
 
       // user2 can read the allowed fields
       const user2ReadAllowedSet = `
         id
         privateContent
         ownersContent
+        groupsContent
       `;
       const getResult2 = await user2TodoHelper.get(
         {
@@ -533,8 +628,9 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         getResult2,
         {
           id: todo['id'],
-          privateContent: todoUpdated1['privateContent'],
+          privateContent: todoUpdated2['privateContent'],
           ownersContent: todo['ownersContent'],
+          groupsContent: todo['groupsContent'],
         },
         `get${modelName}`,
       );
@@ -560,17 +656,17 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         'onCreate',
         [
           async () => {
-            await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersContent);
+            await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersAndGroupsContent);
           },
         ],
         {},
-        setWithOwnersContent,
+        setWithOwnersAndGroupsContent,
         false,
       );
       expect(onCreateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
         onCreateSubscriptionResult[0],
-        { ...todoRandom, privateContent: null, ownersContent: null },
+        { ...todoRandom, group: null, groups: null, privateContent: null, adminContent: null, ownersContent: null, groupsContent: null },
         `onCreate${modelName}`,
       );
 
@@ -578,35 +674,45 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         'onUpdate',
         [
           async () => {
-            await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerContent);
+            await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerAndGroupContent);
           },
         ],
         {},
-        setWithOwnerContent,
+        setWithOwnerAndGroupContent,
         false,
       );
       expect(onUpdateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
         onUpdateSubscriptionResult[0],
-        { ...todoRandomUpdated, privateContent: null, ownerContent: null },
+        {
+          ...todoRandomUpdated,
+          group: null,
+          groups: null,
+          privateContent: null,
+          adminContent: null,
+          ownerContent: null,
+          groupContent: null,
+        },
         `onUpdate${modelName}`,
       );
 
-      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [], {}, setWithOwnersContent, false);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [], {}, setWithOwnersAndGroupsContent, false);
       expect(onDeleteSubscriptionResult).toHaveLength(0);
     });
 
     test('Owner model auth with restricted field operations', async () => {
       const modelName = 'TodoOwnerContentVarious';
-      const user1ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
-      const user2ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
       const user1TodoHelper = user1ModelOperationHelpers[modelName];
       const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
       const todo = {
         authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
         privateContent: 'Private Content',
         ownersContent: 'Owners Content',
+        adminContent: 'Admin Content',
+        groupsContent: 'Groups Content',
       };
       const createResultSetName = `create${modelName}`;
       const updateResultSetName = `update${modelName}`;
@@ -618,42 +724,61 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         ${privateResultSet}
         owner
         authors
+        group
+        groups
       `;
-      const setWithOwnerContent = `
-        ${ownerResultSet}
-        ownerContent
-      `;
-      const setWithOwnersContent = `
-        ${ownerResultSet}
-        ownersContent
-      `;
+      const adminOwnerResultSet = `
+          ${ownerResultSet}
+          adminContent
+        `;
+      const setWithOwnerAndGroupContent = `
+          ${adminOwnerResultSet}
+          ownerContent
+          groupContent
+        `;
+      const setWithOwnersAndGroupsContent = `
+          ${adminOwnerResultSet}
+          ownersContent
+          groupsContent
+        `;
+      const completeResultSet = `
+          ${adminOwnerResultSet}
+          ownerContent
+          ownersContent
+          groupContent
+          groupsContent
+        `;
 
-      /* todo: enable once fixed in auth utils
       // user1 cannot create a record by specifying user2 as the owner
-      await expect(async () => await user1TodoHelper.create(createResultSetName, { ...todo, owner: 'user2' })).rejects.toThrowErrorMatchingInlineSnapshot(
-        expectedOperationError(createResultSetName, 'Mutation'),
-      );
-      */
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, owner: 'user2' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
 
       // user cannot create a record with public protected field
       await expect(
         async () => await user1TodoHelper.create(createResultSetName, { ...todo, publicContent: 'Public Content' }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
 
-      // user cannot create a record with a field that is protected and does not allow create operation
+      // user cannot create a record with a owner protected field that does not allow create operation
       await expect(
         async () => await user1TodoHelper.create(createResultSetName, { ...todo, ownerContent: 'Owner Content' }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
 
+      // user cannot create a record with a group protected field that does not allow create operation
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, groupContent: 'Group Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+
       // Create a record with allowed fields, so we can test the update and delete operations.
-      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersContent);
+      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersAndGroupsContent);
       expect(createResult1.data[createResultSetName].id).toBeDefined();
       expect(createResult1.data[createResultSetName].owner).toEqual(userName1);
       expect(createResult1.data[createResultSetName].authors).toEqual([userName1]);
       todo['id'] = createResult1.data[createResultSetName].id;
       todo['owner'] = userName1;
       // protected fields are nullified in mutation responses
-      expectNullFields(createResult1.data[createResultSetName], ['privateContent', 'ownersContent']);
+      const nulledOwnerFields = ['group', 'groups', 'privateContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledOwnerFields, 'ownersContent']);
 
       const publicFieldSet = `
         id
@@ -664,9 +789,14 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         async () => await user1TodoHelper.update(updateResultSetName, { id: todo['id'], publicContent: 'Public Content' }, publicFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
-      // owner cannot update a record with a protected field that does not allow update operation
+      // owner cannot update a record with dynamic list of owners protected field that does not allow update operation
       await expect(
         async () => await user1TodoHelper.update(updateResultSetName, { ...todo, ownersContent: 'Owners Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // owner cannot update a record with dynamic list of groups protected field that does not allow update operation
+      await expect(
+        async () => await user1TodoHelper.update(updateResultSetName, { ...todo, groupsContent: 'Groups Content' }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // non-owner cannot update a record to re-assign ownership
@@ -687,6 +817,24 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], authors: ['user2'] }, ownersFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
+      // non-owner cannot update a record to re-assign group membership
+      const groupFieldSet = `
+          id
+          group
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], group: devGroupName }, groupFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // non-owner cannot update a record to re-assign group memberships stored as dynamic list
+      const groupsFieldSet = `
+          id
+          groups
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], groups: [devGroupName] }, groupsFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
       // non-owner cannot update a record with an owner protected field
       const ownerContentFieldSet = `
         id
@@ -694,6 +842,15 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       `;
       await expect(
         async () => await user2TodoHelper.update(updateResultSetName, { ...todo, ownerContent: 'Owner Content' }, ownerContentFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // non-member of group cannot update a record with a group protected field
+      const groupContentFieldSet = `
+          id
+          groupContent
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { ...todo, groupContent: 'Group Content' }, groupContentFieldSet),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
       // owner cannot read a record with public protected field
@@ -710,29 +867,51 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       checkListItemExistence(listTodosResult1, `list${modelName}`, todo['id'], true);
       checkListResponseErrors(listTodosResult1, expectedFieldErrors(['publicContent'], modelName, false));
 
-      // non-owner cannot read a record with owner protected fields in the selection set
+      // non-owner cannot read a record with owner and group protected fields in the selection set
       const ownerReadFieldSet = `
         id
         owner
         authors
+        group
+        groups
         ownerContent
         ownersContent
+        adminContent
+        groupContent
+        groupsContent
       `;
       const getResult2 = await user2TodoHelper.get({ id: todo['id'] }, ownerReadFieldSet, false, 'all');
+      const expectedReadErrorFields = [
+        'owner',
+        'authors',
+        'ownerContent',
+        'ownersContent',
+        'adminContent',
+        'groupContent',
+        'groupsContent',
+      ];
       checkOperationResult(
         getResult2,
-        { id: todo['id'], owner: null, authors: null, ownerContent: null, ownersContent: null },
+        {
+          id: todo['id'],
+          owner: null,
+          authors: null,
+          group: null,
+          groups: null,
+          ownerContent: null,
+          ownersContent: null,
+          adminContent: null,
+          groupContent: null,
+          groupsContent: null,
+        },
         `get${modelName}`,
         false,
-        expectedFieldErrors(['owner', 'authors', 'ownerContent', 'ownersContent'], modelName),
+        expectedFieldErrors(expectedReadErrorFields, modelName),
       );
 
       const listTodosResult2 = await user2TodoHelper.list({}, ownerReadFieldSet, `list${modelName}`, false, 'all');
       checkListItemExistence(listTodosResult2, `list${modelName}`, todo['id'], true);
-      checkListResponseErrors(
-        listTodosResult2,
-        expectedFieldErrors(['owner', 'authors', 'ownerContent', 'ownersContent'], modelName, false),
-      );
+      checkListResponseErrors(listTodosResult2, expectedFieldErrors(expectedReadErrorFields, modelName, false));
 
       // non-owner cannot listen to updates on owner protected fields
       const todoRandom = {
@@ -744,41 +923,41 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         owner: userName1,
         privateContent: 'Private Content updated',
         ownerContent: 'Owner Content updated',
+        groupContent: 'Group Content updated',
       };
       const subscriberClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName2]);
       const subTodoHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
 
       const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
         async () => {
-          await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersContent);
+          await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersAndGroupsContent);
         },
       ]);
+      const expectedSubscriptionNullFields = [
+        'ownerContent',
+        'ownersContent',
+        'adminContent',
+        'groupContent',
+        'groupsContent',
+        'privateContent',
+        'publicContent',
+      ];
       expect(onCreateSubscriptionResult).toHaveLength(1);
       expect(onCreateSubscriptionResult[0].data[`onCreate${modelName}`].id).toEqual(todoRandom.id);
       expect(onCreateSubscriptionResult[0].data[`onCreate${modelName}`].owner).toEqual(userName1);
       expect(onCreateSubscriptionResult[0].data[`onCreate${modelName}`].authors).toEqual(todoRandom.authors);
-      expectNullFields(onCreateSubscriptionResult[0].data[`onCreate${modelName}`], [
-        'privateContent',
-        'publicContent',
-        'ownerContent',
-        'ownersContent',
-      ]);
+      expectNullFields(onCreateSubscriptionResult[0].data[`onCreate${modelName}`], expectedSubscriptionNullFields);
 
       const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
         async () => {
-          await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerContent);
+          await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerAndGroupContent);
         },
       ]);
       expect(onUpdateSubscriptionResult).toHaveLength(1);
       expect(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`].id).toEqual(todoRandom.id);
       expect(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`].owner).toEqual(userName1);
       expect(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`].authors).toEqual(todoRandom.authors);
-      expectNullFields(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`], [
-        'privateContent',
-        'publicContent',
-        'ownerContent',
-        'ownersContent',
-      ]);
+      expectNullFields(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`], expectedSubscriptionNullFields);
 
       const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', []);
       expect(onDeleteSubscriptionResult).toHaveLength(0);
@@ -786,8 +965,6 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
 
     test('Custom owner model auth and allowed field operations', async () => {
       const modelName = 'TodoCustomOwnerContentVarious';
-      const user1ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
-      const user2ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
       const user1TodoHelper = user1ModelOperationHelpers[modelName];
       const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
@@ -841,8 +1018,6 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       const listTodosResult1 = await user1TodoHelper.list({}, completeOwnerResultSet, `list${modelName}`, false, 'all');
       checkListItemExistence(listTodosResult1, `list${modelName}`, todo['customId'], true, 'customId');
 
-      /* todo: enable once fixed in auth utils
-
       // user2 can update the private field
       const todoUpdated2 = {
         customId: todo['customId'],
@@ -851,7 +1026,6 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       const updateResult2 = await user2TodoHelper.update(updateResultSetName, todoUpdated2, privateResultSet);
       expect(updateResult2.data[updateResultSetName].customId).toEqual(todo['customId']);
       expectNullFields(updateResult2.data[updateResultSetName], ['privateContent']);
-      */
 
       // user2 can read the allowed fields
       const getResult2 = await user2TodoHelper.get(
@@ -867,7 +1041,7 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         getResult2,
         {
           customId: todo['customId'],
-          privateContent: todoUpdated1['privateContent'],
+          privateContent: todoUpdated2['privateContent'],
         },
         `get${modelName}`,
       );
@@ -875,11 +1049,9 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       const listTodosResult2 = await user2TodoHelper.list({}, privateResultSet, `list${modelName}`, false, 'all');
       checkListItemExistence(listTodosResult2, `list${modelName}`, todo['customId'], true, 'customId');
 
-      /* todo: enable once fixed in auth utils
       // user1 can delete the record
       const deleteResult1 = await user1TodoHelper.delete(deleteResultSetName, { customId: todo['customId'] }, completeOwnerResultSet);
       checkOperationResult(deleteResult1, { ...todo, ...todoUpdated1, privateContent: null, ownerContent: null }, deleteResultSetName);
-      */
 
       // owner(user1) can listen to updates on allowed fields
       const todoRandom = {
@@ -930,27 +1102,27 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         `onUpdate${modelName}`,
       );
 
-      /* TODO: enable once fixed in auth utils
       const onDeleteSubscriptionResult = await subTodoHelper.subscribe(
-        'onDelete', 
+        'onDelete',
         [
           async () => {
             await user1TodoHelper.delete(deleteResultSetName, { customId: todoRandom.customId }, completeOwnerResultSet);
           },
-        ], 
-        {}, 
+        ],
+        {},
         completeOwnerResultSet,
-        false
+        false,
       );
       expect(onDeleteSubscriptionResult).toHaveLength(1);
-      checkOperationResult(onDeleteSubscriptionResult[0], {...todoRandomUpdated, privateContent: null, ownerContent: null}, `onDelete${modelName}`);
-      */
+      checkOperationResult(
+        onDeleteSubscriptionResult[0],
+        { ...todoRandomUpdated, privateContent: null, ownerContent: null },
+        `onDelete${modelName}`,
+      );
     });
 
     test('Custom owner model auth and restricted field operations', async () => {
       const modelName = 'TodoCustomOwnerContentVarious';
-      const user1ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
-      const user2ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
       const user1TodoHelper = user1ModelOperationHelpers[modelName];
       const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
@@ -976,12 +1148,10 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         ownerContent
       `;
 
-      /* todo: enable once fixed in auth utils
       // user1 cannot create a record by specifying user2 as the owner
-      await expect(async () => await user1TodoHelper.create(createResultSetName, { ...todo, author: 'user2' }, completeOwnerResultSet)).rejects.toThrowErrorMatchingInlineSnapshot(
-        expectedOperationError(createResultSetName, 'Mutation'),
-      );
-      */
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, author: 'user2' }, completeOwnerResultSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
 
       // user cannot create a record with public protected field
       await expect(
@@ -1107,23 +1277,19 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       expect(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`].author).toEqual(todoRandom.author);
       expectNullFields(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`], ['privateContent', 'ownerContent']);
 
-      /* TODO: enable once fixed in auth utils
       const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [
         async () => {
-          await user1TodoHelper.delete(deleteResultSetName, { customId: todo['customId'] }, completeOwnerResultSet);
+          await user1TodoHelper.delete(deleteResultSetName, { customId: todoRandom['customId'] }, completeOwnerResultSet);
         },
       ]);
       expect(onDeleteSubscriptionResult).toHaveLength(1);
       expect(onDeleteSubscriptionResult[0].data[`onDelete${modelName}`].customId).toEqual(todoRandom.customId);
       expect(onDeleteSubscriptionResult[0].data[`onDelete${modelName}`].author).toEqual(todoRandom.author);
-      expectNullFields(onDeleteSubscriptionResult[0].data[`onDelete${modelName}`], ['privateContent', 'ownerContent']);
-      */
+      expectNullFields(onDeleteSubscriptionResult[0].data[`onDelete${modelName}`], ['privateContent', 'publicContent', 'ownerContent']);
     });
 
     test('Custom list of owners model auth and allowed field operations', async () => {
       const modelName = 'TodoCustomOwnersContentVarious';
-      const user1ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
-      const user2ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
       const user1TodoHelper = user1ModelOperationHelpers[modelName];
       const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
@@ -1273,8 +1439,6 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
 
     test('Custom list of owners model auth and restricted field operations', async () => {
       const modelName = 'TodoCustomOwnersContentVarious';
-      const user1ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
-      const user2ModelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
       const user1TodoHelper = user1ModelOperationHelpers[modelName];
       const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
@@ -1298,12 +1462,10 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         ownersContent
       `;
 
-      /* todo: enable once fixed in auth utils
       // user1 cannot create a record by specifying user2 as the only owner
-      await expect(async () => await user1TodoHelper.create(createResultSetName, { ...todo, authors: [userName2] }, completeOwnerResultSet)).rejects.toThrowErrorMatchingInlineSnapshot(
-        expectedOperationError(createResultSetName, 'Mutation'),
-      );
-      */
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, authors: [userName2] }, completeOwnerResultSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
 
       // user cannot create a record with dynamic owner list protected field that does not allow create operation
       await expect(
@@ -1437,267 +1599,578 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       expectNullFields(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`], ['privateContent', 'ownersContent']);
     });
 
-    test.skip('non-admin users can perform CRUD and subscription operations with only private fields in selection set', async () => {
+    test('admin group protected model and allowed field operations', async () => {
       const modelName = 'TodoAdminContentVarious';
-      const modelOperationHelpersAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
-      const modelOperationHelpersNonAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
-      const todoHelperAdmin = modelOperationHelpersAdmin[modelName];
-      const todoHelperNonAdmin = modelOperationHelpersNonAdmin[modelName];
+      const user1TodoHelper = user1ModelOperationHelpers[modelName];
+      const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
-      const todoWithPrivateFields = {
-        privateContent: 'PrivateContent',
+      const todo = {
+        owner: userName1,
+        authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
+        privateContent: 'Private Content',
+        ownersContent: 'Owners Content',
+        groupsContent: 'Groups Content',
       };
-      const privateResultSet = `
-        id
-        privateContent
-      `;
       const createResultSetName = `create${modelName}`;
+      const updateResultSetName = `update${modelName}`;
+      const privateResultSet = `
+          id
+          privateContent
+        `;
+      const adminResultSet = `
+          ${privateResultSet}
+          owner
+          authors
+          group
+          groups
+        `;
+      const setWithOwnerAndGroupContent = `
+          ${adminResultSet}
+          ownerContent
+          groupContent
+        `;
+      const setWithOwnersAndGroupsContent = `
+          ${adminResultSet}
+          ownersContent
+          groupsContent
+        `;
+      const completeResultSet = `
+          ${adminResultSet}
+          ownerContent
+          ownersContent
+          groupContent
+          groupsContent
+        `;
 
-      // admin is able to create a record with only private fields
-      const createResult = await todoHelperNonAdmin.create(createResultSetName, todoWithPrivateFields, privateResultSet);
-      expect(createResult.data[createResultSetName].id).toBeDefined();
-      todoWithPrivateFields['id'] = createResult.data[createResultSetName].id;
-      expect(createResult.data[createResultSetName].privateContent).toBeNull();
+      // admin(user1) creates a record with only allowed fields
+      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersAndGroupsContent);
+      expect(createResult1.data[createResultSetName].id).toBeDefined();
+      expect(createResult1.data[createResultSetName].owner).toEqual(userName1);
+      expect(createResult1.data[createResultSetName].authors).toEqual([userName1]);
+      todo['id'] = createResult1.data[createResultSetName].id;
+      todo['owner'] = userName1;
+      // protected fields are nullified in mutation responses
+      const nulledFields = ['group', 'groups', 'privateContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledFields, 'ownersContent', 'groupsContent']);
 
-      const todoUpdated = {
-        id: todoWithPrivateFields['id'],
+      // user1 can update the allowed fields and add user2 to dyamic owners list field
+      const todoUpdated1 = {
+        id: todo['id'],
+        authors: [userName1, userName2],
+        groups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
+        ownerContent: 'Owner Content',
+        groupContent: 'Group Content',
       };
+      const updateResult1 = await user1TodoHelper.update(updateResultSetName, todoUpdated1, setWithOwnerAndGroupContent);
+      expect(updateResult1.data[updateResultSetName].id).toEqual(todo['id']);
+      expectNullFields(updateResult1.data[updateResultSetName], [...nulledFields, 'ownerContent', 'groupContent']);
 
-      const updateResult = await todoHelperNonAdmin.update(`update${modelName}`, todoUpdated, privateResultSet);
-      expect(updateResult.data[`update${modelName}`].id).toEqual(todoWithPrivateFields['id']);
-      expect(updateResult.data[`update${modelName}`].privateContent).toBeNull();
-
-      const getResult = await todoHelperNonAdmin.get(
+      // user1 can read the allowed fields
+      const getResult1 = await user1TodoHelper.get(
         {
-          id: todoWithPrivateFields['id'],
+          id: todo['id'],
         },
-        privateResultSet,
+        completeResultSet,
         false,
       );
-      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+      checkOperationResult(getResult1, { ...todo, ...todoUpdated1 }, `get${modelName}`);
 
-      const listTodosResult = await todoHelperNonAdmin.list({}, privateResultSet, `list${modelName}`, false);
-      checkListItemExistence(listTodosResult, `list${modelName}`, todoWithPrivateFields['id'], true);
+      const listTodosResult1 = await user1TodoHelper.list({}, completeResultSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult1, `list${modelName}`, todo['id'], true);
 
-      // unless all fields have same Auth rules as the model, delete is expected to fail
+      // unless one has delete access to all fields in the model, delete is expected to fail
       await expect(
-        async () => await todoHelperNonAdmin.delete(`delete${modelName}`, { id: todoWithPrivateFields['id'] }, privateResultSet),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access delete${modelName} on type Mutation"`);
+        async () => await user1TodoHelper.delete(`delete${modelName}`, { id: todo['id'] }, privateResultSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(`delete${modelName}`, 'Mutation'));
 
+      // user2 can update the private field
+      const todoUpdated2 = {
+        id: todo['id'],
+        privateContent: 'Private Content updated 1',
+      };
+      const updateResult2 = await user2TodoHelper.update(updateResultSetName, todoUpdated2, privateResultSet);
+      expect(updateResult2.data[updateResultSetName].id).toEqual(todo['id']);
+      expectNullFields(updateResult2.data[updateResultSetName], ['privateContent']);
+
+      // user2 can read the allowed fields
+      const user2ReadAllowedSet = `
+          id
+          privateContent
+          ownersContent
+          groupsContent
+        `;
+      const getResult2 = await user2TodoHelper.get(
+        {
+          id: todo['id'],
+        },
+        user2ReadAllowedSet,
+        false,
+      );
+      checkOperationResult(
+        getResult2,
+        {
+          id: todo['id'],
+          privateContent: todoUpdated2['privateContent'],
+          ownersContent: todo['ownersContent'],
+          groupsContent: todo['groupsContent'],
+        },
+        `get${modelName}`,
+      );
+
+      const listTodosResult2 = await user2TodoHelper.list({}, user2ReadAllowedSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult2, `list${modelName}`, todo['id'], true);
+
+      // owner can listen to updates on allowed fields
       const todoRandom = {
-        ...todoWithPrivateFields,
+        ...todo,
         id: Date.now().toString(),
       };
       const todoRandomUpdated = {
-        ...todoWithPrivateFields,
+        ...todoUpdated1,
         id: todoRandom.id,
+        owner: userName1,
+        privateContent: 'Private Content updated',
       };
-      const actorClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName2]);
-      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const subscriberClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
 
       const onCreateSubscriptionResult = await subTodoHelper.subscribe(
         'onCreate',
         [
           async () => {
-            await todoHelperAdmin.create(createResultSetName, todoRandom, privateResultSet);
+            await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersAndGroupsContent);
           },
         ],
         {},
-        privateResultSet,
+        setWithOwnersAndGroupsContent,
         false,
       );
       expect(onCreateSubscriptionResult).toHaveLength(1);
-      expect(onCreateSubscriptionResult[0].data[`onCreate${modelName}`].id).toEqual(todoRandom.id);
-      expect(onCreateSubscriptionResult[0].data[`onCreate${modelName}`].privateContent).toBeNull();
+      checkOperationResult(
+        onCreateSubscriptionResult[0],
+        { ...todoRandom, group: null, groups: null, privateContent: null, ownersContent: null, groupsContent: null },
+        `onCreate${modelName}`,
+      );
 
       const onUpdateSubscriptionResult = await subTodoHelper.subscribe(
         'onUpdate',
         [
           async () => {
-            await todoHelperAdmin.update(`update${modelName}`, todoRandomUpdated, privateResultSet);
+            await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerAndGroupContent);
           },
         ],
         {},
-        privateResultSet,
+        setWithOwnerAndGroupContent,
         false,
       );
       expect(onUpdateSubscriptionResult).toHaveLength(1);
-      expect(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`].id).toEqual(todoRandom.id);
-      expect(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`].privateContent).toBeNull();
+      checkOperationResult(
+        onUpdateSubscriptionResult[0],
+        { ...todoRandomUpdated, group: null, groups: null, privateContent: null, ownerContent: null, groupContent: null },
+        `onUpdate${modelName}`,
+      );
 
-      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [], {}, privateResultSet, false);
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [], {}, setWithOwnersAndGroupsContent, false);
       expect(onDeleteSubscriptionResult).toHaveLength(0);
     });
 
-    test.skip('admin users cannot perform CRUD and subscription operations on public protected field', async () => {
+    test('admin group protected model and restricted field operations', async () => {
       const modelName = 'TodoAdminContentVarious';
-      const modelOperationHelpers = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
-      const todoHelper = modelOperationHelpers[modelName];
+      const user1TodoHelper = user1ModelOperationHelpers[modelName];
+      const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
-      const todoWithPrivateFields = {
-        privateContent: 'PrivateContent',
-      };
       const todo = {
-        ...todoWithPrivateFields,
-        publicContent: 'PublicContent',
+        authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
+        privateContent: 'Private Content',
+        ownersContent: 'Owners Content',
+        groupsContent: 'Groups Content',
       };
-      const completeResultSet = `
-        id
-        privateContent
-        publicContent
-      `;
       const createResultSetName = `create${modelName}`;
-
-      await expect(async () => await todoHelper.create(createResultSetName, todo)).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"GraphQL error: Not Authorized to access create${modelName} on type Mutation"`,
-      );
-
-      // Create a record with only allowed fields, so we can test the update and delete operations.
+      const updateResultSetName = `update${modelName}`;
       const privateResultSet = `
+          id
+          privateContent
+        `;
+      const adminResultSet = `
+          ${privateResultSet}
+          owner
+          authors
+          group
+          groups
+        `;
+      const setWithOwnerAndGroupContent = `
+          ${adminResultSet}
+          ownerContent
+          groupContent
+        `;
+      const setWithOwnersAndGroupsContent = `
+          ${adminResultSet}
+          ownersContent
+          groupsContent
+        `;
+
+      // admin cannot create a record with public protected field
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, publicContent: 'Public Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+
+      // admin owner cannot create a record with a owner protected field that does not allow create operation
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, ownerContent: 'Owner Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+
+      // admin cannot create a record with a group protected field that does not allow create operation
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, groupContent: 'Group Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+
+      // Create a record with allowed fields, so we can test the update and delete operations.
+      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersAndGroupsContent);
+      expect(createResult1.data[createResultSetName].id).toBeDefined();
+      todo['id'] = createResult1.data[createResultSetName].id;
+      todo['owner'] = userName1;
+      // protected fields are nullified in mutation responses
+      const nulledFields = ['group', 'groups', 'privateContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledFields, 'ownersContent']);
+
+      const publicFieldSet = `
+          id
+          publicContent
+        `;
+      // admin cannot update a record with public protected field
+      await expect(
+        async () => await user1TodoHelper.update(updateResultSetName, { id: todo['id'], publicContent: 'Public Content' }, publicFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // admin cannot update a record with dynamic list of owners protected field that does not allow update operation
+      await expect(
+        async () => await user1TodoHelper.update(updateResultSetName, { ...todo, ownersContent: 'Owners Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // admin cannot update a record with dynamic list of groups protected field that does not allow update operation
+      await expect(
+        async () => await user1TodoHelper.update(updateResultSetName, { ...todo, groupsContent: 'Groups Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // non-admin cannot update a record to re-assign ownership
+      const ownerFieldSet = `
+          id
+          owner
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], owner: 'user2' }, ownerFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // non-admin cannot update a record to re-assign owners in dynamic owners list
+      const ownersFieldSet = `
+          id
+          authors
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], authors: ['user2'] }, ownersFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // non-admin cannot update a record to re-assign group membership
+      const groupFieldSet = `
         id
-        privateContent
+        group
       `;
-      const createResult = await todoHelper.create(createResultSetName, todoWithPrivateFields, privateResultSet);
-      expect(createResult.data[createResultSetName].id).toBeDefined();
-      todo['id'] = createResult.data[createResultSetName].id;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], group: devGroupName }, groupFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
-      const todoUpdated = {
-        id: todo['id'],
-        privateContent: 'Private Content updated',
-        publicContent: 'Public Content updated',
-      };
+      // non-admin cannot update a record to re-assign group memberships stored as dynamic list
+      const groupsFieldSet = `
+          id
+          groups
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { id: todo['id'], groups: [devGroupName] }, groupsFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
 
-      await expect(async () => await todoHelper.update(`update${modelName}`, todoUpdated)).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"GraphQL error: Not Authorized to access update${modelName} on type Mutation"`,
+      // non-owner cannot update a record with an owner protected field
+      const ownerContentFieldSet = `
+          id
+          ownerContent
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { ...todo, ownerContent: 'Owner Content' }, ownerContentFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // non-member of group cannot update a record with a group protected field
+      const groupContentFieldSet = `
+          id
+          groupContent
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { ...todo, groupContent: 'Group Content' }, groupContentFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // admin cannot read a record with public protected field
+      const getResult1 = await user1TodoHelper.get({ id: todo['id'] }, publicFieldSet, false, 'all');
+      checkOperationResult(
+        getResult1,
+        { id: todo['id'], publicContent: null },
+        `get${modelName}`,
+        false,
+        expectedFieldErrors(['publicContent'], modelName),
       );
 
-      const expectedFieldError = `"GraphQL error: Not Authorized to access publicContent on type ${modelName}"`;
-      const getResult = await todoHelper.get({ id: todo['id'] }, undefined, true, 'all');
-      checkOperationResult(getResult, { ...todo, publicContent: null }, `get${modelName}`, false, [expectedFieldError]);
+      const listTodosResult1 = await user1TodoHelper.list({}, publicFieldSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult1, `list${modelName}`, todo['id'], true);
+      checkListResponseErrors(listTodosResult1, expectedFieldErrors(['publicContent'], modelName, false));
 
-      const listTodosResult = await todoHelper.list({}, completeResultSet, `list${modelName}`, false, 'all');
-      checkListItemExistence(listTodosResult, `list${modelName}`, todo['id'], true);
-      checkListResponseErrors(listTodosResult, [`Not Authorized to access publicContent on type ${modelName}`]);
+      // non-admin and non-owner cannot read a record with owner and group protected fields in the selection set
+      const ownerReadFieldSet = `
+        id
+        owner
+        authors
+        group
+        groups
+        ownerContent
+        ownersContent
+        groupContent
+        groupsContent
+      `;
+      const getResult2 = await user2TodoHelper.get({ id: todo['id'] }, ownerReadFieldSet, false, 'all');
+      const expectedReadErrorFields = ['owner', 'authors', 'ownerContent', 'ownersContent', 'groupContent', 'groupsContent'];
+      checkOperationResult(
+        getResult2,
+        {
+          id: todo['id'],
+          owner: null,
+          authors: null,
+          group: null,
+          groups: null,
+          ownerContent: null,
+          ownersContent: null,
+          groupContent: null,
+          groupsContent: null,
+        },
+        `get${modelName}`,
+        false,
+        expectedFieldErrors(expectedReadErrorFields, modelName),
+      );
 
+      const listTodosResult2 = await user2TodoHelper.list({}, ownerReadFieldSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult2, `list${modelName}`, todo['id'], true);
+      checkListResponseErrors(listTodosResult2, expectedFieldErrors(expectedReadErrorFields, modelName, false));
+
+      // non-admin/owner cannot listen to updates on owner/group protected fields
       const todoRandom = {
-        ...todoWithPrivateFields,
+        ...todo,
         id: Date.now().toString(),
       };
       const todoRandomUpdated = {
-        ...todoWithPrivateFields,
         id: todoRandom.id,
+        owner: userName1,
+        privateContent: 'Private Content updated',
+        ownerContent: 'Owner Content updated',
+        groupContent: 'Group Content updated',
       };
-      const actorClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName1]);
-      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const subscriberClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName2]);
+      const subTodoHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
 
       const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
         async () => {
-          await subTodoHelper.create(createResultSetName, todoRandom, privateResultSet);
+          await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersAndGroupsContent);
         },
       ]);
+      const expectedSubscriptionNullFields = [
+        'ownerContent',
+        'ownersContent',
+        'groupContent',
+        'groupsContent',
+        'privateContent',
+        'publicContent',
+      ];
       expect(onCreateSubscriptionResult).toHaveLength(1);
-      checkOperationResult(
-        onCreateSubscriptionResult[0],
-        { ...todoRandom, publicContent: null, privateContent: null },
-        `onCreate${modelName}`,
-      );
+      expect(onCreateSubscriptionResult[0].data[`onCreate${modelName}`].id).toEqual(todoRandom.id);
+      expectNullFields(onCreateSubscriptionResult[0].data[`onCreate${modelName}`], expectedSubscriptionNullFields);
 
       const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
         async () => {
-          await subTodoHelper.update(`update${modelName}`, todoRandomUpdated, privateResultSet);
+          await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerAndGroupContent);
         },
       ]);
       expect(onUpdateSubscriptionResult).toHaveLength(1);
-      checkOperationResult(
-        onUpdateSubscriptionResult[0],
-        { ...todoRandomUpdated, publicContent: null, privateContent: null },
-        `onUpdate${modelName}`,
-      );
+      expect(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`].id).toEqual(todoRandom.id);
+      expectNullFields(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`], expectedSubscriptionNullFields);
 
       const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', []);
       expect(onDeleteSubscriptionResult).toHaveLength(0);
     });
 
-    test.skip('user not part of allowed custom group of a record can perform CRUD and subscription operations with only allowed fields in selection set', async () => {
+    test('custom group field protected model and allowed field operations', async () => {
       const modelName = 'TodoCustomGroupContentVarious';
-      const modelOperationHelpersAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
-      const modelOperationHelpersNonAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
-      const todoHelperAdmin = modelOperationHelpersAdmin[modelName];
-      const todoHelperNonAdmin = modelOperationHelpersNonAdmin[modelName];
+      const user1TodoHelper = user1ModelOperationHelpers[modelName];
+      const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
-      const todoWithAllowedFields = {
-        privateContent: 'PrivateContent',
-        customGroup: adminGroupName,
+      const todo = {
+        customId: Date.now().toString(),
+        owner: userName1,
+        authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
+        privateContent: 'Private Content',
+        ownersContent: 'Owners Content',
+        adminContent: 'Admin Content',
+        groupsContent: 'Groups Content',
       };
-      const allowedResultSet = `
-        id
-        customGroup
-        privateContent
-      `;
       const createResultSetName = `create${modelName}`;
       const updateResultSetName = `update${modelName}`;
+      const deleteResultSetName = `delete${modelName}`;
+      const privateResultSet = `
+          customId
+          privateContent
+        `;
+      const adminResultSet = `
+          ${privateResultSet}
+          owner
+          authors
+          group
+          groups
+          adminContent
+        `;
+      const setWithOwnerContent = `
+          ${adminResultSet}
+          ownerContent
+        `;
+      const setWithOwnersAndGroupsContent = `
+          ${adminResultSet}
+          ownersContent
+          groupsContent
+        `;
+      const completeResultSet = `
+          ${adminResultSet}
+          ownerContent
+          ownersContent
+          groupsContent
+        `;
 
-      // admin is able to create a record with only private fields
-      const createResult = await todoHelperAdmin.create(createResultSetName, todoWithAllowedFields, allowedResultSet);
-      expect(createResult.data[createResultSetName].id).toBeDefined();
-      todoWithAllowedFields['id'] = createResult.data[createResultSetName].id;
-      expect(createResult.data[createResultSetName].privateContent).toBeNull();
-      expect(createResult.data[createResultSetName].customGroup).toBeNull();
+      // admin(user1) creates a record with only allowed fields
+      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersAndGroupsContent);
+      expect(createResult1.data[createResultSetName].customId).toBeDefined();
+      expect(createResult1.data[createResultSetName].owner).toEqual(userName1);
+      expect(createResult1.data[createResultSetName].authors).toEqual([userName1]);
+      todo['customId'] = createResult1.data[createResultSetName].customId;
+      todo['owner'] = userName1;
+      // protected fields are nullified in mutation responses
+      const nulledMutationFields = ['group', 'groups', 'privateContent', 'adminContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledMutationFields, 'ownersContent', 'groupsContent']);
 
-      const todoUpdated = {
-        ...todoWithAllowedFields,
+      // user in allowed group can update the allowed fields and add user2 to dyamic owners list field
+      const todoUpdated1 = {
+        customId: todo['customId'],
+        authors: [userName1, userName2],
+        groups: [adminGroupName, devGroupName],
         privateContent: 'Private Content updated',
+        ownerContent: 'Owner Content',
       };
+      const updateResult1 = await user1TodoHelper.update(updateResultSetName, todoUpdated1, setWithOwnerContent);
+      expect(updateResult1.data[updateResultSetName].customId).toEqual(todo['customId']);
+      expect(updateResult1.data[updateResultSetName].owner).toEqual(userName1);
+      expect(updateResult1.data[updateResultSetName].authors).toEqual(todoUpdated1.authors);
+      expectNullFields(updateResult1.data[updateResultSetName], [...nulledMutationFields, 'ownerContent']);
 
-      // non-admin can update the private protected field
-      const updateResult = await todoHelperNonAdmin.update(updateResultSetName, todoUpdated, allowedResultSet);
-      checkOperationResult(updateResult, { ...todoUpdated, customGroup: null, privateContent: null }, updateResultSetName);
-
-      // non-admin can read the private protected field
-      const getResult = await todoHelperNonAdmin.get(
+      // user in allowed group can read the allowed fields
+      const getResult1 = await user1TodoHelper.get(
         {
-          id: todoWithAllowedFields['id'],
+          customId: todo['customId'],
         },
-        allowedResultSet,
+        completeResultSet,
         false,
+        'all',
+        'customId',
       );
-      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+      checkOperationResult(getResult1, { ...todo, ...todoUpdated1 }, `get${modelName}`);
 
-      const listTodosResult = await todoHelperNonAdmin.list({}, allowedResultSet, `list${modelName}`, false);
-      checkListItemExistence(listTodosResult, `list${modelName}`, todoWithAllowedFields['id'], true);
+      const listTodosResult1 = await user1TodoHelper.list({}, completeResultSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult1, `list${modelName}`, todo['customId'], true, 'customId');
 
-      // unless all fields have same Auth rules as the model, delete is expected to fail
-      await expect(
-        async () => await todoHelperNonAdmin.delete(`delete${modelName}`, { id: todoWithAllowedFields['id'] }, allowedResultSet),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access delete${modelName} on type Mutation"`);
+      // user not in allowed group can update the private field
+      const todoUpdated2 = {
+        customId: todo['customId'],
+        privateContent: 'Private Content updated 1',
+      };
+      const updateResult2 = await user2TodoHelper.update(updateResultSetName, todoUpdated2, privateResultSet);
+      expect(updateResult2.data[updateResultSetName].customId).toEqual(todo['customId']);
+      expectNullFields(updateResult2.data[updateResultSetName], ['privateContent']);
 
+      // user2 who is now in allowed group can read the allowed fields
+      const user2ReadAllowedSet = `
+          customId
+          privateContent
+          ownersContent
+          groupsContent
+        `;
+      const getResult2 = await user2TodoHelper.get(
+        {
+          customId: todo['customId'],
+        },
+        user2ReadAllowedSet,
+        false,
+        'all',
+        'customId',
+      );
+      checkOperationResult(
+        getResult2,
+        {
+          customId: todo['customId'],
+          privateContent: todoUpdated2['privateContent'],
+          ownersContent: todo['ownersContent'],
+          groupsContent: todo['groupsContent'],
+        },
+        `get${modelName}`,
+      );
+
+      const listTodosResult2 = await user2TodoHelper.list({}, user2ReadAllowedSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult2, `list${modelName}`, todo['customId'], true, 'customId');
+
+      // user in allowed group can delete the record
+      const deleteResult1 = await user1TodoHelper.delete(deleteResultSetName, { customId: todo.customId }, completeResultSet);
+      expect(deleteResult1.data[deleteResultSetName].customId).toEqual(todo['customId']);
+      expectNullFields(deleteResult1.data[deleteResultSetName], [
+        ...nulledMutationFields,
+        'ownerContent',
+        'ownersContent',
+        'groupsContent',
+      ]);
+
+      // user in allowed group can listen to updates on allowed fields
       const todoRandom = {
-        ...todoWithAllowedFields,
-        id: Date.now().toString(),
+        ...todo,
+        customId: Date.now().toString(),
       };
       const todoRandomUpdated = {
-        ...todoWithAllowedFields,
-        id: todoRandom.id,
+        ...todoUpdated1,
+        customId: todoRandom.customId,
+        owner: userName1,
+        privateContent: 'Private Content updated',
       };
-      const actorClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName2]);
-      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const subscriberClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
 
       const onCreateSubscriptionResult = await subTodoHelper.subscribe(
         'onCreate',
         [
           async () => {
-            await todoHelperAdmin.create(createResultSetName, todoRandom, allowedResultSet);
+            await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersAndGroupsContent);
           },
         ],
         {},
-        allowedResultSet,
+        setWithOwnersAndGroupsContent,
         false,
       );
       expect(onCreateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
         onCreateSubscriptionResult[0],
-        { ...todoRandom, customGroup: null, privateContent: null },
+        { ...todoRandom, group: null, groups: null, privateContent: null, ownersContent: null, adminContent: null, groupsContent: null },
         `onCreate${modelName}`,
       );
 
@@ -1705,161 +2178,455 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         'onUpdate',
         [
           async () => {
-            await todoHelperAdmin.update(`update${modelName}`, todoRandomUpdated, allowedResultSet);
+            await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerContent);
           },
         ],
         {},
-        allowedResultSet,
+        setWithOwnerContent,
         false,
       );
       expect(onUpdateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
-        onCreateSubscriptionResult[0],
-        { ...todoRandomUpdated, customGroup: null, privateContent: null },
+        onUpdateSubscriptionResult[0],
+        { ...todoRandomUpdated, group: null, groups: null, privateContent: null, ownerContent: null, adminContent: null },
         `onUpdate${modelName}`,
       );
 
-      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [], {}, allowedResultSet, false);
-      expect(onDeleteSubscriptionResult).toHaveLength(0);
-    });
-
-    test.skip('user part of allowed custom group of a record cannot perform CRUD operations on public protected field', async () => {
-      const modelName = 'TodoCustomGroupContentVarious';
-      const modelOperationHelpersAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
-      const modelOperationHelpersNonAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
-      const todoHelperAdmin = modelOperationHelpersAdmin[modelName];
-      const todoHelperNonAdmin = modelOperationHelpersNonAdmin[modelName];
-
-      const todoWithAllowedFields = {
-        privateContent: 'PrivateContent',
-        customGroup: adminGroupName,
-      };
-      const todo = {
-        ...todoWithAllowedFields,
-        publicContent: 'PublicContent',
-      };
-      const completeResultSet = `
-        id
-        customGroup
-        privateContent
-        publicContent
-      `;
-      const createResultSetName = `create${modelName}`;
-
-      await expect(async () => await todoHelperAdmin.create(createResultSetName, todo)).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"GraphQL error: Not Authorized to access create${modelName} on type Mutation"`,
-      );
-
-      // Create a record with allowed fields only, so we can test the update and delete operations.
-      const allowedResultSet = `
-        id
-        customGroup
-        privateContent
-      `;
-      const createResult = await todoHelperAdmin.create(createResultSetName, todoWithAllowedFields, allowedResultSet);
-      expect(createResult.data[createResultSetName].id).toBeDefined();
-      todo['id'] = createResult.data[createResultSetName].id;
-      expect(createResult.data[createResultSetName].privateContent).toBeNull();
-      expect(createResult.data[createResultSetName].customGroup).toBeNull();
-
-      const todoUpdated = {
-        ...todo,
-        privateContent: 'Private Content updated',
-        publicContent: 'Public Content updated',
-      };
-
-      await expect(async () => await todoHelperAdmin.update(`update${modelName}`, todoUpdated)).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"GraphQL error: Not Authorized to access update${modelName} on type Mutation"`,
-      );
-
-      const expectedFieldError = `"GraphQL error: Not Authorized to access publicContent on type ${modelName}"`;
-      const getResult = await todoHelperAdmin.get({ id: todo['id'] }, undefined, true, 'all');
-      checkOperationResult(getResult, { ...todo, publicContent: null }, `get${modelName}`, false, [expectedFieldError]);
-
-      const listTodosResult = await todoHelperAdmin.list({}, completeResultSet, `list${modelName}`, false, 'all');
-      checkListItemExistence(listTodosResult, `list${modelName}`, todo['id'], true);
-      checkListResponseErrors(listTodosResult, [`Not Authorized to access publicContent on type ${modelName}`]);
-    });
-
-    test.skip('user not part of group in allowed custom groups list of a record can perform CRUD and subscription operations with only allowed fields in selection set', async () => {
-      const modelName = 'TodoCustomGroupsContentVarious';
-      const modelOperationHelpersAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
-      const modelOperationHelpersNonAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
-      const todoHelperAdmin = modelOperationHelpersAdmin[modelName];
-      const todoHelperNonAdmin = modelOperationHelpersNonAdmin[modelName];
-
-      const todoWithAllowedFields = {
-        privateContent: 'PrivateContent',
-        customGroups: [adminGroupName],
-      };
-      const allowedResultSet = `
-        id
-        customGroups
-        privateContent
-      `;
-      const createResultSetName = `create${modelName}`;
-      const updateResultSetName = `update${modelName}`;
-
-      // admin is able to create a record with only private fields
-      const createResult = await todoHelperAdmin.create(createResultSetName, todoWithAllowedFields, allowedResultSet);
-      expect(createResult.data[createResultSetName].id).toBeDefined();
-      todoWithAllowedFields['id'] = createResult.data[createResultSetName].id;
-      expect(createResult.data[createResultSetName].privateContent).toBeNull();
-      expect(createResult.data[createResultSetName].customGroups).toBeNull();
-
-      const todoUpdated = {
-        ...todoWithAllowedFields,
-        privateContent: 'Private Content updated',
-      };
-
-      // non-admin can update the private protected field
-      const updateResult = await todoHelperNonAdmin.update(updateResultSetName, todoUpdated, allowedResultSet);
-      checkOperationResult(updateResult, { ...todoUpdated, customGroups: null, privateContent: null }, updateResultSetName);
-
-      // non-admin can read the private protected field
-      const getResult = await todoHelperNonAdmin.get(
-        {
-          id: todoWithAllowedFields['id'],
-        },
-        allowedResultSet,
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe(
+        'onDelete',
+        [
+          async () => {
+            await user1TodoHelper.delete(deleteResultSetName, { customId: todoRandom.customId }, completeResultSet);
+          },
+        ],
+        {},
+        completeResultSet,
         false,
       );
-      checkOperationResult(getResult, todoUpdated, `get${modelName}`);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      checkOperationResult(
+        onDeleteSubscriptionResult[0],
+        {
+          ...todoRandomUpdated,
+          group: null,
+          groups: null,
+          privateContent: null,
+          ownerContent: null,
+          ownersContent: null,
+          adminContent: null,
+          groupsContent: null,
+        },
+        `onDelete${modelName}`,
+      );
+    });
 
-      const listTodosResult = await todoHelperNonAdmin.list({}, allowedResultSet, `list${modelName}`, false);
-      checkListItemExistence(listTodosResult, `list${modelName}`, todoWithAllowedFields['id'], true);
+    test('custom group field protected model and restricted field operations', async () => {
+      const modelName = 'TodoCustomGroupContentVarious';
+      const user1TodoHelper = user1ModelOperationHelpers[modelName];
+      const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
-      // unless all fields have same Auth rules as the model, delete is expected to fail
+      const todo = {
+        customId: Date.now().toString(),
+        owner: userName1,
+        authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
+        privateContent: 'Private Content',
+        ownersContent: 'Owners Content',
+        adminContent: 'Admin Content',
+        groupsContent: 'Groups Content',
+      };
+      const createResultSetName = `create${modelName}`;
+      const updateResultSetName = `update${modelName}`;
+      const deleteResultSetName = `delete${modelName}`;
+      const privateResultSet = `
+          customId
+          privateContent
+        `;
+      const adminResultSet = `
+          ${privateResultSet}
+          owner
+          authors
+          group
+          groups
+          adminContent
+        `;
+      const setWithOwnerContent = `
+          ${adminResultSet}
+          ownerContent
+        `;
+      const setWithOwnersAndGroupsContent = `
+          ${adminResultSet}
+          ownersContent
+          groupsContent
+        `;
+
+      const completeResultSet = `
+          ${adminResultSet}
+          ownerContent
+          ownersContent
+          groupsContent
+        `;
+
+      // user in allowed group cannot create a record with public protected field
       await expect(
-        async () => await todoHelperNonAdmin.delete(`delete${modelName}`, { id: todoWithAllowedFields['id'] }, allowedResultSet),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(`"GraphQL error: Not Authorized to access delete${modelName} on type Mutation"`);
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, publicContent: 'Public Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
 
+      // user in allowed group cannot create a record with owner protected field that does not allow create operation
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, ownerContent: 'Owner Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+
+      // Create a record with allowed fields, so we can test the update and delete operations.
+      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersAndGroupsContent);
+      expect(createResult1.data[createResultSetName].customId).toBeDefined();
+      expect(createResult1.data[createResultSetName].owner).toEqual(userName1);
+      expect(createResult1.data[createResultSetName].authors).toEqual([userName1]);
+      todo['customId'] = createResult1.data[createResultSetName].customId;
+      todo['owner'] = userName1;
+      // protected fields are nullified in mutation responses
+      const nulledAdminFields = ['group', 'groups', 'privateContent', 'adminContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledAdminFields, 'ownersContent', 'groupsContent']);
+
+      const publicFieldSet = `
+          customId
+          publicContent
+        `;
+      // user in allowed group cannot update a record with public protected field
+      await expect(
+        async () =>
+          await user1TodoHelper.update(
+            updateResultSetName,
+            { customId: todo['customId'], publicContent: 'Public Content' },
+            publicFieldSet,
+          ),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user in allowed group cannot update a record with dynamic list of owners protected field that does not allow update operation
+      await expect(
+        async () => await user1TodoHelper.update(updateResultSetName, { ...todo, ownersContent: 'Owners Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user in allowed group cannot update a record with dynamic list of groups protected field that does not allow update operation
+      await expect(
+        async () => await user1TodoHelper.update(updateResultSetName, { ...todo, groupsContent: 'Groups Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user not in allowed group cannot update a record to re-assign ownership
+      const ownerFieldSet = `
+          customId
+          owner
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], owner: 'user2' }, ownerFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user not in allowed group cannot update a record to re-assign owners in dynamic owners list
+      const ownersFieldSet = `
+          customId
+          authors
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], authors: ['user2'] }, ownersFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user not in allowed group cannot update a record to re-assign group membership
+      const groupFieldSet = `
+          customId
+          group
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], group: devGroupName }, groupFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user not in allowed group cannot update a record to re-assign group memberships stored as dynamic list
+      const groupsFieldSet = `
+          customId
+          groups
+        `;
+      await expect(
+        async () =>
+          await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], groups: [devGroupName] }, groupsFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user not in allowed group cannot update a record with an owner protected field
+      const ownerContentFieldSet = `
+          customId
+          ownerContent
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { ...todo, ownerContent: 'Owner Content' }, ownerContentFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user in allowed group cannot read a record with public protected field
+      const getResult1 = await user1TodoHelper.get({ customId: todo['customId'] }, publicFieldSet, false, 'all', 'customId');
+      checkOperationResult(
+        getResult1,
+        { customId: todo['customId'], publicContent: null },
+        `get${modelName}`,
+        false,
+        expectedFieldErrors(['publicContent'], modelName),
+      );
+
+      const listTodosResult1 = await user1TodoHelper.list({}, publicFieldSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult1, `list${modelName}`, todo['customId'], true, 'customId');
+      checkListResponseErrors(listTodosResult1, expectedFieldErrors(['publicContent'], modelName, false));
+
+      // user not in allowed group and non-owner cannot read a record with owner and group protected fields in the selection set
+      const readFieldSet = `
+        customId
+        owner
+        authors
+        group
+        groups
+        ownerContent
+        ownersContent
+        adminContent
+        groupsContent
+      `;
+      const getResult2 = await user2TodoHelper.get({ customId: todo['customId'] }, readFieldSet, false, 'all', 'customId');
+      const expectedReadErrorFields = [
+        'owner',
+        'authors',
+        'group',
+        'groups',
+        'ownerContent',
+        'ownersContent',
+        'adminContent',
+        'groupsContent',
+      ];
+      checkOperationResult(
+        getResult2,
+        {
+          customId: todo['customId'],
+          owner: null,
+          authors: null,
+          group: null,
+          groups: null,
+          ownerContent: null,
+          ownersContent: null,
+          adminContent: null,
+          groupsContent: null,
+        },
+        `get${modelName}`,
+        false,
+        expectedFieldErrors(expectedReadErrorFields, modelName),
+      );
+
+      const listTodosResult2 = await user2TodoHelper.list({}, readFieldSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult2, `list${modelName}`, todo['customId'], true, 'customId');
+      checkListResponseErrors(listTodosResult2, expectedFieldErrors(expectedReadErrorFields, modelName, false));
+
+      // user not in allowed group cannot listen to updates on owner/group protected fields
       const todoRandom = {
-        ...todoWithAllowedFields,
-        id: Date.now().toString(),
+        ...todo,
+        customId: Date.now().toString(),
       };
       const todoRandomUpdated = {
-        ...todoWithAllowedFields,
-        id: todoRandom.id,
+        customId: todoRandom.customId,
+        owner: userName1,
+        privateContent: 'Private Content updated',
+        ownerContent: 'Owner Content updated',
       };
-      const actorClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName2]);
-      const subTodoHelper = createModelOperationHelpers(actorClient, schema)[modelName];
+      const subscriberClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName2]);
+      const subTodoHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
+        async () => {
+          await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersAndGroupsContent);
+        },
+      ]);
+      const expectedSubscriptionNullFields = ['group', 'groups', 'privateContent', 'publicContent'];
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      expect(onCreateSubscriptionResult[0].data[`onCreate${modelName}`].customId).toEqual(todoRandom.customId);
+      expectNullFields(onCreateSubscriptionResult[0].data[`onCreate${modelName}`], [
+        ...expectedSubscriptionNullFields,
+        'ownersContent',
+        'adminContent',
+        'groupsContent',
+      ]);
+
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerContent);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      expect(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`].customId).toEqual(todoRandom.customId);
+      expectNullFields(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`], [
+        ...expectedSubscriptionNullFields,
+        'ownerContent',
+        'adminContent',
+      ]);
+
+      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [
+        async () => {
+          await user1TodoHelper.delete(deleteResultSetName, { customId: todoRandom.customId }, completeResultSet);
+        },
+      ]);
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      expect(onDeleteSubscriptionResult[0].data[`onDelete${modelName}`].customId).toEqual(todoRandom.customId);
+      expectNullFields(onDeleteSubscriptionResult[0].data[`onDelete${modelName}`], [
+        ...expectedSubscriptionNullFields,
+        'ownerContent',
+        'ownersContent',
+        'adminContent',
+        'groupsContent',
+      ]);
+    });
+
+    test('custom list of groups field protected model and allowed field operations', async () => {
+      const modelName = 'TodoCustomGroupsContentVarious';
+      const user1TodoHelper = user1ModelOperationHelpers[modelName];
+      const user2TodoHelper = user2ModelOperationHelpers[modelName];
+
+      const todo = {
+        customId: Date.now().toString(),
+        owner: userName1,
+        authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
+        privateContent: 'Private Content',
+        adminContent: 'Admin Content',
+        ownersContent: 'Owners Content',
+      };
+      const createResultSetName = `create${modelName}`;
+      const updateResultSetName = `update${modelName}`;
+      const privateResultSet = `
+          customId
+          privateContent
+        `;
+      const adminResultSet = `
+          ${privateResultSet}
+          owner
+          authors
+          group
+          groups
+          adminContent
+        `;
+      const setWithOwnerAndGroupContent = `
+          ${adminResultSet}
+          ownerContent
+          groupContent
+        `;
+      const setWithOwnersContent = `
+          ${adminResultSet}
+          ownersContent
+        `;
+      const completeResultSet = `
+          ${adminResultSet}
+          ownerContent
+          ownersContent
+          groupContent
+        `;
+
+      // admin(user1) creates a record with only allowed fields
+      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersContent);
+      expect(createResult1.data[createResultSetName].customId).toBeDefined();
+      expect(createResult1.data[createResultSetName].owner).toEqual(userName1);
+      expect(createResult1.data[createResultSetName].authors).toEqual([userName1]);
+      todo['customId'] = createResult1.data[createResultSetName].customId;
+      todo['owner'] = userName1;
+      // protected fields are nullified in mutation responses
+      const nulledMutationFields = ['group', 'groups', 'privateContent', 'adminContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledMutationFields, 'ownersContent']);
+
+      // user part of allowed groups can update the allowed fields and add user2 to dyamic owners list field
+      const todoUpdated1 = {
+        customId: todo['customId'],
+        authors: [userName1, userName2],
+        groups: [adminGroupName, devGroupName],
+        privateContent: 'Private Content updated',
+        ownerContent: 'Owner Content',
+        groupContent: 'Group Content',
+      };
+      const updateResult1 = await user1TodoHelper.update(updateResultSetName, todoUpdated1, setWithOwnerAndGroupContent);
+      expect(updateResult1.data[updateResultSetName].customId).toEqual(todo['customId']);
+      expect(updateResult1.data[updateResultSetName].owner).toEqual(userName1);
+      expect(updateResult1.data[updateResultSetName].authors).toEqual(todoUpdated1.authors);
+      expectNullFields(updateResult1.data[updateResultSetName], [...nulledMutationFields, 'ownerContent', 'groupContent']);
+
+      // user part of allowed groups can read the allowed fields
+      const getResult1 = await user1TodoHelper.get(
+        {
+          customId: todo['customId'],
+        },
+        completeResultSet,
+        false,
+        'all',
+        'customId',
+      );
+      checkOperationResult(getResult1, { ...todo, ...todoUpdated1 }, `get${modelName}`);
+
+      const listTodosResult1 = await user1TodoHelper.list({}, completeResultSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult1, `list${modelName}`, todo['customId'], true, 'customId');
+
+      // user not part of allowed groups can update the private field
+      const todoUpdated2 = {
+        customId: todo['customId'],
+        privateContent: 'Private Content updated 1',
+      };
+      const updateResult2 = await user2TodoHelper.update(updateResultSetName, todoUpdated2, privateResultSet);
+      expect(updateResult2.data[updateResultSetName].customId).toEqual(todo['customId']);
+      expectNullFields(updateResult2.data[updateResultSetName], ['privateContent']);
+
+      // user2 who is now part of allowed groups can read the allowed fields
+      const user2ReadAllowedSet = `
+          customId
+          privateContent
+          ownersContent
+        `;
+      const getResult2 = await user2TodoHelper.get(
+        {
+          customId: todo['customId'],
+        },
+        user2ReadAllowedSet,
+        false,
+        'all',
+        'customId',
+      );
+      checkOperationResult(
+        getResult2,
+        {
+          customId: todo['customId'],
+          privateContent: todoUpdated2['privateContent'],
+          ownersContent: todo['ownersContent'],
+        },
+        `get${modelName}`,
+      );
+
+      const listTodosResult2 = await user2TodoHelper.list({}, user2ReadAllowedSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult2, `list${modelName}`, todo['customId'], true, 'customId');
+
+      // user part of allowed groups can listen to updates on allowed fields
+      const todoRandom = {
+        ...todo,
+        customId: Date.now().toString(),
+      };
+      const todoRandomUpdated = {
+        ...todoUpdated1,
+        customId: todoRandom.customId,
+        owner: userName1,
+      };
+      const subscriberClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName1]);
+      const subTodoHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
 
       const onCreateSubscriptionResult = await subTodoHelper.subscribe(
         'onCreate',
         [
           async () => {
-            await todoHelperAdmin.create(createResultSetName, todoRandom, allowedResultSet);
+            await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersContent);
           },
         ],
         {},
-        allowedResultSet,
+        setWithOwnersContent,
         false,
       );
       expect(onCreateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
         onCreateSubscriptionResult[0],
-        { ...todoRandom, customGroups: null, privateContent: null },
+        { ...todoRandom, group: null, groups: null, privateContent: null, ownersContent: null, adminContent: null },
         `onCreate${modelName}`,
       );
 
@@ -1867,80 +2634,272 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
         'onUpdate',
         [
           async () => {
-            await todoHelperAdmin.update(`update${modelName}`, todoRandomUpdated, allowedResultSet);
+            await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerAndGroupContent);
           },
         ],
         {},
-        allowedResultSet,
+        setWithOwnerAndGroupContent,
         false,
       );
       expect(onUpdateSubscriptionResult).toHaveLength(1);
       checkOperationResult(
-        onCreateSubscriptionResult[0],
-        { ...todoRandomUpdated, customGroups: null, privateContent: null },
+        onUpdateSubscriptionResult[0],
+        {
+          ...todoRandomUpdated,
+          group: null,
+          groups: null,
+          privateContent: null,
+          ownerContent: null,
+          adminContent: null,
+          groupContent: null,
+        },
         `onUpdate${modelName}`,
       );
-
-      const onDeleteSubscriptionResult = await subTodoHelper.subscribe('onDelete', [], {}, allowedResultSet, false);
-      expect(onDeleteSubscriptionResult).toHaveLength(0);
     });
 
-    test.skip('user part of group in allowed custom groups list of a record cannot perform CRUD operations on public protected field', async () => {
+    test('custom list of groups field protected model and restricted field operations', async () => {
       const modelName = 'TodoCustomGroupsContentVarious';
-      const modelOperationHelpersAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName1], schema);
-      const modelOperationHelpersNonAdmin = createModelOperationHelpers(appSyncClients[userPoolProvider][userName2], schema);
-      const todoHelperAdmin = modelOperationHelpersAdmin[modelName];
-      const todoHelperNonAdmin = modelOperationHelpersNonAdmin[modelName];
+      const user1TodoHelper = user1ModelOperationHelpers[modelName];
+      const user2TodoHelper = user2ModelOperationHelpers[modelName];
 
-      const todoWithAllowedFields = {
-        privateContent: 'PrivateContent',
-        customGroups: [adminGroupName],
-      };
       const todo = {
-        ...todoWithAllowedFields,
-        publicContent: 'PublicContent',
+        customId: Date.now().toString(),
+        owner: userName1,
+        authors: [userName1],
+        group: adminGroupName,
+        groups: [adminGroupName],
+        privateContent: 'Private Content',
+        ownersContent: 'Owners Content',
+        adminContent: 'Admin Content',
       };
-      const completeResultSet = `
-        id
-        customGroups
-        privateContent
-        publicContent
-      `;
       const createResultSetName = `create${modelName}`;
+      const updateResultSetName = `update${modelName}`;
+      const deleteResultSetName = `delete${modelName}`;
+      const privateResultSet = `
+          customId
+          privateContent
+        `;
+      const adminResultSet = `
+          ${privateResultSet}
+          owner
+          authors
+          group
+          groups
+          adminContent
+        `;
+      const setWithOwnerAndGroupContent = `
+          ${adminResultSet}
+          ownerContent
+          groupContent
+        `;
+      const setWithOwnersContent = `
+          ${adminResultSet}
+          ownersContent
+        `;
 
-      await expect(async () => await todoHelperAdmin.create(createResultSetName, todo)).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"GraphQL error: Not Authorized to access create${modelName} on type Mutation"`,
+      const completeResultSet = `
+          ${adminResultSet}
+          ownerContent
+          ownersContent
+          groupContent
+        `;
+
+      // user part of allowed groups cannot create a record with public protected field
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, publicContent: 'Public Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+
+      // user part of allowed groups cannot create a record with owner protected field that does not allow create operation
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, ownerContent: 'Owner Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+
+      // user part of allowed groups cannot create a record with list of groups protected field that does not allow create operation
+      await expect(
+        async () => await user1TodoHelper.create(createResultSetName, { ...todo, groupContent: 'Group Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+
+      // Create a record with allowed fields, so we can test the update and delete operations.
+      const createResult1 = await user1TodoHelper.create(createResultSetName, todo, setWithOwnersContent);
+      expect(createResult1.data[createResultSetName].customId).toBeDefined();
+      expect(createResult1.data[createResultSetName].owner).toEqual(userName1);
+      expect(createResult1.data[createResultSetName].authors).toEqual([userName1]);
+      todo['customId'] = createResult1.data[createResultSetName].customId;
+      todo['owner'] = userName1;
+      // protected fields are nullified in mutation responses
+      const nulledAdminFields = ['group', 'groups', 'privateContent', 'adminContent'];
+      expectNullFields(createResult1.data[createResultSetName], [...nulledAdminFields, 'ownersContent']);
+
+      const publicFieldSet = `
+          customId
+          publicContent
+        `;
+      // user part of allowed groups cannot update a record with public protected field
+      await expect(
+        async () =>
+          await user1TodoHelper.update(
+            updateResultSetName,
+            { customId: todo['customId'], publicContent: 'Public Content' },
+            publicFieldSet,
+          ),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user part of allowed groups cannot update a record with dynamic list of owners protected field that does not allow update operation
+      await expect(
+        async () => await user1TodoHelper.update(updateResultSetName, { ...todo, ownersContent: 'Owners Content' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user not part of allowed groups cannot update a record to re-assign ownership
+      const ownerFieldSet = `
+          customId
+          owner
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], owner: 'user2' }, ownerFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user not part of allowed groups cannot update a record to re-assign owners in dynamic owners list
+      const ownersFieldSet = `
+          customId
+          authors
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], authors: ['user2'] }, ownersFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user not part of allowed groups cannot update a record to re-assign group membership
+      const groupFieldSet = `
+          customId
+          group
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], group: devGroupName }, groupFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user not part of allowed groups cannot update a record to re-assign group memberships stored as dynamic list
+      const groupsFieldSet = `
+          customId
+          groups
+        `;
+      await expect(
+        async () =>
+          await user2TodoHelper.update(updateResultSetName, { customId: todo['customId'], groups: [devGroupName] }, groupsFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user not part of allowed groups cannot update a record with an owner protected field
+      const ownerContentFieldSet = `
+          customId
+          ownerContent
+        `;
+      await expect(
+        async () => await user2TodoHelper.update(updateResultSetName, { ...todo, ownerContent: 'Owner Content' }, ownerContentFieldSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+
+      // user part of allowed groups cannot read a record with public protected field
+      const getResult1 = await user1TodoHelper.get({ customId: todo['customId'] }, publicFieldSet, false, 'all', 'customId');
+      checkOperationResult(
+        getResult1,
+        { customId: todo['customId'], publicContent: null },
+        `get${modelName}`,
+        false,
+        expectedFieldErrors(['publicContent'], modelName),
       );
 
-      // Create a record with allowed fields only, so we can test the update and delete operations.
-      const allowedResultSet = `
-        id
-        customGroups
-        privateContent
+      const listTodosResult1 = await user1TodoHelper.list({}, publicFieldSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult1, `list${modelName}`, todo['customId'], true, 'customId');
+      checkListResponseErrors(listTodosResult1, expectedFieldErrors(['publicContent'], modelName, false));
+
+      // user not part of allowed groups and non-owner cannot read a record with owner and group protected fields in the selection set
+      const readFieldSet = `
+        customId
+        owner
+        authors
+        group
+        groups
+        ownerContent
+        ownersContent
+        adminContent
+        groupContent
       `;
-      const createResult = await todoHelperAdmin.create(createResultSetName, todoWithAllowedFields, allowedResultSet);
-      expect(createResult.data[createResultSetName].id).toBeDefined();
-      todo['id'] = createResult.data[createResultSetName].id;
-      expect(createResult.data[createResultSetName].privateContent).toBeNull();
-      expect(createResult.data[createResultSetName].customGroups).toBeNull();
-
-      const todoUpdated = {
-        ...todo,
-        privateContent: 'Private Content updated',
-        publicContent: 'Public Content updated',
-      };
-
-      await expect(async () => await todoHelperAdmin.update(`update${modelName}`, todoUpdated)).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"GraphQL error: Not Authorized to access update${modelName} on type Mutation"`,
+      const getResult2 = await user2TodoHelper.get({ customId: todo['customId'] }, readFieldSet, false, 'all', 'customId');
+      const expectedReadErrorFields = [
+        'owner',
+        'authors',
+        'group',
+        'groups',
+        'ownerContent',
+        'ownersContent',
+        'adminContent',
+        'groupContent',
+      ];
+      checkOperationResult(
+        getResult2,
+        {
+          customId: todo['customId'],
+          owner: null,
+          authors: null,
+          group: null,
+          groups: null,
+          ownerContent: null,
+          ownersContent: null,
+          adminContent: null,
+          groupContent: null,
+        },
+        `get${modelName}`,
+        false,
+        expectedFieldErrors(expectedReadErrorFields, modelName),
       );
 
-      const expectedFieldError = `"GraphQL error: Not Authorized to access publicContent on type ${modelName}"`;
-      const getResult = await todoHelperAdmin.get({ id: todo['id'] }, undefined, true, 'all');
-      checkOperationResult(getResult, { ...todo, publicContent: null }, `get${modelName}`, false, [expectedFieldError]);
+      const listTodosResult2 = await user2TodoHelper.list({}, readFieldSet, `list${modelName}`, false, 'all');
+      checkListItemExistence(listTodosResult2, `list${modelName}`, todo['customId'], true, 'customId');
+      checkListResponseErrors(listTodosResult2, expectedFieldErrors(expectedReadErrorFields, modelName, false));
 
-      const listTodosResult = await todoHelperAdmin.list({}, completeResultSet, `list${modelName}`, false, 'all');
-      checkListItemExistence(listTodosResult, `list${modelName}`, todo['id'], true);
-      checkListResponseErrors(listTodosResult, [`Not Authorized to access publicContent on type ${modelName}`]);
+      // unless one has delete access to all fields in the model, delete is expected to fail
+      await expect(
+        async () => await user1TodoHelper.delete(`delete${modelName}`, { customId: todo['customId'] }, completeResultSet),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(`delete${modelName}`, 'Mutation'));
+
+      // user not part of allowed groups cannot listen to updates on owner/group protected fields
+      const todoRandom = {
+        ...todo,
+        customId: Date.now().toString(),
+      };
+      const todoRandomUpdated = {
+        customId: todoRandom.customId,
+        owner: userName1,
+        privateContent: 'Private Content updated',
+        ownerContent: 'Owner Content updated',
+      };
+      const subscriberClient = getConfiguredAppsyncClientCognitoAuth(graphQlEndpoint, region, userMap[userName2]);
+      const subTodoHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
+
+      const onCreateSubscriptionResult = await subTodoHelper.subscribe('onCreate', [
+        async () => {
+          await user1TodoHelper.create(createResultSetName, todoRandom, setWithOwnersContent);
+        },
+      ]);
+      const expectedSubscriptionNullFields = ['group', 'groups', 'privateContent', 'publicContent'];
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      expect(onCreateSubscriptionResult[0].data[`onCreate${modelName}`].customId).toEqual(todoRandom.customId);
+      expectNullFields(onCreateSubscriptionResult[0].data[`onCreate${modelName}`], [
+        ...expectedSubscriptionNullFields,
+        'ownersContent',
+        'adminContent',
+      ]);
+
+      const onUpdateSubscriptionResult = await subTodoHelper.subscribe('onUpdate', [
+        async () => {
+          await user1TodoHelper.update(`update${modelName}`, todoRandomUpdated, setWithOwnerAndGroupContent);
+        },
+      ]);
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      expect(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`].customId).toEqual(todoRandom.customId);
+      expectNullFields(onUpdateSubscriptionResult[0].data[`onUpdate${modelName}`], [
+        ...expectedSubscriptionNullFields,
+        'ownerContent',
+        'adminContent',
+        'groupContent',
+      ]);
     });
   });
 };

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -60,6 +60,10 @@ const AWS_REGIONS_TO_RUN_TESTS = [
 const FORCE_REGION_MAP = {
   interactions: 'us-west-2',
   containers: 'us-east-1',
+  'rds-pg-userpool-auth-fields': 'ap-northeast-2',
+  'rds-pg-oidc-auth-fields': 'ap-northeast-2',
+  'rds-mysql-userpool-auth-fields': 'ap-northeast-2',
+  'rds-mysql-oidc-auth-fields': 'ap-northeast-2',
 };
 
 // some tests require additional time, the parent account can handle longer tests (up to 90 minutes)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- Add cognito/OIDC group based field authorization e2e tests. Includes static, dynamic single and list of groups scenarios.
- Remove previous TODOs that were waiting on AppSync Auth utils changes since they are now deployed to ICN region.
- Update split E2E script to run the new tests in ICN until the AppSync Auth utils changes are deployed to all regions.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Running added E2Es locally and on CI environment.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
