### PR TITLE
chore(api): remove scan artifacts command when reporting metrics

### DIFF
--- a/codebuild_specs/emit_createapi_canary_metric.yml
+++ b/codebuild_specs/emit_createapi_canary_metric.yml
@@ -12,4 +12,4 @@ phases:
     commands:
       - source ./shared-scripts.sh && _unassumeTestAccountCredentials
       - aws sts get-caller-identity
-      - source ./shared-scripts.sh && _scanArtifacts && _emitCreateApiCanaryMetric
+      - source ./shared-scripts.sh && _emitCreateApiCanaryMetric


### PR DESCRIPTION
Emit canary metric task doesn't need scan artifacts step, this was added in error in the previous PR https://github.com/aws-amplify/amplify-category-api/pull/2276. This step emits the current status of the pipeline to cloudwatch, any errors while executing the put-metric operation will be recorded in the codebuild logs (no need for artifacts).