### PR TITLE
test: improve E2E test reliability

### DIFF
--- a/client-test-apps/js/api-model-relationship-app/src/__tests__/utils/execUtils.ts
+++ b/client-test-apps/js/api-model-relationship-app/src/__tests__/utils/execUtils.ts
@@ -549,7 +549,7 @@ const chain = (context: Context): ExecutionContext => {
                 .join('\n')
             : 'No output';
           const err = new Error(
-            `Killed the process as no output receive for ${context.noOutputTimeout / 1000} Sec. The no output timeout is set to ${
+            `Killed the process as no output received for ${context.noOutputTimeout / 1000} Sec. The no output timeout is set to ${
               context.noOutputTimeout / 1000
             } seconds.\n\nLast 10 lines:👇🏽👇🏽👇🏽👇🏽\n\n\n\n\n${lastScreen}\n\n\n👆🏼👆🏼👆🏼👆🏼`,
           );

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -808,7 +808,7 @@ export function addV1RDSDataSource(projectDir: string) {
       .sendCarriageReturn() // This will throw an error 'No properly configured Aurora Serverless clusters found'.
       .wait('No properly configured Aurora Serverless clusters found')
       .run((err: Error) => {
-        if (err && !/Killed the process as no output receive for/.test(err.message)) {
+        if (err && !/Killed the process as no output received for/.test(err.message)) {
           reject(err);
         } else {
           resolve();
@@ -995,7 +995,7 @@ export function cancelAmplifyMockApi(cwd: string, settings: any = {}): Promise<v
       .wait('AppSync Mock endpoint is running')
       .sendCtrlC()
       .run((err: Error) => {
-        if (err && !/Killed the process as no output receive for/.test(err.message)) {
+        if (err && !/Killed the process as no output received for/.test(err.message)) {
           reject(err);
         } else {
           resolve();

--- a/packages/amplify-e2e-core/src/init/amplifyPush.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPush.ts
@@ -156,7 +156,7 @@ export function cancelIterativeAmplifyPush(
           if (process.env.CODEBUILD) {
             // In codebuild the code 130 is not sent but with exit code 2
             // This is to catch the error in that scenario so that the test will proceed
-            if (!/Killed the process as no output receive/.test(err.message)) {
+            if (!/Killed the process as no output received/.test(err.message)) {
               reject(err);
             }
           } else if (!/Process exited with non zero exit code 130/.test(err.message)) {

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -49,7 +49,13 @@ export function initJSProjectWithProfile(cwd: string, settings?: Partial<typeof 
   if (s?.name?.length > 20) console.warn('Project names should not be longer than 20 characters. This may cause tests to break.');
 
   return new Promise((resolve, reject) => {
-    const chain = spawn(getCLIPath(), cliArgs, { cwd, stripColors: true, env, disableCIDetection: s.disableCIDetection })
+    const chain = spawn(getCLIPath(), cliArgs, {
+      cwd,
+      stripColors: true,
+      env,
+      disableCIDetection: s.disableCIDetection,
+      noOutputTimeout: 10 * 60 * 1000,
+    })
       .wait('Enter a name for the project')
       .sendLine(s.name)
       .wait('Initialize the project with the above configuration?')

--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -402,7 +402,7 @@ function chain(context: Context): ExecutionContext {
                 .join('\n')
             : 'No output';
           const err = new Error(
-            `Killed the process as no output receive for ${context.noOutputTimeout / 1000} Sec. The no output timeout is set to ${
+            `Killed the process as no output received for ${context.noOutputTimeout / 1000} Sec. The no output timeout is set to ${
               context.noOutputTimeout / 1000
             } seconds.\n\nLast 10 lines:👇🏽👇🏽👇🏽👇🏽\n\n\n\n\n${lastScreen}\n\n\n👆🏼👆🏼👆🏼👆🏼`,
           );

--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -315,7 +315,6 @@ const getS3Buckets = async (account: AWSAccountInfo): Promise<S3BucketInfo[]> =>
         region,
         ...(awsConfig as object),
       });
-      console.log(`region: ${region}; bucket.Name: ${bucket.Name}`);
       const bucketDetails = await regionalizedClient.getBucketTagging({ Bucket: bucket.Name }).promise();
       const jobId = getJobId(bucketDetails.TagSet);
       if (jobId) {
@@ -327,12 +326,14 @@ const getS3Buckets = async (account: AWSAccountInfo): Promise<S3BucketInfo[]> =>
       }
     } catch (e) {
       if (e.code !== 'NoSuchTagSet' && e.code !== 'NoSuchBucket') {
-        throw e;
+        console.error(`Skipping processing ${account.accountId}, bucket ${bucket.Name}`, e);
+        // throw e;
+      } else {
+        result.push({
+          name: bucket.Name,
+          region: 'us-east-1',
+        });
       }
-      result.push({
-        name: bucket.Name,
-        region: 'us-east-1',
-      });
     }
   }
   return result;

--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -304,11 +304,6 @@ const getS3Buckets = async (account: AWSAccountInfo): Promise<S3BucketInfo[]> =>
   for (const bucket of buckets.Buckets) {
     try {
       const region = await getBucketRegion(account, bucket.Name);
-      // This account has buckets created in eu-south-1, even though the account is opted into me-south-1. Attempting to process those
-      // buckets causes a failure. We'll skip them for now, until we can come up with a long term fix.
-      if (account.accountId === '535823242378' && region === 'eu-south-1') {
-        continue;
-      }
 
       // Operations on buckets created in opt-in regions appear to require region-specific clients
       const regionalizedClient = new aws.S3({

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-models.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-models.test.ts
@@ -87,9 +87,7 @@ describe('CDK GraphQL Transformer', () => {
     const templatePath = path.resolve(path.join(__dirname, 'backends', 'sql-models'));
     const name = await initCDKProject(projRoot, templatePath);
     writeDbDetails(dbDetails, projRoot);
-    // The CodegenAssets BucketDeployment resource takes a while. Set the timeout to 10m account for that. (Note that this is the "no output
-    // timeout"--the overall deployment is still allowed to take longer than 10m)
-    const outputs = await cdkDeploy(projRoot, '--all', { timeoutMs: 10 * 60 * 1000 });
+    const outputs = await cdkDeploy(projRoot, '--all');
     const { awsAppsyncApiEndpoint: apiEndpoint, awsAppsyncApiKey: apiKey } = outputs[name];
 
     const description = 'todo description';

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-models.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-models.test.ts
@@ -87,7 +87,9 @@ describe('CDK GraphQL Transformer', () => {
     const templatePath = path.resolve(path.join(__dirname, 'backends', 'sql-models'));
     const name = await initCDKProject(projRoot, templatePath);
     writeDbDetails(dbDetails, projRoot);
-    const outputs = await cdkDeploy(projRoot, '--all');
+    // The CodegenAssets BucketDeployment resource takes a while. Set the timeout to 10m account for that. (Note that this is the "no output
+    // timeout"--the overall deployment is still allowed to take longer than 10m)
+    const outputs = await cdkDeploy(projRoot, '--all', { timeoutMs: 10 * 60 * 1000 });
     const { awsAppsyncApiEndpoint: apiEndpoint, awsAppsyncApiKey: apiKey } = outputs[name];
 
     const description = 'todo description';

--- a/packages/amplify-graphql-api-construct-tests/src/commands.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/commands.ts
@@ -84,12 +84,15 @@ export type CdkDeployProps = {
  * @returns the generated outputs file as a JSON object
  */
 export const cdkDeploy = async (cwd: string, option: string, props?: CdkDeployProps): Promise<any> => {
+  // The CodegenAssets BucketDeployment resource takes a while. Set the timeout to 10m account for that. (Note that this is the "no output
+  // timeout"--the overall deployment is still allowed to take longer than 10m)
+  const noOutputTimeout = props?.timeoutMs ?? 10 * 60 * 1000;
   await spawn(getNpxPath(), ['cdk', 'deploy', '--outputs-file', 'outputs.json', '--require-approval', 'never', option], {
     cwd,
     stripColors: true,
     // npx cdk does not work on verdaccio
     env: { npm_config_registry: 'https://registry.npmjs.org/' },
-    noOutputTimeout: props?.timeoutMs,
+    noOutputTimeout: noOutputTimeout,
   }).runAsync();
 
   return JSON.parse(readFileSync(path.join(cwd, 'outputs.json'), 'utf8'));

--- a/packages/amplify-graphql-api-construct-tests/src/commands.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/commands.ts
@@ -52,7 +52,7 @@ export type InitCDKProjectProps = {
  * @returns a promise which resolves to the stack name
  */
 export const initCDKProject = async (cwd: string, templatePath: string, props?: InitCDKProjectProps): Promise<string> => {
-  const { cdkVersion = '2.80.0', additionalDependencies = [] } = props ?? {};
+  const { cdkVersion = '2.97.0', additionalDependencies = [] } = props ?? {};
 
   await spawn(getNpxPath(), ['cdk', 'init', 'app', '--language', 'typescript'], {
     cwd,


### PR DESCRIPTION
#### Description of changes

- Fixes deployment errors due to unsupported Node14 Lambda runtime in custom resource provider in CDK v2.80.0
- Increases "no output timeout" for a few tests to account for codegen asset BucketDeployment
- Suppresses errors getting bucket tags, so non-erroring buckets can be processed

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] [E2E tests](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow%3A977e7bf8-a103-4352-a84b-c46cb6df7ca4?region=us-east-1) pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
