### PR TITLE
test: upgrade CDK construct tested cdk CLI version

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/commands.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/commands.ts
@@ -52,7 +52,7 @@ export type InitCDKProjectProps = {
  * @returns a promise which resolves to the stack name
  */
 export const initCDKProject = async (cwd: string, templatePath: string, props?: InitCDKProjectProps): Promise<string> => {
-  const { cdkVersion = '2.97.0', additionalDependencies = [] } = props ?? {};
+  const { cdkVersion = '2.128.0', additionalDependencies = [] } = props ?? {};
 
   await spawn(getNpxPath(), ['cdk', 'init', 'app', '--language', 'typescript'], {
     cwd,


### PR DESCRIPTION
## Leaving this in Draft until E2E tests confirmed passing

#### Description of changes

After we upgraded the tested CDK version from 2.80.0 to 2.97.0 in #2269 we discovered timeouts when deploying the SQL Layer resolver custom resource in ap-southeast-1. This PR bumps the version of the CDK CLI we install during CDK Construct E2E tests to 2.128.0 (the latest as of this writing).

This is not a full upgrade of the aws-cdk-lib and aws-cdk-lib-alpha* dependencies. That will come later assuming this PR tests out.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] [E2E tests pass](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:887642c6-8e77-4ccd-a291-e68465a330d9?region=us-east-1)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
