### PR TITLE
feat: add credential retry logic to sql lambda

### DIFF
--- a/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
+++ b/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
@@ -47,10 +47,10 @@ const retryWithRefreshedCredentials = async (event, debugMode): Promise<any> => 
 
 const isRetryableError = (error): boolean => {
   // https://www.postgresql.org/docs/current/errcodes-appendix.html
-  const postgresRetryableError = error.code === '28P01' && error.routine === 'auth_failed';
+  const postgresRetryableError = error.code === '28P01';
 
   // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
-  const mysqlRetryableError = error.errno === '1045' && error.code === 'ER_ACCESS_DENIED_ERROR';
+  const mysqlRetryableError = error.errno === '1045';
 
   return postgresRetryableError || mysqlRetryableError;
 }

--- a/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
+++ b/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
@@ -46,7 +46,10 @@ const retryWithRefreshedCredentials = async (event, debugMode): Promise<any> => 
 };
 
 const isRetryableError = (error): boolean => {
+  // https://www.postgresql.org/docs/current/errcodes-appendix.html
   const postgresRetryableError = error.code === '28P01' && error.routine === 'auth_failed';
+
+  // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
   const mysqlRetryableError = error.errno === '1045' && error.code === 'ER_ACCESS_DENIED_ERROR';
 
   return postgresRetryableError || mysqlRetryableError;

--- a/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
+++ b/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
@@ -47,9 +47,9 @@ const retryWithRefreshedCredentials = async (event, debugMode): Promise<any> => 
 
 const isRetryableError = (error): boolean => {
   const postgresRetryableError = error.code === '28P01' && error.routine === 'auth_failed';
-  const mysqlRetruableError = error.errno === '1045' && error.code === 'ER_ACCESS_DENIED_ERROR';
+  const mysqlRetryableError = error.errno === '1045' && error.code === 'ER_ACCESS_DENIED_ERROR';
 
-  return postgresRetryableError || mysqlRetruableError;
+  return postgresRetryableError || mysqlRetryableError;
 }
 
 const createSSMClient = (): void => {

--- a/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
+++ b/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
@@ -24,9 +24,33 @@ export const run = async (event): Promise<any> => {
     adapter = await getDBAdapter(config);
   }
   const debugMode = process.env.DEBUG_MODE === 'true';
-  const result = await adapter.executeRequest(event, debugMode);
-  return result;
+  try {
+    return await adapter.executeRequest(event, debugMode);
+  } catch (e) {
+    if (isRetryableError(e)) {
+      return await retryWithRefreshedCredentials(event, debugMode)
+    }
+    throw e;
+  }
 };
+
+const retryWithRefreshedCredentials = async (event, debugMode): Promise<any> => {
+  try {
+    const config = await getDBConfig();
+    adapter = await getDBAdapter(config);
+    return await adapter.executeRequest(event, debugMode);
+  } catch (err) {
+    adapter = null;
+    throw err;
+  }
+};
+
+const isRetryableError = (error): boolean => {
+  const postgresRetryableError = error.code === '28P01' && error.routine === 'auth_failed';
+  const mysqlRetruableError = error.errno === '1045' && error.code === 'ER_ACCESS_DENIED_ERROR';
+
+  return postgresRetryableError || mysqlRetruableError;
+}
 
 const createSSMClient = (): void => {
   const PORT_SEPERATOR = ':';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Add credential refresh and retry logic to SQL lambda. 

This is merging into a feature branch.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

N/A

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

Manual testing. E2E tests will come in subsequent PR.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
