### PR TITLE
refactor(graphql-relational-transformer): rename existing ddb-generator to include fields in name

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/graphql-many-to-many-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-many-to-many-transformer.ts
@@ -65,7 +65,7 @@ import {
   getSortKeyFieldsNoContext,
 } from './schema';
 import { HasOneTransformer } from './graphql-has-one-transformer';
-import { DDBRelationalResolverGenerator } from './resolver/ddb-generator';
+import { DDBFieldsRelationalResolverGenerator } from './resolver/ddb-fields-generator';
 
 const directiveName = 'manyToMany';
 const defaultLimit = 100;
@@ -518,7 +518,7 @@ export class ManyToManyTransformer extends TransformerPluginBase {
 
     for (const config of this.directiveList) {
       updateTableForConnection(config, context);
-      new DDBRelationalResolverGenerator().makeHasManyGetItemsConnectionWithKeyResolver(config, context);
+      new DDBFieldsRelationalResolverGenerator().makeHasManyGetItemsConnectionWithKeyResolver(config, context);
     }
   };
 }

--- a/packages/amplify-graphql-relational-transformer/src/resolver/ddb-fields-generator.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolver/ddb-fields-generator.ts
@@ -46,7 +46,7 @@ const CONNECTION_STACK = 'ConnectionStack';
 const authFilter = ref('ctx.stash.authFilter');
 const PARTITION_KEY_VALUE = 'partitionKeyValue';
 
-export class DDBRelationalResolverGenerator extends RelationalResolverGenerator {
+export class DDBFieldsRelationalResolverGenerator extends RelationalResolverGenerator {
   makeExpression = (keySchema: any[], connectionAttributes: string[]): ObjectNode => {
     if (keySchema[1] && connectionAttributes[1]) {
       let condensedSortKeyValue;

--- a/packages/amplify-graphql-relational-transformer/src/resolver/generator-factory.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolver/generator-factory.ts
@@ -1,7 +1,7 @@
 import { MYSQL_DB_TYPE, POSTGRES_DB_TYPE } from '@aws-amplify/graphql-transformer-core';
 import { ModelDataSourceStrategyDbType } from '@aws-amplify/graphql-transformer-interfaces';
 import { RDSRelationalResolverGenerator } from './rds-generator';
-import { DDBRelationalResolverGenerator } from './ddb-generator';
+import { DDBFieldsRelationalResolverGenerator } from './ddb-fields-generator';
 import { RelationalResolverGenerator } from './generator';
 
 export const getGenerator = (dbType: ModelDataSourceStrategyDbType): RelationalResolverGenerator => {
@@ -11,6 +11,6 @@ export const getGenerator = (dbType: ModelDataSourceStrategyDbType): RelationalR
     case MYSQL_DB_TYPE:
       return new RDSRelationalResolverGenerator();
     default:
-      return new DDBRelationalResolverGenerator();
+      return new DDBFieldsRelationalResolverGenerator();
   }
 };


### PR DESCRIPTION
#### Description of changes
Renames `DDBRelationalResolverGenerator` to `DDBFieldsRelationalResolverGenerator` and updates usage.

**No functional change.** This is to disambiguate between the existing the existing DDB fields resolver generator and the incoming `DDBReferencesRelationalResolverGenerator` (coming in subsequent PR).

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] ~Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)~
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
