### PR TITLE
feat(graphql-relational-transformer): add gsi creation for ddb references queries

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -31,7 +31,7 @@ export const updateTableForReferencesConnection = (
     // Ideally validate this further up the chain.
   }
 
-  if (references.length < 1) {
+  if (references.length < 1 || referenceNodes.length < 1) {
     throw new Error('references should not be empty here'); // TODO: better error message
   }
 

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -27,8 +27,8 @@ export const updateTableForReferencesConnection = (
   const indexName = `gsi-${mappedObjectName}.${field.name.value}`;
   config.indexName = indexName;
 
-  const table = getTable(ctx, relatedType);
-  const gsis = table.globalSecondaryIndexes;
+  const relatedTable = getTable(ctx, relatedType);
+  const gsis = relatedTable.globalSecondaryIndexes;
   if (gsis.some((gsi: any) => gsi.indexName === indexName)) {
     // TODO: In the existing `fields` based implementation, this returns.
     // However, this is likely a schema misconfiguration in the `references`
@@ -48,7 +48,7 @@ export const updateTableForReferencesConnection = (
     ? getConnectedSortKeyAttributeDefinitionsForImplicitHasManyObject(ctx, object, field, referenceNodes.slice(1))
     : undefined;
 
-  addGlobalSecondaryIndex(table, {
+  addGlobalSecondaryIndex(relatedTable, {
     indexName: indexName,
     partitionKey: { name: partitionKeyName, type: partitionKeyType },
     sortKey: sortKey,

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -8,6 +8,18 @@ import { getSortKeyFields } from './schema';
 import { HasManyDirectiveConfiguration } from './types';
 import { getConnectionAttributeName, getObjectPrimaryKey } from './utils';
 
+/**
+ * Creates a GSI on the table of the `relatedType` based on the config's `references` / `referenceNodes`
+ *
+ * @remarks
+ * This method sets the `indexName` property of the `config` to the GSI name created on the
+ * table of the `relatedType`
+ *
+ * Preconditions: `config.references >= 1` and `config.referenceNodes >= 1`
+ *
+ * @param config The `HasManyDirectiveConfiguration` for DDB references.
+ * @param ctx The `TransformerContextProvider` for DDB references.
+ */
 export const updateTableForReferencesConnection = (
   config: HasManyDirectiveConfiguration, // TODO: Add support for HasOneDirectiveConfiguration
   ctx: TransformerContextProvider,

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -12,7 +12,7 @@ export const updateTableForReferencesConnection = (
   config: HasManyDirectiveConfiguration, // TODO: Add support for HasOneDirectiveConfiguration
   ctx: TransformerContextProvider,
 ): void => {
-  const { field, fieldNodes, indexName: incomingIndexName, object, references, relatedType } = config;
+  const { field, referenceNodes, indexName: incomingIndexName, object, references, relatedType } = config;
 
   if (incomingIndexName) {
     // TODO: log warning or throw that indexName isn't supported for DDB references
@@ -36,16 +36,16 @@ export const updateTableForReferencesConnection = (
     return;
   }
 
-  const fieldNode = fieldNodes[0];
-  const partitionKeyName = fieldNode.name.value;
+  const referenceNode = referenceNodes[0];
+  const partitionKeyName = referenceNode.name.value;
   // Grabbing the type of the related field.
   // TODO: Validate types of related field and primary's pk match
   // -- ideally further up the chain
-  const partitionKeyType = attributeTypeFromType(fieldNode.type, ctx);
+  const partitionKeyType = attributeTypeFromType(referenceNode.type, ctx);
   const respectPrimaryKeyAttributesOnConnectionField: boolean = ctx.transformParameters.respectPrimaryKeyAttributesOnConnectionField;
 
   const sortKey = respectPrimaryKeyAttributesOnConnectionField
-    ? getConnectedSortKeyAttributeDefinitionsForImplicitHasManyObject(ctx, object, field, fieldNodes.slice(1))
+    ? getConnectedSortKeyAttributeDefinitionsForImplicitHasManyObject(ctx, object, field, referenceNodes.slice(1))
     : undefined;
 
   addGlobalSecondaryIndex(table, {

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -10,7 +10,7 @@ import { getConnectionAttributeName, getObjectPrimaryKey } from './utils';
 
 export const updateTableForReferencesConnection = (
   config: HasManyDirectiveConfiguration, // TODO: Add support for HasOneDirectiveConfiguration
-  ctx: TransformerContextProvider
+  ctx: TransformerContextProvider,
 ): void => {
   const { field, fieldNodes, indexName: incomingIndexName, object, references, relatedType } = config;
 
@@ -20,9 +20,7 @@ export const updateTableForReferencesConnection = (
   }
 
   if (references.length < 1) {
-    throw new Error( // TODO: better error message
-      'references should not be empty here'
-    )
+    throw new Error('references should not be empty here'); // TODO: better error message
   }
 
   const mappedObjectName = ctx.resourceHelper.getModelNameMapping(object.name.value);
@@ -38,17 +36,17 @@ export const updateTableForReferencesConnection = (
     return;
   }
 
-  const fieldNode = fieldNodes[0]
+  const fieldNode = fieldNodes[0];
   const partitionKeyName = fieldNode.name.value;
   // Grabbing the type of the related field.
   // TODO: Validate types of related field and primary's pk match
   // -- ideally further up the chain
-  const partitionKeyType = attributeTypeFromType(fieldNode.type, ctx)
+  const partitionKeyType = attributeTypeFromType(fieldNode.type, ctx);
   const respectPrimaryKeyAttributesOnConnectionField: boolean = ctx.transformParameters.respectPrimaryKeyAttributesOnConnectionField;
 
   const sortKey = respectPrimaryKeyAttributesOnConnectionField
-  ? getConnectedSortKeyAttributeDefinitionsForImplicitHasManyObject(ctx, object, field, fieldNodes.slice(1))
-  : undefined;
+    ? getConnectedSortKeyAttributeDefinitionsForImplicitHasManyObject(ctx, object, field, fieldNodes.slice(1))
+    : undefined;
 
   addGlobalSecondaryIndex(table, {
     indexName: indexName,
@@ -57,7 +55,7 @@ export const updateTableForReferencesConnection = (
     ctx: ctx,
     relatedTypeName: relatedType.name.value,
   });
-}
+};
 
 /**
  * adds GSI to the table if it doesn't already exists for connection
@@ -97,26 +95,26 @@ export const updateTableForConnection = (config: HasManyDirectiveConfiguration, 
     ? getConnectedSortKeyAttributeDefinitionsForImplicitHasManyObject(ctx, object, field, getSortKeyFields(ctx, object))
     : undefined;
 
-    addGlobalSecondaryIndex(table, {
-      indexName: indexName,
-      partitionKey: { name: partitionKeyName, type: partitionKeyType },
-      sortKey: sortKey,
-      ctx: ctx,
-      relatedTypeName: relatedType.name.value,
-    });
+  addGlobalSecondaryIndex(table, {
+    indexName: indexName,
+    partitionKey: { name: partitionKeyName, type: partitionKeyType },
+    sortKey: sortKey,
+    ctx: ctx,
+    relatedTypeName: relatedType.name.value,
+  });
 };
 
 const addGlobalSecondaryIndex = (
   table: any,
   props: {
-    indexName: string,
-    partitionKey: KeyAttributeDefinition,
-    sortKey: KeyAttributeDefinition | undefined,
-    ctx: TransformerContextProvider,
-    relatedTypeName: string,
-  }
+    indexName: string;
+    partitionKey: KeyAttributeDefinition;
+    sortKey: KeyAttributeDefinition | undefined;
+    ctx: TransformerContextProvider;
+    relatedTypeName: string;
+  },
 ): void => {
-  const { indexName, partitionKey, sortKey, ctx, relatedTypeName } = props
+  const { indexName, partitionKey, sortKey, ctx, relatedTypeName } = props;
 
   table.addGlobalSecondaryIndex({
     indexName,
@@ -151,12 +149,12 @@ const addGlobalSecondaryIndex = (
   };
 
   overrideIndexAtCfnLevel(ctx, relatedTypeName, table, newIndex);
-}
+};
 
 type KeyAttributeDefinition = {
   name: string;
-  type: 'S' | 'N'
-}
+  type: 'S' | 'N';
+};
 
 const getConnectedSortKeyAttributeDefinitionsForImplicitHasManyObject = (
   ctx: TransformerContextProvider,

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -48,6 +48,12 @@ export const updateTableForReferencesConnection = (
     return;
   }
 
+  // `referenceNodes` are ordered based on the `references` argument in the `@<relational-directive>(references:)`
+  // argument. If we've gotten this far, the array is not empty and the passed `references` args represent valid
+  // fields on the related type.
+  //
+  // The first element (required) is the parition key of the GSI we're about to create.
+  // Any remaining elements (optional) represent the sort key of the GSI we're about to create.
   const referenceNode = referenceNodes[0];
   const partitionKeyName = referenceNode.name.value;
   // Grabbing the type of the related field.

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -109,9 +109,9 @@ export const updateTableForConnection = (config: HasManyDirectiveConfiguration, 
   const partitionKeyType = respectPrimaryKeyAttributesOnConnectionField
     ? attributeTypeFromType(getObjectPrimaryKey(object).type, ctx)
     : 'S';
-  const sortKey = respectPrimaryKeyAttributesOnConnectionField
-    ? getConnectedSortKeyAttributeDefinitionsForImplicitHasManyObject(ctx, object, field, getSortKeyFields(ctx, object))
-    : undefined;
+
+  // TODO: Add support for sortKey in GSI
+  const sortKey = undefined;
 
   addGlobalSecondaryIndex(table, {
     indexName: indexName,

--- a/packages/amplify-graphql-relational-transformer/src/types.ts
+++ b/packages/amplify-graphql-relational-transformer/src/types.ts
@@ -23,6 +23,7 @@ export type HasManyDirectiveConfiguration = {
   fields: string[];
   references: string[];
   fieldNodes: FieldDefinitionNode[];
+  referenceNodes: FieldDefinitionNode[];
   relatedType: ObjectTypeDefinitionNode;
   relatedTypeIndex: FieldDefinitionNode[];
   connectionFields: string[];
@@ -54,6 +55,7 @@ export type ManyToManyDirectiveConfiguration = {
   fields: string[];
   references: string[];
   fieldNodes: FieldDefinitionNode[];
+  referenceNodes: FieldDefinitionNode[];
   relatedType: ObjectTypeDefinitionNode;
   relatedTypeIndex: FieldDefinitionNode[];
   connectionFields: string[];

--- a/packages/amplify-graphql-relational-transformer/src/types.ts
+++ b/packages/amplify-graphql-relational-transformer/src/types.ts
@@ -20,9 +20,13 @@ export type HasManyDirectiveConfiguration = {
   field: FieldDefinitionNode;
   directive: DirectiveNode;
   indexName: string;
+  /** `fields` strings passed to `@hasMany(fields:)` */
   fields: string[];
+  /** `references` strings passed to `@hasMany(references:)` */
   references: string[];
+  /** `FieldDefinitionNode`s for each of the `fields` including type information from the `relatedType`. */
   fieldNodes: FieldDefinitionNode[];
+  /** `FieldDefinitionNode`s for each of the `references` including type information from the `relatedType`. */
   referenceNodes: FieldDefinitionNode[];
   relatedType: ObjectTypeDefinitionNode;
   relatedTypeIndex: FieldDefinitionNode[];
@@ -52,9 +56,13 @@ export type ManyToManyDirectiveConfiguration = {
   directive: DirectiveNode;
   relationName: string;
   indexName: string;
+  /** `fields` strings passed to `@hasMany(fields:)` */
   fields: string[];
+  /** `references` strings passed to `@hasMany(references:)` */
   references: string[];
+  /** `FieldDefinitionNode`s for each of the `fields` including type information from the `relatedType`. */
   fieldNodes: FieldDefinitionNode[];
+  /** `FieldDefinitionNode`s for each of the `references` including type information from the `relatedType`. */
   referenceNodes: FieldDefinitionNode[];
   relatedType: ObjectTypeDefinitionNode;
   relatedTypeIndex: FieldDefinitionNode[];


### PR DESCRIPTION
#### Description of changes

- Adds the `updateTableForReferencesConnection` method, which will be invoked in `generateResolvers` in the incoming `HasManyDirectiveDDBReferencesTransformer` (subsequent PR). 

- Makes an initial pass at consolidating common parts of `updateTableForConnection` (fields) and `updateTableForReferencesConnection`.

There are few TODOs included with this change that will be resolved in later PRs.
Once we have a commit in `feat/ddb-references`, I'll open a draft PR against main and start tracking these as open items in feature branch PR description.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] ~Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)~
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
