### PR TITLE
chore(ci): increase npm timeout and emit canary metrics

### DIFF
--- a/codebuild_specs/createapi_canary_workflow.yml
+++ b/codebuild_specs/createapi_canary_workflow.yml
@@ -28,7 +28,7 @@ batch:
       depend-on:
         - build_linux
     - identifier: api_test_us_east_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_createapi_canary_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -38,7 +38,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ap_northeast_2
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_createapi_canary_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -48,7 +48,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ap_south_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_createapi_canary_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -58,7 +58,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ap_southeast_2
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_createapi_canary_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -68,7 +68,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_eu_central_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_createapi_canary_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -78,7 +78,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_us_east_2
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_createapi_canary_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -88,7 +88,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ap_southeast_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_createapi_canary_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -98,7 +98,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ca_central_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_createapi_canary_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -108,7 +108,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_eu_west_2
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_createapi_canary_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -118,7 +118,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_us_west_2
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_createapi_canary_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -138,7 +138,7 @@ batch:
     #   depend-on:
     #     - publish_to_local_registry
     - identifier: api_test_ap_northeast_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_createapi_canary_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -148,7 +148,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ap_northeast_3
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_createapi_canary_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -158,7 +158,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_eu_north_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_createapi_canary_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -168,7 +168,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_eu_west_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_createapi_canary_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -188,7 +188,7 @@ batch:
     #   depend-on:
     #     - publish_to_local_registry
     - identifier: api_test_eu_west_3
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_createapi_canary_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -208,7 +208,7 @@ batch:
     #   depend-on:
     #     - publish_to_local_registry
     - identifier: api_test_sa_east_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_createapi_canary_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -218,7 +218,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_us_west_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_createapi_canary_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:

--- a/codebuild_specs/createapi_canary_workflow.yml
+++ b/codebuild_specs/createapi_canary_workflow.yml
@@ -28,7 +28,7 @@ batch:
       depend-on:
         - build_linux
     - identifier: api_test_us_east_1
-      buildspec: codebuild_specs/run_createapi_canary_tests.yml
+      buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -38,7 +38,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ap_northeast_2
-      buildspec: codebuild_specs/run_createapi_canary_tests.yml
+      buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -48,7 +48,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ap_south_1
-      buildspec: codebuild_specs/run_createapi_canary_tests.yml
+      buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -58,7 +58,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ap_southeast_2
-      buildspec: codebuild_specs/run_createapi_canary_tests.yml
+      buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -68,7 +68,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_eu_central_1
-      buildspec: codebuild_specs/run_createapi_canary_tests.yml
+      buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -78,7 +78,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_us_east_2
-      buildspec: codebuild_specs/run_createapi_canary_tests.yml
+      buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -88,7 +88,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ap_southeast_1
-      buildspec: codebuild_specs/run_createapi_canary_tests.yml
+      buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -98,7 +98,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ca_central_1
-      buildspec: codebuild_specs/run_createapi_canary_tests.yml
+      buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -108,7 +108,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_eu_west_2
-      buildspec: codebuild_specs/run_createapi_canary_tests.yml
+      buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -118,7 +118,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_us_west_2
-      buildspec: codebuild_specs/run_createapi_canary_tests.yml
+      buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -138,7 +138,7 @@ batch:
     #   depend-on:
     #     - publish_to_local_registry
     - identifier: api_test_ap_northeast_1
-      buildspec: codebuild_specs/run_createapi_canary_tests.yml
+      buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -148,7 +148,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ap_northeast_3
-      buildspec: codebuild_specs/run_createapi_canary_tests.yml
+      buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -158,7 +158,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_eu_north_1
-      buildspec: codebuild_specs/run_createapi_canary_tests.yml
+      buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -168,7 +168,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_eu_west_1
-      buildspec: codebuild_specs/run_createapi_canary_tests.yml
+      buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -188,7 +188,7 @@ batch:
     #   depend-on:
     #     - publish_to_local_registry
     - identifier: api_test_eu_west_3
-      buildspec: codebuild_specs/run_createapi_canary_tests.yml
+      buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -208,7 +208,7 @@ batch:
     #   depend-on:
     #     - publish_to_local_registry
     - identifier: api_test_sa_east_1
-      buildspec: codebuild_specs/run_createapi_canary_tests.yml
+      buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -218,7 +218,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_us_west_1
-      buildspec: codebuild_specs/run_createapi_canary_tests.yml
+      buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -227,6 +227,12 @@ batch:
           CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
+    - identifier: report_status
+      buildspec: codebuild_specs/emit_createapi_canary_metric.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+      depend-on:
+        - api_test_us_east_1
     # - identifier: cleanup_e2e_resources
     #   buildspec: codebuild_specs/cleanup_e2e_resources.yml
     #   env:

--- a/codebuild_specs/emit_createapi_canary_metric.yml
+++ b/codebuild_specs/emit_createapi_canary_metric.yml
@@ -10,16 +10,6 @@ env:
 phases:
   build:
     commands:
-      - codebuild-breakpoint
-      - source ./shared-scripts.sh && _setupE2ETestsLinux
-      - source ./shared-scripts.sh && _runE2ETestsLinux
-  post_build:
-    commands:
       - source ./shared-scripts.sh && _unassumeTestAccountCredentials
       - aws sts get-caller-identity
       - source ./shared-scripts.sh && _scanArtifacts && _emitCreateApiCanaryMetric
-
-artifacts:
-  files:
-    - '**/*'
-  base-directory: $CODEBUILD_SRC_DIR/packages/amplify-e2e-tests/amplify-e2e-reports

--- a/codebuild_specs/run_createapi_canary_tests.yml
+++ b/codebuild_specs/run_createapi_canary_tests.yml
@@ -1,0 +1,25 @@
+version: 0.2
+env:
+  shell: bash
+  variables:
+    AMPLIFY_DIR: /root/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin
+    AMPLIFY_PATH: /root/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify
+    CI: true
+    CODEBUILD: true
+    NODE_OPTIONS: --max-old-space-size=8096
+phases:
+  build:
+    commands:
+      - codebuild-breakpoint
+      - source ./shared-scripts.sh && _setupE2ETestsLinux
+      - source ./shared-scripts.sh && _runE2ETestsLinux
+  post_build:
+    commands:
+      - source ./shared-scripts.sh && _unassumeTestAccountCredentials
+      - aws sts get-caller-identity
+      - source ./shared-scripts.sh && _scanArtifacts && _emitCreateApiCanaryMetric
+
+artifacts:
+  files:
+    - '**/*'
+  base-directory: $CODEBUILD_SRC_DIR/packages/amplify-e2e-tests/amplify-e2e-reports

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -436,3 +436,14 @@ function _emitCanaryMetric {
     --dimensions branch=main \
     --region us-west-2
 }
+
+function _emitCreateApiCanaryMetric {
+  aws cloudwatch \
+    put-metric-data \
+    --metric-name CreateApiCanarySuccessRate \
+    --namespace amplify-category-api-e2e-tests \
+    --unit Count \
+    --value $CODEBUILD_BUILD_SUCCEEDING \
+    --dimensions branch=main \
+    --region us-west-2
+}

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -179,8 +179,9 @@ function _installCLIFromLocalRegistry {
     setNpmRegistryUrlToLocal
     changeNpmGlobalPath
     # set longer timeout to avoid socket timeout error
-    npm config set fetch-retry-mintimeout 20000
-    npm config set fetch-retry-maxtimeout 120000
+    npm config set fetch-retries 5
+    npm config set fetch-retry-mintimeout 120000
+    npm config set fetch-retry-maxtimeout 360000
     npm install -g @aws-amplify/cli-internal
     echo "using Amplify CLI version: "$(amplify --version)
     npm list -g --depth=1 | grep -e '@aws-amplify/amplify-category-api' -e 'amplify-codegen'

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -180,8 +180,9 @@ function _installCLIFromLocalRegistry {
     changeNpmGlobalPath
     # set longer timeout to avoid socket timeout error
     npm config set fetch-retries 5
-    npm config set fetch-retry-mintimeout 120000
-    npm config set fetch-retry-maxtimeout 360000
+    npm config set fetch-timeout 600000
+    npm config set fetch-retry-mintimeout 20000
+    npm config set fetch-retry-maxtimeout 120000
     npm install -g @aws-amplify/cli-internal
     echo "using Amplify CLI version: "$(amplify --version)
     npm list -g --depth=1 | grep -e '@aws-amplify/amplify-category-api' -e 'amplify-codegen'


### PR DESCRIPTION
- Increase npm fetch retries to 5 (default is 2).
- Increase npm fetch fetch timeout to 10 minutes (default is 5 min).
- Emit canary metrics.