### PR TITLE
test(api): increase cypress page load timeout

### DIFF
--- a/client-test-apps/js/api-model-relationship-app/cypress.config.ts
+++ b/client-test-apps/js/api-model-relationship-app/cypress.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
       // implement node event listeners here
     },
   },
+  pageLoadTimeout: 180000,
 });


### PR DESCRIPTION
Currently our canary test is failing intermittently because the page fails to load within one min (the default pageload timeout). Increasing the pageload timeout to 3 minutes in attempt to fix it.