### PR TITLE
chore(ci): add max socket to npm config

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -181,8 +181,9 @@ function _installCLIFromLocalRegistry {
     # set longer timeout to avoid socket timeout error
     npm config set fetch-retries 5
     npm config set fetch-timeout 600000
-    npm config set fetch-retry-mintimeout 20000
-    npm config set fetch-retry-maxtimeout 120000
+    npm config set fetch-retry-mintimeout 30000
+    npm config set fetch-retry-maxtimeout 180000
+    npm config set maxsockets 1
     npm install -g @aws-amplify/cli-internal
     echo "using Amplify CLI version: "$(amplify --version)
     npm list -g --depth=1 | grep -e '@aws-amplify/amplify-category-api' -e 'amplify-codegen'


### PR DESCRIPTION
Another attempt to solve intermittent ERR_SOCKET_TIMEOUT errors on E2E tests.
- Increase npm config maxsockets to 1. (This will cause downloads to be slow but expected to be more reliable).
- Slightly increase min and max retry timeouts.

(I have run full pipeline to make sure there is no adverse behavior).
