### PR TITLE
test(api): increase canary test yarn install timeout

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -243,7 +243,7 @@ function _runCanaryTest {
     _loadTestAccountCredentials
     _setShell
     cd client-test-apps/js/api-model-relationship-app
-    yarn
+    yarn --network-timeout 180000
     retry yarn test:ci
 }
 function _scanArtifacts {


### PR DESCRIPTION
Increase canary test build step `yarn` timeout to 3 minutes.