### PR TITLE
chore: fix fetching test regions in e2e retry

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -282,7 +282,7 @@ function useChildAccountCredentials {
         parent_acct=$(aws sts get-caller-identity | jq -cr '.Account')
         child_accts=$(aws organizations list-accounts | jq -c "[.Accounts[].Id | select(. != \"$parent_acct\")]")
         org_size=$(echo $child_accts | jq 'length')
-        opt_in_regions=$(jq -r '.[] | select(.optIn == true) | .name' ./scripts/e2e-test-regions.json)
+        opt_in_regions=$(jq -r '.[] | select(.optIn == true) | .name' $$CODEBUILD_SRC_DIR/scripts/e2e-test-regions.json)
         if echo "$opt_in_regions" | grep -qw "$CLI_REGION"; then
             child_accts=$(echo $child_accts | jq -cr '.[]')
             for child_acct in $child_accts; do

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -282,7 +282,7 @@ function useChildAccountCredentials {
         parent_acct=$(aws sts get-caller-identity | jq -cr '.Account')
         child_accts=$(aws organizations list-accounts | jq -c "[.Accounts[].Id | select(. != \"$parent_acct\")]")
         org_size=$(echo $child_accts | jq 'length')
-        opt_in_regions=$(jq -r '.[] | select(.optIn == true) | .name' $$CODEBUILD_SRC_DIR/scripts/e2e-test-regions.json)
+        opt_in_regions=$(jq -r '.[] | select(.optIn == true) | .name' $CODEBUILD_SRC_DIR/scripts/e2e-test-regions.json)
         if echo "$opt_in_regions" | grep -qw "$CLI_REGION"; then
             child_accts=$(echo $child_accts | jq -cr '.[]')
             for child_acct in $child_accts; do


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Using absolute path since the current directory is not reset to root in E2E retries.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
