### PR TITLE
chore(ci): emit canary metrics on each region test

### DIFF
--- a/codebuild_specs/createapi_canary_workflow.yml
+++ b/codebuild_specs/createapi_canary_workflow.yml
@@ -28,7 +28,7 @@ batch:
       depend-on:
         - build_linux
     - identifier: api_test_us_east_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -38,7 +38,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ap_northeast_2
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -48,7 +48,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ap_south_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -58,7 +58,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ap_southeast_2
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -68,7 +68,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_eu_central_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -78,7 +78,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_us_east_2
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -88,7 +88,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ap_southeast_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -98,7 +98,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ca_central_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -108,7 +108,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_eu_west_2
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -118,7 +118,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_us_west_2
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -128,7 +128,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     # - identifier: api_test_ap_east_1
-    #   buildspec: codebuild_specs/run_e2e_tests.yml
+    #   buildspec: codebuild_specs/run_canary_e2e_tests.yml
     #   env:
     #     compute-type: BUILD_GENERAL1_MEDIUM
     #     variables:
@@ -138,7 +138,7 @@ batch:
     #   depend-on:
     #     - publish_to_local_registry
     - identifier: api_test_ap_northeast_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -148,7 +148,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_ap_northeast_3
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -158,7 +158,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_eu_north_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -168,7 +168,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_eu_west_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -178,7 +178,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     # - identifier: api_test_eu_south_1
-    #   buildspec: codebuild_specs/run_e2e_tests.yml
+    #   buildspec: codebuild_specs/run_canary_e2e_tests.yml
     #   env:
     #     compute-type: BUILD_GENERAL1_MEDIUM
     #     variables:
@@ -188,7 +188,7 @@ batch:
     #   depend-on:
     #     - publish_to_local_registry
     - identifier: api_test_eu_west_3
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -198,7 +198,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     # - identifier: api_test_me_south_1
-    #   buildspec: codebuild_specs/run_e2e_tests.yml
+    #   buildspec: codebuild_specs/run_canary_e2e_tests.yml
     #   env:
     #     compute-type: BUILD_GENERAL1_MEDIUM
     #     variables:
@@ -208,7 +208,7 @@ batch:
     #   depend-on:
     #     - publish_to_local_registry
     - identifier: api_test_sa_east_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -218,7 +218,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: api_test_us_west_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
+      buildspec: codebuild_specs/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
@@ -227,12 +227,6 @@ batch:
           CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
-    - identifier: report_status
-      buildspec: codebuild_specs/emit_createapi_canary_metric.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-      depend-on:
-        - api_test_us_east_1
     # - identifier: cleanup_e2e_resources
     #   buildspec: codebuild_specs/cleanup_e2e_resources.yml
     #   env:

--- a/codebuild_specs/run_canary_e2e_tests.yml
+++ b/codebuild_specs/run_canary_e2e_tests.yml
@@ -10,6 +10,16 @@ env:
 phases:
   build:
     commands:
+      - codebuild-breakpoint
+      - source ./shared-scripts.sh && _setupE2ETestsLinux
+      - source ./shared-scripts.sh && _runE2ETestsLinux
+  post_build:
+    commands:
       - source ./shared-scripts.sh && _unassumeTestAccountCredentials
       - aws sts get-caller-identity
-      - source ./shared-scripts.sh && _emitCreateApiCanaryMetric
+      - source ./shared-scripts.sh && _scanArtifacts && _emitCreateApiCanaryMetric
+
+artifacts:
+  files:
+    - '**/*'
+  base-directory: $CODEBUILD_SRC_DIR/packages/amplify-e2e-tests/amplify-e2e-reports

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -445,6 +445,6 @@ function _emitCreateApiCanaryMetric {
     --namespace amplify-category-api-e2e-tests \
     --unit Count \
     --value $CODEBUILD_BUILD_SUCCEEDING \
-    --dimensions branch=main \
+    --dimensions branch=main,region=$CLI_REGION \
     --region us-west-2
 }


### PR DESCRIPTION
Currently the metrics for failed canaries are not emitted to cloudwatch. We expect codebuild to send '0' for failed canary runs.

This is fundamentally due to how codebuild works, codebuild sets the environment variable `CODEBUILD_BUILD_SUCCEEDING` to 1 if the last step of the build step is succeeding (based on error code). Since we have emit metrics command in 'build' step, this emits `1` when all the tests are passing but skipped if any of the prior steps fail.

In this PR, we are changing this behavior. We will emit metrics for each test. The alarm would consolidate all these values and work as expected because we consider only the AVERAGE to trigger it.