### PR TITLE
test(rds): add e2e tests for field auth (userpool static & dynamic)

### DIFF
--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -160,7 +160,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/sync_query_datastore.test.ts|src/__tests__/api_6.test.ts|src/__tests__/graphql-v2/api_lambda_auth.test.ts|src/__tests__/api_9.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_v2
@@ -455,13 +455,22 @@ batch:
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
+    - identifier: rds_mysql_field_auth_userpool_static_dynamic
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-field-auth-userpool-static-dynamic.test.ts
+          CLI_REGION: us-east-2
+      depend-on:
+        - publish_to_local_registry
     - identifier: rds_mysql_model_v2
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-model-v2.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_multi_auth_1
@@ -470,7 +479,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-multi-auth-1.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_oidc_auth_fields
@@ -488,7 +497,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-oidc-auth.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_refers_to_fields
@@ -497,7 +506,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-refers-to-fields.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_refers_to
@@ -506,7 +515,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-refers-to.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_userpool_auth_fields
@@ -524,7 +533,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-userpool-auth.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_v2_generate_schema
@@ -533,7 +542,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-mysql-v2-generate-schema.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_array_objects
@@ -542,7 +551,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-array-objects.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_auth_apikey_lambda
@@ -551,7 +560,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-auth-apikey-lambda.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_auth_iam_apikey_lambda_subscription
@@ -560,7 +569,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-auth-iam-apikey-lambda-subscription.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_auth_iam
@@ -569,7 +578,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-auth-iam.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_custom_claims_refersto_auth
@@ -578,7 +587,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-custom-claims-refersto-auth.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_field_auth_apikey
@@ -587,7 +596,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-field-auth-apikey.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_field_auth_iam
@@ -596,7 +605,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-field-auth-iam.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_field_auth_lambda
@@ -605,7 +614,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-field-auth-lambda.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_field_auth_userpool_iam
@@ -614,7 +623,16 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-field-auth-userpool-iam.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_field_auth_userpool_static_dynamic
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-field-auth-userpool-static-dynamic.test.ts
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_import
@@ -623,7 +641,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-import.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_model_v2
@@ -632,7 +650,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-model-v2.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_oidc_auth_fields
@@ -650,7 +668,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-oidc-auth.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_refers_to_fields
@@ -659,7 +677,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-refers-to-fields.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_refers_to
@@ -668,7 +686,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-refers-to.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_relational_directives
@@ -677,7 +695,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-relational-directives.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_userpool_auth_fields
@@ -695,7 +713,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-userpool-auth.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_v2_generate_schema
@@ -704,7 +722,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-pg-v2-generate-schema.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_relational_directives
@@ -713,7 +731,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-relational-directives.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_v2_test_utils
@@ -722,7 +740,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/rds-v2-test-utils.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_model
@@ -731,7 +749,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-model.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: apigw
@@ -740,7 +758,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/apigw.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: containers_api_2
@@ -758,7 +776,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-14.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_7
@@ -767,7 +785,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-7.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_9
@@ -776,7 +794,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-9.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_5
@@ -785,7 +803,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-5.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_datastore
@@ -794,7 +812,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: us-east-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -804,7 +822,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_searchable
@@ -813,7 +831,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-searchable.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: eu-west-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -823,7 +841,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-6.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_connection
@@ -832,7 +850,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-connection.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_had_node_to_node
@@ -842,7 +860,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-had-node-to-node.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_no_node_to_node
@@ -852,7 +870,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-no-node-to-node.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: api_2
@@ -861,7 +879,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/api_2.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_migration
@@ -870,7 +888,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/searchable-migration.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-west-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry

--- a/packages/amplify-e2e-core/src/categories/auth.ts
+++ b/packages/amplify-e2e-core/src/categories/auth.ts
@@ -384,14 +384,11 @@ export function updateAuthAddUserGroups(projectDir: string, groupNames: string[]
     if (settings?.overrides?.category === 'auth') {
       chain.wait('A migration is needed to support latest updates on auth resources').sendConfirmYes();
     }
-    chain
-      .wait('What do you want to do?')
-      .send(KEY_DOWN_ARROW)
-      .send(KEY_DOWN_ARROW)
-      .sendCarriageReturn()
-      .wait('Provide a name for your user pool group')
-      .send(groupNames[0])
-      .sendCarriageReturn();
+    chain.wait('What do you want to do?').send(KEY_DOWN_ARROW).send(KEY_DOWN_ARROW);
+    if (settings?.useSocialProvider) {
+      chain.send(KEY_DOWN_ARROW);
+    }
+    chain.sendCarriageReturn().wait('Provide a name for your user pool group').send(groupNames[0]).sendCarriageReturn();
 
     if (groupNames.length > 1) {
       let index = 1;

--- a/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/userpool-static-dynamic-fields.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/userpool-static-dynamic-fields.ts
@@ -1,0 +1,87 @@
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { generateDDL } from '../../rds-v2-test-utils';
+
+export const schema = `
+  # Owners may update their owned records.
+  # Admins may create Employee records.
+  # Any authenticated user may view Employee ids, bios & emails.
+  # Owners and members of "Admin" group may see employee salaries.
+  # Owners of "Admin" group may create and update employee salaries.
+  type Employee
+    @model
+    @auth(
+      rules: [
+        { allow: groups, groups: ["Admin"] }
+        { allow: private, operations: [read] }
+        { allow: owner, ownerField: "email", operations: [read, update] }
+        { allow: groups, groupsField: "team", operations: [read] }
+      ]
+    ) {
+    id: ID! @primaryKey
+    # bio, notes and accolades are the only fields an owner can update
+    # bio can be read by all signed-in users
+    bio: String
+
+    # The delete operation means you cannot update the value to "null" or "undefined".
+    # Since delete operations are at the object level, this actually adds auth rules to the update mutation.
+    
+    # notes are only available for owners, teammates and admins
+    notes: String
+      @auth(
+        rules: [
+          { allow: groups, groups: ["Admin"] },
+          {
+            allow: owner
+            ownerField: "email"
+            operations: [read, update, delete]
+          }
+          { allow: groups, groupsField: "team", operations: [read] }
+        ]
+      )
+    # Both owners and teammates can update the accolades
+    # Other signed-in users can only read them
+    accolades: [String]
+      @auth(
+        rules: [
+          { allow: groups, groups: ["Admin"] }
+          { allow: owner, ownerField: "email", operations: [update, read] }
+          { allow: groups, groupsField: "team", operations: [update, read]}
+          { allow: private, operations: [read] }
+        ]
+      )
+
+    # Fields with ownership conditions take precendence to the Object @auth.
+    # That means that both the @auth on Object AND the @auth on the field must
+    # be satisfied.
+
+    # Only "Admin"s may create/update/delete email.
+    # Read-only access for all signed-in users
+    email: String
+      @auth(
+        rules: [
+          { allow: groups, groups: ["Admin"] }
+          { allow: private, operations: [read] }
+        ]
+      )
+
+    # The owner & "Admin"s may view the salary. Only "Admins" may create/update.
+    # Salary is not available for non-owner users
+    salary: Int
+      @auth(
+        rules: [
+          { allow: groups, groups: ["Admin"] }
+          { allow: owner, ownerField: "email", operations: [read] }
+        ]
+      )
+    # Only Admin group users can CRUD the team
+    team: [String]
+      @auth(
+        rules: [
+          { allow: groups, groups: ["Admin"] }
+          { allow: private, operations: [read] }
+        ]
+      )
+  }
+`;
+
+export const sqlCreateStatements = (engine: ImportedRDSType): string[] => generateDDL(schema, engine);

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-field-auth-userpool-static-dynamic.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-field-auth-userpool-static-dynamic.test.ts
@@ -1,0 +1,9 @@
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { testRdsUserpoolStaticAndDynamicFieldAuth } from '../rds-v2-tests-common/rds-auth-userpool-static-dynamic-fields';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+describe('RDS MySQL userpool static & dynamic field auth rules', () => {
+  testRdsUserpoolStaticAndDynamicFieldAuth(ImportedRDSType.MYSQL, []);
+});

--- a/packages/amplify-e2e-tests/src/__tests__/rds-pg-field-auth-userpool-static-dynamic.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-pg-field-auth-userpool-static-dynamic.test.ts
@@ -1,0 +1,9 @@
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { testRdsUserpoolStaticAndDynamicFieldAuth } from '../rds-v2-tests-common/rds-auth-userpool-static-dynamic-fields';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+describe('RDS Postgres userpool static & dynamic field auth rules', () => {
+  testRdsUserpoolStaticAndDynamicFieldAuth(ImportedRDSType.POSTGRESQL, []);
+});

--- a/packages/amplify-e2e-tests/src/rds-v2-test-utils/index.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-test-utils/index.ts
@@ -419,6 +419,17 @@ export const appendAmplifyInput = (schema: string, engine: ImportedRDSType): str
   return amplifyInput(engine) + '\n' + schema;
 };
 
+export const appendAmplifyInputWithoutGlobalAuthRule = (schema: string, engine: ImportedRDSType): string => {
+  const amplifyInput = (engineName: ImportedRDSType): string => {
+    return `
+      input AMPLIFY {
+        engine: String = "${engineName}",
+      }
+    `;
+  };
+  return amplifyInput(engine) + '\n' + schema;
+};
+
 export const updatePreAuthTrigger = (projRoot: string, usernameClaim: string) => {
   const backendFunctionDirPath = path.join(projRoot, 'amplify', 'backend', 'function');
   const functionName = fs.readdirSync(backendFunctionDirPath)[0];
@@ -452,3 +463,6 @@ export const expectedFieldErrors = (fields: string[], typeName: string, includeP
 
 export const expectedOperationError = (operation: string, typeName: string) =>
   `"GraphQL error: Not Authorized to access ${operation} on type ${typeName}"`;
+
+export const omit = <T extends {}, K extends keyof T>(obj: T, ...keys: K[]) =>
+  Object.fromEntries(Object.entries(obj).filter(([key]) => !keys.includes(key as K))) as Omit<T, K>;

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool-static-dynamic-fields.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool-static-dynamic-fields.ts
@@ -331,8 +331,11 @@ export const testRdsUserpoolStaticAndDynamicFieldAuth = (engine: ImportedRDSType
         team: [buildTimeGroupName],
       };
       // Setup admin user client for subscription (user1)
-      const subscriberClient = getConfiguredAppsyncClientCognitoAuth(apiEndPoint, region, userMap[userName1]);
-      const subEmployeeHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
+      let subEmployeeHelper;
+      test('Should setup a client for subscriber', () => {
+        const subscriberClient = getConfiguredAppsyncClientCognitoAuth(apiEndPoint, region, userMap[userName1]);
+        subEmployeeHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
+      });
       test('Can listen to the create event', async () => {
         const onCreateSubscriptionResult = await subEmployeeHelper.subscribe(
           'onCreate',
@@ -428,13 +431,13 @@ export const testRdsUserpoolStaticAndDynamicFieldAuth = (engine: ImportedRDSType
       describe('User can update fields of bio, notes and accolades of their own', () => {
         let updateEmployeeResult1;
         const updatedEmployee1 = {
-          id: employeeUser2.id,
+          id: 'E-2',
           bio: 'Bio2 updated',
           notes: 'My note 2 updated',
           accolades: ['Good Job!', 'Cool!'],
-          team: employeeUser2.team,
-          salary: employeeUser2.salary,
-          email: employeeUser2.email,
+          team: [buildTimeGroupName],
+          salary: 1000,
+          email: userName2,
         };
         test('should update the restricted fields successfully', async () => {
           updateEmployeeResult1 = await employeeUser2Client.update(updateResultSetName, omit(updatedEmployee1, 'team', 'salary', 'email'));
@@ -451,8 +454,13 @@ export const testRdsUserpoolStaticAndDynamicFieldAuth = (engine: ImportedRDSType
       describe('User can update accolades for their teammates', () => {
         let updateEmployeeResult2;
         const updatedEmployee2 = {
-          ...employeeUser4,
-          accolades: [...employeeUser4.accolades, 'He has ownership'],
+          id: 'E-4',
+          bio: 'Bio4',
+          notes: 'My note 4',
+          email: userName4,
+          accolades: ['Awesome!', 'He has ownership'],
+          salary: 3000,
+          team: [buildTimeGroupName, runTimeGroupName],
         };
         test('should update the employee successfully', async () => {
           updateEmployeeResult2 = await employeeUser2Client.update(
@@ -467,10 +475,10 @@ export const testRdsUserpoolStaticAndDynamicFieldAuth = (engine: ImportedRDSType
               accolades
             `,
           );
+          expect(updateEmployeeResult2.data[updateResultSetName]).toEqual(
+            expect.objectContaining(omit(updatedEmployee2, 'notes', 'salary', 'team')),
+          );
         });
-        expect(updateEmployeeResult2.data[updateResultSetName]).toEqual(
-          expect.objectContaining(omit(updatedEmployee2, 'notes', 'salary', 'team')),
-        );
         test('notes field is protected and cannot be read upon mutation', () => {
           expect(updateEmployeeResult2.data[updateResultSetName].notes).toBeNull();
         });
@@ -526,8 +534,11 @@ export const testRdsUserpoolStaticAndDynamicFieldAuth = (engine: ImportedRDSType
         team: [buildTimeGroupName],
       };
       // Setup non-admin user client for subscription (user2)
-      const subscriberClient = getConfiguredAppsyncClientCognitoAuth(apiEndPoint, region, userMap[userName2]);
-      const subEmployeeHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
+      let subEmployeeHelper;
+      test('Should setup a client for subscriber', () => {
+        const subscriberClient = getConfiguredAppsyncClientCognitoAuth(apiEndPoint, region, userMap[userName2]);
+        subEmployeeHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
+      });
       test('Can listen to the create event', async () => {
         const onCreateSubscriptionResult = await subEmployeeHelper.subscribe(
           'onCreate',

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool-static-dynamic-fields.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool-static-dynamic-fields.ts
@@ -1,0 +1,610 @@
+import {
+  addApiWithAllAuthModes,
+  amplifyPush,
+  createNewProjectDir,
+  deleteDBInstance,
+  deleteProject,
+  deleteProjectDir,
+  enableUserPoolUnauthenticatedAccess,
+  getAppSyncApi,
+  getProjectMeta,
+  importRDSDatabase,
+  initJSProjectWithProfile,
+  setupRDSInstanceAndData,
+  sleep,
+  updateAuthAddUserGroups,
+} from 'amplify-category-api-e2e-core';
+import { existsSync, removeSync, writeFileSync } from 'fs-extra';
+import generator from 'generate-password';
+import path from 'path';
+import { GQLQueryHelper } from '../query-utils/gql-helper';
+import {
+  configureAmplify,
+  getConfiguredAppsyncClientCognitoAuth,
+  getConfiguredAppsyncClientIAMAuth,
+  getUserPoolId,
+  setupUser,
+  signInUser,
+} from '../schema-api-directives';
+import { ImportedRDSType } from '@aws-amplify/graphql-transformer-core';
+import { SQL_TESTS_USE_BETA } from './sql-e2e-config';
+import {
+  appendAmplifyInputWithoutGlobalAuthRule,
+  checkListItemExistence,
+  checkListResponseErrors,
+  checkOperationResult,
+  configureAppSyncClients,
+  createModelOperationHelpers,
+  expectNullFields,
+  expectedFieldErrors,
+  expectedOperationError,
+  getDefaultDatabasePort,
+  omit,
+} from '../rds-v2-test-utils';
+import { Auth } from 'aws-amplify';
+import { schema, sqlCreateStatements } from '../__tests__/auth-test-schemas/userpool-static-dynamic-fields';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+export const testRdsUserpoolStaticAndDynamicFieldAuth = (engine: ImportedRDSType, queries: string[]): void => {
+  describe('RDS userpool static & dynamic field auth', () => {
+    const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
+
+    // Generate settings for RDS instance
+    const username = db_user;
+    const password = db_password;
+    let region = 'us-east-1'; // This get overwritten in beforeAll
+    let port = getDefaultDatabasePort(engine);
+    const database = 'default_db';
+    let host = 'localhost';
+    const identifier = `integtest${db_identifier}`;
+    const engineSuffix = engine === ImportedRDSType.MYSQL ? 'ms' : 'pg';
+    const engineName = engine === ImportedRDSType.MYSQL ? 'mysql' : 'postgres';
+    const projName = `${engineSuffix}multifieldauth2`;
+    const apiName = projName;
+
+    const modelName = 'Employee';
+    const createResultSetName = `create${modelName}`;
+    const updateResultSetName = `update${modelName}`;
+    const deleteResultSetName = `delete${modelName}`;
+    const getResultSetName = `get${modelName}`;
+    const listResultSetName = `list${modelName}s`;
+    const onCreateResultSetName = `onCreate${modelName}`;
+    const onUpdateResultSetName = `onUpdate${modelName}`;
+    const onDeleteResultSetName = `onDelete${modelName}`;
+
+    const userName1 = 'user1'; // Admin
+    const userName2 = 'user2'; // BuildTime
+    const userName3 = 'user3'; // RunTime
+    const userName4 = 'user4'; // BuildTime & RunTime
+    const adminGroupName = 'Admin';
+    const buildTimeGroupName = 'BuildTime';
+    const runTimeGroupName = 'RunTime';
+    const userPassword = 'user@Password';
+    const userPoolProvider = 'userPools';
+    const userMap = {};
+
+    let projRoot;
+    let apiEndPoint;
+    let appSyncClients = {};
+    let userpoolAppSyncClients;
+    let employeeUser1Client: GQLQueryHelper,
+      employeeUser2Client: GQLQueryHelper,
+      employeeUser3Client: GQLQueryHelper,
+      employeeUser4Client: GQLQueryHelper;
+    let employeeUser2, employeeUser3, employeeUser4;
+    beforeAll(async () => {
+      projRoot = await createNewProjectDir(projName);
+      await initProjectAndImportSchema();
+      await sleep(2 * 60 * 1000); // Wait for 2 minutes for the VPC endpoints to be live.
+
+      const meta = getProjectMeta(projRoot);
+      const appRegion = meta.providers.awscloudformation.Region;
+      const { output } = meta.api[apiName];
+      const { GraphQLAPIIdOutput, GraphQLAPIEndpointOutput, GraphQLAPIKeyOutput } = output;
+      apiEndPoint = GraphQLAPIEndpointOutput as string;
+
+      const { graphqlApi } = await getAppSyncApi(GraphQLAPIIdOutput, appRegion);
+
+      expect(GraphQLAPIIdOutput).toBeDefined();
+      expect(GraphQLAPIEndpointOutput).toBeDefined();
+      expect(GraphQLAPIKeyOutput).toBeDefined();
+
+      expect(graphqlApi).toBeDefined();
+      expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
+
+      await createAppSyncClients();
+      await setupInitialEntries();
+    });
+
+    const createAppSyncClients = async (): Promise<void> => {
+      const userPoolId = getUserPoolId(projRoot);
+      configureAmplify(projRoot);
+
+      // cognito userpool clients
+      await setupUser(userPoolId, userName1, userPassword, adminGroupName);
+      await setupUser(userPoolId, userName2, userPassword, buildTimeGroupName);
+      await setupUser(userPoolId, userName3, userPassword, runTimeGroupName);
+      await setupUser(userPoolId, userName4, userPassword, [buildTimeGroupName, runTimeGroupName]);
+      const user1 = await signInUser(userName1, userPassword);
+      userMap[userName1] = user1;
+      const user2 = await signInUser(userName2, userPassword);
+      userMap[userName2] = user2;
+      const user3 = await signInUser(userName3, userPassword);
+      userMap[userName3] = user3;
+      const user4 = await signInUser(userName4, userPassword);
+      userMap[userName4] = user4;
+      appSyncClients = await configureAppSyncClients(projRoot, apiName, [userPoolProvider], userMap);
+      userpoolAppSyncClients = appSyncClients[userPoolProvider];
+
+      employeeUser1Client = constructModelHelper(modelName, userpoolAppSyncClients[userName1]);
+      employeeUser2Client = constructModelHelper(modelName, userpoolAppSyncClients[userName2]);
+      employeeUser3Client = constructModelHelper(modelName, userpoolAppSyncClients[userName3]);
+      employeeUser4Client = constructModelHelper(modelName, userpoolAppSyncClients[userName4]);
+    };
+
+    const setupInitialEntries = async (): Promise<void> => {
+      // Set up employees for tests
+      employeeUser2 = {
+        id: 'E-2',
+        bio: 'Bio2',
+        notes: 'My note 2',
+        email: userName2,
+        accolades: ['Good Job!'],
+        salary: 1000,
+        team: [buildTimeGroupName],
+      };
+      employeeUser3 = {
+        id: 'E-3',
+        bio: 'Bio3',
+        notes: 'My note 3',
+        email: userName3,
+        accolades: ['Well Done!'],
+        salary: 2000,
+        team: [runTimeGroupName],
+      };
+      employeeUser4 = {
+        id: 'E-4',
+        bio: 'Bio4',
+        notes: 'My note 4',
+        email: userName4,
+        accolades: ['Awesome!'],
+        salary: 3000,
+        team: [buildTimeGroupName, runTimeGroupName],
+      };
+      await employeeUser1Client.create(createResultSetName, employeeUser2);
+      await employeeUser1Client.create(createResultSetName, employeeUser3);
+      await employeeUser1Client.create(createResultSetName, employeeUser4);
+    };
+
+    afterAll(async () => {
+      const metaFilePath = path.join(projRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
+      if (existsSync(metaFilePath)) {
+        await deleteProject(projRoot);
+      }
+      deleteProjectDir(projRoot);
+      await cleanupDatabase();
+    });
+
+    const setupDatabase = async (): Promise<void> => {
+      const dbConfig = {
+        identifier,
+        engine,
+        dbname: database,
+        username,
+        password,
+        region,
+      };
+
+      const db = await setupRDSInstanceAndData(dbConfig, sqlCreateStatements(engine));
+      port = db.port;
+      host = db.endpoint;
+    };
+
+    const cleanupDatabase = async (): Promise<void> => {
+      await deleteDBInstance(identifier, region);
+    };
+
+    const initProjectAndImportSchema = async (): Promise<void> => {
+      await initJSProjectWithProfile(projRoot, {
+        disableAmplifyAppCreation: false,
+        name: projName,
+      });
+
+      const metaAfterInit = getProjectMeta(projRoot);
+      region = metaAfterInit.providers.awscloudformation.Region;
+      await setupDatabase();
+      await addApiWithAllAuthModes(projRoot, { transformerVersion: 2, apiName });
+      // Remove DDB schema
+      const ddbSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.graphql');
+      removeSync(ddbSchemaFilePath);
+      await importRDSDatabase(projRoot, {
+        database,
+        engine,
+        host,
+        port,
+        username,
+        password,
+        useVpc: true,
+        apiExists: true,
+      });
+      // Write RDS schema
+      const rdsSchemaFilePath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'schema.sql.graphql');
+      const rdsSchema = appendAmplifyInputWithoutGlobalAuthRule(schema, engine);
+      writeFileSync(rdsSchemaFilePath, rdsSchema, 'utf8');
+      // Enable unauthenticated access to the Cognito resource and push again
+      await enableUserPoolUnauthenticatedAccess(projRoot);
+      await updateAuthAddUserGroups(projRoot, [adminGroupName, buildTimeGroupName, runTimeGroupName], { useSocialProvider: true });
+      await amplifyPush(projRoot, false, {
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
+      });
+      // Make a dummy edit for schema and re-push
+      // This is a known bug in which deploying the userpool auth with sql schema cannot be done within one push
+      writeFileSync(rdsSchemaFilePath, `${rdsSchema}\n`, 'utf8');
+      await amplifyPush(projRoot, false, {
+        skipCodegen: true,
+        useBetaSqlLayer: SQL_TESTS_USE_BETA,
+      });
+    };
+
+    test('Admin user can perform all valid operations on employee', async () => {
+      const employee = {
+        id: 'E-1',
+        bio: 'Bio1',
+        notes: 'My note 1',
+        email: userName1,
+        accolades: ['You did it!'],
+        salary: 1000,
+        team: [buildTimeGroupName, runTimeGroupName],
+      };
+      const createEmployeeResult = await employeeUser1Client.create(createResultSetName, employee);
+      expect(createEmployeeResult.data[createResultSetName]).toEqual(expect.objectContaining(omit(employee, 'notes', 'salary', 'team')));
+      // notes, team and salary are protected and cannot be read upon mutation
+      expect(createEmployeeResult.data[createResultSetName].notes).toBeNull();
+      expect(createEmployeeResult.data[createResultSetName].salary).toBeNull();
+      expect(createEmployeeResult.data[createResultSetName].team).toBeNull();
+      // Admin group user can read all fields
+      const getEmployeeResult = await employeeUser1Client.get({
+        id: employee.id,
+      });
+      expect(getEmployeeResult.data[getResultSetName]).toEqual(expect.objectContaining(employee));
+      const listEmployeesResult = await employeeUser1Client.list();
+      expect(listEmployeesResult.data[listResultSetName].items).toEqual(expect.arrayContaining([expect.objectContaining(employee)]));
+      // Admin group user can update all fields
+      const updatedEmployee = {
+        id: employee.id,
+        bio: 'Bio1 updated',
+        notes: 'My note 1 updated',
+        email: userName1,
+        accolades: ['You did it!', 'Thank you!'],
+        salary: 2000,
+        team: [buildTimeGroupName],
+      };
+      const updateEmployeeResult = await employeeUser1Client.update(updateResultSetName, updatedEmployee);
+      expect(updateEmployeeResult.data[updateResultSetName]).toEqual(
+        expect.objectContaining(omit(updatedEmployee, 'notes', 'salary', 'team')),
+      );
+      // notes, team and salary fields are protected and cannot be read upon mutation
+      expect(updateEmployeeResult.data[updateResultSetName].notes).toBeNull();
+      expect(updateEmployeeResult.data[updateResultSetName].salary).toBeNull();
+      expect(updateEmployeeResult.data[updateResultSetName].team).toBeNull();
+      // unless one has delete access to all fields in the model, delete is expected to fail
+      // admin user can delete the employee
+      const deleteEmployeeResult = await employeeUser1Client.delete(deleteResultSetName, { id: employee.id });
+      expect(deleteEmployeeResult.data[deleteResultSetName]).toEqual(
+        expect.objectContaining(omit(updatedEmployee, 'notes', 'salary', 'team')),
+      );
+      // notes, team and salary fields are protected and cannot be read upon deletion
+      expect(deleteEmployeeResult.data[deleteResultSetName].notes).toBeNull();
+      expect(deleteEmployeeResult.data[deleteResultSetName].salary).toBeNull();
+      expect(deleteEmployeeResult.data[deleteResultSetName].team).toBeNull();
+    });
+    test('Admin user can subscribe all updates on employee', async () => {
+      const employee = {
+        id: 'E-1-sub',
+        bio: 'Bio1 sub',
+        notes: 'My note 1 sub',
+        email: userName2,
+        accolades: ['You did it!'],
+        salary: 1000,
+        team: [buildTimeGroupName, runTimeGroupName],
+      };
+      // Setup admin user client for subscription (user1)
+      const subscriberClient = getConfiguredAppsyncClientCognitoAuth(apiEndPoint, region, userMap[userName1]);
+      const subEmployeeHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
+      // Can listen to the create event
+      const onCreateSubscriptionResult = await subEmployeeHelper.subscribe(
+        'onCreate',
+        [
+          async () => {
+            await employeeUser1Client.create(createResultSetName, employee);
+          },
+        ],
+        {},
+      );
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      expect(onCreateSubscriptionResult[0].data[onCreateResultSetName]).toEqual(
+        expect.objectContaining(omit(employee, 'notes', 'salary', 'team')),
+      );
+      expectNullFields(onCreateSubscriptionResult[0].data[onCreateResultSetName], ['notes', 'salary', 'team']);
+      // Can listen to the update event
+      const updatedEmployee = {
+        id: employee.id,
+        bio: 'Bio1 updated',
+        notes: 'My note 1 updated',
+        email: userName2,
+        accolades: ['You did it!', 'Thank you!'],
+        salary: 2000,
+        team: [buildTimeGroupName],
+      };
+      const onUpdateSubscriptionResult = await subEmployeeHelper.subscribe(
+        'onUpdate',
+        [
+          async () => {
+            await employeeUser1Client.update(updateResultSetName, updatedEmployee);
+          },
+        ],
+        {},
+      );
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      expect(onUpdateSubscriptionResult[0].data[onUpdateResultSetName]).toEqual(
+        expect.objectContaining(omit(updatedEmployee, 'notes', 'salary', 'team')),
+      );
+      expectNullFields(onUpdateSubscriptionResult[0].data[onUpdateResultSetName], ['notes', 'salary', 'team']);
+      // Can listen to the delete event
+      const onDeleteSubscriptionResult = await subEmployeeHelper.subscribe(
+        'onDelete',
+        [
+          async () => {
+            await employeeUser1Client.delete(deleteResultSetName, { id: updatedEmployee.id });
+          },
+        ],
+        {},
+      );
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      expect(onDeleteSubscriptionResult[0].data[onDeleteResultSetName]).toEqual(
+        expect.objectContaining(omit(updatedEmployee, 'notes', 'salary', 'team')),
+      );
+      expectNullFields(onDeleteSubscriptionResult[0].data[onDeleteResultSetName], ['notes', 'salary', 'team']);
+    });
+    test('Non-admin group users can perform all valid operations on employee', async () => {
+      // User not in Admin group cannot create or delete the employee even if the owner field is himself
+      await expect(
+        async () =>
+          await employeeUser2Client.create(createResultSetName, {
+            id: 'invalid2',
+            email: userName2,
+            team: [buildTimeGroupName],
+          }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(createResultSetName, 'Mutation'));
+      await expect(
+        async () =>
+          await employeeUser2Client.delete(deleteResultSetName, {
+            id: employeeUser2.id,
+          }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(deleteResultSetName, 'Mutation'));
+      // User can read all fields of its own record
+      const getEmployeeResult1 = await employeeUser2Client.get({
+        id: employeeUser2.id,
+      });
+      expect(getEmployeeResult1.data[getResultSetName]).toEqual(expect.objectContaining(employeeUser2));
+      // User can read restricted fields of other employees
+      // User cannot read team notes of those he is not a member
+      // User cannot read salary info of others
+      const getEmployeeResult2 = await employeeUser2Client.get(
+        {
+          id: employeeUser3.id,
+        },
+        undefined,
+        true,
+        'all',
+      );
+      checkOperationResult(
+        getEmployeeResult2,
+        { ...employeeUser3, notes: null, salary: null },
+        getResultSetName,
+        false,
+        expectedFieldErrors(['notes', 'salary'], 'Employee'),
+      );
+      const listEmployeesResult = await employeeUser2Client.list({}, undefined, listResultSetName, true, 'all');
+      checkListItemExistence(listEmployeesResult, listResultSetName, employeeUser3.id, true);
+      checkListResponseErrors(listEmployeesResult, expectedFieldErrors(['notes', 'salary'], 'Employee', false));
+      // User can update fields of bio, notes and accolades of their own
+      const updatedEmployee1 = {
+        id: employeeUser2.id,
+        bio: 'Bio2 updated',
+        notes: 'My note 2 updated',
+        accolades: ['Good Job!', 'Cool!'],
+        team: employeeUser2.team,
+        salary: employeeUser2.salary,
+        email: employeeUser2.email,
+      };
+      const updateEmployeeResult1 = await employeeUser2Client.update(
+        updateResultSetName,
+        omit(updatedEmployee1, 'team', 'salary', 'email'),
+      );
+      expect(updateEmployeeResult1.data[updateResultSetName]).toEqual(
+        expect.objectContaining(omit(updatedEmployee1, 'notes', 'salary', 'team')),
+      );
+      // notes, team and salary fields are protected and cannot be read upon mutation
+      expect(updateEmployeeResult1.data[updateResultSetName].notes).toBeNull();
+      expect(updateEmployeeResult1.data[updateResultSetName].salary).toBeNull();
+      expect(updateEmployeeResult1.data[updateResultSetName].team).toBeNull();
+      // User can update accolades for their teammates
+      const updatedEmployee2 = {
+        ...employeeUser4,
+        accolades: [...employeeUser4.accolades, 'He has ownership'],
+      };
+      const updateEmployeeResult2 = await employeeUser2Client.update(
+        updateResultSetName,
+        { id: updatedEmployee2.id, accolades: updatedEmployee2.accolades },
+        `
+          id
+          bio
+          notes
+          email
+          team
+          accolades
+        `,
+      );
+      expect(updateEmployeeResult2.data[updateResultSetName]).toEqual(
+        expect.objectContaining(omit(updatedEmployee2, 'notes', 'salary', 'team')),
+      );
+      // notes field is protected and cannot be read upon mutation
+      expect(updateEmployeeResult2.data[updateResultSetName].notes).toBeNull();
+
+      // User cannot update bio or notes if they are not owner
+      await expect(
+        async () => await employeeUser2Client.update(updateResultSetName, { id: employeeUser3.id, bio: 'invalid bio' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+      await expect(
+        async () => await employeeUser2Client.update(updateResultSetName, { id: employeeUser3.id, notes: 'invalid notes' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+      // User cannot update accolades for an employee from a non-overlapping team
+      await expect(
+        async () =>
+          await employeeUser2Client.update(updateResultSetName, {
+            id: employeeUser3.id,
+            accolades: [...employeeUser3.accolades, 'Best employee!'],
+          }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+      // User cannot update any of the fields left
+      const forbiddenFields = {
+        team: [runTimeGroupName],
+        email: userName1,
+        salary: 10000,
+      };
+      Object.entries(forbiddenFields).forEach(async (entry) => {
+        const updateInput = Object.fromEntries([['id', employeeUser2.id], entry]);
+        await expect(
+          async () => await employeeUser2Client.update(updateResultSetName, updateInput),
+        ).rejects.toThrowErrorMatchingInlineSnapshot(expectedOperationError(updateResultSetName, 'Mutation'));
+      });
+    });
+    test('Non-admin user can subscribe all updates on employee except for restricted fields', async () => {
+      const employee = {
+        id: 'E-2-sub',
+        bio: 'Bio2 sub',
+        notes: 'My note 2 sub',
+        email: userName3,
+        accolades: ['You did it!'],
+        salary: 1000,
+        team: [buildTimeGroupName, runTimeGroupName],
+      };
+      // Setup non-admin user client for subscription (user2)
+      const subscriberClient = getConfiguredAppsyncClientCognitoAuth(apiEndPoint, region, userMap[userName2]);
+      const subEmployeeHelper = createModelOperationHelpers(subscriberClient, schema)[modelName];
+      // Can listen to the create event
+      const onCreateSubscriptionResult = await subEmployeeHelper.subscribe(
+        'onCreate',
+        [
+          async () => {
+            await employeeUser1Client.create(createResultSetName, employee);
+          },
+        ],
+        {},
+      );
+      expect(onCreateSubscriptionResult).toHaveLength(1);
+      expect(onCreateSubscriptionResult[0].data[onCreateResultSetName]).toEqual(
+        expect.objectContaining(omit(employee, 'notes', 'salary', 'team')),
+      );
+      expectNullFields(onCreateSubscriptionResult[0].data[onCreateResultSetName], ['notes', 'salary', 'team']);
+      // Can listen to the update event
+      const updatedEmployee = {
+        id: employee.id,
+        bio: 'Bio1 updated',
+        notes: 'My note 1 updated',
+        email: userName2,
+        accolades: ['You did it!', 'Thank you!'],
+        salary: 2000,
+        team: [buildTimeGroupName],
+      };
+      const onUpdateSubscriptionResult = await subEmployeeHelper.subscribe(
+        'onUpdate',
+        [
+          async () => {
+            await employeeUser1Client.update(updateResultSetName, updatedEmployee);
+          },
+        ],
+        {},
+      );
+      expect(onUpdateSubscriptionResult).toHaveLength(1);
+      expect(onUpdateSubscriptionResult[0].data[onUpdateResultSetName]).toEqual(
+        expect.objectContaining(omit(updatedEmployee, 'notes', 'salary', 'team')),
+      );
+      expectNullFields(onUpdateSubscriptionResult[0].data[onUpdateResultSetName], ['notes', 'salary', 'team']);
+      // Can listen to the delete event
+      const onDeleteSubscriptionResult = await subEmployeeHelper.subscribe(
+        'onDelete',
+        [
+          async () => {
+            await employeeUser1Client.delete(deleteResultSetName, { id: updatedEmployee.id });
+          },
+        ],
+        {},
+      );
+      expect(onDeleteSubscriptionResult).toHaveLength(1);
+      expect(onDeleteSubscriptionResult[0].data[onDeleteResultSetName]).toEqual(
+        expect.objectContaining(omit(updatedEmployee, 'notes', 'salary', 'team')),
+      );
+      expectNullFields(onDeleteSubscriptionResult[0].data[onDeleteResultSetName], ['notes', 'salary', 'team']);
+    });
+
+    // helper functions
+    const constructModelHelper = (name: string, client): GQLQueryHelper => {
+      const createSelectionSet = /* GraphQL */ `
+        id
+        bio
+        notes
+        email
+        salary
+        team
+        accolades
+      `;
+      const updateSelectionSet = createSelectionSet;
+      const deleteSelectionSet = createSelectionSet;
+      const getSelectionSet = /* GraphQL */ `
+        query Get${name}($id: ID!) {
+          get${name}(id: $id) {
+            id
+            bio
+            notes
+            email
+            salary
+            team
+            accolades
+          }
+        }
+      `;
+      const listSelectionSet = /* GraphQL */ `
+        query List${name}s {
+          list${name}s {
+            items {
+              id
+              bio
+              notes
+              email
+              salary
+              team
+              accolades
+            }
+          }
+        }
+      `;
+      const helper = new GQLQueryHelper(client, name, {
+        mutation: {
+          create: createSelectionSet,
+          update: updateSelectionSet,
+          delete: deleteSelectionSet,
+        },
+        query: {
+          get: getSelectionSet,
+          list: listSelectionSet,
+        },
+      });
+
+      return helper;
+    };
+  });
+};

--- a/packages/amplify-e2e-tests/src/schema-api-directives/authHelper.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/authHelper.ts
@@ -9,7 +9,7 @@ const tempPassword = 'tempPassword';
 
 // setupUser will add user to a cognito group and make its status to be "CONFIRMED",
 // if groupName is specified, add the user to the group.
-export async function setupUser(userPoolId: string, username: string, password: string, groupName?: string) {
+export async function setupUser(userPoolId: string, username: string, password: string, groupName?: string | string[]) {
   const region = userPoolId.split('_')[0]; // UserPoolId is in format `region_randomid`
   const cognitoClient = getConfiguredCognitoClient(region);
   await cognitoClient
@@ -25,13 +25,25 @@ export async function setupUser(userPoolId: string, username: string, password: 
   await authenticateUser(username, tempPassword, password);
 
   if (groupName) {
-    await cognitoClient
-      .adminAddUserToGroup({
-        UserPoolId: userPoolId,
-        Username: username,
-        GroupName: groupName,
-      })
-      .promise();
+    if (Array.isArray(groupName)) {
+      groupName.forEach(async (group) => {
+        await cognitoClient
+          .adminAddUserToGroup({
+            UserPoolId: userPoolId,
+            Username: username,
+            GroupName: group,
+          })
+          .promise();
+      });
+    } else {
+      await cognitoClient
+        .adminAddUserToGroup({
+          UserPoolId: userPoolId,
+          Username: username,
+          GroupName: groupName,
+        })
+        .promise();
+    }
   }
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Added the field auth combination tests(userpool static & dynamic) for mysql and postgres
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
