### PR TITLE
refactor(graphql-relational-transformer): split out datasource specific directive logic

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-ddb-fields-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-ddb-fields-transformer.ts
@@ -7,6 +7,12 @@ import { BelongsToDirectiveConfiguration } from '../types';
 import { getRelatedTypeIndex, ensureFieldsArray, getFieldsNodes, registerHasOneForeignKeyMappings } from '../utils';
 import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
 
+/**
+ * BelongsToDirectiveDDBFieldsTransformer executes transformations based on `@belongsTo(fields: [String!])` configurations
+ * and surrounding TransformerContextProviders for DynamoDB data sources.
+ *
+ * This should not be used for `@belongsTo(references: [String!])` definitions.
+ */
 export class BelongsToDirectiveDDBFieldsTransformer implements DataSourceBasedDirectiveTransformer<BelongsToDirectiveConfiguration> {
   dbType: 'DYNAMODB';
   constructor(dbType: 'DYNAMODB') {
@@ -31,7 +37,8 @@ export class BelongsToDirectiveDDBFieldsTransformer implements DataSourceBasedDi
     config.relatedTypeIndex = getRelatedTypeIndex(config, context as TransformerContextProvider);
   };
 
-  generateResolvers = (context: TransformerContextProvider, config: BelongsToDirectiveConfiguration): void => {
+  /** no-op */
+  generateResolvers = (_context: TransformerContextProvider, _config: BelongsToDirectiveConfiguration): void => {
     return;
   };
 

--- a/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-ddb-fields-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-ddb-fields-transformer.ts
@@ -1,0 +1,42 @@
+import {
+  TransformerContextProvider,
+  TransformerPrepareStepContextProvider,
+  TransformerTransformSchemaStepContextProvider,
+} from '@aws-amplify/graphql-transformer-interfaces';
+import { BelongsToDirectiveConfiguration } from '../types';
+import { getRelatedTypeIndex, ensureFieldsArray, getFieldsNodes, registerHasOneForeignKeyMappings } from '../utils';
+import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
+
+export class BelongsToDirectiveDDBFieldsTransformer implements DataSourceBasedDirectiveTransformer<BelongsToDirectiveConfiguration> {
+  dbType: 'DYNAMODB';
+  constructor(dbType: 'DYNAMODB') {
+    this.dbType = dbType;
+  }
+
+  prepare = (context: TransformerPrepareStepContextProvider, config: BelongsToDirectiveConfiguration): void => {
+    if (config.relationType !== 'hasOne') {
+      return;
+    }
+    const modelName = config.object.name.value;
+    registerHasOneForeignKeyMappings({
+      transformParameters: context.transformParameters,
+      resourceHelper: context.resourceHelper,
+      thisTypeName: modelName,
+      thisFieldName: config.field.name.value,
+      relatedType: config.relatedType,
+    });
+  };
+
+  transformSchema = (context: TransformerTransformSchemaStepContextProvider, config: BelongsToDirectiveConfiguration): void => {
+    config.relatedTypeIndex = getRelatedTypeIndex(config, context as TransformerContextProvider);
+  };
+
+  generateResolvers = (context: TransformerContextProvider, config: BelongsToDirectiveConfiguration): void => {
+    return;
+  };
+
+  validate = (context: TransformerContextProvider, config: BelongsToDirectiveConfiguration): void => {
+    ensureFieldsArray(config);
+    config.fieldNodes = getFieldsNodes(config, context);
+  };
+}

--- a/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-sql-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-sql-transformer.ts
@@ -9,6 +9,10 @@ import { BelongsToDirectiveConfiguration } from '../types';
 import { ensureReferencesArray, validateChildReferencesFields, getBelongsToReferencesNodes } from '../utils';
 import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
 
+/**
+ * BelongsToDirectiveSQLTransformer executes transformations based on `@belongsTo(references: [String!])` configurations
+ * and surrounding TransformerContextProviders for SQL data sources.
+ */
 export class BelongsToDirectiveSQLTransformer implements DataSourceBasedDirectiveTransformer<BelongsToDirectiveConfiguration> {
   dbType: ModelDataSourceStrategySqlDbType;
   constructor(dbType: ModelDataSourceStrategySqlDbType) {
@@ -24,7 +28,8 @@ export class BelongsToDirectiveSQLTransformer implements DataSourceBasedDirectiv
     validateChildReferencesFields(config, context as TransformerContextProvider);
   };
 
-  generateResolvers = (context: TransformerContextProvider, config: BelongsToDirectiveConfiguration): void => {
+  /** no-op */
+  generateResolvers = (_context: TransformerContextProvider, _config: BelongsToDirectiveConfiguration): void => {
     return;
   };
 

--- a/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-sql-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-sql-transformer.ts
@@ -1,0 +1,34 @@
+import {
+  TransformerContextProvider,
+  TransformerPrepareStepContextProvider,
+  TransformerTransformSchemaStepContextProvider,
+} from '@aws-amplify/graphql-transformer-interfaces';
+import { setFieldMappingResolverReference } from '../resolvers';
+import { BelongsToDirectiveConfiguration } from '../types';
+import { ensureReferencesArray, validateChildReferencesFields, getBelongsToReferencesNodes } from '../utils';
+import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
+
+export class BelongsToDirectiveSQLTransformer implements DataSourceBasedDirectiveTransformer<BelongsToDirectiveConfiguration> {
+  dbType: 'MYSQL' | 'POSTGRES';
+  constructor(dbType: 'MYSQL' | 'POSTGRES') {
+    this.dbType = dbType;
+  }
+
+  prepare = (context: TransformerPrepareStepContextProvider, config: BelongsToDirectiveConfiguration): void => {
+    const modelName = config.object.name.value;
+    setFieldMappingResolverReference(context, config.relatedType?.name?.value, modelName, config.field.name.value);
+  };
+
+  transformSchema = (context: TransformerTransformSchemaStepContextProvider, config: BelongsToDirectiveConfiguration): void => {
+    validateChildReferencesFields(config, context as TransformerContextProvider);
+  };
+
+  generateResolvers = (context: TransformerContextProvider, config: BelongsToDirectiveConfiguration): void => {
+    return;
+  };
+
+  validate = (context: TransformerContextProvider, config: BelongsToDirectiveConfiguration): void => {
+    ensureReferencesArray(config);
+    getBelongsToReferencesNodes(config, context);
+  };
+}

--- a/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-sql-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-sql-transformer.ts
@@ -1,4 +1,5 @@
 import {
+  ModelDataSourceStrategySqlDbType,
   TransformerContextProvider,
   TransformerPrepareStepContextProvider,
   TransformerTransformSchemaStepContextProvider,
@@ -9,8 +10,8 @@ import { ensureReferencesArray, validateChildReferencesFields, getBelongsToRefer
 import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
 
 export class BelongsToDirectiveSQLTransformer implements DataSourceBasedDirectiveTransformer<BelongsToDirectiveConfiguration> {
-  dbType: 'MYSQL' | 'POSTGRES';
-  constructor(dbType: 'MYSQL' | 'POSTGRES') {
+  dbType: ModelDataSourceStrategySqlDbType;
+  constructor(dbType: ModelDataSourceStrategySqlDbType) {
     this.dbType = dbType;
   }
 

--- a/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-transformer-factory.ts
+++ b/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-transformer-factory.ts
@@ -1,0 +1,17 @@
+import { ModelDataSourceStrategyDbType } from '@aws-amplify/graphql-transformer-interfaces';
+import { BelongsToDirectiveConfiguration } from '../types';
+import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
+import { BelongsToDirectiveSQLTransformer } from './belongs-to-directive-sql-transformer';
+import { BelongsToDirectiveDDBFieldsTransformer } from './belongs-to-directive-ddb-fields-transformer';
+
+export const getBelongsToDirectiveTransformer = (
+  dbType: ModelDataSourceStrategyDbType,
+): DataSourceBasedDirectiveTransformer<BelongsToDirectiveConfiguration> => {
+  switch (dbType) {
+    case 'MYSQL':
+    case 'POSTGRES':
+      return new BelongsToDirectiveSQLTransformer(dbType);
+    case 'DYNAMODB':
+      return new BelongsToDirectiveDDBFieldsTransformer(dbType);
+  }
+};

--- a/packages/amplify-graphql-relational-transformer/src/data-source-based-directive-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/data-source-based-directive-transformer.ts
@@ -1,0 +1,21 @@
+import {
+  TransformerContextProvider,
+  TransformerPrepareStepContextProvider,
+  ModelDataSourceStrategyDbType,
+  TransformerTransformSchemaStepContextProvider,
+} from '@aws-amplify/graphql-transformer-interfaces';
+import { BelongsToDirectiveConfiguration, HasManyDirectiveConfiguration, HasOneDirectiveConfiguration } from './types';
+
+export type DirectiveConfiguration = HasOneDirectiveConfiguration | HasManyDirectiveConfiguration | BelongsToDirectiveConfiguration;
+
+/**
+ * Represents a subset of transformer methods based on a specific
+ * data source (currently SQL / DDB Fields).
+*/
+export interface DataSourceBasedDirectiveTransformer<Config extends DirectiveConfiguration> {
+  dbType: ModelDataSourceStrategyDbType;
+  prepare: (context: TransformerPrepareStepContextProvider, config: Config) => void;
+  transformSchema: (context: TransformerTransformSchemaStepContextProvider, config: Config) => void;
+  generateResolvers: (context: TransformerContextProvider, config: Config) => void;
+  validate: (context: TransformerContextProvider, config: Config) => void;
+}

--- a/packages/amplify-graphql-relational-transformer/src/data-source-based-directive-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/data-source-based-directive-transformer.ts
@@ -11,8 +11,12 @@ export type DirectiveConfiguration = HasOneDirectiveConfiguration | HasManyDirec
 /**
  * Represents a subset of transformer methods based on a specific
  * data source (currently SQL / DDB Fields).
+ *
+ * Each method is to be invoked by the applicable relational transformer when iterating through
+ * its directive configurations the applicable transformer step.
  */
 export interface DataSourceBasedDirectiveTransformer<Config extends DirectiveConfiguration> {
+  // Constrains the DataSourceBasedDirectiveTransformer to a specific database type
   dbType: ModelDataSourceStrategyDbType;
   prepare: (context: TransformerPrepareStepContextProvider, config: Config) => void;
   transformSchema: (context: TransformerTransformSchemaStepContextProvider, config: Config) => void;

--- a/packages/amplify-graphql-relational-transformer/src/data-source-based-directive-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/data-source-based-directive-transformer.ts
@@ -11,7 +11,7 @@ export type DirectiveConfiguration = HasOneDirectiveConfiguration | HasManyDirec
 /**
  * Represents a subset of transformer methods based on a specific
  * data source (currently SQL / DDB Fields).
-*/
+ */
 export interface DataSourceBasedDirectiveTransformer<Config extends DirectiveConfiguration> {
   dbType: ModelDataSourceStrategyDbType;
   prepare: (context: TransformerPrepareStepContextProvider, config: Config) => void;

--- a/packages/amplify-graphql-relational-transformer/src/data-source-based-directive-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/data-source-based-directive-transformer.ts
@@ -6,7 +6,10 @@ import {
 } from '@aws-amplify/graphql-transformer-interfaces';
 import { BelongsToDirectiveConfiguration, HasManyDirectiveConfiguration, HasOneDirectiveConfiguration } from './types';
 
-export type DirectiveConfiguration = HasOneDirectiveConfiguration | HasManyDirectiveConfiguration | BelongsToDirectiveConfiguration;
+export type RelationalDirectiveConfiguration =
+  | HasOneDirectiveConfiguration
+  | HasManyDirectiveConfiguration
+  | BelongsToDirectiveConfiguration;
 
 /**
  * Represents a subset of transformer methods based on a specific
@@ -15,7 +18,7 @@ export type DirectiveConfiguration = HasOneDirectiveConfiguration | HasManyDirec
  * Each method is to be invoked by the applicable relational transformer when iterating through
  * its directive configurations the applicable transformer step.
  */
-export interface DataSourceBasedDirectiveTransformer<Config extends DirectiveConfiguration> {
+export interface DataSourceBasedDirectiveTransformer<Config extends RelationalDirectiveConfiguration> {
   // Constrains the DataSourceBasedDirectiveTransformer to a specific database type
   dbType: ModelDataSourceStrategyDbType;
   prepare: (context: TransformerPrepareStepContextProvider, config: Config) => void;

--- a/packages/amplify-graphql-relational-transformer/src/graphql-belongs-to-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-belongs-to-transformer.ts
@@ -134,7 +134,8 @@ export class BelongsToTransformer extends TransformerPluginBase {
     this.directiveList.forEach((config) => {
       const modelName = config.object.name.value;
       const dbType = getStrategyDbTypeFromModel(context as TransformerContextProvider, modelName);
-      getBelongsToDirectiveTransformer(dbType).prepare(context, config);
+      const dataSourceBasedTransformer = getBelongsToDirectiveTransformer(dbType);
+      dataSourceBasedTransformer.prepare(context, config);
     });
   };
 
@@ -143,7 +144,8 @@ export class BelongsToTransformer extends TransformerPluginBase {
 
     for (const config of this.directiveList) {
       const dbType = getStrategyDbTypeFromTypeNode(config.field.type, context);
-      getBelongsToDirectiveTransformer(dbType).transformSchema(ctx, config);
+      const dataSourceBasedTransformer = getBelongsToDirectiveTransformer(dbType);
+      dataSourceBasedTransformer.transformSchema(ctx, config);
       ensureBelongsToConnectionField(config, context);
     }
   };
@@ -176,7 +178,8 @@ const validate = (config: BelongsToDirectiveConfiguration, ctx: TransformerConte
   }
 
   config.relatedType = getRelatedType(config, ctx);
-  getBelongsToDirectiveTransformer(dbType).validate(ctx, config);
+  const dataSourceBasedTransformer = getBelongsToDirectiveTransformer(dbType);
+  dataSourceBasedTransformer.validate(ctx, config);
   validateModelDirective(config);
 
   if (isListType(field.type)) {

--- a/packages/amplify-graphql-relational-transformer/src/graphql-belongs-to-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-belongs-to-transformer.ts
@@ -131,12 +131,11 @@ export class BelongsToTransformer extends TransformerPluginBase {
    * During the prepare step, register any foreign keys that are renamed due to a model rename
    */
   prepare = (context: TransformerPrepareStepContextProvider): void => {
-    this.directiveList
-      .forEach((config) => {
-        const modelName = config.object.name.value;
-        const dbType = getStrategyDbTypeFromModel(context as TransformerContextProvider, modelName);
-        getBelongsToDirectiveTransformer(dbType).prepare(context, config);
-      });
+    this.directiveList.forEach((config) => {
+      const modelName = config.object.name.value;
+      const dbType = getStrategyDbTypeFromModel(context as TransformerContextProvider, modelName);
+      getBelongsToDirectiveTransformer(dbType).prepare(context, config);
+    });
   };
 
   transformSchema = (ctx: TransformerTransformSchemaStepContextProvider): void => {

--- a/packages/amplify-graphql-relational-transformer/src/graphql-belongs-to-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-belongs-to-transformer.ts
@@ -4,10 +4,10 @@ import {
   DirectiveWrapper,
   generateGetArgumentsInput,
   getStrategyDbTypeFromTypeNode,
+  getStrategyDbTypeFromModel,
   InvalidDirectiveError,
   TransformerPluginBase,
 } from '@aws-amplify/graphql-transformer-core';
-import { getStrategyDbTypeFromModel } from '@aws-amplify/graphql-transformer-core/src/utils';
 import {
   TransformerContextProvider,
   TransformerPrepareStepContextProvider,

--- a/packages/amplify-graphql-relational-transformer/src/graphql-belongs-to-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-belongs-to-transformer.ts
@@ -132,7 +132,6 @@ export class BelongsToTransformer extends TransformerPluginBase {
    */
   prepare = (context: TransformerPrepareStepContextProvider): void => {
     this.directiveList
-      // .filter((config) => config.relationType === 'hasOne')
       .forEach((config) => {
         const modelName = config.object.name.value;
         const dbType = getStrategyDbTypeFromModel(context as TransformerContextProvider, modelName);

--- a/packages/amplify-graphql-relational-transformer/src/graphql-has-many-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-has-many-transformer.ts
@@ -131,7 +131,8 @@ export class HasManyTransformer extends TransformerPluginBase {
     this.directiveList.forEach((config) => {
       const modelName = config.object.name.value;
       const dbType = getStrategyDbTypeFromModel(context as TransformerContextProvider, modelName);
-      getHasManyDirectiveTransformer(dbType).prepare(context, config);
+      const dataSourceBasedTransformer = getHasManyDirectiveTransformer(dbType);
+      dataSourceBasedTransformer.prepare(context, config);
     });
   };
 
@@ -140,7 +141,8 @@ export class HasManyTransformer extends TransformerPluginBase {
 
     for (const config of this.directiveList) {
       const dbType = getStrategyDbTypeFromTypeNode(config.field.type, context);
-      getHasManyDirectiveTransformer(dbType).transformSchema(ctx, config);
+      const dataSourceBasedTransformer = getHasManyDirectiveTransformer(dbType);
+      dataSourceBasedTransformer.transformSchema(ctx, config);
       ensureHasManyConnectionField(config, context);
       extendTypeWithConnection(config, context);
     }
@@ -151,7 +153,8 @@ export class HasManyTransformer extends TransformerPluginBase {
 
     for (const config of this.directiveList) {
       const dbType = getStrategyDbTypeFromTypeNode(config.field.type, context);
-      getHasManyDirectiveTransformer(dbType).generateResolvers(ctx, config);
+      const dataSourceBasedTransformer = getHasManyDirectiveTransformer(dbType);
+      dataSourceBasedTransformer.generateResolvers(ctx, config);
       const generator = getGenerator(dbType);
       generator.makeHasManyGetItemsConnectionWithKeyResolver(config, context);
     }
@@ -164,7 +167,8 @@ const validate = (config: HasManyDirectiveConfiguration, ctx: TransformerContext
   const dbType = getStrategyDbTypeFromTypeNode(field.type, ctx);
   config.relatedType = getRelatedType(config, ctx);
 
-  getHasManyDirectiveTransformer(dbType).validate(ctx, config);
+  const dataSourceBasedTransformer = getHasManyDirectiveTransformer(dbType);
+  dataSourceBasedTransformer.validate(ctx, config);
   validateModelDirective(config);
 
   if (!isListType(field.type)) {

--- a/packages/amplify-graphql-relational-transformer/src/graphql-has-many-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-has-many-transformer.ts
@@ -3,6 +3,7 @@ import {
   DirectiveWrapper,
   generateGetArgumentsInput,
   getStrategyDbTypeFromTypeNode,
+  getStrategyDbTypeFromModel,
   InvalidDirectiveError,
   TransformerPluginBase,
 } from '@aws-amplify/graphql-transformer-core';
@@ -24,7 +25,6 @@ import {
 } from 'graphql';
 import produce from 'immer';
 import { WritableDraft } from 'immer/dist/types/types-external';
-import { getStrategyDbTypeFromModel } from '@aws-amplify/graphql-transformer-core/src/utils';
 import {
   addFieldsToDefinition,
   convertSortKeyFieldsToSortKeyConnectionFields,

--- a/packages/amplify-graphql-relational-transformer/src/graphql-has-many-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-has-many-transformer.ts
@@ -3,14 +3,15 @@ import {
   DirectiveWrapper,
   generateGetArgumentsInput,
   getStrategyDbTypeFromTypeNode,
-  InvalidDirectiveError, TransformerPluginBase
+  InvalidDirectiveError,
+  TransformerPluginBase,
 } from '@aws-amplify/graphql-transformer-core';
 import {
   TransformerContextProvider,
   TransformerPrepareStepContextProvider,
   TransformerSchemaVisitStepContextProvider,
   TransformerTransformSchemaStepContextProvider,
-  TransformerPreProcessContextProvider
+  TransformerPreProcessContextProvider,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import { getBaseType, isListType, isNonNullType, makeField, makeNamedType, makeNonNullType } from 'graphql-transformer-common';
 import {
@@ -33,8 +34,12 @@ import {
 } from './schema';
 import { HasManyDirectiveConfiguration } from './types';
 import {
-  getConnectionAttributeName, getObjectPrimaryKey, getRelatedType, validateDisallowedDataStoreRelationships,
-  validateModelDirective, validateRelatedModelDirective
+  getConnectionAttributeName,
+  getObjectPrimaryKey,
+  getRelatedType,
+  validateDisallowedDataStoreRelationships,
+  validateModelDirective,
+  validateRelatedModelDirective,
 } from './utils';
 import { getGenerator } from './resolver/generator-factory';
 import { getHasManyDirectiveTransformer } from './has-many/has-many-directive-transformer-factory';

--- a/packages/amplify-graphql-relational-transformer/src/graphql-has-one-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-has-one-transformer.ts
@@ -3,7 +3,8 @@ import {
   DirectiveWrapper,
   generateGetArgumentsInput,
   getStrategyDbTypeFromTypeNode,
-  InvalidDirectiveError, TransformerPluginBase
+  InvalidDirectiveError,
+  TransformerPluginBase,
 } from '@aws-amplify/graphql-transformer-core';
 import {
   TransformerContextProvider,
@@ -41,8 +42,12 @@ import {
 } from './schema';
 import { HasOneDirectiveConfiguration, ObjectDefinition } from './types';
 import {
-  getConnectionAttributeName, getObjectPrimaryKey, getRelatedType, validateDisallowedDataStoreRelationships,
-  validateModelDirective, validateRelatedModelDirective
+  getConnectionAttributeName,
+  getObjectPrimaryKey,
+  getRelatedType,
+  validateDisallowedDataStoreRelationships,
+  validateModelDirective,
+  validateRelatedModelDirective,
 } from './utils';
 import { getGenerator } from './resolver/generator-factory';
 import { getHasOneDirectiveTransformer } from './has-one/has-one-directive-transformer-factory';
@@ -153,7 +158,7 @@ export class HasOneTransformer extends TransformerPluginBase {
   prepare = (context: TransformerPrepareStepContextProvider): void => {
     this.directiveList.forEach((config) => {
       const modelName = config.object.name.value;
-      const dbType = getStrategyDbTypeFromModel(context as TransformerContextProvider, modelName)
+      const dbType = getStrategyDbTypeFromModel(context as TransformerContextProvider, modelName);
       getHasOneDirectiveTransformer(dbType).prepare(context, config);
     });
   };

--- a/packages/amplify-graphql-relational-transformer/src/graphql-has-one-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-has-one-transformer.ts
@@ -159,7 +159,8 @@ export class HasOneTransformer extends TransformerPluginBase {
     this.directiveList.forEach((config) => {
       const modelName = config.object.name.value;
       const dbType = getStrategyDbTypeFromModel(context as TransformerContextProvider, modelName);
-      getHasOneDirectiveTransformer(dbType).prepare(context, config);
+      const dataSourceBasedTransformer = getHasOneDirectiveTransformer(dbType);
+      dataSourceBasedTransformer.prepare(context, config);
     });
   };
 
@@ -168,7 +169,8 @@ export class HasOneTransformer extends TransformerPluginBase {
 
     for (const config of this.directiveList) {
       const dbType = getStrategyDbTypeFromTypeNode(config.field.type, context);
-      getHasOneDirectiveTransformer(dbType).transformSchema(ctx, config);
+      const dataSourceBasedTransformer = getHasOneDirectiveTransformer(dbType);
+      dataSourceBasedTransformer.transformSchema(ctx, config);
       ensureHasOneConnectionField(config, context);
     }
   };
@@ -189,7 +191,8 @@ const validate = (config: HasOneDirectiveConfiguration, ctx: TransformerContextP
 
   const dbType = getStrategyDbTypeFromTypeNode(field.type, ctx);
   config.relatedType = getRelatedType(config, ctx);
-  getHasOneDirectiveTransformer(dbType).validate(ctx, config);
+  const dataSourceBasedTransformer = getHasOneDirectiveTransformer(dbType);
+  dataSourceBasedTransformer.validate(ctx, config);
   validateModelDirective(config);
 
   if (isListType(field.type)) {

--- a/packages/amplify-graphql-relational-transformer/src/graphql-has-one-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-has-one-transformer.ts
@@ -3,6 +3,7 @@ import {
   DirectiveWrapper,
   generateGetArgumentsInput,
   getStrategyDbTypeFromTypeNode,
+  getStrategyDbTypeFromModel,
   InvalidDirectiveError,
   TransformerPluginBase,
 } from '@aws-amplify/graphql-transformer-core';
@@ -33,7 +34,6 @@ import {
 } from 'graphql-transformer-common';
 import { produce } from 'immer';
 import { WritableDraft } from 'immer/dist/types/types-external';
-import { getStrategyDbTypeFromModel } from '@aws-amplify/graphql-transformer-core/src/utils';
 import {
   addFieldsToDefinition,
   convertSortKeyFieldsToSortKeyConnectionFields,

--- a/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-ddb-fields-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-ddb-fields-transformer.ts
@@ -1,0 +1,46 @@
+/* eslint-disable max-classes-per-file */
+import {
+    TransformerContextProvider,
+    TransformerPrepareStepContextProvider,
+    TransformerTransformSchemaStepContextProvider
+} from '@aws-amplify/graphql-transformer-interfaces';
+import { updateTableForConnection } from '../resolvers';
+import { HasManyDirectiveConfiguration } from '../types';
+import {
+    registerHasManyForeignKeyMappings,
+    getRelatedTypeIndex,
+    ensureFieldsArray,
+    getFieldsNodes,
+} from '../utils';
+import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
+
+export class HasManyDirectiveDDBFieldsTransformer implements DataSourceBasedDirectiveTransformer<HasManyDirectiveConfiguration> {
+  dbType: 'DYNAMODB';
+  constructor(dbType: 'DYNAMODB') {
+    this.dbType = dbType;
+  }
+
+  prepare = (context: TransformerPrepareStepContextProvider, config: HasManyDirectiveConfiguration): void => {
+    const modelName = config.object.name.value;
+    registerHasManyForeignKeyMappings({
+        transformParameters: context.transformParameters,
+        resourceHelper: context.resourceHelper,
+        thisTypeName: modelName,
+        thisFieldName: config.field.name.value,
+        relatedType: config.relatedType,
+      });
+  };
+
+  transformSchema = (context: TransformerTransformSchemaStepContextProvider, config: HasManyDirectiveConfiguration): void => {
+    config.relatedTypeIndex = getRelatedTypeIndex(config, context as TransformerContextProvider, config.indexName);
+};
+
+  generateResolvers = (context: TransformerContextProvider, config: HasManyDirectiveConfiguration): void => {
+    updateTableForConnection(config, context);
+};
+
+  validate = (context: TransformerContextProvider, config: HasManyDirectiveConfiguration): void => {
+    ensureFieldsArray(config);
+    config.fieldNodes = getFieldsNodes(config, context);
+  };
+}

--- a/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-ddb-fields-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-ddb-fields-transformer.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-classes-per-file */
 import {
   TransformerContextProvider,
   TransformerPrepareStepContextProvider,

--- a/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-ddb-fields-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-ddb-fields-transformer.ts
@@ -8,6 +8,12 @@ import { HasManyDirectiveConfiguration } from '../types';
 import { registerHasManyForeignKeyMappings, getRelatedTypeIndex, ensureFieldsArray, getFieldsNodes } from '../utils';
 import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
 
+/**
+ * HasManyDirectiveDDBFieldsTransformer executes transformations based on `@hasMany(fields: [String!])` configurations
+ * and surrounding TransformerContextProviders for DynamoDB data sources.
+ *
+ * This should not be used for `@hasMany(references: [String!])` definitions.
+ */
 export class HasManyDirectiveDDBFieldsTransformer implements DataSourceBasedDirectiveTransformer<HasManyDirectiveConfiguration> {
   dbType: 'DYNAMODB';
   constructor(dbType: 'DYNAMODB') {

--- a/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-ddb-fields-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-ddb-fields-transformer.ts
@@ -1,17 +1,12 @@
 /* eslint-disable max-classes-per-file */
 import {
-    TransformerContextProvider,
-    TransformerPrepareStepContextProvider,
-    TransformerTransformSchemaStepContextProvider
+  TransformerContextProvider,
+  TransformerPrepareStepContextProvider,
+  TransformerTransformSchemaStepContextProvider,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import { updateTableForConnection } from '../resolvers';
 import { HasManyDirectiveConfiguration } from '../types';
-import {
-    registerHasManyForeignKeyMappings,
-    getRelatedTypeIndex,
-    ensureFieldsArray,
-    getFieldsNodes,
-} from '../utils';
+import { registerHasManyForeignKeyMappings, getRelatedTypeIndex, ensureFieldsArray, getFieldsNodes } from '../utils';
 import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
 
 export class HasManyDirectiveDDBFieldsTransformer implements DataSourceBasedDirectiveTransformer<HasManyDirectiveConfiguration> {
@@ -23,21 +18,21 @@ export class HasManyDirectiveDDBFieldsTransformer implements DataSourceBasedDire
   prepare = (context: TransformerPrepareStepContextProvider, config: HasManyDirectiveConfiguration): void => {
     const modelName = config.object.name.value;
     registerHasManyForeignKeyMappings({
-        transformParameters: context.transformParameters,
-        resourceHelper: context.resourceHelper,
-        thisTypeName: modelName,
-        thisFieldName: config.field.name.value,
-        relatedType: config.relatedType,
-      });
+      transformParameters: context.transformParameters,
+      resourceHelper: context.resourceHelper,
+      thisTypeName: modelName,
+      thisFieldName: config.field.name.value,
+      relatedType: config.relatedType,
+    });
   };
 
   transformSchema = (context: TransformerTransformSchemaStepContextProvider, config: HasManyDirectiveConfiguration): void => {
     config.relatedTypeIndex = getRelatedTypeIndex(config, context as TransformerContextProvider, config.indexName);
-};
+  };
 
   generateResolvers = (context: TransformerContextProvider, config: HasManyDirectiveConfiguration): void => {
     updateTableForConnection(config, context);
-};
+  };
 
   validate = (context: TransformerContextProvider, config: HasManyDirectiveConfiguration): void => {
     ensureFieldsArray(config);

--- a/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-sql-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-sql-transformer.ts
@@ -1,0 +1,34 @@
+import {
+  TransformerContextProvider,
+  TransformerPrepareStepContextProvider,
+  TransformerTransformSchemaStepContextProvider,
+} from '@aws-amplify/graphql-transformer-interfaces';
+import { setFieldMappingResolverReference } from '../resolvers';
+import { HasManyDirectiveConfiguration } from '../types';
+import { validateParentReferencesFields, ensureReferencesArray, getReferencesNodes } from '../utils';
+import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
+
+export class HasManyDirectiveSQLTransformer implements DataSourceBasedDirectiveTransformer<HasManyDirectiveConfiguration> {
+  dbType: 'MYSQL' | 'POSTGRES';
+  constructor(dbType: 'MYSQL' | 'POSTGRES') {
+    this.dbType = dbType;
+  }
+
+  prepare = (context: TransformerPrepareStepContextProvider, config: HasManyDirectiveConfiguration): void => {
+    const modelName = config.object.name.value;
+    setFieldMappingResolverReference(context, config.relatedType?.name?.value, modelName, config.field.name.value, true);
+  };
+
+  transformSchema = (context: TransformerTransformSchemaStepContextProvider, config: HasManyDirectiveConfiguration): void => {
+    validateParentReferencesFields(config, context as TransformerContextProvider);
+  };
+
+  generateResolvers = (context: TransformerContextProvider, config: HasManyDirectiveConfiguration): void => {
+    return;
+  };
+
+  validate = (context: TransformerContextProvider, config: HasManyDirectiveConfiguration): void => {
+    ensureReferencesArray(config);
+    getReferencesNodes(config, context);
+  };
+}

--- a/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-sql-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-sql-transformer.ts
@@ -1,4 +1,5 @@
 import {
+  ModelDataSourceStrategySqlDbType,
   TransformerContextProvider,
   TransformerPrepareStepContextProvider,
   TransformerTransformSchemaStepContextProvider,
@@ -9,8 +10,8 @@ import { validateParentReferencesFields, ensureReferencesArray, getReferencesNod
 import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
 
 export class HasManyDirectiveSQLTransformer implements DataSourceBasedDirectiveTransformer<HasManyDirectiveConfiguration> {
-  dbType: 'MYSQL' | 'POSTGRES';
-  constructor(dbType: 'MYSQL' | 'POSTGRES') {
+  dbType: ModelDataSourceStrategySqlDbType;
+  constructor(dbType: ModelDataSourceStrategySqlDbType) {
     this.dbType = dbType;
   }
 

--- a/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-sql-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-sql-transformer.ts
@@ -9,6 +9,10 @@ import { HasManyDirectiveConfiguration } from '../types';
 import { validateParentReferencesFields, ensureReferencesArray, getReferencesNodes } from '../utils';
 import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
 
+/**
+ * HasManyDirectiveSQLTransformer executes transformations based on `@hasMany(references: [String!])` configurations
+ * and surrounding TransformerContextProviders for SQL data sources.
+ */
 export class HasManyDirectiveSQLTransformer implements DataSourceBasedDirectiveTransformer<HasManyDirectiveConfiguration> {
   dbType: ModelDataSourceStrategySqlDbType;
   constructor(dbType: ModelDataSourceStrategySqlDbType) {
@@ -24,7 +28,8 @@ export class HasManyDirectiveSQLTransformer implements DataSourceBasedDirectiveT
     validateParentReferencesFields(config, context as TransformerContextProvider);
   };
 
-  generateResolvers = (context: TransformerContextProvider, config: HasManyDirectiveConfiguration): void => {
+  /** no-op */
+  generateResolvers = (_context: TransformerContextProvider, _config: HasManyDirectiveConfiguration): void => {
     return;
   };
 

--- a/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-transformer-factory.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-transformer-factory.ts
@@ -1,0 +1,17 @@
+import { ModelDataSourceStrategyDbType } from '@aws-amplify/graphql-transformer-interfaces';
+import { HasManyDirectiveConfiguration } from '../types';
+import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
+import { HasManyDirectiveDDBFieldsTransformer } from './has-many-directive-ddb-fields-transformer';
+import { HasManyDirectiveSQLTransformer } from './has-many-directive-sql-transformer';
+
+export const getHasManyDirectiveTransformer = (
+  dbType: ModelDataSourceStrategyDbType,
+): DataSourceBasedDirectiveTransformer<HasManyDirectiveConfiguration> => {
+  switch (dbType) {
+    case 'MYSQL':
+    case 'POSTGRES':
+      return new HasManyDirectiveSQLTransformer(dbType);
+    case 'DYNAMODB':
+      return new HasManyDirectiveDDBFieldsTransformer(dbType);
+  }
+};

--- a/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-ddb-fields-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-ddb-fields-transformer.ts
@@ -1,0 +1,39 @@
+import {
+  TransformerContextProvider,
+  TransformerPrepareStepContextProvider,
+  TransformerTransformSchemaStepContextProvider,
+} from '@aws-amplify/graphql-transformer-interfaces';
+import { HasOneDirectiveConfiguration } from '../types';
+import { getRelatedTypeIndex, ensureFieldsArray, getFieldsNodes, registerHasOneForeignKeyMappings } from '../utils';
+import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
+
+export class HasOneDirectiveDDBFieldsTransformer implements DataSourceBasedDirectiveTransformer<HasOneDirectiveConfiguration> {
+  dbType: 'DYNAMODB';
+  constructor(dbType: 'DYNAMODB') {
+    this.dbType = dbType;
+  }
+
+  prepare = (context: TransformerPrepareStepContextProvider, config: HasOneDirectiveConfiguration): void => {
+    const modelName = config.object.name.value;
+    registerHasOneForeignKeyMappings({
+      transformParameters: context.transformParameters,
+      resourceHelper: context.resourceHelper,
+      thisTypeName: modelName,
+      thisFieldName: config.field.name.value,
+      relatedType: config.relatedType,
+    });
+  };
+
+  transformSchema = (context: TransformerTransformSchemaStepContextProvider, config: HasOneDirectiveConfiguration): void => {
+    config.relatedTypeIndex = getRelatedTypeIndex(config, context as TransformerContextProvider);
+  };
+
+  generateResolvers = (_context: TransformerContextProvider, _config: HasOneDirectiveConfiguration): void => {
+    return;
+  };
+
+  validate = (context: TransformerContextProvider, config: HasOneDirectiveConfiguration): void => {
+    ensureFieldsArray(config);
+    config.fieldNodes = getFieldsNodes(config, context);
+  };
+}

--- a/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-ddb-fields-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-ddb-fields-transformer.ts
@@ -7,6 +7,12 @@ import { HasOneDirectiveConfiguration } from '../types';
 import { getRelatedTypeIndex, ensureFieldsArray, getFieldsNodes, registerHasOneForeignKeyMappings } from '../utils';
 import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
 
+/**
+ * HasOneDirectiveDDBFieldsTransformer executes transformations based on `@hasOne(fields: [String!])` configurations
+ * and surrounding TransformerContextProviders for DynamoDB data sources.
+ *
+ * This should not be used for `@hasOne(references: [String!])` definitions.
+ */
 export class HasOneDirectiveDDBFieldsTransformer implements DataSourceBasedDirectiveTransformer<HasOneDirectiveConfiguration> {
   dbType: 'DYNAMODB';
   constructor(dbType: 'DYNAMODB') {
@@ -28,6 +34,7 @@ export class HasOneDirectiveDDBFieldsTransformer implements DataSourceBasedDirec
     config.relatedTypeIndex = getRelatedTypeIndex(config, context as TransformerContextProvider);
   };
 
+  /** no-op */
   generateResolvers = (_context: TransformerContextProvider, _config: HasOneDirectiveConfiguration): void => {
     return;
   };

--- a/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-sql-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-sql-transformer.ts
@@ -1,0 +1,34 @@
+import {
+  TransformerContextProvider,
+  TransformerPrepareStepContextProvider,
+  TransformerTransformSchemaStepContextProvider,
+} from '@aws-amplify/graphql-transformer-interfaces';
+import { setFieldMappingResolverReference } from '../resolvers';
+import { HasOneDirectiveConfiguration } from '../types';
+import { validateParentReferencesFields, ensureReferencesArray, getReferencesNodes } from '../utils';
+import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
+
+export class HasOneDirectiveSQLTransformer implements DataSourceBasedDirectiveTransformer<HasOneDirectiveConfiguration> {
+  dbType: 'MYSQL' | 'POSTGRES';
+  constructor(dbType: 'MYSQL' | 'POSTGRES') {
+    this.dbType = dbType;
+  }
+
+  prepare = (context: TransformerPrepareStepContextProvider, config: HasOneDirectiveConfiguration): void => {
+    const modelName = config.object.name.value;
+    setFieldMappingResolverReference(context, config.relatedType?.name?.value, modelName, config.field.name.value, true);
+  };
+
+  transformSchema = (context: TransformerTransformSchemaStepContextProvider, config: HasOneDirectiveConfiguration): void => {
+    validateParentReferencesFields(config, context as TransformerContextProvider);
+  };
+
+  generateResolvers = (_context: TransformerContextProvider, _config: HasOneDirectiveConfiguration): void => {
+    return;
+  };
+
+  validate = (context: TransformerContextProvider, config: HasOneDirectiveConfiguration): void => {
+    ensureReferencesArray(config);
+    getReferencesNodes(config, context);
+  };
+}

--- a/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-sql-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-sql-transformer.ts
@@ -1,4 +1,5 @@
 import {
+  ModelDataSourceStrategySqlDbType,
   TransformerContextProvider,
   TransformerPrepareStepContextProvider,
   TransformerTransformSchemaStepContextProvider,
@@ -9,8 +10,8 @@ import { validateParentReferencesFields, ensureReferencesArray, getReferencesNod
 import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
 
 export class HasOneDirectiveSQLTransformer implements DataSourceBasedDirectiveTransformer<HasOneDirectiveConfiguration> {
-  dbType: 'MYSQL' | 'POSTGRES';
-  constructor(dbType: 'MYSQL' | 'POSTGRES') {
+  dbType: ModelDataSourceStrategySqlDbType;
+  constructor(dbType: ModelDataSourceStrategySqlDbType) {
     this.dbType = dbType;
   }
 

--- a/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-sql-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-sql-transformer.ts
@@ -9,6 +9,10 @@ import { HasOneDirectiveConfiguration } from '../types';
 import { validateParentReferencesFields, ensureReferencesArray, getReferencesNodes } from '../utils';
 import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
 
+/**
+ * HasOneDirectiveSQLTransformer executes transformations based on `@hasOne(references: [String!])` configurations
+ * and surrounding TransformerContextProviders for SQL data sources.
+ */
 export class HasOneDirectiveSQLTransformer implements DataSourceBasedDirectiveTransformer<HasOneDirectiveConfiguration> {
   dbType: ModelDataSourceStrategySqlDbType;
   constructor(dbType: ModelDataSourceStrategySqlDbType) {
@@ -24,6 +28,7 @@ export class HasOneDirectiveSQLTransformer implements DataSourceBasedDirectiveTr
     validateParentReferencesFields(config, context as TransformerContextProvider);
   };
 
+  /** no-op */
   generateResolvers = (_context: TransformerContextProvider, _config: HasOneDirectiveConfiguration): void => {
     return;
   };

--- a/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-transformer-factory.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-transformer-factory.ts
@@ -1,0 +1,17 @@
+import { ModelDataSourceStrategyDbType } from '@aws-amplify/graphql-transformer-interfaces';
+import { HasOneDirectiveConfiguration } from '../types';
+import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
+import { HasOneDirectiveDDBFieldsTransformer } from './has-one-directive-ddb-fields-transformer';
+import { HasOneDirectiveSQLTransformer } from './has-one-directive-sql-transformer';
+
+export const getHasOneDirectiveTransformer = (
+  dbType: ModelDataSourceStrategyDbType,
+): DataSourceBasedDirectiveTransformer<HasOneDirectiveConfiguration> => {
+  switch (dbType) {
+    case 'MYSQL':
+    case 'POSTGRES':
+      return new HasOneDirectiveSQLTransformer(dbType);
+    case 'DYNAMODB':
+      return new HasOneDirectiveDDBFieldsTransformer(dbType);
+  }
+};

--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -250,6 +250,9 @@ export const getResourceNamesForStrategyName: (strategyName: string) => SQLLambd
 export const getSortKeyFieldNames: (type: ObjectTypeDefinitionNode) => string[];
 
 // @public (undocumented)
+export const getStrategyDbTypeFromModel: (ctx: DataSourceStrategiesProvider, typename: string) => ModelDataSourceStrategyDbType;
+
+// @public (undocumented)
 export const getStrategyDbTypeFromTypeNode: (type: TypeNode, ctx: TransformerContextProvider) => ModelDataSourceStrategyDbType;
 
 // @public (undocumented)

--- a/packages/amplify-graphql-transformer-core/src/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/index.ts
@@ -61,6 +61,7 @@ export {
   getConditionInputName,
   getSubscriptionFilterInputName,
   getConnectionName,
+  getStrategyDbTypeFromModel,
 } from './utils';
 export type { SetResourceNameProps } from './utils';
 export * from './utils/operation-names';

--- a/packages/amplify-graphql-transformer-core/src/utils/model-datasource-strategy-utils.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/model-datasource-strategy-utils.ts
@@ -161,7 +161,7 @@ export const getStrategyDbTypeFromModel = (ctx: DataSourceStrategiesProvider, ty
     return 'DYNAMODB';
   }
   return getModelDataSourceStrategy(ctx, typename).dbType;
-;}
+};
 
 /**
  * Normalize known variants of a database type to its canonical representation. E.g.:

--- a/packages/amplify-graphql-transformer-core/src/utils/model-datasource-strategy-utils.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/model-datasource-strategy-utils.ts
@@ -158,7 +158,7 @@ export const isSqlStrategy = (strategy: ModelDataSourceStrategy): strategy is SQ
  */
 export const getStrategyDbTypeFromModel = (ctx: DataSourceStrategiesProvider, typename: string): ModelDataSourceStrategyDbType => {
   if (isBuiltInGraphqlType(typename)) {
-    return 'DYNAMODB';
+    return DDB_DB_TYPE;
   }
   return getModelDataSourceStrategy(ctx, typename).dbType;
 };

--- a/packages/amplify-graphql-transformer-core/src/utils/model-datasource-strategy-utils.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/model-datasource-strategy-utils.ts
@@ -151,6 +151,19 @@ export const isSqlStrategy = (strategy: ModelDataSourceStrategy): strategy is SQ
 };
 
 /**
+ * Provides the data source strategy for a given model
+ * @param ctx Transformer Context
+ * @param typename Model name
+ * @returns ModelDataSourceStrategyDbType
+ */
+export const getStrategyDbTypeFromModel = (ctx: DataSourceStrategiesProvider, typename: string): ModelDataSourceStrategyDbType => {
+  if (isBuiltInGraphqlType(typename)) {
+    return 'DYNAMODB';
+  }
+  return getModelDataSourceStrategy(ctx, typename).dbType;
+;}
+
+/**
  * Normalize known variants of a database type to its canonical representation. E.g.:
  *
  * ```ts


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Refactor of `amplify-graphql-relational-transformer` splitting out datasource specific directive logic. The goal of refactor is to allow additional logical branches for data sources & directive parameter combinations (e.g. DynamoDB references) to be added in a maintainable way.

There are no functional changes included in this PR.

**Changes:**
- Adds `DataSourceBasedDirectiveTransformer` interface to represent the methods called in the existing relational transformers that operate on individual `<RelationType>DirectiveConfiguration` types. [[11efed6](https://github.com/aws-amplify/amplify-category-api/pull/2330/commits/11efed6a5f54c87153c773046ea0f043e635a34f)]
- Adds `DataSourceBasedDirectiveTransformer` implementing types for:
  - `belongsTo` [[2d4b7fe](https://github.com/aws-amplify/amplify-category-api/pull/2330/commits/2d4b7fe90365cdb1e9679a61852f81ebb86fd6cf)]
  - `hasMany`: [[b87f784](https://github.com/aws-amplify/amplify-category-api/pull/2330/commits/b87f78414f05d27982a7226aa5bb509229108bd6)]
  - `hasOne`: [[4ea48e6](https://github.com/aws-amplify/amplify-category-api/pull/2330/commits/4ea48e6f809ff993bab5c5300efd97f31843390e)]
as well as applicable factory methods, for the currently supported data sources: SQL w/ references and DynamoDB w/ fields. `manyToMany` is explicitly not included in this change because it's currently only supported for a single data source (DynamoDB w/ fields parameter).
- Moves all data source specific directive logic out of the relational transformer methods into the `DataSourceBasedDirectiveTransformer` implementing types.

Note: I'd like to move the existing relational directive transformer files into the directive based directories created in this PR. But let's do that in a follow up to keep the scope of this diff as focused as possible.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes

E2E Tests: https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow%3A683530a8-acba-4a46-9d8b-0b809c5ca988?region=us-east-1

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] ~Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)~
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
