### PR TITLE
chore: use updated ca certificate for rds instances

### DIFF
--- a/packages/amplify-e2e-core/src/utils/rds.ts
+++ b/packages/amplify-e2e-core/src/utils/rds.ts
@@ -62,6 +62,7 @@ export const createRDSInstance = async (
     MasterUsername: config.username,
     MasterUserPassword: config.password,
     PubliclyAccessible: config.publiclyAccessible ?? true,
+    CACertificateIdentifier: 'rds-ca-rsa2048-g1',
   };
   const command = new CreateDBInstanceCommand(params);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The RDS instances that we create in our E2E tests use the default CA certification which is `rds-ca-2019` that has an expiry date in August, 2024. This PR updates it to the newly [recommended](https://w.amazon.com/bin/view/RDS/CA_Certificate_Rotation_Program_2024) certificate i.e `rds-ca-rsa2048-g1`

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
[Link to full E2Es](https://tiny.amazon.com/1bs1gnwlg/IsenLink).
Some of these are known failures that are being fixed on `main`. What we care about here is that atleast one RDS E2E succeeds which verifies that the Lambda data source is able to connect to the DB with updated certificate.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
