### PR TITLE
test: increase no output timeout for sql-models test

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-models.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-models.test.ts
@@ -87,7 +87,11 @@ describe('CDK GraphQL Transformer', () => {
     const templatePath = path.resolve(path.join(__dirname, 'backends', 'sql-models'));
     const name = await initCDKProject(projRoot, templatePath);
     writeDbDetails(dbDetails, projRoot);
-    const outputs = await cdkDeploy(projRoot, '--all');
+
+    // Between the SQL Layer custom resource, Codegen asset auto delete custom resource, Codegen asset bucket deployment, and Lambda layer
+    // provisioned concurrency, this test doesn't produce output frequently enough to keep nexpect happy. The test itself appears to be
+    // stable, but we'll increase the timeout to account for slower deployment times in CICD.
+    const outputs = await cdkDeploy(projRoot, '--all', {timeoutMs: 30 * 60 * 1000});
     const { awsAppsyncApiEndpoint: apiEndpoint, awsAppsyncApiKey: apiKey } = outputs[name];
 
     const description = 'todo description';

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-models.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-models.test.ts
@@ -91,7 +91,7 @@ describe('CDK GraphQL Transformer', () => {
     // Between the SQL Layer custom resource, Codegen asset auto delete custom resource, Codegen asset bucket deployment, and Lambda layer
     // provisioned concurrency, this test doesn't produce output frequently enough to keep nexpect happy. The test itself appears to be
     // stable, but we'll increase the timeout to account for slower deployment times in CICD.
-    const outputs = await cdkDeploy(projRoot, '--all', {timeoutMs: 30 * 60 * 1000});
+    const outputs = await cdkDeploy(projRoot, '--all', { timeoutMs: 50 * 60 * 1000 });
     const { awsAppsyncApiEndpoint: apiEndpoint, awsAppsyncApiKey: apiKey } = outputs[name];
 
     const description = 'todo description';


### PR DESCRIPTION
#### Description of changes

Between the SQL Layer custom resource, Codegen asset auto delete custom resource, Codegen asset bucket deployment, and Lambda layer provisioned concurrency, this test doesn't produce output frequently enough to keep nexpect happy. The test itself appears to be stable, but this change increases the timeout to account for slower deployment times in CICD.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] [E2E tests pass](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:195bf1ce-9b91-47e5-bd53-d3ce4c98d73f?region=us-east-1)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
