### PR TITLE
fix(rds): userpool & iam e2e tests

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/userpool-iam-fields.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/userpool-iam-fields.ts
@@ -19,6 +19,7 @@ export const schema = `
         { allow: public, provider: iam, operations: [read] }
         # Signed in users can read posts
         { allow: private, operations: [read] }
+        { allow: owner, ownerField: "subscriberList", operations: [read]}
       ]
     ) {
     id: ID! @primaryKey

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool-iam-fields.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool-iam-fields.ts
@@ -213,9 +213,10 @@ export const testRdsUserpoolIAMFieldAuth = (engine: ImportedRDSType, queries: st
       };
       // userpool owner cannot create a post without restricted field `likes`
       const createPostResult = await postUser1Client.create(createResultSetName, omit(post, 'likes'));
-      expect(createPostResult.data[createResultSetName]).toEqual(expect.objectContaining(omit(post, 'subscriberContent')));
-      // subscriber content is protected and cannot be read upon mutation
+      expect(createPostResult.data[createResultSetName]).toEqual(expect.objectContaining(omit(post, 'subscriberContent', 'likes')));
+      // subscriber content and likes are protected and cannot be read upon mutation
       expect(createPostResult.data[createResultSetName].subscriberContent).toBeNull();
+      expect(createPostResult.data[createResultSetName].likes).toBeNull();
       // userpool owner cannot create a post with field input `likes`
       await expect(
         async () =>
@@ -252,9 +253,10 @@ export const testRdsUserpoolIAMFieldAuth = (engine: ImportedRDSType, queries: st
           }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
       const updatePostResult = await postUser1Client.update(updateResultSetName, omit(updatedPost, 'likes'));
-      expect(updatePostResult.data[updateResultSetName]).toEqual(expect.objectContaining(omit(updatedPost, 'subscriberContent')));
-      // subscriber content is protected and cannot be read upon mutation
+      expect(updatePostResult.data[updateResultSetName]).toEqual(expect.objectContaining(omit(updatedPost, 'subscriberContent', 'likes')));
+      // subscriber content and likes are protected and cannot be read upon mutation
       expect(updatePostResult.data[updateResultSetName].subscriberContent).toBeNull();
+      expect(updatePostResult.data[updateResultSetName].likes).toBeNull();
       // unless one has delete access to all fields in the model, delete is expected to fail
       // userpool owner cannot delete the post
       await expect(
@@ -278,7 +280,7 @@ export const testRdsUserpoolIAMFieldAuth = (engine: ImportedRDSType, queries: st
       );
 
       const createPostResult = await postIAMPrivateClient.create(createResultSetName, omit(post, 'likes', 'subscriberContent'));
-      expect(createPostResult.data[createResultSetName]).toEqual(expect.objectContaining(omit(post, 'subscriberContent')));
+      expect(createPostResult.data[createResultSetName]).toEqual(expect.objectContaining(omit(post, 'subscriberContent', 'likes')));
       // user2 should be able to update subscriber content to the post created by private iam
       await postUser2Client.update(updateResultSetName, {
         id: post.id,
@@ -301,14 +303,16 @@ export const testRdsUserpoolIAMFieldAuth = (engine: ImportedRDSType, queries: st
         subscriberContent: 'Exclusive content 2 updated',
       };
       const updatePostResult = await postIAMPrivateClient.update(updateResultSetName, updatedPost);
-      expect(updatePostResult.data[updateResultSetName]).toEqual(expect.objectContaining(omit(updatedPost, 'subscriberContent')));
-      // subscriber content is protected and cannot be read upon mutation
+      expect(updatePostResult.data[updateResultSetName]).toEqual(expect.objectContaining(omit(updatedPost, 'subscriberContent', 'likes')));
+      // subscriber content and likes are protected and cannot be read upon mutation
       expect(updatePostResult.data[updateResultSetName].subscriberContent).toBeNull();
+      expect(updatePostResult.data[updateResultSetName].likes).toBeNull();
       // private iam role can delete a post
       const deletePostResult = await postIAMPrivateClient.delete(deleteResultSetName, { id: post.id });
-      expect(deletePostResult.data[deleteResultSetName]).toEqual(expect.objectContaining(omit(updatedPost, 'subscriberContent')));
-      // subscriber content is protected and cannot be read upon mutation
+      expect(deletePostResult.data[deleteResultSetName]).toEqual(expect.objectContaining(omit(updatedPost, 'subscriberContent', 'likes')));
+      // subscriber content and likes are protected and cannot be read upon mutation
       expect(deletePostResult.data[deleteResultSetName].subscriberContent).toBeNull();
+      expect(deletePostResult.data[deleteResultSetName].likes).toBeNull();
     });
     test('public iam role can perform all valid operations on post', async () => {
       const post = {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Fixed failing e2e tests
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
