### PR TITLE
chore(ci): temp disable opt-in regions in canary

### DIFF
--- a/codebuild_specs/createapi_canary_workflow.yml
+++ b/codebuild_specs/createapi_canary_workflow.yml
@@ -127,16 +127,16 @@ batch:
           CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: api_test_ap_east_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_MEDIUM
-        variables:
-          TEST_SUITE: >-
-            src/__tests__/api_canary.test.ts
-          CLI_REGION: ap-east-1
-      depend-on:
-        - publish_to_local_registry
+    # - identifier: api_test_ap_east_1
+    #   buildspec: codebuild_specs/run_e2e_tests.yml
+    #   env:
+    #     compute-type: BUILD_GENERAL1_MEDIUM
+    #     variables:
+    #       TEST_SUITE: >-
+    #         src/__tests__/api_canary.test.ts
+    #       CLI_REGION: ap-east-1
+    #   depend-on:
+    #     - publish_to_local_registry
     - identifier: api_test_ap_northeast_1
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -177,16 +177,16 @@ batch:
           CLI_REGION: eu-west-1
       depend-on:
         - publish_to_local_registry
-    - identifier: api_test_eu_south_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_MEDIUM
-        variables:
-          TEST_SUITE: >-
-            src/__tests__/api_canary.test.ts
-          CLI_REGION: eu-south-1
-      depend-on:
-        - publish_to_local_registry
+    # - identifier: api_test_eu_south_1
+    #   buildspec: codebuild_specs/run_e2e_tests.yml
+    #   env:
+    #     compute-type: BUILD_GENERAL1_MEDIUM
+    #     variables:
+    #       TEST_SUITE: >-
+    #         src/__tests__/api_canary.test.ts
+    #       CLI_REGION: eu-south-1
+    #   depend-on:
+    #     - publish_to_local_registry
     - identifier: api_test_eu_west_3
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -197,16 +197,16 @@ batch:
           CLI_REGION: eu-west-3
       depend-on:
         - publish_to_local_registry
-    - identifier: api_test_me_south_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_MEDIUM
-        variables:
-          TEST_SUITE: >-
-            src/__tests__/api_canary.test.ts
-          CLI_REGION: me-south-1
-      depend-on:
-        - publish_to_local_registry
+    # - identifier: api_test_me_south_1
+    #   buildspec: codebuild_specs/run_e2e_tests.yml
+    #   env:
+    #     compute-type: BUILD_GENERAL1_MEDIUM
+    #     variables:
+    #       TEST_SUITE: >-
+    #         src/__tests__/api_canary.test.ts
+    #       CLI_REGION: me-south-1
+    #   depend-on:
+    #     - publish_to_local_registry
     - identifier: api_test_sa_east_1
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -227,9 +227,9 @@ batch:
           CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
-    - identifier: cleanup_e2e_resources
-      buildspec: codebuild_specs/cleanup_e2e_resources.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-      depend-on:
-        - api_test_us_east_1
+    # - identifier: cleanup_e2e_resources
+    #   buildspec: codebuild_specs/cleanup_e2e_resources.yml
+    #   env:
+    #     compute-type: BUILD_GENERAL1_SMALL
+    #   depend-on:
+    #     - api_test_us_east_1


### PR DESCRIPTION
Temporarily disable running the tests in opt-in regions and clean up script.

These will be enabled again once we merge https://github.com/aws-amplify/amplify-category-api/pull/2261.