### PR TITLE
test(api): add e2e for iam private field auth

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-field-auth-iam.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-field-auth-iam.test.ts
@@ -9,6 +9,7 @@ describe('RDS MySQL IAM Mode field auth rules', () => {
     'CREATE TABLE Person1 (id INT PRIMARY KEY, firstName VARCHAR(255), lastName VARCHAR(255), ssn VARCHAR(20))',
     'CREATE TABLE Person2 (id INT PRIMARY KEY, firstName VARCHAR(255), lastName VARCHAR(255), ssn VARCHAR(20))',
     'CREATE TABLE Person3 (id INT PRIMARY KEY, firstName VARCHAR(255), lastName VARCHAR(255), ssn VARCHAR(20))',
+    'CREATE TABLE Person4 (id INT PRIMARY KEY, firstName VARCHAR(255), lastName VARCHAR(255), ssn VARCHAR(20))',
   ];
 
   testRdsIAMFieldAuth(ImportedRDSType.MYSQL, queries);

--- a/packages/amplify-e2e-tests/src/__tests__/rds-pg-field-auth-iam.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-pg-field-auth-iam.test.ts
@@ -9,6 +9,7 @@ describe('RDS Postgres IAM Mode field auth rules', () => {
     'CREATE TABLE "Person1" (id INT PRIMARY KEY, "firstName" VARCHAR(255), "lastName" VARCHAR(255), ssn VARCHAR(20))',
     'CREATE TABLE "Person2" (id INT PRIMARY KEY, "firstName" VARCHAR(255), "lastName" VARCHAR(255), ssn VARCHAR(20))',
     'CREATE TABLE "Person3" (id INT PRIMARY KEY, "firstName" VARCHAR(255), "lastName" VARCHAR(255), ssn VARCHAR(20))',
+    'CREATE TABLE "Person4" (id INT PRIMARY KEY, "firstName" VARCHAR(255), "lastName" VARCHAR(255), ssn VARCHAR(20))',
   ];
 
   testRdsIAMFieldAuth(ImportedRDSType.POSTGRESQL, queries);


### PR DESCRIPTION
Add E2E test cases for validating IAM provider field level auth for update and delete operations.