### PR TITLE
test: re-enabled custom operations E2E tests

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-oidc-auth.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-oidc-auth.test.ts
@@ -1218,8 +1218,7 @@ describe('RDS OIDC provider Auth tests', () => {
     checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
   });
 
-  // TODO: enable once fixed in auth utils
-  test.skip('logged in user can perform custom operations', async () => {
+  test('logged in user can perform custom operations', async () => {
     const appSyncClient = appSyncClients[oidcProvider][userName2];
     const todo = {
       id: Date.now().toString(),
@@ -1259,8 +1258,8 @@ describe('RDS OIDC provider Auth tests', () => {
     expect(getResult.data.customGetTodoPrivate[0].id).toEqual(todo.id);
     expect(getResult.data.customGetTodoPrivate[0].content).toEqual(todo.content);
   });
-  // TODO: enable once fixed in auth utils
-  test.skip('users in static group can perform custom operations', async () => {
+
+  test('users in static group can perform custom operations', async () => {
     const appSyncClient = appSyncClients[oidcProvider][userName1];
     const todo = {
       id: Date.now().toString(),
@@ -1300,8 +1299,8 @@ describe('RDS OIDC provider Auth tests', () => {
     expect(getResult.data.customGetTodoStaticGroup[0].id).toEqual(todo.id);
     expect(getResult.data.customGetTodoStaticGroup[0].content).toEqual(todo.content);
   });
-  // TODO: enable once fixed in auth utils
-  test.skip('users not in static group cannot perform custom operations', async () => {
+
+  test('users not in static group cannot perform custom operations', async () => {
     const appSyncClient = appSyncClients[oidcProvider][userName2];
     const todo = {
       id: Date.now().toString(),

--- a/packages/amplify-e2e-tests/src/__tests__/rds-mysql-userpool-auth.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/rds-mysql-userpool-auth.test.ts
@@ -1195,8 +1195,7 @@ describe('RDS Cognito userpool provider Auth tests', () => {
     checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
   });
 
-  // TODO: enable once fixed in auth utils
-  test.skip('logged in user can perform custom operations', async () => {
+  test('logged in user can perform custom operations', async () => {
     const appSyncClient = appSyncClients[userPoolProvider][userName2];
     const todo = {
       id: Date.now().toString(),
@@ -1236,8 +1235,8 @@ describe('RDS Cognito userpool provider Auth tests', () => {
     expect(getResult.data.customGetTodoPrivate[0].id).toEqual(todo.id);
     expect(getResult.data.customGetTodoPrivate[0].content).toEqual(todo.content);
   });
-  // TODO: enable once fixed in auth utils
-  test.skip('users in static group can perform custom operations', async () => {
+
+  test('users in static group can perform custom operations', async () => {
     const appSyncClient = appSyncClients[userPoolProvider][userName1];
     const todo = {
       id: Date.now().toString(),
@@ -1277,8 +1276,8 @@ describe('RDS Cognito userpool provider Auth tests', () => {
     expect(getResult.data.customGetTodoStaticGroup[0].id).toEqual(todo.id);
     expect(getResult.data.customGetTodoStaticGroup[0].content).toEqual(todo.content);
   });
-  // TODO: enable once fixed in auth utils
-  test.skip('users not in static group cannot perform custom operations', async () => {
+
+  test('users not in static group cannot perform custom operations', async () => {
     const appSyncClient = appSyncClients[userPoolProvider][userName2];
     const todo = {
       id: Date.now().toString(),

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-oidc.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-oidc.ts
@@ -1222,8 +1222,7 @@ export const testOIDCAuth = (engine: ImportedRDSType): void => {
       checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
     });
 
-    // TODO: enable once fixed in auth utils
-    test.skip('logged in user can perform custom operations', async () => {
+    test('logged in user can perform custom operations', async () => {
       const appSyncClient = appSyncClients[oidcProvider][userName2];
       const todo = {
         id: Date.now().toString(),
@@ -1263,8 +1262,8 @@ export const testOIDCAuth = (engine: ImportedRDSType): void => {
       expect(getResult.data.customGetTodoPrivate[0].id).toEqual(todo.id);
       expect(getResult.data.customGetTodoPrivate[0].content).toEqual(todo.content);
     });
-    // TODO: enable once fixed in auth utils
-    test.skip('users in static group can perform custom operations', async () => {
+
+    test('users in static group can perform custom operations', async () => {
       const appSyncClient = appSyncClients[oidcProvider][userName1];
       const todo = {
         id: Date.now().toString(),
@@ -1304,8 +1303,8 @@ export const testOIDCAuth = (engine: ImportedRDSType): void => {
       expect(getResult.data.customGetTodoStaticGroup[0].id).toEqual(todo.id);
       expect(getResult.data.customGetTodoStaticGroup[0].content).toEqual(todo.content);
     });
-    // TODO: enable once fixed in auth utils
-    test.skip('users not in static group cannot perform custom operations', async () => {
+
+    test('users not in static group cannot perform custom operations', async () => {
       const appSyncClient = appSyncClients[oidcProvider][userName2];
       const todo = {
         id: Date.now().toString(),

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool.ts
@@ -1209,8 +1209,7 @@ export const testUserPoolAuth = (engine: ImportedRDSType): void => {
       checkOperationResult(onDeleteSubscriptionResult[0], todoRandomUpdated, `onDelete${modelName}`);
     });
 
-    // TODO: enable once fixed in auth utils
-    test.skip('logged in user can perform custom operations', async () => {
+    test('logged in user can perform custom operations', async () => {
       const appSyncClient = appSyncClients[userPoolProvider][userName2];
       const todo = {
         id: Date.now().toString(),
@@ -1250,8 +1249,8 @@ export const testUserPoolAuth = (engine: ImportedRDSType): void => {
       expect(getResult.data.customGetTodoPrivate[0].id).toEqual(todo.id);
       expect(getResult.data.customGetTodoPrivate[0].content).toEqual(todo.content);
     });
-    // TODO: enable once fixed in auth utils
-    test.skip('users in static group can perform custom operations', async () => {
+
+    test('users in static group can perform custom operations', async () => {
       const appSyncClient = appSyncClients[userPoolProvider][userName1];
       const todo = {
         id: Date.now().toString(),
@@ -1291,8 +1290,8 @@ export const testUserPoolAuth = (engine: ImportedRDSType): void => {
       expect(getResult.data.customGetTodoStaticGroup[0].id).toEqual(todo.id);
       expect(getResult.data.customGetTodoStaticGroup[0].content).toEqual(todo.content);
     });
-    // TODO: enable once fixed in auth utils
-    test.skip('users not in static group cannot perform custom operations', async () => {
+
+    test('users not in static group cannot perform custom operations', async () => {
       const appSyncClient = appSyncClients[userPoolProvider][userName2];
       const todo = {
         id: Date.now().toString(),


### PR DESCRIPTION
#### Description of changes

Re-enabled custom operations E2E tests. NOTE: These changes are currently only deployed to ICN (ap-northeast-2), so make sure we only run tests there. The updated tests run successfully.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
