### PR TITLE
test(rds): add e2e tests for field auth (userpool+iam)

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/userpool-iam-fields.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/userpool-iam-fields.ts
@@ -1,0 +1,55 @@
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { generateDDL } from '../../rds-v2-test-utils';
+
+export const schema = `
+  # I have a model that is protected by userPools by default.
+  # I can call CRUD post from my lambda using iam role.
+  # I can create posts visiable for all unauthenticated and sigend in users
+  # I can create content only visable for subscribers
+  # The likes of post are only mutable by lambda using iam role
+  type Post
+    @model
+    @auth(
+      rules: [
+        # The cognito user pool owner can CRUD.
+        { allow: owner }
+        # A lambda function using IAM can call CRUD.
+        { allow: private, provider: iam }
+        # Unauthenticated users using IAM can read posts
+        { allow: public, provider: iam, operations: [read] }
+        # Signed in users can read posts
+        { allow: private, operations: [read] }
+      ]
+    ) {
+    id: ID! @primaryKey
+    title: String
+    owner: String
+    subscriberList: [String] 
+      @auth(
+        rules: [
+          # Unauthenticated users cannot read subscriber list
+          { allow: owner }
+          { allow: private, provider: iam }
+          { allow: private, operations: [read] }
+        ]
+      )
+    subscriberContent: String
+      @auth(rules:[
+        # Owner(all ops) and subscribers(read-only) have access to subscriber content
+        { allow: owner }
+        { allow: owner, ownerField: "subscriberList", operations: [read]}
+        # Lambda using iam role can RUD subscriber content
+        { allow: private, provider: iam, operations: [read, update, delete]}
+      ])
+    likes: Int @default(value: "0")
+      @auth(rules:[
+        # Only lambda function using IAM can update this field
+        { allow: private, provider: iam, operations: [read, update, delete]}
+        # Others can only read this field
+        { allow: public, provider: iam, operations: [read] }
+        { allow: private, operations: [read] }
+      ])
+  }
+`;
+
+export const sqlCreateStatements = (engine: ImportedRDSType): string[] => generateDDL(schema, engine);

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-field-auth-userpool-iam.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-field-auth-userpool-iam.test.ts
@@ -4,6 +4,6 @@ import { testRdsUserpoolIAMFieldAuth } from '../rds-v2-tests-common/rds-auth-use
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
 
-describe('RDS MySQL Lambda Authorizer field auth rules', () => {
+describe('RDS MySQL Userpool and IAM field auth rules', () => {
   testRdsUserpoolIAMFieldAuth(ImportedRDSType.MYSQL, []);
 });

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-field-auth-userpool-iam.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-field-auth-userpool-iam.test.ts
@@ -1,0 +1,9 @@
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { testRdsUserpoolIAMFieldAuth } from '../rds-v2-tests-common/rds-auth-userpool-iam-fields';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+describe('RDS MySQL Lambda Authorizer field auth rules', () => {
+  testRdsUserpoolIAMFieldAuth(ImportedRDSType.MYSQL, []);
+});

--- a/packages/amplify-e2e-tests/src/__tests__/rds-pg-field-auth-userpool-iam.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-pg-field-auth-userpool-iam.test.ts
@@ -4,6 +4,6 @@ import { testRdsUserpoolIAMFieldAuth } from '../rds-v2-tests-common/rds-auth-use
 // to deal with bug in cognito-identity-js
 (global as any).fetch = require('node-fetch');
 
-describe('RDS MySQL Lambda Authorizer field auth rules', () => {
+describe('RDS Postgres Userpool and IAM field auth rules', () => {
   testRdsUserpoolIAMFieldAuth(ImportedRDSType.POSTGRESQL, []);
 });

--- a/packages/amplify-e2e-tests/src/__tests__/rds-pg-field-auth-userpool-iam.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-pg-field-auth-userpool-iam.test.ts
@@ -1,0 +1,9 @@
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { testRdsUserpoolIAMFieldAuth } from '../rds-v2-tests-common/rds-auth-userpool-iam-fields';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+describe('RDS MySQL Lambda Authorizer field auth rules', () => {
+  testRdsUserpoolIAMFieldAuth(ImportedRDSType.POSTGRESQL, []);
+});

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool-iam-fields.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool-iam-fields.ts
@@ -1,0 +1,532 @@
+import {
+  addApiWithAllAuthModes,
+  amplifyPush,
+  createNewProjectDir,
+  deleteDBInstance,
+  deleteProject,
+  deleteProjectDir,
+  enableUserPoolUnauthenticatedAccess,
+  getAppSyncApi,
+  getProjectMeta,
+  importRDSDatabase,
+  initJSProjectWithProfile,
+  setupRDSInstanceAndData,
+  sleep,
+} from 'amplify-category-api-e2e-core';
+import { existsSync, removeSync, writeFileSync } from 'fs-extra';
+import generator from 'generate-password';
+import path from 'path';
+import { GQLQueryHelper } from '../query-utils/gql-helper';
+import {
+  configureAmplify,
+  getConfiguredAppsyncClientAPIKeyAuth,
+  getConfiguredAppsyncClientIAMAuth,
+  getUserPoolId,
+  setupUser,
+  signInUser,
+} from '../schema-api-directives';
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { SQL_TESTS_USE_BETA } from './sql-e2e-config';
+import {
+  checkListItemExistence,
+  checkListResponseErrors,
+  checkOperationResult,
+  configureAppSyncClients,
+  expectedFieldErrors,
+  expectedOperationError,
+  getAppSyncEndpoint,
+  getDefaultDatabasePort,
+} from '../rds-v2-test-utils';
+import { API, Auth } from 'aws-amplify';
+import gql from 'graphql-tag';
+import { withTimeOut } from '../utils/api';
+import { GRAPHQL_AUTH_MODE } from '@aws-amplify/api';
+import { Observable, ZenObservable } from 'zen-observable-ts';
+import { schema, sqlCreateStatements } from '../__tests__/auth-test-schemas/userpool-iam-fields';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+export const testRdsUserpoolIAMFieldAuth = (engine: ImportedRDSType, queries: string[]): void => {
+  describe('RDS userpool & IAM field auth', () => {
+    const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
+
+    // Generate settings for RDS instance
+    const username = db_user;
+    const password = db_password;
+    let region = 'us-east-1'; // This get overwritten in beforeAll
+    let port = getDefaultDatabasePort(engine);
+    const database = 'default_db';
+    let host = 'localhost';
+    const identifier = `integtest${db_identifier}`;
+    const engineSuffix = engine === ImportedRDSType.MYSQL ? 'ms' : 'pg';
+    const engineName = engine === ImportedRDSType.MYSQL ? 'mysql' : 'postgres';
+    const projName = `${engineSuffix}multifieldauth1`;
+    const apiName = projName;
+
+    const userName1 = 'user1';
+    const userName2 = 'user2';
+    const userName3 = 'user3';
+    const privateIAMUserName = 'iamuser';
+    const userPassword = 'user@Password';
+    const userPoolProvider = 'userPools';
+    const userMap = {};
+
+    let projRoot;
+    let apiEndPoint;
+    let appSyncClients = {};
+    let userpoolAppSyncClients;
+    let postIAMPublicClient: GQLQueryHelper, postIAMPrivateClient: GQLQueryHelper;
+    let postUser1Client: GQLQueryHelper, postUser2Client: GQLQueryHelper, postUser3Client: GQLQueryHelper;
+
+    beforeAll(async () => {
+      console.log(sqlCreateStatements(engine));
+
+      projRoot = await createNewProjectDir(projName);
+      await initProjectAndImportSchema();
+      await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
+
+      const meta = getProjectMeta(projRoot);
+      const appRegion = meta.providers.awscloudformation.Region;
+      const { output } = meta.api[apiName];
+      const { GraphQLAPIIdOutput, GraphQLAPIEndpointOutput, GraphQLAPIKeyOutput } = output;
+      apiEndPoint = GraphQLAPIEndpointOutput as string;
+
+      const { graphqlApi } = await getAppSyncApi(GraphQLAPIIdOutput, appRegion);
+
+      expect(GraphQLAPIIdOutput).toBeDefined();
+      expect(GraphQLAPIEndpointOutput).toBeDefined();
+      expect(GraphQLAPIKeyOutput).toBeDefined();
+
+      expect(graphqlApi).toBeDefined();
+      expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
+
+      await createAppSyncClients(apiEndPoint, appRegion);
+    });
+
+    const createAppSyncClients = async (apiEndPoint, appRegion): Promise<void> => {
+      const userPoolId = getUserPoolId(projRoot);
+      configureAmplify(projRoot);
+
+      // unauth IAM client
+      const unAuthCredentials = await Auth.currentCredentials();
+      const unauthAppSyncClient = getConfiguredAppsyncClientIAMAuth(apiEndPoint, appRegion, unAuthCredentials);
+      // auth IAM client
+      // in this case use signed-in user from cognito to be authenticated IAM role
+      // to simulate the lambda function role scenario
+      await setupUser(userPoolId, privateIAMUserName, userPassword);
+      await signInUser(privateIAMUserName, userPassword);
+      const authCredentials = await Auth.currentCredentials();
+      const authAppSyncClient = getConfiguredAppsyncClientIAMAuth(apiEndPoint, appRegion, authCredentials);
+      // cognito userpool clients
+      await setupUser(userPoolId, userName1, userPassword);
+      await setupUser(userPoolId, userName2, userPassword);
+      await setupUser(userPoolId, userName3, userPassword);
+      const user1 = await signInUser(userName1, userPassword);
+      userMap[userName1] = user1;
+      const user2 = await signInUser(userName2, userPassword);
+      userMap[userName2] = user2;
+      const user3 = await signInUser(userName3, userPassword);
+      userMap[userName3] = user3;
+      appSyncClients = await configureAppSyncClients(projRoot, apiName, [userPoolProvider], userMap);
+      userpoolAppSyncClients = appSyncClients[userPoolProvider];
+
+      postIAMPublicClient = constructModelHelper('Post', unauthAppSyncClient);
+      postIAMPrivateClient = constructModelHelper('Post', authAppSyncClient);
+      postUser1Client = constructModelHelper('Post', userpoolAppSyncClients[userName1]);
+      postUser2Client = constructModelHelper('Post', userpoolAppSyncClients[userName2]);
+      postUser3Client = constructModelHelper('Post', userpoolAppSyncClients[userName3]);
+    };
+
+    afterAll(async () => {
+      const metaFilePath = path.join(projRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
+      if (existsSync(metaFilePath)) {
+        await deleteProject(projRoot);
+      }
+      deleteProjectDir(projRoot);
+      await cleanupDatabase();
+    });
+
+    const setupDatabase = async (): Promise<void> => {
+      const dbConfig = {
+        identifier,
+        engine,
+        dbname: database,
+        username,
+        password,
+        region,
+      };
+
+      const db = await setupRDSInstanceAndData(dbConfig, sqlCreateStatements(engine));
+      port = db.port;
+      host = db.endpoint;
+    };
+
+    const cleanupDatabase = async (): Promise<void> => {
+      await deleteDBInstance(identifier, region);
+    };
+
+    const initProjectAndImportSchema = async (): Promise<void> => {
+      await initJSProjectWithProfile(projRoot, {
+        disableAmplifyAppCreation: false,
+        name: projName,
+      });
+
+      const metaAfterInit = getProjectMeta(projRoot);
+      region = metaAfterInit.providers.awscloudformation.Region;
+      await setupDatabase();
+      await addApiWithAllAuthModes(projRoot, { transformerVersion: 2, apiName });
+      // Remove DDB schema
+      const ddbSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.graphql');
+      removeSync(ddbSchemaFilePath);
+      await importRDSDatabase(projRoot, {
+        database,
+        engine,
+        host,
+        port,
+        username,
+        password,
+        useVpc: true,
+        apiExists: true,
+      });
+      // Write RDS schema
+      const rdsSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.sql.graphql');
+      const rdsSchema = appendAmplifyInput(schema, engine);
+      writeFileSync(rdsSchemaFilePath, rdsSchema, 'utf8');
+      // Enable unauthenticated access to the Cognito resource and push again
+      await enableUserPoolUnauthenticatedAccess(projRoot);
+      await amplifyPush(projRoot, false, {
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
+      });
+      // Make a dummy edit for schema and re-push
+      // This is a known bug in which deploying the userpool auth with sql schema cannot be done within one push
+      writeFileSync(rdsSchemaFilePath, `${rdsSchema}\n`, 'utf8');
+      await amplifyPush(projRoot, false, {
+        skipCodegen: true,
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
+      });
+    };
+
+    test('userpool owner can perform all valid operations on post', async () => {
+      const post = {
+        id: 'P-1',
+        title: 'My Post 1',
+        owner: userName1,
+        subscriberList: [userName2],
+        likes: 0,
+        subscriberContent: 'Exclusive content 1',
+      };
+      // userpool owner cannot create a post without restricted field `likes`
+      const createPostResult = await postUser1Client.create('createPost', omit(post, 'likes'));
+      expect(createPostResult.data.createPost).toEqual(expect.objectContaining(omit(post, 'subscriberContent')));
+      // subscriber content is protected and cannot be read upon mutation
+      expect(createPostResult.data.createPost.subscriberContent).toBeNull();
+      // userpool owner cannot create a post with field input `likes`
+      await expect(
+        async () =>
+          await postUser1Client.create('createPost', {
+            id: 'P-2',
+            title: 'My Post 2',
+            subscriberList: [userName1],
+            subscriberContent: 'Exclusive content 2',
+            likes: 10,
+          }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError('createPost', 'Mutation'));
+      // userpool owner can read allowed fields
+      const getPostResult = await postUser1Client.get({
+        id: post.id,
+      });
+      expect(getPostResult.data.getPost).toEqual(expect.objectContaining(post));
+      const listPostsResult = await postUser1Client.list();
+      expect(listPostsResult.data.listPosts.items).toEqual(expect.arrayContaining([expect.objectContaining(post)]));
+      // userpool owner can update allowed fields
+      const updatedPost = {
+        id: post.id,
+        title: 'My Post 1 updated',
+        owner: userName1,
+        subscriberList: [userName2, userName3],
+        likes: 0,
+        subscriberContent: 'Exclusive content 1 updated',
+      };
+      // cannot update likes
+      await expect(
+        async () =>
+          await postUser1Client.update('updatePost', {
+            id: updatedPost.id,
+            likes: 10,
+          }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError('updatePost', 'Mutation'));
+      const updatePostResult = await postUser1Client.update('updatePost', omit(updatedPost, 'likes'));
+      expect(updatePostResult.data.updatePost).toEqual(expect.objectContaining(omit(updatedPost, 'subscriberContent')));
+      // subscriber content is protected and cannot be read upon mutation
+      expect(updatePostResult.data.updatePost.subscriberContent).toBeNull();
+      // unless one has delete access to all fields in the model, delete is expected to fail
+      // userpool owner cannot delete the post
+      await expect(async () => await postUser1Client.delete('deletePost', { id: post.id })).rejects.toThrowErrorMatchingInlineSnapshot(
+        expectedOperationError('deletePost', 'Mutation'),
+      );
+      // remove the post by private iam role
+      await postIAMPrivateClient.delete('deletePost', { id: post.id });
+    });
+    test('private iam role can perform all valid operations on post', async () => {
+      // private iam role can create a post with allowed fields (except `likes`, `subscriberContent`)
+      const post = {
+        id: 'P-2',
+        title: 'My Post 2',
+        owner: userName2,
+        subscriberList: [userName3],
+        likes: 0,
+        subscriberContent: 'Exclusive content 2',
+      };
+      await expect(async () => await postIAMPrivateClient.create('createPost', post)).rejects.toThrowErrorMatchingInlineSnapshot(
+        expectedOperationError('createPost', 'Mutation'),
+      );
+
+      const createPostResult = await postIAMPrivateClient.create('createPost', omit(post, 'likes', 'subscriberContent'));
+      expect(createPostResult.data.createPost).toEqual(expect.objectContaining(omit(post, 'subscriberContent')));
+      // user2 should be able to update subscriber content to the post created by private iam
+      await postUser2Client.update('updatePost', {
+        id: post.id,
+        subscriberContent: post.subscriberContent,
+      });
+      // private iam role can read all the fields
+      const getPostResult = await postIAMPrivateClient.get({
+        id: post.id,
+      });
+      expect(getPostResult.data.getPost).toEqual(expect.objectContaining(post));
+      const listPostsResult = await postIAMPrivateClient.list();
+      expect(listPostsResult.data.listPosts.items).toEqual(expect.arrayContaining([expect.objectContaining(post)]));
+      // private iam role can update all the fields
+      const updatedPost = {
+        id: post.id,
+        title: 'My Post 2 updated',
+        owner: userName2,
+        likes: 10,
+        subscriberList: [userName1, userName3],
+        subscriberContent: 'Exclusive content 2 updated',
+      };
+      const updatePostResult = await postIAMPrivateClient.update('updatePost', updatedPost);
+      expect(updatePostResult.data.updatePost).toEqual(expect.objectContaining(omit(updatedPost, 'subscriberContent')));
+      // subscriber content is protected and cannot be read upon mutation
+      expect(updatePostResult.data.updatePost.subscriberContent).toBeNull();
+      // private iam role can delete a post
+      const deletePostResult = await postIAMPrivateClient.delete('deletePost', { id: post.id });
+      expect(deletePostResult.data.deletePost).toEqual(expect.objectContaining(omit(updatedPost, 'subscriberContent')));
+      // subscriber content is protected and cannot be read upon mutation
+      expect(deletePostResult.data.deletePost.subscriberContent).toBeNull();
+    });
+    test('public iam role can perform all valid operations on post', async () => {
+      const post = {
+        id: 'P-3',
+        title: 'My Post 3',
+        owner: userName3,
+        subscriberList: [userName1, userName2],
+        likes: 0,
+        subscriberContent: 'Exclusive content 3',
+      };
+      await postUser3Client.create('createPost', omit(post, 'likes'));
+      // public iam role can only read restricted fields
+      const getPostResult = await postIAMPublicClient.get(
+        {
+          id: post.id,
+        },
+        undefined,
+        true,
+        'all',
+      );
+      checkOperationResult(
+        getPostResult,
+        { ...post, subscriberList: null, subscriberContent: null },
+        'getPost',
+        false,
+        expectedFieldErrors(['subscriberContent', 'subscriberList'], 'Post'),
+      );
+      const listPostsResult = await postIAMPublicClient.list({}, undefined, 'listPosts', true, 'all');
+      checkListItemExistence(listPostsResult, 'listPosts', post.id, true);
+      checkListResponseErrors(listPostsResult, expectedFieldErrors(['subscriberContent', 'subscriberList'], 'Post', false));
+
+      // public iam role cannot do CUD operatioins
+      await expect(
+        async () => await postIAMPublicClient.create('createPost', { id: 'P-invalid', title: 'My Post 3' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError('createPost', 'Mutation'));
+
+      const updatedPost = {
+        id: post.id,
+        title: 'My Post 3 updated',
+        owner: userName2,
+        subscriberList: [userName2, userName3],
+        likes: 10,
+        subscriberContent: 'Exclusive content 3 updated',
+      };
+      Object.entries(omit(updatedPost, 'id')).forEach(async (entry) => {
+        const updateInput = Object.fromEntries([['id', post.id], entry]);
+        await expect(async () => await postIAMPublicClient.update('updatePost', updateInput)).rejects.toThrowErrorMatchingInlineSnapshot(
+          expectedOperationError('updatePost', 'Mutation'),
+        );
+      });
+
+      await expect(async () => await postIAMPublicClient.delete('deletePost', { id: post.id })).rejects.toThrowErrorMatchingInlineSnapshot(
+        expectedOperationError('deletePost', 'Mutation'),
+      );
+      // remove the post by private iam role
+      await postIAMPrivateClient.delete('deletePost', { id: post.id });
+    });
+    test('signed in non-owner users(private userpool) can perform all valid operations on post', async () => {
+      const post = {
+        id: 'P-4',
+        title: 'My Post 4',
+        owner: userName1,
+        subscriberList: [userName2],
+        likes: 0,
+        subscriberContent: 'Exclusive content 4',
+      };
+      await postUser1Client.create('createPost', omit(post, 'likes'));
+      // private userpool(signed-in) users cannot read subscriber content if they are not in the subscriber list or owner
+      const getPostResult = await postUser3Client.get(
+        {
+          id: post.id,
+        },
+        undefined,
+        true,
+        'all',
+      );
+      checkOperationResult(
+        getPostResult,
+        { ...post, subscriberContent: null },
+        'getPost',
+        false,
+        expectedFieldErrors(['subscriberContent'], 'Post'),
+      );
+      const listPostsResult = await postUser3Client.list({}, undefined, 'listPosts', true, 'all');
+      checkListItemExistence(listPostsResult, 'listPosts', post.id, true);
+      checkListResponseErrors(listPostsResult, expectedFieldErrors(['subscriberContent'], 'Post', false));
+      // private userpool(signed-in) users cannot update or delete fields in post if they are not owner
+      const updatedPost = {
+        id: post.id,
+        title: 'My Post 4 updated',
+        owner: userName2,
+        subscriberList: [userName1, userName3],
+        likes: 10,
+        subscriberContent: 'Exclusive content 4 updated',
+      };
+      Object.entries(omit(updatedPost, 'id')).forEach(async (entry) => {
+        const updateInput = Object.fromEntries([['id', post.id], entry]);
+        await expect(async () => await postUser3Client.update('updatePost', updateInput)).rejects.toThrowErrorMatchingInlineSnapshot(
+          expectedOperationError('updatePost', 'Mutation'),
+        );
+      });
+
+      await expect(async () => await postUser3Client.delete('deletePost', { id: post.id })).rejects.toThrowErrorMatchingInlineSnapshot(
+        expectedOperationError('deletePost', 'Mutation'),
+      );
+
+      // remove the post by private iam role
+      await postIAMPrivateClient.delete('deletePost', { id: post.id });
+    });
+    test('subscribers(onwer field as array) can perform all valid operations on post', async () => {
+      const post = {
+        id: 'P-5',
+        title: 'My Post 5',
+        owner: userName1,
+        subscriberList: [userName2],
+        likes: 0,
+        subscriberContent: 'Exclusive content 5',
+      };
+      await postUser1Client.create('createPost', omit(post, 'likes'));
+      // subscriber can read subscriber content
+      const getPostResult = await postUser2Client.get({
+        id: post.id,
+      });
+      expect(getPostResult.data.getPost).toEqual(expect.objectContaining(post));
+      const listPostsResult = await postUser2Client.list();
+      expect(listPostsResult.data.listPosts.items).toEqual(expect.arrayContaining([expect.objectContaining(post)]));
+      // non-owner subscriber cannot update or delete any fields in post
+      const updatedPost = {
+        id: 'P-5',
+        title: 'My Post 5 updated',
+        owner: userName2,
+        subscriberList: [userName2, userName3],
+        likes: 10,
+        subscriberContent: 'Exclusive content 5 updated',
+      };
+      Object.entries(omit(updatedPost, 'id')).forEach(async (entry) => {
+        const updateInput = Object.fromEntries([['id', post.id], entry]);
+        await expect(async () => await postUser2Client.update('updatePost', updateInput)).rejects.toThrowErrorMatchingInlineSnapshot(
+          expectedOperationError('updatePost', 'Mutation'),
+        );
+      });
+      // cannot delete the post
+      await expect(async () => await postUser2Client.delete('deletePost', { id: post.id })).rejects.toThrowErrorMatchingInlineSnapshot(
+        expectedOperationError('deletePost', 'Mutation'),
+      );
+
+      // remove the post by private iam role
+      await postIAMPrivateClient.delete('deletePost', { id: post.id });
+    });
+
+    // helper functions
+    const constructModelHelper = (name: string, client): GQLQueryHelper => {
+      const createSelectionSet = /* GraphQL */ `
+        id
+        title
+        owner
+        subscriberList
+        subscriberContent
+        likes
+      `;
+      const updateSelectionSet = createSelectionSet;
+      const deleteSelectionSet = createSelectionSet;
+      const getSelectionSet = /* GraphQL */ `
+        query Get${name}($id: ID!) {
+          get${name}(id: $id) {
+            id
+            title
+            owner
+            subscriberList
+            subscriberContent
+            likes
+          }
+        }
+      `;
+      const listSelectionSet = /* GraphQL */ `
+        query List${name}s {
+          list${name}s {
+            items {
+              id
+              title
+              owner
+              subscriberList
+              subscriberContent
+              likes
+            }
+          }
+        }
+      `;
+      const helper = new GQLQueryHelper(client, name, {
+        mutation: {
+          create: createSelectionSet,
+          update: updateSelectionSet,
+          delete: deleteSelectionSet,
+        },
+        query: {
+          get: getSelectionSet,
+          list: listSelectionSet,
+        },
+      });
+
+      return helper;
+    };
+    const appendAmplifyInput = (schema: string, engine: ImportedRDSType): string => {
+      const amplifyInput = (engineName: ImportedRDSType): string => {
+        return `
+          input AMPLIFY {
+            engine: String = "${engineName}",
+          }
+        `;
+      };
+      return amplifyInput(engine) + '\n' + schema;
+    };
+    const omit = <T extends {}, K extends keyof T>(obj: T, ...keys: K[]) =>
+      Object.fromEntries(Object.entries(obj).filter(([key]) => !keys.includes(key as K))) as Omit<T, K>;
+  });
+};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Added the field auth combination tests(userpool + public/private iam) for mysql and postgres
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Run the e2e tests locally and get both passed.
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
