### PR TITLE
chore: upgrade CDK version in tests to `2.129.0`

### DIFF
--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -983,7 +983,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-1k-records.test.ts
-          CLI_REGION: ap-south-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -994,7 +994,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-1k-records.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -1005,7 +1005,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-1k-records.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: single_gsi_empty_table_single_gsi_single_record_relationships
@@ -1015,7 +1015,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-single-record.test.ts|src/__tests__/relationships.test.ts
-          CLI_REGION: ca-central-1
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: amplify_table_1
@@ -1025,6 +1025,15 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/amplify-table-1.test.ts
           CLI_REGION: ap-northeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: amplify_table_3
+      buildspec: codebuild_specs/run_cdk_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/amplify-table-3.test.ts
+          CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: base_cdk_ap_east_1
@@ -1204,7 +1213,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/deploy-velocity/3-gsis-100k-records.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: eu-north-1
       depend-on:
         - publish_to_local_registry
     - identifier: replace_2_gsis_100k_records
@@ -1213,7 +1222,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/deploy-velocity/replace-2-gsis-100k-records.test.ts
-          CLI_REGION: eu-north-1
+          CLI_REGION: eu-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: replace_2_gsis_update_attr_100k_records
@@ -1223,7 +1232,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/deploy-velocity/replace-2-gsis-update-attr-100k-records.test.ts
-          CLI_REGION: eu-south-1
+          CLI_REGION: eu-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: single_gsi_100k_records
@@ -1232,7 +1241,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/deploy-velocity/single-gsi-100k-records.test.ts
-          CLI_REGION: eu-west-1
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: sql_models
@@ -1241,7 +1250,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-models.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: eu-west-3
       depend-on:
         - publish_to_local_registry
     - identifier: >-

--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -955,67 +955,76 @@ batch:
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
-    - identifier: add_resources_admin_role_all_auth_modes_amplify_table_2
+    - identifier: add_resources_custom_logic_data_construct_3_gsis_10k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/add-resources.test.ts|src/__tests__/admin-role.test.ts|src/__tests__/all-auth-modes.test.ts|src/__tests__/amplify-table-2.test.ts
+            src/__tests__/add-resources.test.ts|src/__tests__/custom-logic.test.ts|src/__tests__/data-construct.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-10k-records.test.ts
           CLI_REGION: ap-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: custom_logic_data_construct_3_gsis_10k_records_3_gsis_1k_records
-      buildspec: codebuild_specs/run_cdk_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_MEDIUM
-        variables:
-          TEST_SUITE: >-
-            src/__tests__/custom-logic.test.ts|src/__tests__/data-construct.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-1k-records.test.ts
-          CLI_REGION: ap-northeast-2
-      depend-on:
-        - publish_to_local_registry
     - identifier: >-
-        3_gsis_empty_table_3_gsis_single_record_replace_2_gsis_10k_records_replace_2_gsis_1k_records
+        3_gsis_1k_records_3_gsis_empty_table_3_gsis_single_record_replace_2_gsis_10k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-1k-records.test.ts
-          CLI_REGION: ap-southeast-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: >-
-        replace_2_gsis_empty_table_replace_2_gsis_single_record_replace_2_gsis_update_attr_10k_records_replace_2_gsis_update_attr_1k_re
-      buildspec: codebuild_specs/run_cdk_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_MEDIUM
-        variables:
-          TEST_SUITE: >-
-            src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-1k-records.test.ts
-          CLI_REGION: ap-southeast-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: >-
-        replace_2_gsis_update_attr_empty_table_replace_2_gsis_update_attr_single_record_single_gsi_10k_records_single_gsi_1k_records
-      buildspec: codebuild_specs/run_cdk_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_MEDIUM
-        variables:
-          TEST_SUITE: >-
-            src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-1k-records.test.ts
+            src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-1k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-10k-records.test.ts
           CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
-    - identifier: single_gsi_empty_table_single_gsi_single_record_relationships
+    - identifier: >-
+        replace_2_gsis_1k_records_replace_2_gsis_empty_table_replace_2_gsis_single_record_replace_2_gsis_update_attr_10k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-single-record.test.ts|src/__tests__/relationships.test.ts
+            src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-1k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-10k-records.test.ts
           CLI_REGION: eu-central-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: >-
+        replace_2_gsis_update_attr_1k_records_replace_2_gsis_update_attr_empty_table_replace_2_gsis_update_attr_single_record_single_gs
+      buildspec: codebuild_specs/run_cdk_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-1k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-10k-records.test.ts
+          CLI_REGION: eu-north-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: >-
+        single_gsi_1k_records_single_gsi_empty_table_single_gsi_single_record_relationships
+      buildspec: codebuild_specs/run_cdk_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-1k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-single-record.test.ts|src/__tests__/relationships.test.ts
+          CLI_REGION: eu-south-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: admin_role
+      buildspec: codebuild_specs/run_cdk_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/admin-role.test.ts
+          CLI_REGION: ap-northeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: all_auth_modes
+      buildspec: codebuild_specs/run_cdk_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/all-auth-modes.test.ts
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: amplify_table_1
@@ -1024,7 +1033,16 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-table-1.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-south-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: amplify_table_2
+      buildspec: codebuild_specs/run_cdk_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/amplify-table-2.test.ts
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: amplify_table_3
@@ -1033,7 +1051,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-table-3.test.ts
-          CLI_REGION: ap-south-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: base_cdk_ap_east_1
@@ -1213,7 +1231,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/deploy-velocity/3-gsis-100k-records.test.ts
-          CLI_REGION: eu-north-1
+          CLI_REGION: eu-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: replace_2_gsis_100k_records
@@ -1222,7 +1240,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/deploy-velocity/replace-2-gsis-100k-records.test.ts
-          CLI_REGION: eu-south-1
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: replace_2_gsis_update_attr_100k_records
@@ -1232,7 +1250,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/deploy-velocity/replace-2-gsis-update-attr-100k-records.test.ts
-          CLI_REGION: eu-west-1
+          CLI_REGION: eu-west-3
       depend-on:
         - publish_to_local_registry
     - identifier: single_gsi_100k_records
@@ -1241,7 +1259,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/deploy-velocity/single-gsi-100k-records.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: me-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: sql_models
@@ -1250,7 +1268,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-models.test.ts
-          CLI_REGION: eu-west-3
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/amplify-table-1.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/amplify-table-1.test.ts
@@ -37,7 +37,7 @@ describe('CDK amplify table 1', () => {
     expect(table.Table.StreamSpecification.StreamViewType).toBe('NEW_AND_OLD_IMAGES');
     const updateTemplatePath = path.resolve(path.join(__dirname, 'backends', 'amplify-table', 'simple-todo', 'updateIndex'));
     updateCDKAppWithTemplate(projRoot, updateTemplatePath);
-    await cdkDeploy(projRoot, '--all', { timeoutMs: 10 * 60 * 1000 /* 10m */ });
+    await cdkDeploy(projRoot, '--all');
     const updatedTable = await getDDBTable(tableName, region);
     expect(updatedTable).toBeDefined();
     expect(updatedTable.Table.BillingModeSummary.BillingMode).toBe('PROVISIONED');

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/amplify-table-1.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/amplify-table-1.test.ts
@@ -46,7 +46,7 @@ describe('CDK amplify table 1', () => {
     expect(updatedTable.Table.StreamSpecification.StreamViewType).toBe('KEYS_ONLY');
   });
 
-  test('cannot replace table when destructive updates are not allowed', async () => {
+  test.skip('cannot replace table when destructive updates are not allowed', async () => {
     const templatePath = path.resolve(path.join(__dirname, 'backends', 'amplify-table', 'simple-todo'));
     const name = await initCDKProject(projRoot, templatePath);
     const outputs = await cdkDeploy(projRoot, '--all');

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/amplify-table-3.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/amplify-table-3.test.ts
@@ -4,12 +4,12 @@ import { cdkDestroy, initCDKProject, cdkDeploy, updateCDKAppWithTemplate } from 
 
 jest.setTimeout(1000 * 60 * 60 /* 1 hour */);
 
-describe('CDK amplify table 1', () => {
+describe('CDK amplify table 3', () => {
   let projRoot: string;
   let projFolderName: string;
 
   beforeEach(async () => {
-    projFolderName = 'cdkamplifytable1';
+    projFolderName = 'cdkamplifytable3';
     projRoot = await createNewProjectDir(projFolderName);
   });
 
@@ -23,26 +23,35 @@ describe('CDK amplify table 1', () => {
     deleteProjectDir(projRoot);
   });
 
-  test('can update multiple GSIs along with other non-GSI updates', async () => {
+  test('cannot replace table when destructive updates are not allowed', async () => {
     const templatePath = path.resolve(path.join(__dirname, 'backends', 'amplify-table', 'simple-todo'));
     const name = await initCDKProject(projRoot, templatePath);
     const outputs = await cdkDeploy(projRoot, '--all');
     const { awsAppsyncApiId: apiId, awsAppsyncRegion: region } = outputs[name];
     const tableName = `Todo-${apiId}-NONE`;
     const table = await getDDBTable(tableName, region);
-    expect(table).toBeDefined();
-    expect(table.Table.BillingModeSummary.BillingMode).toBe('PAY_PER_REQUEST');
-    expect(table.Table.GlobalSecondaryIndexes[0].IndexName).toBe('byName');
-    expect(table.Table.SSEDescription.Status).toBe('ENABLED');
-    expect(table.Table.StreamSpecification.StreamViewType).toBe('NEW_AND_OLD_IMAGES');
-    const updateTemplatePath = path.resolve(path.join(__dirname, 'backends', 'amplify-table', 'simple-todo', 'updateIndex'));
+    expect(table.Table.KeySchema[0]).toEqual({
+      AttributeName: 'id',
+      KeyType: 'HASH',
+    });
+    // deploy with destructive update disabled
+    let updateTemplatePath;
+    updateTemplatePath = path.resolve(path.join(__dirname, 'backends', 'amplify-table', 'simple-todo', 'updateKeySchema', 'disabled'));
+    updateCDKAppWithTemplate(projRoot, updateTemplatePath);
+    await expect(() => cdkDeploy(projRoot, '--all')).rejects.toThrow();
+    const tableAfterFailure = await getDDBTable(tableName, region);
+    expect(tableAfterFailure.Table.KeySchema[0]).toEqual({
+      AttributeName: 'id',
+      KeyType: 'HASH',
+    });
+    // deploy with destructive update enabled
+    updateTemplatePath = path.resolve(path.join(__dirname, 'backends', 'amplify-table', 'simple-todo', 'updateKeySchema', 'enabled'));
     updateCDKAppWithTemplate(projRoot, updateTemplatePath);
     await cdkDeploy(projRoot, '--all');
     const updatedTable = await getDDBTable(tableName, region);
-    expect(updatedTable).toBeDefined();
-    expect(updatedTable.Table.BillingModeSummary.BillingMode).toBe('PROVISIONED');
-    expect(updatedTable.Table.GlobalSecondaryIndexes[0].IndexName).toBe('byName2');
-    expect(updatedTable.Table.SSEDescription).toBeUndefined();
-    expect(updatedTable.Table.StreamSpecification.StreamViewType).toBe('KEYS_ONLY');
+    expect(updatedTable.Table.KeySchema[0]).toEqual({
+      AttributeName: 'todoid',
+      KeyType: 'HASH',
+    });
   });
 });

--- a/packages/amplify-graphql-api-construct-tests/src/commands.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/commands.ts
@@ -86,13 +86,13 @@ export type CdkDeployProps = {
 export const cdkDeploy = async (cwd: string, option: string, props?: CdkDeployProps): Promise<any> => {
   // The CodegenAssets BucketDeployment resource takes a while. Set the timeout to 10m account for that. (Note that this is the "no output
   // timeout"--the overall deployment is still allowed to take longer than 10m)
-  // const noOutputTimeout = props?.timeoutMs ?? 10 * 60 * 1000;
+  const noOutputTimeout = props?.timeoutMs ?? 10 * 60 * 1000;
   const commandOptions = {
     cwd,
     stripColors: true,
     // npx cdk does not work on verdaccio
     env: { npm_config_registry: 'https://registry.npmjs.org/' },
-    noOutputTimeout: props?.timeoutMs,
+    noOutputTimeout,
   };
   // This prevents us from maintaining a separate CDK account bootstrap process as we add support for new accounts, regions.
   // Checks and succeeds early (a no-op) if the account-region combination is already bootstrapped.

--- a/packages/amplify-graphql-api-construct-tests/src/commands.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/commands.ts
@@ -52,7 +52,7 @@ export type InitCDKProjectProps = {
  * @returns a promise which resolves to the stack name
  */
 export const initCDKProject = async (cwd: string, templatePath: string, props?: InitCDKProjectProps): Promise<string> => {
-  const { cdkVersion = '2.97.0', additionalDependencies = [] } = props ?? {};
+  const { cdkVersion = '2.129.0', additionalDependencies = [] } = props ?? {};
 
   await spawn(getNpxPath(), ['cdk', 'init', 'app', '--language', 'typescript'], {
     cwd,
@@ -86,13 +86,13 @@ export type CdkDeployProps = {
 export const cdkDeploy = async (cwd: string, option: string, props?: CdkDeployProps): Promise<any> => {
   // The CodegenAssets BucketDeployment resource takes a while. Set the timeout to 10m account for that. (Note that this is the "no output
   // timeout"--the overall deployment is still allowed to take longer than 10m)
-  const noOutputTimeout = props?.timeoutMs ?? 10 * 60 * 1000;
+  // const noOutputTimeout = props?.timeoutMs ?? 10 * 60 * 1000;
   const commandOptions = {
     cwd,
     stripColors: true,
     // npx cdk does not work on verdaccio
     env: { npm_config_registry: 'https://registry.npmjs.org/' },
-    noOutputTimeout,
+    noOutputTimeout: props?.timeoutMs,
   };
   // This prevents us from maintaining a separate CDK account bootstrap process as we add support for new accounts, regions.
   // Checks and succeeds early (a no-op) if the account-region combination is already bootstrapped.

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -129,6 +129,7 @@ const RUN_SOLO: (string | RegExp)[] = [
   // CDK tests
   /src\/__tests__\/base-cdk.*\.test\.ts/,
   'src/__tests__/amplify-table-1.test.ts',
+  'src/__tests__/amplify-table-3.test.ts',
   'src/__tests__/api_canary.test.ts',
   'src/__tests__/sql-models.test.ts',
 ];

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -132,6 +132,9 @@ const RUN_SOLO: (string | RegExp)[] = [
   'src/__tests__/amplify-table-3.test.ts',
   'src/__tests__/api_canary.test.ts',
   'src/__tests__/sql-models.test.ts',
+  'src/__tests__/amplify-table-2.test.ts',
+  'src/__tests__/admin-role.test.ts',
+  'src/__tests__/all-auth-modes.test.ts',
 ];
 
 const RUN_IN_ALL_REGIONS = [


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Upgrades the version of CDK used in our E2E tests. This does not include the version of CDK libs we use in our construct or plugin.
Other changes:
- Split up the long running `amplify_table_1`.
- Added couple of tests that were prone to failures to solo jobs so we can better monitor them going forward.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
[Full E2E suite passed](https://tiny.amazon.com/yfrhl0k6/IsenLink)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
