### PR TITLE
fix: support 'read' operation alias for SQL data sources

### DIFF
--- a/packages/amplify-graphql-auth-transformer/API.md
+++ b/packages/amplify-graphql-auth-transformer/API.md
@@ -211,6 +211,7 @@ export const getAuthDirectiveRules: (authDir: DirectiveWrapper, options?: GetAut
 // @public (undocumented)
 export type GetAuthRulesOptions = GetArgumentsOptions & {
     isField?: boolean;
+    isSqlDataSource?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/combination-tests/auth-operations-custom-mutations-queries.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/combination-tests/auth-operations-custom-mutations-queries.test.ts
@@ -49,7 +49,7 @@ const schemas = {
   },
 };
 
-const operations = ['create', 'update', 'delete', /* 'read', */ 'get', 'list', 'sync', 'listen', 'search'];
+const operations = ['create', 'update', 'delete', 'read', 'get', 'list', 'sync', 'listen', 'search'];
 
 describe('Auth operation combinations: custom mutations', () => {
   beforeEach(() => {

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/combination-tests/auth-operations-models.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/combination-tests/auth-operations-models.test.ts
@@ -34,7 +34,7 @@ const sqlSchemaTemplate = /* GraphQL */ `
   }
 `;
 
-const operations = ['create', 'update', 'delete', /* 'read', */ 'get', 'list', 'sync', 'listen', 'search'];
+const operations = ['create', 'update', 'delete', 'read', 'get', 'list', 'sync', 'listen', 'search'];
 
 describe('Auth operation combinations: model', () => {
   beforeEach(() => {

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/combination-tests/auth-operations-non-models.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/combination-tests/auth-operations-non-models.test.ts
@@ -40,7 +40,7 @@ const sqlSchemaTemplate = /* GraphQL */ `
   }
 `;
 
-const operations = ['create', 'update', 'delete', /* 'read', */ 'get', 'list', 'sync', 'listen', 'search'];
+const operations = ['create', 'update', 'delete', 'read', 'get', 'list', 'sync', 'listen', 'search'];
 
 describe('Auth operation combinations: non-model', () => {
   beforeEach(() => {

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -201,7 +201,8 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     if (context.metadata.has('joinTypeList')) {
       isJoinType = context.metadata.get<Array<string>>('joinTypeList')!.includes(typeName);
     }
-    const getAuthRulesOptions = merge({ isField: false }, generateGetArgumentsInput(context.transformParameters));
+    const isSqlDataSource = isModelType(context, typeName) && isSqlModel(context, typeName);
+    const getAuthRulesOptions = merge({ isField: false, isSqlDataSource }, generateGetArgumentsInput(context.transformParameters));
     this.rules = getAuthDirectiveRules(new DirectiveWrapper(directive), getAuthRulesOptions);
 
     // validate rules
@@ -267,7 +268,8 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
     const modelDirective = parent.directives?.find((dir) => dir.name.value === 'model');
     const typeName = parent.name.value;
     const fieldName = field.name.value;
-    const getAuthRulesOptions = merge({ isField: true }, generateGetArgumentsInput(context.transformParameters));
+    const isSqlDataSource = isModelType(context, parent.name.value) && isSqlModel(context, parent.name.value);
+    const getAuthRulesOptions = merge({ isField: true, isSqlDataSource }, generateGetArgumentsInput(context.transformParameters));
     const rules: AuthRule[] = getAuthDirectiveRules(new DirectiveWrapper(directive), getAuthRulesOptions);
     validateFieldRules(
       new DirectiveWrapper(directive),

--- a/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
@@ -32,6 +32,7 @@ export interface SearchableConfig {
 
 export type GetAuthRulesOptions = GetArgumentsOptions & {
   isField?: boolean;
+  isSqlDataSource?: boolean;
 };
 
 /**

--- a/packages/amplify-graphql-auth-transformer/src/utils/index.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/index.ts
@@ -47,9 +47,11 @@ export const getAuthDirectiveRules = (authDir: DirectiveWrapper, options?: GetAu
       operations.splice(indexOfRead, 1);
       operations.push('get');
       operations.push('list');
-      operations.push('search');
-      operations.push('sync');
       operations.push('listen');
+      if (!options.isSqlDataSource) {
+        operations.push('search');
+        operations.push('sync');
+      }
       // eslint-disable-next-line no-param-reassign
       rule.operations = operations as ModelOperation[];
     }

--- a/packages/amplify-graphql-auth-transformer/src/utils/index.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/index.ts
@@ -48,7 +48,7 @@ export const getAuthDirectiveRules = (authDir: DirectiveWrapper, options?: GetAu
       operations.push('get');
       operations.push('list');
       operations.push('listen');
-      if (!options.isSqlDataSource) {
+      if (!options?.isSqlDataSource) {
         operations.push('search');
         operations.push('sync');
       }


### PR DESCRIPTION
#### Description of changes

Support 'read' operation alias for SQL data sources:

```graphql
type Todo @model @auth(rules: [{allow: owner, operations: [read]}]) { ... }
```

This change is enabled by adding an `isSqlDataSource` option to the `getAuthDirectiveRules` utility function. That function is exported from the V2 transformer and so changes the API.md, but does not change the customer-facing API.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
