### PR TITLE
feat: Fetch SNS topic ARN from SQL manifest

### DIFF
--- a/packages/amplify-category-api/API.md
+++ b/packages/amplify-category-api/API.md
@@ -15,15 +15,21 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import { ResolverConfig } from 'graphql-transformer-core';
 
 // @public (undocumented)
-export function addAdminQueriesApi(context: $TSContext, apiProps: {
+export function addAdminQueriesApi(
+context: $TSContext,
+apiProps: {
     apiName: string;
     functionName: string;
     authResourceName: string;
     dependsOn: Record<string, any>[];
-}): Promise<void>;
+},
+): Promise<void>;
 
 // @public (undocumented)
-export const addGraphQLAuthorizationMode: (context: $TSContext, args: Record<string, any>) => Promise<{
+export const addGraphQLAuthorizationMode: (
+context: $TSContext,
+args: Record<string, any>,
+) => Promise<{
     authenticationType: string;
 }>;
 
@@ -58,16 +64,20 @@ const console_2: (context: $TSContext) => Promise<void>;
 export { console_2 as console }
 
 // @public (undocumented)
-export function convertDeperecatedRestApiPaths(deprecatedParametersFileName: string, deprecatedParametersFilePath: string, resourceName: string): {};
+export function convertDeperecatedRestApiPaths(
+deprecatedParametersFileName: string,
+deprecatedParametersFilePath: string,
+resourceName: string,
+): {};
 
 // @public (undocumented)
 export enum DEPLOYMENT_MECHANISM {
     // (undocumented)
-    FULLY_MANAGED = "FULLY_MANAGED",
+    FULLY_MANAGED = 'FULLY_MANAGED',
     // (undocumented)
-    INDENPENDENTLY_MANAGED = "INDENPENDENTLY_MANAGED",
+    INDENPENDENTLY_MANAGED = 'INDENPENDENTLY_MANAGED',
     // (undocumented)
-    SELF_MANAGED = "SELF_MANAGED"
+    SELF_MANAGED = 'SELF_MANAGED',
 }
 
 // Warning: (ae-forgotten-export) The symbol "ContainersStack" needs to be exported by the entry point index.d.ts
@@ -93,10 +103,17 @@ export const executeAmplifyHeadlessCommand: (context: $TSContext, headlessPayloa
 // Warning: (ae-forgotten-export) The symbol "ContainerArtifactsMetadata" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function generateContainersArtifacts(context: $TSContext, resource: ApiResource, askForExposedContainer?: boolean): Promise<ContainerArtifactsMetadata>;
+export function generateContainersArtifacts(
+context: $TSContext,
+resource: ApiResource,
+askForExposedContainer?: boolean,
+): Promise<ContainerArtifactsMetadata>;
 
 // @public (undocumented)
-export const getAuthConfig: (context: $TSContext, resourceName: string) => Promise<{
+export const getAuthConfig: (
+context: $TSContext,
+resourceName: string,
+) => Promise<{
     defaultAuthentication: any;
     additionalAuthenticationProviders: any[];
 }>;
@@ -118,13 +135,19 @@ export function getGitHubOwnerRepoFromPath(path: string): {
 };
 
 // @public (undocumented)
-export const getPermissionPolicies: (context: $TSContext, resourceOpsMapping: Record<string, any>) => Promise<{
+export const getPermissionPolicies: (
+context: $TSContext,
+resourceOpsMapping: Record<string, any>,
+) => Promise<{
     permissionPolicies: any[];
     resourceAttributes: any[];
 }>;
 
 // @public (undocumented)
-export const getResolverConfig: (context: $TSContext, resourceName: string) => Promise<ResolverConfig>;
+export const getResolverConfig: (
+context: $TSContext,
+resourceName: string,
+) => Promise<ResolverConfig>;
 
 // @public (undocumented)
 export const getTransformerVersion: (context: any) => Promise<number>;
@@ -142,10 +165,15 @@ export const isDataStoreEnabled: (context: $TSContext) => Promise<boolean>;
 export const migrate: (context: $TSContext, serviceName?: string) => Promise<void>;
 
 // @public (undocumented)
-export const NETWORK_STACK_LOGICAL_ID = "NetworkStack";
+export const NETWORK_STACK_LOGICAL_ID = 'NetworkStack';
 
 // @public (undocumented)
-export function processDockerConfig(context: $TSContext, resource: ApiResource, srcPath: string, askForExposedContainer?: boolean): Promise<{
+export function processDockerConfig(
+context: $TSContext,
+resource: ApiResource,
+srcPath: string,
+askForExposedContainer?: boolean,
+): Promise<{
     containersPorts: number[];
     containers: Container[];
     isInitialDeploy: boolean;
@@ -169,21 +197,27 @@ export const transformCategoryStack: (context: $TSContext, resource: Record<stri
 // Warning: (ae-forgotten-export) The symbol "DeploymentResources" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const transformGraphQLSchema: (context: $TSContext, options: any) => Promise<DeploymentResources | DeploymentResources_2 | undefined>;
+export const transformGraphQLSchema: (
+context: $TSContext,
+options: any,
+) => Promise<DeploymentResources | DeploymentResources_2 | undefined>;
 
 // @public (undocumented)
-export function updateAdminQueriesApi(context: $TSContext, apiProps: {
+export function updateAdminQueriesApi(
+context: $TSContext,
+apiProps: {
     apiName: string;
     functionName: string;
     authResourceName: string;
     dependsOn: Record<string, any>[];
-}): Promise<void>;
+},
+): Promise<void>;
 
 // Warnings were encountered during analysis:
 //
-// src/provider-utils/awscloudformation/utils/containers-artifacts.ts:30:3 - (ae-forgotten-export) The symbol "ResourceDependency" needs to be exported by the entry point index.d.ts
-// src/provider-utils/awscloudformation/utils/containers-artifacts.ts:35:3 - (ae-forgotten-export) The symbol "API_TYPE" needs to be exported by the entry point index.d.ts
-// src/provider-utils/awscloudformation/utils/containers-artifacts.ts:124:42 - (ae-forgotten-export) The symbol "Container" needs to be exported by the entry point index.d.ts
+// src/provider-utils/awscloudformation/utils/containers-artifacts.ts:30:1 - (ae-forgotten-export) The symbol "ResourceDependency" needs to be exported by the entry point index.d.ts
+// src/provider-utils/awscloudformation/utils/containers-artifacts.ts:35:1 - (ae-forgotten-export) The symbol "API_TYPE" needs to be exported by the entry point index.d.ts
+// src/provider-utils/awscloudformation/utils/containers-artifacts.ts:317:1 - (ae-forgotten-export) The symbol "Container" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/amplify-category-api/API.md
+++ b/packages/amplify-category-api/API.md
@@ -15,21 +15,15 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import { ResolverConfig } from 'graphql-transformer-core';
 
 // @public (undocumented)
-export function addAdminQueriesApi(
-context: $TSContext,
-apiProps: {
+export function addAdminQueriesApi(context: $TSContext, apiProps: {
     apiName: string;
     functionName: string;
     authResourceName: string;
     dependsOn: Record<string, any>[];
-},
-): Promise<void>;
+}): Promise<void>;
 
 // @public (undocumented)
-export const addGraphQLAuthorizationMode: (
-context: $TSContext,
-args: Record<string, any>,
-) => Promise<{
+export const addGraphQLAuthorizationMode: (context: $TSContext, args: Record<string, any>) => Promise<{
     authenticationType: string;
 }>;
 
@@ -64,20 +58,16 @@ const console_2: (context: $TSContext) => Promise<void>;
 export { console_2 as console }
 
 // @public (undocumented)
-export function convertDeperecatedRestApiPaths(
-deprecatedParametersFileName: string,
-deprecatedParametersFilePath: string,
-resourceName: string,
-): {};
+export function convertDeperecatedRestApiPaths(deprecatedParametersFileName: string, deprecatedParametersFilePath: string, resourceName: string): {};
 
 // @public (undocumented)
 export enum DEPLOYMENT_MECHANISM {
     // (undocumented)
-    FULLY_MANAGED = 'FULLY_MANAGED',
+    FULLY_MANAGED = "FULLY_MANAGED",
     // (undocumented)
-    INDENPENDENTLY_MANAGED = 'INDENPENDENTLY_MANAGED',
+    INDENPENDENTLY_MANAGED = "INDENPENDENTLY_MANAGED",
     // (undocumented)
-    SELF_MANAGED = 'SELF_MANAGED',
+    SELF_MANAGED = "SELF_MANAGED"
 }
 
 // Warning: (ae-forgotten-export) The symbol "ContainersStack" needs to be exported by the entry point index.d.ts
@@ -103,17 +93,10 @@ export const executeAmplifyHeadlessCommand: (context: $TSContext, headlessPayloa
 // Warning: (ae-forgotten-export) The symbol "ContainerArtifactsMetadata" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function generateContainersArtifacts(
-context: $TSContext,
-resource: ApiResource,
-askForExposedContainer?: boolean,
-): Promise<ContainerArtifactsMetadata>;
+export function generateContainersArtifacts(context: $TSContext, resource: ApiResource, askForExposedContainer?: boolean): Promise<ContainerArtifactsMetadata>;
 
 // @public (undocumented)
-export const getAuthConfig: (
-context: $TSContext,
-resourceName: string,
-) => Promise<{
+export const getAuthConfig: (context: $TSContext, resourceName: string) => Promise<{
     defaultAuthentication: any;
     additionalAuthenticationProviders: any[];
 }>;
@@ -135,19 +118,13 @@ export function getGitHubOwnerRepoFromPath(path: string): {
 };
 
 // @public (undocumented)
-export const getPermissionPolicies: (
-context: $TSContext,
-resourceOpsMapping: Record<string, any>,
-) => Promise<{
+export const getPermissionPolicies: (context: $TSContext, resourceOpsMapping: Record<string, any>) => Promise<{
     permissionPolicies: any[];
     resourceAttributes: any[];
 }>;
 
 // @public (undocumented)
-export const getResolverConfig: (
-context: $TSContext,
-resourceName: string,
-) => Promise<ResolverConfig>;
+export const getResolverConfig: (context: $TSContext, resourceName: string) => Promise<ResolverConfig>;
 
 // @public (undocumented)
 export const getTransformerVersion: (context: any) => Promise<number>;
@@ -165,15 +142,10 @@ export const isDataStoreEnabled: (context: $TSContext) => Promise<boolean>;
 export const migrate: (context: $TSContext, serviceName?: string) => Promise<void>;
 
 // @public (undocumented)
-export const NETWORK_STACK_LOGICAL_ID = 'NetworkStack';
+export const NETWORK_STACK_LOGICAL_ID = "NetworkStack";
 
 // @public (undocumented)
-export function processDockerConfig(
-context: $TSContext,
-resource: ApiResource,
-srcPath: string,
-askForExposedContainer?: boolean,
-): Promise<{
+export function processDockerConfig(context: $TSContext, resource: ApiResource, srcPath: string, askForExposedContainer?: boolean): Promise<{
     containersPorts: number[];
     containers: Container[];
     isInitialDeploy: boolean;
@@ -197,27 +169,21 @@ export const transformCategoryStack: (context: $TSContext, resource: Record<stri
 // Warning: (ae-forgotten-export) The symbol "DeploymentResources" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const transformGraphQLSchema: (
-context: $TSContext,
-options: any,
-) => Promise<DeploymentResources | DeploymentResources_2 | undefined>;
+export const transformGraphQLSchema: (context: $TSContext, options: any) => Promise<DeploymentResources | DeploymentResources_2 | undefined>;
 
 // @public (undocumented)
-export function updateAdminQueriesApi(
-context: $TSContext,
-apiProps: {
+export function updateAdminQueriesApi(context: $TSContext, apiProps: {
     apiName: string;
     functionName: string;
     authResourceName: string;
     dependsOn: Record<string, any>[];
-},
-): Promise<void>;
+}): Promise<void>;
 
 // Warnings were encountered during analysis:
 //
-// src/provider-utils/awscloudformation/utils/containers-artifacts.ts:30:1 - (ae-forgotten-export) The symbol "ResourceDependency" needs to be exported by the entry point index.d.ts
-// src/provider-utils/awscloudformation/utils/containers-artifacts.ts:35:1 - (ae-forgotten-export) The symbol "API_TYPE" needs to be exported by the entry point index.d.ts
-// src/provider-utils/awscloudformation/utils/containers-artifacts.ts:317:1 - (ae-forgotten-export) The symbol "Container" needs to be exported by the entry point index.d.ts
+// src/provider-utils/awscloudformation/utils/containers-artifacts.ts:30:3 - (ae-forgotten-export) The symbol "ResourceDependency" needs to be exported by the entry point index.d.ts
+// src/provider-utils/awscloudformation/utils/containers-artifacts.ts:35:3 - (ae-forgotten-export) The symbol "API_TYPE" needs to be exported by the entry point index.d.ts
+// src/provider-utils/awscloudformation/utils/containers-artifacts.ts:124:42 - (ae-forgotten-export) The symbol "Container" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -401,7 +401,7 @@ export const getUserOverridenSlots = (userDefinedSlots: Record<string, UserDefin
     .filter((slotName) => slotName !== undefined);
 
 const getRDSLayerMapping = async (context: $TSContext, useBetaSqlLayer = false): Promise<RDSLayerMapping> => {
-  const bucket = `${ResourceConstants.RESOURCES.SQLLayerVersionManifestBucket}${useBetaSqlLayer ? '-beta' : ''}`;
+  const bucket = `${ResourceConstants.RESOURCES.SQLLayerManifestBucket}${useBetaSqlLayer ? '-beta' : ''}`;
   const region = context.amplify.getProjectMeta().providers.awscloudformation.Region;
   const url = `https://${bucket}.s3.amazonaws.com/${ResourceConstants.RESOURCES.SQLLayerVersionManifestKeyPrefix}${region}`;
   const response = await fetch(url);

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-model-v2.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-model-v2.ts
@@ -18,7 +18,6 @@ import { existsSync, readFileSync } from 'fs-extra';
 import generator from 'generate-password';
 import { ObjectTypeDefinitionNode, parse } from 'graphql';
 import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
-import { ResourceConstants } from 'graphql-transformer-common';
 import gql from 'graphql-tag';
 import {
   ImportedRDSType,
@@ -37,7 +36,6 @@ export const testRDSModel = (engine: ImportedRDSType, queries: string[]): void =
   const CDK_VPC_ENDPOINT_TYPE = 'AWS::EC2::VPCEndpoint';
   const CDK_SUBSCRIPTION_TYPE = 'AWS::SNS::Subscription';
   const APPSYNC_DATA_SOURCE_TYPE = 'AWS::AppSync::DataSource';
-  const { AmplifySQLLayerNotificationTopicAccount, AmplifySQLLayerNotificationTopicName } = ResourceConstants.RESOURCES;
 
   describe(`RDS Model Directive - ${engine}`, () => {
     const [db_user, db_password, db_identifier] = generator.generateMultiple(3);
@@ -138,13 +136,6 @@ export const testRDSModel = (engine: ImportedRDSType, queries: string[]): void =
       );
 
       // Validate subscription
-      const expectedTopicArn = {
-        'Fn::Join': [
-          ':',
-          ['arn:aws:sns', { Ref: 'AWS::Region' }, `${AmplifySQLLayerNotificationTopicAccount}:${AmplifySQLLayerNotificationTopicName}`],
-        ],
-      };
-
       // Counterintuitively, the subscription actually gets created with the resource prefix of the FUNCTION that gets triggered,
       // rather than the scope created specifically for the subscription
       const rdsPatchingSubscription = getResource(resources, resourceNames.sqlPatchingLambdaFunction, CDK_SUBSCRIPTION_TYPE);
@@ -154,7 +145,6 @@ export const testRDSModel = (engine: ImportedRDSType, queries: string[]): void =
       expect(rdsPatchingSubscription.Properties.Protocol).toEqual('lambda');
       expect(rdsPatchingSubscription.Properties.Endpoint).toBeDefined();
       expect(rdsPatchingSubscription.Properties.TopicArn).toBeDefined();
-      expect(rdsPatchingSubscription.Properties.TopicArn).toMatchObject(expectedTopicArn);
       expect(rdsPatchingSubscription.Properties.Region).toBeDefined();
       expect(rdsPatchingSubscription.Properties.FilterPolicy).toBeDefined();
       expect(rdsPatchingSubscription.Properties.FilterPolicy.Region).toBeDefined();

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-model-v2.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-model-v2.ts
@@ -145,6 +145,10 @@ export const testRDSModel = (engine: ImportedRDSType, queries: string[]): void =
       expect(rdsPatchingSubscription.Properties.Protocol).toEqual('lambda');
       expect(rdsPatchingSubscription.Properties.Endpoint).toBeDefined();
       expect(rdsPatchingSubscription.Properties.TopicArn).toBeDefined();
+      const topicArnMappingRef = rdsPatchingSubscription.Properties.TopicArn['Fn::FindInMap'];
+      expect(topicArnMappingRef?.length).toEqual(3);
+      expect(topicArnMappingRef[1]).toEqual({ Ref: 'AWS::Region' });
+      expect(topicArnMappingRef[2]).toEqual('topicArn');
       expect(rdsPatchingSubscription.Properties.Region).toBeDefined();
       expect(rdsPatchingSubscription.Properties.FilterPolicy).toBeDefined();
       expect(rdsPatchingSubscription.Properties.FilterPolicy.Region).toBeDefined();

--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -3998,7 +3998,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 285
+            "line": 286
           },
           "name": "addDynamoDbDataSource",
           "parameters": [
@@ -4047,7 +4047,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 297
+            "line": 298
           },
           "name": "addElasticsearchDataSource",
           "parameters": [
@@ -4094,7 +4094,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 307
+            "line": 308
           },
           "name": "addEventBridgeDataSource",
           "parameters": [
@@ -4141,7 +4141,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 389
+            "line": 390
           },
           "name": "addFunction",
           "parameters": [
@@ -4176,7 +4176,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 318
+            "line": 319
           },
           "name": "addHttpDataSource",
           "parameters": [
@@ -4224,7 +4224,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 329
+            "line": 330
           },
           "name": "addLambdaDataSource",
           "parameters": [
@@ -4272,7 +4272,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 340
+            "line": 341
           },
           "name": "addNoneDataSource",
           "parameters": [
@@ -4311,7 +4311,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 351
+            "line": 352
           },
           "name": "addOpenSearchDataSource",
           "parameters": [
@@ -4359,7 +4359,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 364
+            "line": 365
           },
           "name": "addRdsDataSource",
           "parameters": [
@@ -4426,7 +4426,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 380
+            "line": 381
           },
           "name": "addResolver",
           "parameters": [

--- a/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
+++ b/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
@@ -218,6 +218,7 @@ export class AmplifyGraphqlApi extends Construct {
       // CDK construct uses a custom resource. We'll define this explicitly here to remind ourselves that this value is unused in the CDK
       // construct flow
       rdsLayerMapping: undefined,
+      rdsSnsTopicMapping: undefined,
       ...getDataSourceStrategiesProvider(definition),
     };
 

--- a/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
@@ -29,6 +29,7 @@ import {
   isSqlModelDataSourceSsmDbConnectionConfig,
   isSqlModelDataSourceSecretsManagerDbConnectionConfig,
   isSqlModelDataSourceSsmDbConnectionStringConfig,
+  RDSSNSTopicMapping,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import { Effect, IRole, Policy, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { IFunction, LayerVersion, Runtime, Alias, Function as LambdaFunction } from 'aws-cdk-lib/aws-lambda';
@@ -62,6 +63,18 @@ const OPERATION_KEY = '__operation';
  */
 export const setRDSLayerMappings = (scope: Construct, mapping: RDSLayerMapping, resourceNames: SQLLambdaResourceNames): CfnMapping =>
   new CfnMapping(scope, resourceNames.sqlLayerVersionMapping, {
+    mapping,
+  });
+
+/**
+ * Define RDS Patching SNS Topic ARN region mappings. The optional `mapping` can be specified in place of the defaults that are hardcoded at the time
+ * this package is published. For the CLI flow, the `mapping` will be downloaded at runtime during the `amplify push` flow. For the CDK,
+ * the layer version will be resolved by a custom CDK resource.
+ * @param scope Construct
+ * @param mapping an RDSSNSTopicMapping to use in place of the defaults
+ */
+export const setRDSSNSTopicMappings = (scope: Construct, mapping: RDSSNSTopicMapping, resourceNames: SQLLambdaResourceNames): CfnMapping =>
+  new CfnMapping(scope, resourceNames.sqlSNSTopicArnMapping, {
     mapping,
   });
 

--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -59,6 +59,8 @@ import { OperationTypeDefinitionNode } from 'graphql';
 import { QueryFieldType } from '@aws-amplify/graphql-transformer-interfaces';
 import { RDSLayerMapping } from '@aws-amplify/graphql-transformer-interfaces';
 import { RDSLayerMappingProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { RDSSNSTopicMapping } from '@aws-amplify/graphql-transformer-interfaces';
+import { RDSSNSTopicMappingProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { S3MappingTemplateProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { SchemaDefinitionNode } from 'graphql';
 import { SqlDirectiveDataSourceStrategy } from '@aws-amplify/graphql-transformer-interfaces';
@@ -279,7 +281,7 @@ export class GraphQLTransform {
     // Warning: (ae-forgotten-export) The symbol "TransformOption" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    transform({ assetProvider, dataSourceStrategies, nestedStackProvider, parameterProvider, rdsLayerMapping, schema, scope, sqlDirectiveDataSourceStrategies, synthParameters, }: TransformOption): void;
+    transform({ assetProvider, dataSourceStrategies, nestedStackProvider, parameterProvider, rdsLayerMapping, rdsSnsTopicMapping, schema, scope, sqlDirectiveDataSourceStrategies, synthParameters, }: TransformOption): void;
 }
 
 // @public (undocumented)
@@ -551,6 +553,10 @@ export interface SQLLambdaResourceNames {
     sqlPatchingSubscription: string;
     // (undocumented)
     sqlPatchingTopic: string;
+    // (undocumented)
+    sqlSNSTopicArnMapping: string;
+    // (undocumented)
+    sqlSNSTopicARNResolverCustomResource: string;
     // (undocumented)
     sqlStack: string;
     // (undocumented)

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -14,6 +14,7 @@ import type {
   TransformParameters,
   DataSourceStrategiesProvider,
   RDSLayerMappingProvider,
+  RDSSNSTopicMappingProvider,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import { AuthorizationMode, AuthorizationType } from 'aws-cdk-lib/aws-appsync';
 import { Aws, CfnOutput, Fn, Stack } from 'aws-cdk-lib';
@@ -87,7 +88,7 @@ export interface GraphQLTransformOptions {
   readonly resolverConfig?: ResolverConfig;
 }
 
-export interface TransformOption extends DataSourceStrategiesProvider, RDSLayerMappingProvider {
+export interface TransformOption extends DataSourceStrategiesProvider, RDSLayerMappingProvider, RDSSNSTopicMappingProvider {
   scope: Construct;
   nestedStackProvider: NestedStackProvider;
   parameterProvider?: TransformParameterProvider;
@@ -189,6 +190,7 @@ export class GraphQLTransform {
     nestedStackProvider,
     parameterProvider,
     rdsLayerMapping,
+    rdsSnsTopicMapping,
     schema,
     scope,
     sqlDirectiveDataSourceStrategies,
@@ -204,6 +206,7 @@ export class GraphQLTransform {
       nestedStackProvider,
       parameterProvider,
       rdsLayerMapping,
+      rdsSnsTopicMapping,
       resolverConfig: this.resolverConfig,
       scope,
       sqlDirectiveDataSourceStrategies: sqlDirectiveDataSourceStrategies ?? [],

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
@@ -9,6 +9,7 @@ import {
   NestedStackProvider,
   RDSLayerMapping,
   RDSLayerMappingProvider,
+  RDSSNSTopicMappingProvider,
   StackManagerProvider,
   SynthParameters,
   TransformerContextMetadataProvider,
@@ -17,6 +18,7 @@ import {
   TransformerDataSourceManagerProvider,
   TransformParameterProvider,
   TransformParameters,
+  RDSSNSTopicMapping,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import { DocumentNode } from 'graphql';
 import { Construct } from 'constructs';
@@ -50,7 +52,10 @@ export class TransformerContextMetadata implements TransformerContextMetadataPro
   }
 }
 
-export interface TransformerContextConstructorOptions extends DataSourceStrategiesProvider, RDSLayerMappingProvider {
+export interface TransformerContextConstructorOptions
+  extends DataSourceStrategiesProvider,
+    RDSLayerMappingProvider,
+    RDSSNSTopicMappingProvider {
   assetProvider: AssetProvider;
   authConfig: AppSyncAuthConfiguration;
   inputDocument: DocumentNode;
@@ -90,6 +95,8 @@ export class TransformerContext implements TransformerContextProvider {
 
   public readonly rdsLayerMapping?: RDSLayerMapping;
 
+  public readonly rdsSnsTopicMapping?: RDSSNSTopicMapping;
+
   public metadata: TransformerContextMetadata;
 
   public readonly synthParameters: SynthParameters;
@@ -106,6 +113,7 @@ export class TransformerContext implements TransformerContextProvider {
       nestedStackProvider,
       parameterProvider,
       rdsLayerMapping,
+      rdsSnsTopicMapping,
       resolverConfig,
       scope,
       stackMapping,
@@ -122,6 +130,7 @@ export class TransformerContext implements TransformerContextProvider {
     this.output = new TransformerOutput(inputDocument);
     this.providerRegistry = new TransformerContextProviderRegistry();
     this.rdsLayerMapping = rdsLayerMapping;
+    this.rdsSnsTopicMapping = rdsSnsTopicMapping;
     this.resolverConfig = resolverConfig;
     this.resolvers = new ResolverManager();
     this.resourceHelper = new TransformerResourceHelper(synthParameters);

--- a/packages/amplify-graphql-transformer-core/src/utils/resource-name.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/resource-name.ts
@@ -86,6 +86,12 @@ export interface SQLLambdaResourceNames {
    */
   sqlLayerVersionMapping: string;
 
+  /**
+   * A mapping that stores Patching SNS Topic ARNs by region. The Gen1 resource generator updates this map at deployment time by retrieving the
+   * latest manifests from an S3 bucket.
+   */
+  sqlSNSTopicArnMapping: string;
+
   /** In the CDK construct flow, Lambda Layer versions are resolved by a custom resource with this name. */
   sqlLayerVersionResolverCustomResource: string;
 
@@ -148,6 +154,7 @@ export const getResourceNamesForStrategyName = (strategyName: string): SQLLambda
     sqlLambdaExecutionRolePolicy: `SQLLambdaRolePolicy${strategyName}`,
     sqlLambdaFunction,
     sqlLayerVersionMapping: `SQLLayerVersionMapping${strategyName}`,
+    sqlSNSTopicArnMapping: `SQLSNSTopicArnMapping${strategyName}`,
     sqlLayerVersionResolverCustomResource: `SQLLayerVersionCustomResource${strategyName}`,
     sqlPatchingLambdaExecutionRole: `SQLPatchingLambdaRole${strategyName}`,
     sqlPatchingLambdaExecutionRolePolicy: `SQLPatchingLambdaRolePolicy${strategyName}`,

--- a/packages/amplify-graphql-transformer-core/src/utils/resource-name.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/resource-name.ts
@@ -110,6 +110,9 @@ export interface SQLLambdaResourceNames {
   /** The CDK logical ID of the topic imported from the Amplify Notification Topic ARN */
   sqlPatchingTopic: string;
 
+  /** SQL patching lambda's SNS Topic ARN is resolved by a custom resource with this name. */
+  sqlSNSTopicARNResolverCustomResource: string;
+
   /** The name of the stack holding the SQL Lambda and associated resources */
   sqlStack: string;
 
@@ -151,6 +154,7 @@ export const getResourceNamesForStrategyName = (strategyName: string): SQLLambda
     sqlPatchingLambdaFunction: `SQLLambdaLayerPatchingFunction${strategyName}`,
     sqlPatchingSubscription: `SQLLambdaLayerPatchingSubscription${strategyName}`,
     sqlPatchingTopic: `SQLLambdaLayerPatchingTopic${strategyName}`,
+    sqlSNSTopicARNResolverCustomResource: `SQLLambdaLayerPatchingTopicARNResolver${strategyName}`,
     sqlStack: `SQLApiStack${strategyName}`,
     sqlVpcEndpointPrefix: `SQLVpcEndpoint${strategyName}`,
   };

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -314,6 +314,20 @@ export interface RDSLayerMappingProvider {
 }
 
 // @public (undocumented)
+export interface RDSSNSTopicMapping {
+    // (undocumented)
+    readonly [key: string]: {
+        topicArn: string;
+    };
+}
+
+// @public (undocumented)
+export interface RDSSNSTopicMappingProvider {
+    // (undocumented)
+    rdsSnsTopicMapping?: RDSSNSTopicMapping;
+}
+
+// @public (undocumented)
 type ReadonlyArray_2<T> = Readonly<Array<Readonly<T>>>;
 export { ReadonlyArray_2 as ReadonlyArray }
 
@@ -546,7 +560,7 @@ export interface TransformerContextOutputProvider {
 }
 
 // @public (undocumented)
-export interface TransformerContextProvider extends DataSourceStrategiesProvider, RDSLayerMappingProvider {
+export interface TransformerContextProvider extends DataSourceStrategiesProvider, RDSLayerMappingProvider, RDSSNSTopicMappingProvider {
     // (undocumented)
     api: GraphQLAPIProvider;
     // (undocumented)

--- a/packages/amplify-graphql-transformer-interfaces/src/model-datasource/types.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/model-datasource/types.ts
@@ -230,11 +230,30 @@ export interface RDSLayerMapping {
 }
 
 /**
+ * Maps a given AWS region to the SQL SNS topic ARN for that region. TODO: Once we remove SQL imports from Gen1 CLI, remove this
+ * from the transformer interfaces package in favor of the model generator, which is the only place that needs it now that we always resolve
+ * the layer mapping at deploy time.
+ */
+export interface RDSSNSTopicMapping {
+  readonly [key: string]: {
+    topicArn: string;
+  };
+}
+
+/**
  * Defines types that vend an rdsLayerMapping field. This is used solely for the Gen1 CLI import API flow, since wiring the custom resource
  * provider used by the CDK isn't worth the cost. TODO: Remove this once we remove SQL imports from Gen1 CLI.
  */
 export interface RDSLayerMappingProvider {
   rdsLayerMapping?: RDSLayerMapping;
+}
+
+/**
+ * Defines types that vend an rdsSnsTopicMapping field. This is used solely for the Gen1 CLI import API flow, since wiring the custom resource
+ * provider used by the CDK isn't worth the cost. TODO: Remove this once we remove SQL imports from Gen1 CLI.
+ */
+export interface RDSSNSTopicMappingProvider {
+  rdsSnsTopicMapping?: RDSSNSTopicMapping;
 }
 
 /**

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
@@ -1,6 +1,6 @@
 import { DocumentNode } from 'graphql';
 import { AppSyncAuthConfiguration, GraphQLAPIProvider } from '../graphql-api-provider';
-import { DataSourceStrategiesProvider, RDSLayerMappingProvider } from '../model-datasource';
+import { DataSourceStrategiesProvider, RDSLayerMappingProvider, RDSSNSTopicMappingProvider } from '../model-datasource';
 import { TransformerDataSourceManagerProvider } from './transformer-datasource-provider';
 import { TransformerProviderRegistry } from './transformer-provider-registry';
 import { TransformerContextOutputProvider } from './transformer-context-output-provider';
@@ -18,7 +18,7 @@ export interface TransformerContextMetadataProvider {
 
 export type TransformerSecrets = { [key: string]: any };
 
-export interface TransformerContextProvider extends DataSourceStrategiesProvider, RDSLayerMappingProvider {
+export interface TransformerContextProvider extends DataSourceStrategiesProvider, RDSLayerMappingProvider, RDSSNSTopicMappingProvider {
   metadata: TransformerContextMetadataProvider;
   resolvers: TransformerResolversManagerProvider;
   dataSources: TransformerDataSourceManagerProvider;

--- a/packages/amplify-graphql-transformer-test-utils/API.md
+++ b/packages/amplify-graphql-transformer-test-utils/API.md
@@ -27,6 +27,7 @@ import { ModelDataSourceStrategySqlDbType } from '@aws-amplify/graphql-transform
 import type { NestedStackProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { ProvisionedConcurrencyConfig } from '@aws-amplify/graphql-transformer-interfaces';
 import type { RDSLayerMappingProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import type { RDSSNSTopicMappingProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { ResolverConfig } from '@aws-amplify/graphql-transformer-core';
 import type { SqlDirectiveDataSourceStrategy } from '@aws-amplify/graphql-transformer-interfaces';
 import { SQLLambdaModelDataSourceStrategy } from '@aws-amplify/graphql-transformer-interfaces';
@@ -206,7 +207,7 @@ export const testTransform: (params: TestTransformParameters) => DeploymentResou
 };
 
 // @public (undocumented)
-export type TestTransformParameters = RDSLayerMappingProvider & {
+export type TestTransformParameters = RDSLayerMappingProvider & RDSSNSTopicMappingProvider & {
     authConfig?: AppSyncAuthConfiguration;
     dataSourceStrategies?: Record<string, ModelDataSourceStrategy>;
     overrideConfig?: OverrideConfig;
@@ -241,7 +242,7 @@ export class TransformManager {
 
 // Warnings were encountered during analysis:
 //
-// src/test-transform.ts:23:3 - (ae-forgotten-export) The symbol "OverrideConfig" needs to be exported by the entry point index.d.ts
+// src/test-transform.ts:24:3 - (ae-forgotten-export) The symbol "OverrideConfig" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/amplify-graphql-transformer-test-utils/API.md
+++ b/packages/amplify-graphql-transformer-test-utils/API.md
@@ -242,7 +242,7 @@ export class TransformManager {
 
 // Warnings were encountered during analysis:
 //
-// src/test-transform.ts:24:3 - (ae-forgotten-export) The symbol "OverrideConfig" needs to be exported by the entry point index.d.ts
+// src/test-transform.ts:25:5 - (ae-forgotten-export) The symbol "OverrideConfig" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/amplify-graphql-transformer-test-utils/src/test-transform.ts
+++ b/packages/amplify-graphql-transformer-test-utils/src/test-transform.ts
@@ -2,6 +2,7 @@ import { AppSyncAuthConfiguration, TransformerPluginProvider, TransformerLogLeve
 import type {
   ModelDataSourceStrategy,
   RDSLayerMappingProvider,
+  RDSSNSTopicMappingProvider,
   SqlDirectiveDataSourceStrategy,
   SynthParameters,
   TransformParameters,
@@ -16,20 +17,21 @@ import {
 import { OverrideConfig, TransformManager } from './cdk-compat/transform-manager';
 import { DeploymentResources } from './deployment-resources';
 
-export type TestTransformParameters = RDSLayerMappingProvider & {
-  authConfig?: AppSyncAuthConfiguration;
-  // Making this optional so test code can simply use a default DDB strategy for each model in the schema.
-  dataSourceStrategies?: Record<string, ModelDataSourceStrategy>;
-  overrideConfig?: OverrideConfig;
-  resolverConfig?: ResolverConfig;
-  schema: string;
-  sqlDirectiveDataSourceStrategies?: SqlDirectiveDataSourceStrategy[];
-  stackMapping?: Record<string, string>;
-  synthParameters?: Partial<SynthParameters>;
-  transformers: TransformerPluginProvider[];
-  transformParameters?: Partial<TransformParameters>;
-  userDefinedSlots?: Record<string, UserDefinedSlot[]>;
-};
+export type TestTransformParameters = RDSLayerMappingProvider &
+  RDSSNSTopicMappingProvider & {
+    authConfig?: AppSyncAuthConfiguration;
+    // Making this optional so test code can simply use a default DDB strategy for each model in the schema.
+    dataSourceStrategies?: Record<string, ModelDataSourceStrategy>;
+    overrideConfig?: OverrideConfig;
+    resolverConfig?: ResolverConfig;
+    schema: string;
+    sqlDirectiveDataSourceStrategies?: SqlDirectiveDataSourceStrategy[];
+    stackMapping?: Record<string, string>;
+    synthParameters?: Partial<SynthParameters>;
+    transformers: TransformerPluginProvider[];
+    transformParameters?: Partial<TransformParameters>;
+    userDefinedSlots?: Record<string, UserDefinedSlot[]>;
+  };
 
 /**
  * This mirrors the old behavior of the graphql transformer, where we fully synthesize internally, for the purposes of
@@ -41,6 +43,7 @@ export const testTransform = (params: TestTransformParameters): DeploymentResour
     dataSourceStrategies,
     overrideConfig,
     rdsLayerMapping,
+    rdsSnsTopicMapping,
     resolverConfig,
     schema,
     sqlDirectiveDataSourceStrategies,
@@ -79,6 +82,7 @@ export const testTransform = (params: TestTransformParameters): DeploymentResour
     },
     schema,
     rdsLayerMapping,
+    rdsSnsTopicMapping,
     dataSourceStrategies: dataSourceStrategies ?? constructDataSourceStrategies(schema, DDB_DEFAULT_DATASOURCE_STRATEGY),
     sqlDirectiveDataSourceStrategies,
   });

--- a/packages/amplify-graphql-transformer/API.md
+++ b/packages/amplify-graphql-transformer/API.md
@@ -12,6 +12,7 @@ import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import { IFunction } from 'aws-cdk-lib/aws-lambda';
 import { NestedStackProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import type { RDSLayerMappingProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import type { RDSSNSTopicMappingProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { ResolverConfig } from '@aws-amplify/graphql-transformer-core';
 import { SynthParameters } from '@aws-amplify/graphql-transformer-interfaces';
 import { TransformerLog } from '@aws-amplify/graphql-transformer-interfaces';
@@ -30,7 +31,7 @@ export const constructTransformerChain: (options?: TransformerFactoryArgs) => Tr
 export const executeTransform: (config: ExecuteTransformConfig) => void;
 
 // @public (undocumented)
-export type ExecuteTransformConfig = TransformConfig & DataSourceStrategiesProvider & RDSLayerMappingProvider & {
+export type ExecuteTransformConfig = TransformConfig & DataSourceStrategiesProvider & RDSLayerMappingProvider & RDSSNSTopicMappingProvider & {
     schema: string;
     printTransformerLog?: (log: TransformerLog) => void;
     scope: Construct;

--- a/packages/amplify-graphql-transformer/src/graphql-transformer.ts
+++ b/packages/amplify-graphql-transformer/src/graphql-transformer.ts
@@ -27,6 +27,7 @@ import {
 import type {
   DataSourceStrategiesProvider,
   RDSLayerMappingProvider,
+  RDSSNSTopicMappingProvider,
   TransformParameters,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import { GraphQLTransform, ResolverConfig, UserDefinedSlot } from '@aws-amplify/graphql-transformer-core';
@@ -105,7 +106,8 @@ export const constructTransform = (config: TransformConfig): GraphQLTransform =>
 
 export type ExecuteTransformConfig = TransformConfig &
   DataSourceStrategiesProvider &
-  RDSLayerMappingProvider & {
+  RDSLayerMappingProvider &
+  RDSSNSTopicMappingProvider & {
     schema: string;
     printTransformerLog?: (log: TransformerLog) => void;
     scope: Construct;
@@ -151,6 +153,7 @@ export const executeTransform = (config: ExecuteTransformConfig): void => {
     parameterProvider,
     printTransformerLog,
     rdsLayerMapping,
+    rdsSnsTopicMapping,
     schema,
     scope,
     sqlDirectiveDataSourceStrategies,
@@ -166,6 +169,7 @@ export const executeTransform = (config: ExecuteTransformConfig): void => {
       nestedStackProvider,
       parameterProvider,
       rdsLayerMapping,
+      rdsSnsTopicMapping,
       schema,
       scope,
       sqlDirectiveDataSourceStrategies,

--- a/packages/graphql-transformer-common/API.md
+++ b/packages/graphql-transformer-common/API.md
@@ -407,11 +407,10 @@ export class ResourceConstants {
         OpenSearchStreamingLambdaIAMRoleLogicalID: string;
         OpenSearchStreamingLambdaFunctionLogicalID: string;
         OpenSearchDataSourceLogicalID: string;
-        AmplifySQLLayerNotificationTopicName: string;
-        AmplifySQLLayerNotificationTopicAccount: string;
-        SQLLayerVersionManifestBucket: string;
-        SQLLayerVersionManifestBucketRegion: string;
+        SQLLayerManifestBucket: string;
+        SQLLayerManifestBucketRegion: string;
         SQLLayerVersionManifestKeyPrefix: string;
+        SQLSNSTopicARNManifestKeyPrefix: string;
         NoneDataSource: string;
         AuthCognitoUserPoolLogicalID: string;
         AuthCognitoUserPoolNativeClientLogicalID: string;

--- a/packages/graphql-transformer-common/src/ResourceConstants.ts
+++ b/packages/graphql-transformer-common/src/ResourceConstants.ts
@@ -30,22 +30,6 @@ export class ResourceConstants {
     OpenSearchDataSourceLogicalID: 'OpenSearchDataSource',
 
     // SQL Lambda global resources
-
-    /**
-     * The topic name to which Amplify publishes new layer notification messages. Amplify subscribes customers to this topic, which triggers
-     * the patching Lambda to update lambda versions when the new layer is published.
-     *
-     * DO NOT CHANGE THIS VALUE. It is a well-known value shared amongst multiple components of the patching infrastructure.
-     */
-    AmplifySQLLayerNotificationTopicName: 'AmplifySQLLayerNotification',
-
-    /**
-     * The Amplify AWS account that owns the Amplify Notification Topic
-     *
-     * DO NOT CHANGE THIS VALUE. It is a well-known value shared amongst multiple components of the patching infrastructure.
-     */
-    AmplifySQLLayerNotificationTopicAccount: '582037449441',
-
     // Lambda Layer version resolution. LayerVersion ARNs are stored at `{bucket}/{prefix}{region}`, as in:
     // `amplify-rds-layer-resources/sql-layer-versions/us-west-2`
 
@@ -54,21 +38,28 @@ export class ResourceConstants {
      *
      * DO NOT CHANGE THIS VALUE. It is a well-known value shared amongst multiple components of the patching infrastructure.
      */
-    SQLLayerVersionManifestBucket: 'amplify-rds-layer-resources',
+    SQLLayerManifestBucket: 'amplify-rds-layer-resources',
 
     /**
      * The region in which the version manifest bucket was created.
      *
      * DO NOT CHANGE THIS VALUE. It is a well-known value shared amongst multiple components of the patching infrastructure.
      */
-    SQLLayerVersionManifestBucketRegion: 'us-east-1',
+    SQLLayerManifestBucketRegion: 'us-east-1',
 
     /**
-     * The prefix of the manifest file
+     * The prefix of the manifest file that stores the SQL layer ARNs.
      *
      * DO NOT CHANGE THIS VALUE. It is a well-known value shared amongst multiple components of the patching infrastructure.
      */
     SQLLayerVersionManifestKeyPrefix: 'sql-layer-versions/',
+
+    /**
+     * The prefix of the manifest file that stores the SNS topic ARNs that the patching lambda subscribes to.
+     *
+     * DO NOT CHANGE THIS VALUE. It is a well-known value shared amongst multiple components of the patching infrastructure.
+     */
+    SQLSNSTopicARNManifestKeyPrefix: 'sql-sns-topic-versions/',
 
     // Local. Try not to collide with model data sources.
     NoneDataSource: 'NoneDataSource',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change removes the hard-coded account number of the SQL Lambda Pipeline that is used to construct the SNS Topic ARN, subscribed to by the SQL lambda patcher.

The alternative approach that is implemented here is to fetch the service vended SNS Topic ARN per region from the SQL manifest bucket using a custom resource that is deployed to the customer's account for Gen2 deployments. 
For Gen1 deployments, we read it from the manifest bucket directly during the build step since Async operations are allowed. The necessary backend changes are already deployed. This approach is no different from the one we use fetch the SQL Lambda layer mapping from the manifest bucket and was already discussed with the team.

**Related API changes:** The API changes supporting this will be very similar to the `LayerMapping` wordings since we took the same approach as fetching the Layer ARN we already had in place for Gen1.


##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
[Full E2E passed](https://tiny.amazon.com/1fyaruowm/IsenLink)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
