### PR TITLE
feat(api): enable cors on codegen asset bucket

### DIFF
--- a/packages/amplify-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-core/src/utils/sdk-calls.ts
@@ -206,7 +206,7 @@ export const listAttachedRolePolicies = async (roleName: string, region: string)
   return (await service.listAttachedRolePolicies({ RoleName: roleName }).promise()).AttachedPolicies;
 };
 
-export const getBucketNameFromModelSchemaS3Uri = (uri: string | null): string => {
+export const getBucketNameFromModelSchemaS3Uri = (uri: string | null): string | null => {
   const pattern = /(s3:\/\/)(.*)(\/.*)/;
   const matches = uri.match(pattern);
   // Sample Input Uri looks like 's3://bucket-name/model-schema.graphql'.
@@ -217,12 +217,12 @@ export const getBucketNameFromModelSchemaS3Uri = (uri: string | null): string =>
   //     "bucket-name",
   //     "/model-schema.graphql"
   // ]
-  const HOST_INDEX = 2;
+  const BUCKET_NAME_INDEX = 2;
   if (!matches) {
     return null;
   }
-  if (matches.length && matches.length > 2) {
-    return matches[HOST_INDEX];
+  if (matches.length && matches.length > BUCKET_NAME_INDEX) {
+    return matches[BUCKET_NAME_INDEX];
   }
   return null;
 };

--- a/packages/amplify-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-core/src/utils/sdk-calls.ts
@@ -205,3 +205,33 @@ export const listAttachedRolePolicies = async (roleName: string, region: string)
   const service = new IAM({ region });
   return (await service.listAttachedRolePolicies({ RoleName: roleName }).promise()).AttachedPolicies;
 };
+
+export const getBucketNameFromModelSchemaS3Uri = (uri: string | null): string => {
+  const pattern = /(s3:\/\/)(.*)(\/.*)/;
+  const matches = uri.match(pattern);
+  // Sample Input Uri looks like 's3://bucket-name/model-schema.graphql'.
+  // The output of string.match returns an array which looks like the below. The third element is the bucket name.
+  // [
+  //     "s3://bucket-name/model-schema.graphql",
+  //     "s3://",
+  //     "bucket-name",
+  //     "/model-schema.graphql"
+  // ]
+  const HOST_INDEX = 2;
+  if (!matches) {
+    return null;
+  }
+  if (matches.length && matches.length > 2) {
+    return matches[HOST_INDEX];
+  }
+  return null;
+};
+
+export const getBucketCorsPolicy = async (bucketName: string, region: string): Promise<Record<string, any>[]> => {
+  const service = new S3({ region });
+  const params = {
+    Bucket: bucketName,
+  };
+  const corsPolicy = await service.getBucketCors(params).promise();
+  return corsPolicy.CORSRules;
+};

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/base-cdk.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/base-cdk.test.ts
@@ -1,5 +1,10 @@
 import * as path from 'path';
-import { createNewProjectDir, deleteProjectDir, getBucketNameFromModelSchemaS3Uri, getBucketCorsPolicy } from 'amplify-category-api-e2e-core';
+import {
+  createNewProjectDir,
+  deleteProjectDir,
+  getBucketNameFromModelSchemaS3Uri,
+  getBucketCorsPolicy,
+} from 'amplify-category-api-e2e-core';
 import { initCDKProject, cdkDeploy, cdkDestroy } from '../commands';
 import { graphql } from '../graphql-request';
 
@@ -29,7 +34,7 @@ describe('CDK GraphQL Transformer', () => {
       const templatePath = path.resolve(path.join(__dirname, 'backends', 'base-cdk'));
       const name = await initCDKProject(projRoot, templatePath, { cdkVersion });
       const outputs = await cdkDeploy(projRoot, '--all');
-      
+
       // Console requires CORS enabled on codegen asset bucket.
       const { awsAppsyncRegion: region, amplifyApiModelSchemaS3Uri: codegenModelSchemaS3Uri } = outputs[name];
       const codegenBucketName = getBucketNameFromModelSchemaS3Uri(codegenModelSchemaS3Uri);
@@ -37,9 +42,9 @@ describe('CDK GraphQL Transformer', () => {
       expect(corsPolicy).toMatchObject(
         expect.arrayContaining([
           expect.objectContaining({
-            'AllowedHeaders': expect.arrayContaining(['*']),
-            'AllowedMethods': expect.arrayContaining(['GET', 'HEAD']),
-            'AllowedOrigins': expect.arrayContaining(['https://*.console.aws.amazon.com/amplify']),
+            AllowedHeaders: expect.arrayContaining(['*']),
+            AllowedMethods: expect.arrayContaining(['GET', 'HEAD']),
+            AllowedOrigins: expect.arrayContaining(['https://*.console.aws.amazon.com/amplify']),
           }),
         ]),
       );

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/base-cdk.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/base-cdk.test.ts
@@ -44,7 +44,7 @@ describe('CDK GraphQL Transformer', () => {
           expect.objectContaining({
             AllowedHeaders: expect.arrayContaining(['*']),
             AllowedMethods: expect.arrayContaining(['GET', 'HEAD']),
-            AllowedOrigins: expect.arrayContaining(['https://*.console.aws.amazon.com/amplify']),
+            AllowedOrigins: expect.arrayContaining([`https://${region}.console.aws.amazon.com/amplify`]),
           }),
         ]),
       );

--- a/packages/amplify-graphql-api-construct/src/internal/codegen-assets.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/codegen-assets.ts
@@ -8,11 +8,7 @@ export type CodegenAssetsProps = {
 };
 
 const MODEL_SCHEMA_KEY = 'model-schema.graphql';
-const CONSOLE_SERVICE_ENDPOINT = Fn.join('', [
-  'https://',
-  Fn.ref('AWS::Region'),
-  '.console.aws.amazon.com/amplify',
-]);
+const CONSOLE_SERVICE_ENDPOINT = Fn.join('', ['https://', Fn.ref('AWS::Region'), '.console.aws.amazon.com/amplify']);
 
 /**
  * Construct an S3 URI string for a given bucket and key.

--- a/packages/amplify-graphql-api-construct/src/internal/codegen-assets.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/codegen-assets.ts
@@ -31,12 +31,14 @@ export class CodegenAssets extends Construct {
     const bucket = new Bucket(this, `${id}Bucket`, {
       removalPolicy: RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
-      // Enabling CORS to allow console to access the codegen assets. 
-      cors: [{
-        allowedMethods: [HttpMethods.GET, HttpMethods.HEAD],
-        allowedHeaders: ['*'],
-        allowedOrigins: [ CONSOLE_SERVICE_ENDPOINT ],
-      }],
+      // Enabling CORS to allow console to access the codegen assets.
+      cors: [
+        {
+          allowedMethods: [HttpMethods.GET, HttpMethods.HEAD],
+          allowedHeaders: ['*'],
+          allowedOrigins: [CONSOLE_SERVICE_ENDPOINT],
+        },
+      ],
     });
 
     const deployment = new BucketDeployment(this, `${id}Deployment`, {

--- a/packages/amplify-graphql-api-construct/src/internal/codegen-assets.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/codegen-assets.ts
@@ -1,4 +1,4 @@
-import { RemovalPolicy } from 'aws-cdk-lib';
+import { RemovalPolicy, Fn } from 'aws-cdk-lib';
 import { Bucket, HttpMethods, IBucket } from 'aws-cdk-lib/aws-s3';
 import { BucketDeployment, Source } from 'aws-cdk-lib/aws-s3-deployment';
 import { Construct } from 'constructs';
@@ -8,7 +8,11 @@ export type CodegenAssetsProps = {
 };
 
 const MODEL_SCHEMA_KEY = 'model-schema.graphql';
-const CONSOLE_SERVICE_ENDPOINT = 'https://*.console.aws.amazon.com/amplify';
+const CONSOLE_SERVICE_ENDPOINT = Fn.join('', [
+  'https://',
+  Fn.ref('AWS::Region'),
+  '.console.aws.amazon.com/amplify',
+]);
 
 /**
  * Construct an S3 URI string for a given bucket and key.

--- a/packages/amplify-graphql-api-construct/src/internal/codegen-assets.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/codegen-assets.ts
@@ -1,5 +1,5 @@
 import { RemovalPolicy } from 'aws-cdk-lib';
-import { Bucket, IBucket } from 'aws-cdk-lib/aws-s3';
+import { Bucket, HttpMethods, IBucket } from 'aws-cdk-lib/aws-s3';
 import { BucketDeployment, Source } from 'aws-cdk-lib/aws-s3-deployment';
 import { Construct } from 'constructs';
 
@@ -8,6 +8,7 @@ export type CodegenAssetsProps = {
 };
 
 const MODEL_SCHEMA_KEY = 'model-schema.graphql';
+const CONSOLE_SERVICE_ENDPOINT = 'https://*.console.aws.amazon.com/amplify';
 
 /**
  * Construct an S3 URI string for a given bucket and key.
@@ -30,6 +31,12 @@ export class CodegenAssets extends Construct {
     const bucket = new Bucket(this, `${id}Bucket`, {
       removalPolicy: RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
+      // Enabling CORS to allow console to access the codegen assets. 
+      cors: [{
+        allowedMethods: [HttpMethods.GET, HttpMethods.HEAD],
+        allowedHeaders: ['*'],
+        allowedOrigins: [ CONSOLE_SERVICE_ENDPOINT ],
+      }],
     });
 
     const deployment = new BucketDeployment(this, `${id}Deployment`, {


### PR DESCRIPTION
#### Description of changes

Enable CORS on the codegen assets bucket. This is required for console team to access the objects from user context.

##### CDK / CloudFormation Parameters Changed

No.

#### Issue #, if available
NA.

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Local Testing
- Added E2E tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
