### PR TITLE
test(api): add create api canary codebuild buildspec

### DIFF
--- a/codebuild_specs/createapi_canary_workflow.yml
+++ b/codebuild_specs/createapi_canary_workflow.yml
@@ -1,0 +1,267 @@
+version: 0.2
+env:
+  shell: bash
+  compute-type: BUILD_GENERAL1_MEDIUM
+batch:
+  fast-fail: false
+  build-graph:
+    - identifier: build_linux
+      buildspec: codebuild_specs/build_linux.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+    - identifier: build_windows
+      buildspec: codebuild_specs/build_windows.yml
+      env:
+        type: WINDOWS_SERVER_2019_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        image: $WINDOWS_IMAGE_2019
+      depend-on:
+        - build_linux
+    - identifier: test
+      buildspec: codebuild_specs/test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+      depend-on:
+        - build_linux
+    - identifier: mock_e2e_tests
+      buildspec: codebuild_specs/mock_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+      depend-on:
+        - build_linux
+    - identifier: verify_cdk_version
+      buildspec: codebuild_specs/verify_cdk_version.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+      depend-on:
+        - build_linux
+    - identifier: verify_api_extract
+      buildspec: codebuild_specs/verify_api_extract.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+      depend-on:
+        - build_linux
+    - identifier: verify_yarn_lock
+      buildspec: codebuild_specs/verify_yarn_lock.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+      depend-on:
+        - build_linux
+    - identifier: verify_dependency_licenses_extract
+      buildspec: codebuild_specs/verify_dependency_licenses_extract.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+      depend-on:
+        - build_linux
+    - identifier: publish_to_local_registry
+      buildspec: codebuild_specs/publish_to_local_registry.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+      depend-on:
+        - build_linux
+    - identifier: api_test_us_east_1
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: us-east-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_ap_northeast_2
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: ap-northeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_ap_south_1
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: ap-south-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_ap_southeast_2
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: ap-southeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_eu_central_1
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: eu-central-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_us_east_2
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: us-east-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_ap_southeast_1
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: ap-southeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_ca_central_1
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: ca-central-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_eu_west_2
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: eu-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_us_west_2
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: us-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_ap_east_1
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: ap-east-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_ap_northeast_1
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: ap-northeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_ap_northeast_3
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: ap-northeast-3
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_eu_north_1
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: eu-north-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_eu_west_1
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: eu-west-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_eu_south_1
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: eu-south-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_eu_west_3
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: eu-west-3
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_me_south_1
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: me-south-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_sa_east_1
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: sa-east-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: api_test_us_west_1
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/api_1.test.ts|src/__tests__/resolvers.test.ts
+          CLI_REGION: us-west-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: cleanup_e2e_resources
+      buildspec: codebuild_specs/cleanup_e2e_resources.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+      depend-on:
+        - api_test_us_east_1


### PR DESCRIPTION
Add codebuild spec to run a canary test in all supported regions. The region list is taken from the SQL layer pipeline.