### PR TITLE
chore(api): add cleanup script to delete rds instances

### DIFF
--- a/packages/amplify-e2e-tests/src/cleanup-e2e-rds-instances.sh
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-rds-instances.sh
@@ -1,0 +1,16 @@
+declare -a regions=( 'us-east-1' 'us-east-2' 'us-west-2' 'eu-west-2' 'eu-central-1' 'ap-northeast-1' 'ap-southeast-1' 'ap-southeast-2') ## now loop through the above array
+for region in "${regions[@]}"
+do
+   echo "Deleting all the RDS instances in $region"
+   aws rds describe-db-instances --region $region \
+    --query 'DBInstances[*].[DBInstanceIdentifier]' \
+    --output text | xargs -I {} \
+      aws rds delete-db-instance \
+         --region $region \
+         --db-instance-identifier {} \
+         --skip-final-snapshot \
+         --query 'DBInstance.DBInstanceIdentifier' \
+         --no-delete-automated-backups \
+         --output text | xargs -I {} \
+      echo "--- Deleting DB instance" {}
+done


### PR DESCRIPTION
Add cleanup script to delete the RDS instances from the E2E account.
For now, we will run this manually when required.