### PR TITLE
test: fix resource cleanup regex for cdkamplifytable roles

### DIFF
--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -85,7 +85,7 @@ type AWSAccountInfo = {
 
 const BUCKET_TEST_REGEX = /test/;
 const IAM_TEST_REGEX =
-  /!RotateE2eAwsToken-e2eTestContextRole|-integtest$|^amplify-|^eu-|^us-|^ap-|^auth-exhaustive-tests|rds-schema-inspector-integtest|^amplify_e2e_tests_lambda|^JsonMockStack-jsonMockApi|^SubscriptionAuthV2Tests|^cdkamplifytable-/;
+  /!RotateE2eAwsToken-e2eTestContextRole|-integtest$|^amplify-|^eu-|^us-|^ap-|^auth-exhaustive-tests|rds-schema-inspector-integtest|^amplify_e2e_tests_lambda|^JsonMockStack-jsonMockApi|^SubscriptionAuthV2Tests|^cdkamplifytable[0-9]*-/;
 const STALE_DURATION_MS = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
 
 const isCI = (): boolean => !!(process.env.CI && process.env.CODEBUILD);


### PR DESCRIPTION
#### Description of changes

Fixes the resource cleanup regex for cdkamplifytable IAM roles. Currently test accounts are not destroying those roles. Note: I'm assuming that the regex evaluation allows character classes and normal `*` wildcards. If it does not, the behavior will be that roles continue to not be removed. In no case will this impact any production code.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
