### PR TITLE
feat(graphql-relational-transformer): DDB references relational directives support

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/graphql-has-many-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-has-many-transformer.ts
@@ -83,6 +83,7 @@ export class HasManyTransformer extends TransformerPluginBase {
    * so that it represents any schema modifications the plugin needs
    */
   mutateSchema = (context: TransformerPreProcessContextProvider): DocumentNode => {
+    // TODO: Split out fields and references based logic
     const resultDoc: DocumentNode = produce(context.inputDocument, (draftDoc) => {
       const connectingFieldsMap = new Map<string, Array<WritableDraft<FieldDefinitionNode>>>(); // key: type name | value: connecting field
       const filteredDefs = draftDoc?.definitions?.filter(

--- a/packages/amplify-graphql-relational-transformer/src/graphql-many-to-many-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-many-to-many-transformer.ts
@@ -65,7 +65,7 @@ import {
   getSortKeyFieldsNoContext,
 } from './schema';
 import { HasOneTransformer } from './graphql-has-one-transformer';
-import { DDBRelationalResolverGenerator } from './resolver/ddb-generator';
+import { DDBFieldsRelationalResolverGenerator } from './resolver/ddb-fields-generator';
 
 const directiveName = 'manyToMany';
 const defaultLimit = 100;
@@ -518,7 +518,7 @@ export class ManyToManyTransformer extends TransformerPluginBase {
 
     for (const config of this.directiveList) {
       updateTableForConnection(config, context);
-      new DDBRelationalResolverGenerator().makeHasManyGetItemsConnectionWithKeyResolver(config, context);
+      new DDBFieldsRelationalResolverGenerator().makeHasManyGetItemsConnectionWithKeyResolver(config, context);
     }
   };
 }

--- a/packages/amplify-graphql-relational-transformer/src/resolver/ddb-fields-generator.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolver/ddb-fields-generator.ts
@@ -46,7 +46,7 @@ const CONNECTION_STACK = 'ConnectionStack';
 const authFilter = ref('ctx.stash.authFilter');
 const PARTITION_KEY_VALUE = 'partitionKeyValue';
 
-export class DDBRelationalResolverGenerator extends RelationalResolverGenerator {
+export class DDBFieldsRelationalResolverGenerator extends RelationalResolverGenerator {
   makeExpression = (keySchema: any[], connectionAttributes: string[]): ObjectNode => {
     if (keySchema[1] && connectionAttributes[1]) {
       let condensedSortKeyValue;

--- a/packages/amplify-graphql-relational-transformer/src/resolver/ddb-references-generator.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolver/ddb-references-generator.ts
@@ -1,5 +1,12 @@
-import { MappingTemplate, getModelDataSourceNameForTypeName, getKeySchema, getTable } from '@aws-amplify/graphql-transformer-core';
+import {
+  MappingTemplate,
+  getKeySchema,
+  getModelDataSourceNameForTypeName,
+  getPrimaryKeyFields,
+  getTable,
+} from '@aws-amplify/graphql-transformer-core';
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { ObjectTypeDefinitionNode } from 'graphql';
 import {
   DynamoDBMappingTemplate,
   Expression,
@@ -36,71 +43,38 @@ import {
   setArgs,
   toCamelCase,
 } from 'graphql-transformer-common';
-import { ObjectTypeDefinitionNode } from 'graphql';
-import { BelongsToDirectiveConfiguration, HasManyDirectiveConfiguration, HasOneDirectiveConfiguration } from '../types';
 import { condenseRangeKey } from '../resolvers';
-import { RelationalResolverGenerator } from './generator';
+import { BelongsToDirectiveConfiguration, HasManyDirectiveConfiguration, HasOneDirectiveConfiguration } from '../types';
+import { DDBRelationalResolverGenerator } from './ddb-generator';
 
 const SORT_KEY_VALUE = 'sortKeyValue';
 const CONNECTION_STACK = 'ConnectionStack';
 const authFilter = ref('ctx.stash.authFilter');
 const PARTITION_KEY_VALUE = 'partitionKeyValue';
 
-export class DDBFieldsRelationalResolverGenerator extends RelationalResolverGenerator {
-  makeExpression = (keySchema: any[], connectionAttributes: string[]): ObjectNode => {
-    if (keySchema[1] && connectionAttributes[1]) {
-      let condensedSortKeyValue;
-
-      if (connectionAttributes.length > 2) {
-        const rangeKeyFields = connectionAttributes.slice(1);
-
-        condensedSortKeyValue = rangeKeyFields
-          .map((keyField, idx) => `\${${SORT_KEY_VALUE}${idx}}`)
-          .join(ModelResourceIDs.ModelCompositeKeySeparator());
-      }
-
-      return obj({
-        expression: str('#partitionKey = :partitionKey AND #sortKey = :sortKey'),
-        expressionNames: obj({
-          '#partitionKey': str(keySchema[0].attributeName),
-          '#sortKey': str(keySchema[1].attributeName),
-        }),
-        expressionValues: obj({
-          ':partitionKey': ref(`util.dynamodb.toDynamoDB($${PARTITION_KEY_VALUE})`),
-          ':sortKey': ref(`util.dynamodb.toDynamoDB(${condensedSortKeyValue ? `"${condensedSortKeyValue}"` : `$${SORT_KEY_VALUE}0`})`),
-        }),
-      });
-    }
-
-    return obj({
-      expression: str('#partitionKey = :partitionKey'),
-      expressionNames: obj({
-        '#partitionKey': str(keySchema[0].attributeName),
-      }),
-      expressionValues: obj({
-        ':partitionKey': ref(`util.dynamodb.toDynamoDB($${PARTITION_KEY_VALUE})`),
-      }),
-    });
-  };
-
+export class DDBRelationalReferencesResolverGenerator extends DDBRelationalResolverGenerator {
   /**
    * Create a resolver that queries an item in DynamoDB.
    * @param config The connection directive configuration.
    * @param ctx The transformer context provider.
    */
   makeHasManyGetItemsConnectionWithKeyResolver = (config: HasManyDirectiveConfiguration, ctx: TransformerContextProvider): void => {
-    const { connectionFields, field, fields, indexName, limit, object, relatedType } = config;
-    const connectionAttributes: string[] = fields.length > 0 ? fields : connectionFields;
-    if (connectionAttributes.length === 0) {
-      throw new Error('Either connection fields or local fields should be populated.');
+    const { field, indexName, limit, object, references, relatedType } = config;
+
+    if (references.length < 1) {
+      // TODO: Better error message
+      throw new Error('references should be populated.');
     }
+
+    const primaryKeyFields: string[] = getPrimaryKeyFields(object);
     const table = getTable(ctx, relatedType);
     const dataSourceName = getModelDataSourceNameForTypeName(ctx, relatedType.name.value);
     const dataSource = ctx.api.host.getDataSource(dataSourceName);
     const keySchema = getKeySchema(table, indexName);
+
     const setup: Expression[] = [
       set(ref('limit'), ref(`util.defaultIfNull($context.args.limit, ${limit})`)),
-      ...connectionAttributes
+      ...primaryKeyFields
         .slice(1)
         .map((ca, idx) =>
           set(
@@ -108,23 +82,9 @@ export class DDBFieldsRelationalResolverGenerator extends RelationalResolverGene
             methodCall(ref('util.defaultIfNull'), ref(`ctx.stash.connectionAttibutes.get("${ca}")`), ref(`ctx.source.${ca}`)),
           ),
         ),
-      set(ref('query'), this.makeExpression(keySchema, connectionAttributes)),
+      set(ref('query'), this.makeExpression(keySchema, references)),
     ];
 
-    // If the key schema has a sort key but one is not provided for the query, let a sort key be
-    // passed in via $ctx.args.
-    if (keySchema[1] && !connectionAttributes[1]) {
-      const sortKeyFieldName = keySchema[1].attributeName;
-      const sortKeyField = relatedType.fields!.find((f) => f.name.value === sortKeyFieldName);
-
-      if (sortKeyField) {
-        setup.push(applyKeyConditionExpression(sortKeyFieldName, attributeTypeFromScalar(sortKeyField.type), 'query'));
-      } else {
-        const sortKeyFieldNames = sortKeyFieldName.split(ModelResourceIDs.ModelCompositeKeySeparator());
-
-        setup.push(applyCompositeKeyConditionExpression(sortKeyFieldNames, 'query', toCamelCase(sortKeyFieldNames), sortKeyFieldName));
-      }
-    }
     // add setup filter to query
     setup.push(
       setArgs,
@@ -188,8 +148,8 @@ export class DDBFieldsRelationalResolverGenerator extends RelationalResolverGene
               ref(PARTITION_KEY_VALUE),
               methodCall(
                 ref('util.defaultIfNull'),
-                ref(`ctx.stash.connectionAttributes.get("${connectionAttributes[0]}")`),
-                ref(`ctx.source.${connectionAttributes[0]}`),
+                ref(`ctx.stash.connectionAttributes.get("${primaryKeyFields[0]}")`),
+                ref(`ctx.source.${primaryKeyFields[0]}`),
               ),
             ),
             ifElse(
@@ -216,20 +176,17 @@ export class DDBFieldsRelationalResolverGenerator extends RelationalResolverGene
     ctx.resolvers.addResolver(object.name.value, field.name.value, resolver);
   };
 
+  makeHasOneGetItemConnectionWithKeyResolver = (_config: HasOneDirectiveConfiguration, _ctx: TransformerContextProvider): void => {
+    // TODO: Implement hasOne resolver -- this should be nearly identical to hasMany
+  };
+
   /**
    * Create a get item resolver for singular connections.
    * @param config The connection directive configuration.
    * @param ctx The transformer context provider.
    */
-  makeHasOneGetItemConnectionWithKeyResolver = (
-    config: HasOneDirectiveConfiguration | BelongsToDirectiveConfiguration,
-    ctx: TransformerContextProvider,
-  ): void => {
-    const { connectionFields, field, fields, object, relatedType, relatedTypeIndex } = config;
-    if (relatedTypeIndex.length === 0) {
-      throw new Error('Expected relatedType index fields to be set for connection.');
-    }
-    const localFields = fields.length > 0 ? fields : connectionFields;
+  makeBelongsToGetItemConnectionWithKeyResolver = (config: BelongsToDirectiveConfiguration, ctx: TransformerContextProvider): void => {
+    const { field, references, object, relatedType } = config;
     const table = getTable(ctx, relatedType);
     const { keySchema } = table as any;
     const dataSourceName = getModelDataSourceNameForTypeName(ctx, relatedType.name.value);
@@ -241,12 +198,12 @@ export class DDBFieldsRelationalResolverGenerator extends RelationalResolverGene
     };
 
     const totalExpressionValues: Record<string, Expression> = {
-      ':partitionValue': this.buildKeyValueExpression(localFields[0], ctx.output.getObject(object.name.value)!, true),
+      ':partitionValue': this.buildKeyValueExpression(references[0], ctx.output.getObject(object.name.value)!, true),
     };
 
     // Add a composite sort key or simple sort key if there is one.
-    if (relatedTypeIndex.length > 2) {
-      const rangeKeyFields = localFields.slice(1);
+    if (references.length > 2) {
+      const rangeKeyFields = references.slice(1);
       const sortKeyName = keySchema[1].attributeName;
       const condensedSortKeyValue = condenseRangeKey(rangeKeyFields.map((keyField) => `\${ctx.source.${keyField}}`));
 
@@ -255,11 +212,11 @@ export class DDBFieldsRelationalResolverGenerator extends RelationalResolverGene
       totalExpressionValues[':sortKeyName'] = ref(
         `util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank("${condensedSortKeyValue}", "${NONE_VALUE}")))`,
       );
-    } else if (relatedTypeIndex.length === 2) {
+    } else if (references.length === 2) {
       const sortKeyName = keySchema[1].attributeName;
       totalExpressions.push('#sortKeyName = :sortKeyName');
       totalExpressionNames['#sortKeyName'] = str(sortKeyName);
-      totalExpressionValues[':sortKeyName'] = this.buildKeyValueExpression(localFields[1], ctx.output.getObject(object.name.value)!);
+      totalExpressionValues[':sortKeyName'] = this.buildKeyValueExpression(references[1], ctx.output.getObject(object.name.value)!);
     }
 
     const resolverResourceId = ResolverResourceIDs.ResolverResourceID(object.name.value, field.name.value);
@@ -276,14 +233,14 @@ export class DDBFieldsRelationalResolverGenerator extends RelationalResolverGene
               ref(PARTITION_KEY_VALUE),
               methodCall(
                 ref('util.defaultIfNull'),
-                ref(`ctx.stash.connectionAttibutes.get("${localFields[0]}")`),
-                ref(`ctx.source.${localFields[0]}`),
+                ref(`ctx.stash.connectionAttibutes.get("${references[0]}")`),
+                ref(`ctx.source.${references[0]}`),
               ),
             ),
             ifElse(
               or([
                 methodCall(ref('util.isNull'), ref(PARTITION_KEY_VALUE)),
-                ...localFields.slice(1).map((f) => raw(`$util.isNull($ctx.source.${f})`)),
+                ...references.slice(1).map((f) => raw(`$util.isNull($ctx.source.${f})`)),
               ]),
               raw('#return'),
               compoundExpression([
@@ -336,22 +293,5 @@ export class DDBFieldsRelationalResolverGenerator extends RelationalResolverGene
 
     resolver.setScope(ctx.stackManager.getScopeFor(resolverResourceId, CONNECTION_STACK));
     ctx.resolvers.addResolver(object.name.value, field.name.value, resolver);
-  };
-
-  buildKeyValueExpression = (fieldName: string, object: ObjectTypeDefinitionNode, isPartitionKey = false): Expression => {
-    const field = object.fields?.find((it) => it.name.value === fieldName);
-
-    // can be auto-generated
-    const attributeType = field ? attributeTypeFromScalar(field.type) : 'S';
-
-    return ref(
-      `util.parseJson($util.dynamodb.toDynamoDBJson($util.${attributeType === 'S' ? 'defaultIfNullOrBlank' : 'defaultIfNull'}(${
-        isPartitionKey ? `$${PARTITION_KEY_VALUE}` : `$ctx.source.${fieldName}`
-      }, "${NONE_VALUE}")))`,
-    );
-  };
-
-  makeBelongsToGetItemConnectionWithKeyResolver = (config: BelongsToDirectiveConfiguration, ctx: TransformerContextProvider): void => {
-    this.makeHasOneGetItemConnectionWithKeyResolver(config, ctx);
   };
 }

--- a/packages/amplify-graphql-relational-transformer/src/resolver/generator-factory.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolver/generator-factory.ts
@@ -1,7 +1,7 @@
 import { MYSQL_DB_TYPE, POSTGRES_DB_TYPE } from '@aws-amplify/graphql-transformer-core';
 import { ModelDataSourceStrategyDbType } from '@aws-amplify/graphql-transformer-interfaces';
 import { RDSRelationalResolverGenerator } from './rds-generator';
-import { DDBRelationalResolverGenerator } from './ddb-generator';
+import { DDBFieldsRelationalResolverGenerator } from './ddb-fields-generator';
 import { RelationalResolverGenerator } from './generator';
 
 export const getGenerator = (dbType: ModelDataSourceStrategyDbType): RelationalResolverGenerator => {
@@ -11,6 +11,6 @@ export const getGenerator = (dbType: ModelDataSourceStrategyDbType): RelationalR
     case MYSQL_DB_TYPE:
       return new RDSRelationalResolverGenerator();
     default:
-      return new DDBRelationalResolverGenerator();
+      return new DDBFieldsRelationalResolverGenerator();
   }
 };

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -9,6 +9,73 @@ import { HasManyDirectiveConfiguration } from './types';
 import { getConnectionAttributeName, getObjectPrimaryKey } from './utils';
 
 /**
+ * Creates a GSI on the table of the `relatedType` based on the config's `references` / `referenceNodes`
+ *
+ * @remarks
+ * This method sets the `indexName` property of the `config` to the GSI name created on the
+ * table of the `relatedType`
+ *
+ * Preconditions: `config.references >= 1` and `config.referenceNodes >= 1`
+ *
+ * @param config The `HasManyDirectiveConfiguration` for DDB references.
+ * @param ctx The `TransformerContextProvider` for DDB references.
+ */
+export const updateTableForReferencesConnection = (
+  config: HasManyDirectiveConfiguration, // TODO: Add support for HasOneDirectiveConfiguration
+  ctx: TransformerContextProvider,
+): void => {
+  const { field, referenceNodes, indexName: incomingIndexName, object, references, relatedType } = config;
+
+  if (incomingIndexName) {
+    // TODO: log warning or throw that indexName isn't supported for DDB references
+    // Ideally validate this further up the chain.
+  }
+
+  if (references.length < 1 || referenceNodes.length < 1) {
+    throw new Error('references should not be empty here'); // TODO: better error message
+  }
+
+  const mappedObjectName = ctx.resourceHelper.getModelNameMapping(object.name.value);
+  const indexName = `gsi-${mappedObjectName}.${field.name.value}`;
+  config.indexName = indexName;
+
+  const relatedTable = getTable(ctx, relatedType);
+  const gsis = relatedTable.globalSecondaryIndexes;
+  if (gsis.some((gsi: any) => gsi.indexName === indexName)) {
+    // TODO: In the existing `fields` based implementation, this returns.
+    // However, this is likely a schema misconfiguration in the `references`
+    // world because we don't support specifying indexName.
+    return;
+  }
+
+  // `referenceNodes` are ordered based on the `references` argument in the `@<relational-directive>(references:)`
+  // argument. If we've gotten this far, the array is not empty and the passed `references` args represent valid
+  // fields on the related type.
+  //
+  // The first element (required) is the parition key of the GSI we're about to create.
+  // Any remaining elements (optional) represent the sort key of the GSI we're about to create.
+  const referenceNode = referenceNodes[0];
+  const partitionKeyName = referenceNode.name.value;
+  // Grabbing the type of the related field.
+  // TODO: Validate types of related field and primary's pk match
+  // -- ideally further up the chain
+  const partitionKeyType = attributeTypeFromType(referenceNode.type, ctx);
+  const respectPrimaryKeyAttributesOnConnectionField: boolean = ctx.transformParameters.respectPrimaryKeyAttributesOnConnectionField;
+
+  const sortKey = respectPrimaryKeyAttributesOnConnectionField
+    ? getConnectedSortKeyAttributeDefinitionsForImplicitHasManyObject(ctx, object, field, referenceNodes.slice(1))
+    : undefined;
+
+  addGlobalSecondaryIndex(relatedTable, {
+    indexName: indexName,
+    partitionKey: { name: partitionKeyName, type: partitionKeyType },
+    sortKey: sortKey,
+    ctx: ctx,
+    relatedTypeName: relatedType.name.value,
+  });
+};
+
+/**
  * adds GSI to the table if it doesn't already exists for connection
  */
 export const updateTableForConnection = (config: HasManyDirectiveConfiguration, ctx: TransformerContextProvider): void => {
@@ -42,20 +109,42 @@ export const updateTableForConnection = (config: HasManyDirectiveConfiguration, 
   const partitionKeyType = respectPrimaryKeyAttributesOnConnectionField
     ? attributeTypeFromType(getObjectPrimaryKey(object).type, ctx)
     : 'S';
-  const sortKeyAttributeDefinitions = respectPrimaryKeyAttributesOnConnectionField
-    ? getConnectedSortKeyAttributeDefinitionsForImplicitHasManyObject(ctx, object, field)
-    : undefined;
+
+  // TODO: Add support for sortKey in GSI
+  const sortKey = undefined;
+
+  addGlobalSecondaryIndex(table, {
+    indexName: indexName,
+    partitionKey: { name: partitionKeyName, type: partitionKeyType },
+    sortKey: sortKey,
+    ctx: ctx,
+    relatedTypeName: relatedType.name.value,
+  });
+};
+
+const addGlobalSecondaryIndex = (
+  table: any,
+  props: {
+    indexName: string;
+    partitionKey: KeyAttributeDefinition;
+    sortKey: KeyAttributeDefinition | undefined;
+    ctx: TransformerContextProvider;
+    relatedTypeName: string;
+  },
+): void => {
+  const { indexName, partitionKey, sortKey, ctx, relatedTypeName } = props;
+
   table.addGlobalSecondaryIndex({
     indexName,
     projectionType: 'ALL',
     partitionKey: {
-      name: partitionKeyName,
-      type: partitionKeyType,
+      name: partitionKey.name,
+      type: partitionKey.type,
     },
-    sortKey: sortKeyAttributeDefinitions
+    sortKey: sortKey
       ? {
-          name: sortKeyAttributeDefinitions.sortKeyName,
-          type: sortKeyAttributeDefinitions.sortKeyType,
+          name: sortKey.name,
+          type: sortKey.type,
         }
       : undefined,
     readCapacity: cdk.Fn.ref(ResourceConstants.PARAMETERS.DynamoDBModelTableReadIOPS),
@@ -65,7 +154,7 @@ export const updateTableForConnection = (config: HasManyDirectiveConfiguration, 
   // At the L2 level, the CDK does not handle the way Amplify sets GSI read and write capacity
   // very well. At the L1 level, the CDK does not create the correct IAM policy for accessing the
   // GSI. To get around these issues, keep the L1 and L2 GSI list in sync.
-  const gsi = gsis.find((g: any) => g.indexName === indexName);
+  const gsi = table.globalSecondaryIndexes.find((g: any) => g.indexName === indexName);
 
   const newIndex = {
     indexName,
@@ -77,20 +166,20 @@ export const updateTableForConnection = (config: HasManyDirectiveConfiguration, 
     }),
   };
 
-  overrideIndexAtCfnLevel(ctx, relatedType.name.value, table, newIndex);
+  overrideIndexAtCfnLevel(ctx, relatedTypeName, table, newIndex);
 };
 
-type SortKeyAttributeDefinitions = {
-  sortKeyName: string;
-  sortKeyType: 'S' | 'N';
+type KeyAttributeDefinition = {
+  name: string;
+  type: 'S' | 'N';
 };
 
 const getConnectedSortKeyAttributeDefinitionsForImplicitHasManyObject = (
   ctx: TransformerContextProvider,
   object: ObjectTypeDefinitionNode,
   hasManyField: FieldDefinitionNode,
-): SortKeyAttributeDefinitions | undefined => {
-  const sortKeyFields = getSortKeyFields(ctx, object);
+  sortKeyFields: FieldDefinitionNode[],
+): KeyAttributeDefinition | undefined => {
   if (!sortKeyFields.length) {
     return undefined;
   }
@@ -100,13 +189,13 @@ const getConnectedSortKeyAttributeDefinitionsForImplicitHasManyObject = (
   );
   if (connectedSortKeyFieldNames.length === 1) {
     return {
-      sortKeyName: connectedSortKeyFieldNames[0],
-      sortKeyType: attributeTypeFromType(sortKeyFields[0].type, ctx),
+      name: connectedSortKeyFieldNames[0],
+      type: attributeTypeFromType(sortKeyFields[0].type, ctx),
     };
   } else if (sortKeyFields.length > 1) {
     return {
-      sortKeyName: condenseRangeKey(connectedSortKeyFieldNames),
-      sortKeyType: 'S',
+      name: condenseRangeKey(connectedSortKeyFieldNames),
+      type: 'S',
     };
   }
   return undefined;

--- a/packages/amplify-graphql-relational-transformer/src/types.ts
+++ b/packages/amplify-graphql-relational-transformer/src/types.ts
@@ -20,9 +20,14 @@ export type HasManyDirectiveConfiguration = {
   field: FieldDefinitionNode;
   directive: DirectiveNode;
   indexName: string;
+  /** `fields` strings passed to `@hasMany(fields:)` */
   fields: string[];
+  /** `references` strings passed to `@hasMany(references:)` */
   references: string[];
+  /** `FieldDefinitionNode`s for each of the `fields` including type information from the `relatedType`. */
   fieldNodes: FieldDefinitionNode[];
+  /** `FieldDefinitionNode`s for each of the `references` including type information from the `relatedType`. */
+  referenceNodes: FieldDefinitionNode[];
   relatedType: ObjectTypeDefinitionNode;
   relatedTypeIndex: FieldDefinitionNode[];
   connectionFields: string[];
@@ -51,9 +56,14 @@ export type ManyToManyDirectiveConfiguration = {
   directive: DirectiveNode;
   relationName: string;
   indexName: string;
+  /** `fields` strings passed to `@hasMany(fields:)` */
   fields: string[];
+  /** `references` strings passed to `@hasMany(references:)` */
   references: string[];
+  /** `FieldDefinitionNode`s for each of the `fields` including type information from the `relatedType`. */
   fieldNodes: FieldDefinitionNode[];
+  /** `FieldDefinitionNode`s for each of the `references` including type information from the `relatedType`. */
+  referenceNodes: FieldDefinitionNode[];
   relatedType: ObjectTypeDefinitionNode;
   relatedTypeIndex: FieldDefinitionNode[];
   connectionFields: string[];


### PR DESCRIPTION
## Description of changes
- https://github.com/aws-amplify/amplify-category-api/pull/2360
- https://github.com/aws-amplify/amplify-category-api/pull/2362
- https://github.com/aws-amplify/amplify-category-api/pull/2363
- https://github.com/aws-amplify/amplify-category-api/pull/2364

## Open Items
- [ ] https://github.com/aws-amplify/amplify-category-api/pull/2362/files#r1527181272
- [ ] Add sortKey support for implicit GSI creation on related model table.
- [ ] Unit tests for references -- DDB and heterogeneous data sources
- [ ] E2E tests for references -- DDB and heterogeneous data sources.
- [ ] Reduce duplicate generation of directive transformer classes (https://github.com/aws-amplify/amplify-category-api/pull/2364#discussion_r1529788481)
- [ ] https://github.com/aws-amplify/amplify-category-api/pull/2363#discussion_r1532568333

### CDK / CloudFormation Parameters Changed
N/A

## Issue #, if available


## Description of how you validated changes

## Checklist

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
