### PR TITLE
fix: deep merge default behavior

### DIFF
--- a/packages/amplify-graphql-api-construct/src/internal/default-parameters.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/default-parameters.ts
@@ -6,7 +6,7 @@ import { TranslationBehavior } from '../types';
  * Be sure to document default values when adding new keys in the top level `types` file.
  */
 export const defaultTranslationBehavior: TranslationBehavior = {
-  shouldDeepMergeDirectiveConfigDefaults: false,
+  shouldDeepMergeDirectiveConfigDefaults: true,
   disableResolverDeduping: true,
   sandboxModeEnabled: false,
   useSubUsernameForDefaultIdentityClaim: true,

--- a/packages/amplify-graphql-api-construct/src/internal/default-parameters.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/default-parameters.ts
@@ -6,7 +6,7 @@ import { TranslationBehavior } from '../types';
  * Be sure to document default values when adding new keys in the top level `types` file.
  */
 export const defaultTranslationBehavior: TranslationBehavior = {
-  shouldDeepMergeDirectiveConfigDefaults: true,
+  shouldDeepMergeDirectiveConfigDefaults: false,
   disableResolverDeduping: true,
   sandboxModeEnabled: false,
   useSubUsernameForDefaultIdentityClaim: true,

--- a/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
@@ -54,8 +54,9 @@ export class DirectiveWrapper {
       }),
       {},
     );
-    if (options?.deepMergeArguments) {
-      return _.merge(_.cloneDeep(defaultValue), argValues);
+    if (options?.deepMergeArguments && !_.isEmpty(argValues)) {
+      const clonedDefaultArgValues = _.cloneDeep(defaultValue);
+      return _.merge(clonedDefaultArgValues, argValues);
     }
     return Object.assign(defaultValue, argValues);
   };

--- a/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/directive-wrapper.ts
@@ -54,9 +54,8 @@ export class DirectiveWrapper {
       }),
       {},
     );
-    if (options?.deepMergeArguments && !_.isEmpty(argValues)) {
-      const clonedDefaultArgValues = _.cloneDeep(defaultValue);
-      return _.merge(clonedDefaultArgValues, argValues);
+    if (options?.deepMergeArguments && needsDeepMerge(defaultValue, argValues)) {
+      return _.merge(_.cloneDeep(defaultValue), argValues);
     }
     return Object.assign(defaultValue, argValues);
   };
@@ -65,3 +64,20 @@ export class DirectiveWrapper {
 export const generateGetArgumentsInput = ({ shouldDeepMergeDirectiveConfigDefaults }: TransformParameters): GetArgumentsOptions => ({
   deepMergeArguments: shouldDeepMergeDirectiveConfigDefaults,
 });
+
+/**
+ * Checks for cases where we don't need to do deep cloning and merging of arguments.
+ * These include cases when the user provided arguments are empty or when there are no common keys between the default and user provided arguments.
+ * @param defaultValue the default properties set for the directive
+ * @param argValues the user provided arguments for the directive
+ * @returns if deep cloning and merging of arguments is needed
+ */
+export const needsDeepMerge = <T>(defaultValue: Required<T>, argValues: { [x: string]: any }): boolean => {
+  if (_.isEmpty(argValues)) {
+    return false;
+  }
+  if (typeof defaultValue === 'object') {
+    return Object.keys(argValues)?.some((key) => Object.keys(defaultValue)?.includes(key));
+  }
+  return true;
+};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR optimizes the merging of default and user provided directive arguments by avoiding deep cloning of default values in cases where:
- No user provided args exist. In this case, we essentially just return the default values as is.
- No common properties exist. In this case, we include properties from both inputs and no need for recursively merging them.

This fixes the https://github.com/aws-amplify/amplify-category-api/issues/1978 without changing the default behavior of the construct. The stack size error is being thrown by lodash's deep clone utility due to some circular references in the nested object which includes GraphQL AST nodes with multiple sub-nodes within them. These don't imply any relational circular dependencies between models in the schema.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Added unit tests which also include the [examples from docs](https://docs.amplify.aws/react/build-a-backend/graphqlapi/data-modeling/#rename-generated-queries-mutations-and-subscriptions) that were missing previously.
[E2Es are Green](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:7e2943aa-c553-4cf2-a544-a43319ac829f?region=us-east-1#).

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
