### PR TITLE
chore(api): remove amplify prompts dep from schema generator

### DIFF
--- a/packages/amplify-graphql-schema-generator/package.json
+++ b/packages/amplify-graphql-schema-generator/package.json
@@ -46,9 +46,6 @@
     "pluralize": "^8.0.0",
     "typescript": "^4.8.4"
   },
-  "peerDependencies": {
-    "@aws-amplify/amplify-prompts": "^2.8.4"
-  },
   "devDependencies": {
     "@types/node": "^18.17.0",
     "@types/pluralize": "^0.0.29"

--- a/packages/amplify-graphql-schema-generator/src/__tests__/schema-overrides.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/schema-overrides.test.ts
@@ -1,9 +1,7 @@
-import { applySchemaOverrides } from '../schema-generator';
-import { print, parse, FieldDefinitionNode, ObjectTypeDefinitionNode } from 'graphql';
-import { printer } from '@aws-amplify/amplify-prompts';
-import { findMatchingField } from '../schema-generator';
+import { print, parse } from 'graphql';
+import { applySchemaOverrides, findMatchingField } from '../schema-generator';
 
-jest.mock('@aws-amplify/amplify-prompts');
+jest.spyOn(global.console, 'warn')
 
 describe('apply schema overrides for JSON fields', () => {
   it('should retain JSON to List type edits', () => {
@@ -201,7 +199,7 @@ describe('apply schema overrides for JSON fields', () => {
     const editedDocument = parse(editedSchema);
     const updatedDocument = applySchemaOverrides(document, editedDocument);
     stringsMatchWithoutWhitespace(print(updatedDocument), editedSchema);
-    expect(printer.warn).toHaveBeenCalledWith(
+    expect(console.warn).toHaveBeenCalledWith(
       'The field title has been changed to an optional type while it is required in the database. This may result in SQL errors in the mutations.',
     );
   });
@@ -226,7 +224,7 @@ describe('apply schema overrides for JSON fields', () => {
     const editedDocument = parse(editedSchema);
     const updatedDocument = applySchemaOverrides(document, editedDocument);
     stringsMatchWithoutWhitespace(print(updatedDocument), editedSchema);
-    expect(printer.warn).toHaveBeenCalledWith(
+    expect(console.warn).toHaveBeenCalledWith(
       'The field title has been changed to an optional type while it is required in the database. This may result in SQL errors in the mutations.',
     );
   });

--- a/packages/amplify-graphql-schema-generator/src/datasource-adapter/mysql-datasource-adapter.ts
+++ b/packages/amplify-graphql-schema-generator/src/datasource-adapter/mysql-datasource-adapter.ts
@@ -1,5 +1,4 @@
 import { knex } from 'knex';
-import { printer } from '@aws-amplify/amplify-prompts';
 import { invokeSchemaInspectorLambda } from '../utils/vpc-helper';
 import ora from 'ora';
 import { Field, Index } from '../schema-representation';
@@ -74,7 +73,7 @@ export class MySQLDataSourceAdapter extends DataSourceAdapter {
         debug: false,
       });
     } catch (err) {
-      printer.info(err);
+      console.info(err);
       throw err;
     }
   }

--- a/packages/amplify-graphql-schema-generator/src/datasource-adapter/pg-datasource-adapter.ts
+++ b/packages/amplify-graphql-schema-generator/src/datasource-adapter/pg-datasource-adapter.ts
@@ -1,5 +1,4 @@
 import { knex } from 'knex';
-import { printer } from '@aws-amplify/amplify-prompts';
 import { invokeSchemaInspectorLambda } from '../utils/vpc-helper';
 import ora from 'ora';
 import { EnumType, Field, FieldDataType, FieldType, Index } from '../schema-representation';
@@ -76,7 +75,7 @@ export class PostgresDataSourceAdapter extends DataSourceAdapter {
         debug: false,
       });
     } catch (err) {
-      printer.info(err);
+      console.info(err);
       throw err;
     }
   }

--- a/packages/amplify-graphql-schema-generator/src/schema-generator/schema-overrides.ts
+++ b/packages/amplify-graphql-schema-generator/src/schema-generator/schema-overrides.ts
@@ -1,6 +1,5 @@
 import { DocumentNode, EnumTypeDefinitionNode, FieldDefinitionNode, ObjectTypeDefinitionNode, StringValueNode, visit } from 'graphql';
 import { isArrayOrObject, getNonModelTypes, isOfType, isNonNullType } from 'graphql-transformer-common';
-import { printer } from '@aws-amplify/amplify-prompts';
 import { FieldWrapper, ObjectDefinitionWrapper } from '@aws-amplify/graphql-transformer-core';
 
 const MODEL_DIRECTIVE_NAME = 'model';
@@ -214,7 +213,7 @@ export const checkDestructiveNullabilityChange = (field: FieldDefinitionNode, ex
   const isFieldRequired = isNonNullType(field?.type);
   const isExistingFieldRequired = isNonNullType(existingField?.type);
   if (isFieldRequired && !isExistingFieldRequired) {
-    printer.warn(
+    console.warn(
       `The field ${field?.name?.value} has been changed to an optional type while it is required in the database. This may result in SQL errors in the mutations.`,
     );
   }

--- a/packages/amplify-graphql-schema-generator/src/utils/vpc-helper.ts
+++ b/packages/amplify-graphql-schema-generator/src/utils/vpc-helper.ts
@@ -29,7 +29,6 @@ import {
 } from '@aws-sdk/client-lambda';
 import * as fs from 'fs-extra';
 import ora from 'ora';
-import { printer } from '@aws-amplify/amplify-prompts';
 import { VpcConfig } from '@aws-amplify/graphql-transformer-interfaces';
 import { checkHostInDBClusters } from './vpc-helper-cluster';
 import { checkHostInDBProxies } from './vpc-helper-proxy';
@@ -60,13 +59,13 @@ export const getHostVpc = async (hostname: string, region: string): Promise<VpcC
 
   const clusterResult = await checkHostInDBClusters(hostname, region);
   if (clusterResult) {
-    printer.warn(warning('cluster'));
+    console.warn(warning('cluster'));
     return clusterResult;
   }
 
   const instanceResult = await checkHostInDBInstances(hostname, region);
   if (instanceResult) {
-    printer.warn(warning('instance'));
+    console.warn(warning('instance'));
     return instanceResult;
   }
 
@@ -104,7 +103,7 @@ export const provisionSchemaInspectorLambda = async (lambdaName: string, vpc: Vp
     }
   } catch (err) {
     spinner.fail('Failed to provision a function to introspect the database schema.');
-    printer.debug(`Error provisioning a function to introspect the database schema: ${err}`);
+    console.debug(`Error provisioning a function to introspect the database schema: ${err}`);
     throw err;
   }
   spinner.succeed('Successfully provisioned a function to introspect the database schema.');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Remove amplify-prompts dependency from graphql-schema-generator package.

**Why are we doing this?**
`graphql-schema-generator` package is used with amplify generate command in Gen2 CLI. Adding amplify-prompts polluting Gen2 dep tree with Gen1 deps.

##### CDK / CloudFormation Parameters Changed
NA
<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Full E2E pipeline
- Manual test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
