### PR TITLE
feat(graphql-relational-transformer): add ddb references support for hasOne directive

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-one-references-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-one-references-transformer.test.ts.snap
@@ -74,11 +74,11 @@ exports[`has one references with multiple sort keys 1`] = `
   \\"expression\\": \\"#partitionKey = :partitionValue AND #sortKeyName = :sortKeyName\\",
   \\"expressionNames\\": {
       \\"#partitionKey\\": \\"teamId\\",
-      \\"#sortKeyName\\": \\"teamMantra\\"
+      \\"#sortKeyName\\": \\"teamMantra#teamOrganization\\"
   },
   \\"expressionValues\\": {
       \\":partitionValue\\": $util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($partitionKeyValue, \\"___xamznone____\\"))),
-      \\":sortKeyName\\": $util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank(\\"\${ctx.source.teamMantra}#\${ctx.source.teamOrganization}\\", \\"___xamznone____\\")))
+      \\":sortKeyName\\": $util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank(\\"\${ctx.source.mantra}#\${ctx.source.organization}\\", \\"___xamznone____\\")))
   }
 }))
   #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
@@ -139,7 +139,7 @@ exports[`has one references with partition key + sort key 1`] = `
   },
   \\"expressionValues\\": {
       \\":partitionValue\\": $util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($partitionKeyValue, \\"___xamznone____\\"))),
-      \\":sortKeyName\\": $util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.teamMantra, \\"___xamznone____\\")))
+      \\":sortKeyName\\": $util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.mantra, \\"___xamznone____\\")))
   }
 }))
   #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-one-references-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-one-references-transformer.test.ts.snap
@@ -1,0 +1,180 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`has one references single partition key 1`] = `
+"#if( $ctx.stash.deniedField )
+  #return($util.toJson(null))
+#end
+#set( $partitionKeyValue = $util.defaultIfNull($ctx.stash.connectionAttibutes.get(\\"id\\"), $ctx.source.id) )
+#if( $util.isNull($partitionKeyValue) )
+  #return
+#else
+  #set( $GetRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\",
+  \\"index\\": \\"gsi-Team.project\\"
+} )
+  $util.qr($GetRequest.put(\\"query\\", {
+  \\"expression\\": \\"#partitionKey = :partitionValue\\",
+  \\"expressionNames\\": {
+      \\"#partitionKey\\": \\"teamId\\"
+  },
+  \\"expressionValues\\": {
+      \\":partitionValue\\": $util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($partitionKeyValue, \\"___xamznone____\\")))
+  }
+}))
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
+  #end
+  $util.toJson($GetRequest)
+#end"
+`;
+
+exports[`has one references single partition key 2`] = `
+"#if( $ctx.stash.deniedField )
+  #return($util.toJson(null))
+#end
+#set( $partitionKeyValue = $util.defaultIfNull($ctx.stash.connectionAttibutes.get(\\"teamId\\"), $ctx.source.teamId) )
+#if( $util.isNull($partitionKeyValue) )
+  #return
+#else
+  #set( $GetRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\"
+} )
+  $util.qr($GetRequest.put(\\"query\\", {
+  \\"expression\\": \\"#partitionKey = :partitionValue\\",
+  \\"expressionNames\\": {
+      \\"#partitionKey\\": \\"id\\"
+  },
+  \\"expressionValues\\": {
+      \\":partitionValue\\": $util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($partitionKeyValue, \\"___xamznone____\\")))
+  }
+}))
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
+  #end
+  $util.toJson($GetRequest)
+#end"
+`;
+
+exports[`has one references with multiple sort keys 1`] = `
+"#if( $ctx.stash.deniedField )
+  #return($util.toJson(null))
+#end
+#set( $partitionKeyValue = $util.defaultIfNull($ctx.stash.connectionAttibutes.get(\\"id\\"), $ctx.source.id) )
+#if( $util.isNull($partitionKeyValue) || $util.isNull($ctx.source.mantra) || $util.isNull($ctx.source.organization) )
+  #return
+#else
+  #set( $GetRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\",
+  \\"index\\": \\"gsi-Team.project\\"
+} )
+  $util.qr($GetRequest.put(\\"query\\", {
+  \\"expression\\": \\"#partitionKey = :partitionValue AND #sortKeyName = :sortKeyName\\",
+  \\"expressionNames\\": {
+      \\"#partitionKey\\": \\"teamId\\",
+      \\"#sortKeyName\\": \\"teamMantra\\"
+  },
+  \\"expressionValues\\": {
+      \\":partitionValue\\": $util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($partitionKeyValue, \\"___xamznone____\\"))),
+      \\":sortKeyName\\": $util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank(\\"\${ctx.source.teamMantra}#\${ctx.source.teamOrganization}\\", \\"___xamznone____\\")))
+  }
+}))
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
+  #end
+  $util.toJson($GetRequest)
+#end"
+`;
+
+exports[`has one references with multiple sort keys 2`] = `
+"#if( $ctx.stash.deniedField )
+  #return($util.toJson(null))
+#end
+#set( $partitionKeyValue = $util.defaultIfNull($ctx.stash.connectionAttibutes.get(\\"teamId\\"), $ctx.source.teamId) )
+#if( $util.isNull($partitionKeyValue) || $util.isNull($ctx.source.teamMantra) || $util.isNull($ctx.source.teamOrganization) )
+  #return
+#else
+  #set( $GetRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\"
+} )
+  $util.qr($GetRequest.put(\\"query\\", {
+  \\"expression\\": \\"#partitionKey = :partitionValue AND #sortKeyName = :sortKeyName\\",
+  \\"expressionNames\\": {
+      \\"#partitionKey\\": \\"id\\",
+      \\"#sortKeyName\\": \\"mantra#organization\\"
+  },
+  \\"expressionValues\\": {
+      \\":partitionValue\\": $util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($partitionKeyValue, \\"___xamznone____\\"))),
+      \\":sortKeyName\\": $util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank(\\"\${ctx.source.teamMantra}#\${ctx.source.teamOrganization}\\", \\"___xamznone____\\")))
+  }
+}))
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
+  #end
+  $util.toJson($GetRequest)
+#end"
+`;
+
+exports[`has one references with partition key + sort key 1`] = `
+"#if( $ctx.stash.deniedField )
+  #return($util.toJson(null))
+#end
+#set( $partitionKeyValue = $util.defaultIfNull($ctx.stash.connectionAttibutes.get(\\"id\\"), $ctx.source.id) )
+#if( $util.isNull($partitionKeyValue) || $util.isNull($ctx.source.mantra) )
+  #return
+#else
+  #set( $GetRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\",
+  \\"index\\": \\"gsi-Team.project\\"
+} )
+  $util.qr($GetRequest.put(\\"query\\", {
+  \\"expression\\": \\"#partitionKey = :partitionValue AND #sortKeyName = :sortKeyName\\",
+  \\"expressionNames\\": {
+      \\"#partitionKey\\": \\"teamId\\",
+      \\"#sortKeyName\\": \\"teamMantra\\"
+  },
+  \\"expressionValues\\": {
+      \\":partitionValue\\": $util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($partitionKeyValue, \\"___xamznone____\\"))),
+      \\":sortKeyName\\": $util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.teamMantra, \\"___xamznone____\\")))
+  }
+}))
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
+  #end
+  $util.toJson($GetRequest)
+#end"
+`;
+
+exports[`has one references with partition key + sort key 2`] = `
+"#if( $ctx.stash.deniedField )
+  #return($util.toJson(null))
+#end
+#set( $partitionKeyValue = $util.defaultIfNull($ctx.stash.connectionAttibutes.get(\\"teamId\\"), $ctx.source.teamId) )
+#if( $util.isNull($partitionKeyValue) || $util.isNull($ctx.source.teamMantra) )
+  #return
+#else
+  #set( $GetRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\"
+} )
+  $util.qr($GetRequest.put(\\"query\\", {
+  \\"expression\\": \\"#partitionKey = :partitionValue AND #sortKeyName = :sortKeyName\\",
+  \\"expressionNames\\": {
+      \\"#partitionKey\\": \\"id\\",
+      \\"#sortKeyName\\": \\"mantra\\"
+  },
+  \\"expressionValues\\": {
+      \\":partitionValue\\": $util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($partitionKeyValue, \\"___xamznone____\\"))),
+      \\":sortKeyName\\": $util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.source.teamMantra, \\"___xamznone____\\")))
+  }
+}))
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
+  #end
+  $util.toJson($GetRequest)
+#end"
+`;

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-one-references-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-one-references-transformer.test.ts
@@ -1,0 +1,378 @@
+import { PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { validateModelSchema } from '@aws-amplify/graphql-transformer-core';
+import { parse } from 'graphql';
+import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
+import { BelongsToTransformer, HasManyTransformer, HasOneTransformer } from '..';
+
+test('fails if @hasOne was used on an object that is not a model type', () => {
+  const inputSchema = `
+    type Project {
+      id: ID!
+      name: String
+      team: Team @hasOne(references: ["projectID"])
+    }
+
+    type Team @model {
+      id: ID!
+      name: String
+      projectID: ID
+      project: Project @belongsTo(references: ["projectID"])
+    }`;
+
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
+    }),
+  ).toThrowError('@hasOne must be on an @model object type field.');
+});
+
+test('fails if @hasOne was used with a related type that is not a model', () => {
+  const inputSchema = `
+    type Project @model {
+      id: ID!
+      name: String
+      team: Team @hasOne(references: ["projectID"])
+    }
+
+    type Team {
+      id: ID!
+      name: String
+      projectID: ID
+      project: Project @belongsTo(references: ["projectID"])
+    }`;
+
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
+    }),
+  ).toThrowError();
+  // TODO: Fix error message
+  // Currently throws 'Cannot find datasource type for model Team'
+  // Should throw 'Object type Team must be annotated with @model.'
+});
+
+test('fails if the related type does not exist', () => {
+  const inputSchema = `
+    type Project @Model {
+        id: ID!
+        name: String
+        team: Team1 @hasOne(references: ["projectID"])
+    }
+
+    type Team @model {
+        id: ID!
+        name: String
+        projectID: ID
+        project: Project @belongsTo(references: ["projectID"])
+    }
+  `;
+
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
+    }),
+  ).toThrowError('Unknown type "Team1". Did you mean "Team"?');
+});
+
+test('fails if an empty list of fields is passed in', () => {
+  const inputSchema = `
+    type Project @Model {
+        id: ID!
+        name: String
+        team: Team @hasOne(references: [])
+    }
+
+    type Team @model {
+        id: ID!
+        name: String
+        projectID: ID
+        project: Project @belongsTo(references: ["projectID"])
+    }`;
+
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
+    }),
+  ).toThrowError(); // TODO -- Error message
+});
+
+test('fails if any of the fields passed in are not in the related model', () => {
+  const inputSchema = `
+      type Project @model {
+        id: ID!
+        name: String
+        team: Team @hasOne(references: ["foo"])
+    }
+
+    type Team @model {
+        id: ID!
+        name: String
+        projectID: ID
+        project: Project @belongsTo(references: ["foo"])
+    }
+  `;
+
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
+    }),
+  ).toThrowError('foo is not a field in Team');
+});
+
+test('fails if @hasOne field does not match related type primary key', () => {
+  const inputSchema = `
+    type Project @model {
+        id: ID!
+        name: String
+        team: Team @hasOne(references: ["projectID"])
+    }
+
+    type Team @model {
+        id: ID!
+        name: String
+        projectID: String!
+        project: Project @belongsTo(references: ["projectID"])
+    }
+  `;
+  // TODO: Currently not throwing. Need to add some validation that types match.
+  // expect(() =>
+  //   testTransform({
+  //     schema: inputSchema,
+  //     transformers: [new ModelTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
+  //   }),
+  // ).toThrowError('projectID field is not of type ID');
+});
+
+test('fails if sort key type does not match related type sort key', () => {
+  const inputSchema = `
+      type Project @model {
+        id: ID! @primaryKey(sortKeyFields: ["resourceID"])
+        resourceID: ID!
+        name: String
+        team: Team @hasOne(references: ["projectID", "projectResourceID"])
+      }
+
+      type Team @model {
+        id: ID!
+        name: String
+        projectID: ID
+        projectResourceID: String
+        project: Project @belongsTo(references: ["projectID", "projectResourceID"])
+      }
+    `;
+  // TODO: Currently not throwing. Need to add some validation that types match.
+  // expect(() =>
+  //   testTransform({
+  //     schema: inputSchema,
+  //     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
+  //   }),
+  // ).toThrowError('projectResourceID field is not of type ID');
+});
+
+test('fails if partial sort key is provided', () => {
+  const inputSchema = `
+    type Project @model {
+        id: ID! @primaryKey(sortKeyFields: ["resourceID"])
+        resourceID: ID!
+        name: String
+        team: Team @hasOne(references: ["projectID"])
+    }
+
+    type Team @model {
+        id: ID!
+        name: String
+        projectID: ID
+        project: Project @belongsTo(references: ["projectID"])
+    }
+  `;
+
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
+    }),
+  ).toThrowError('The number of references provided to @hasOne must match the number of primary keys on Project.');
+});
+
+test('accepts @hasOne without a sort key', () => {
+  const inputSchema = `
+    type Test @model {
+      id: ID!
+      email: String!
+      testObj: Test1 @hasOne(references: ["id"])
+    }
+
+    type Test1 @model {
+      id: ID! @primaryKey(sortKeyFields: ["friendID", "name"])
+      friendID: ID!
+      name: String!
+    }
+    `;
+
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
+    }),
+  ).not.toThrowError();
+});
+
+test('fails if used as a has many relation', () => {
+  const inputSchema = `
+    type Project @model {
+      id: ID!
+      email: String!
+      team: [Team] @hasOne(references: "projectID")
+    }
+
+    type Team @model {
+      id: ID! @primaryKey
+      name: String!
+      projectID: ID
+      project: Project @belongsTo(references: "projectID")
+    }`;
+
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
+    }),
+  ).toThrowError('@hasOne cannot be used with lists. Use @hasMany instead.');
+});
+
+test('fails if object type fields are provided', () => {
+  const inputSchema = `
+  type Project @model {
+    id: ID!
+    email: String!
+    team: [Team] @hasOne(references: "projectID")
+  }
+
+  type Team @model {
+    id: ID!
+    name: String!
+    projectID: Test
+    project: Project @belongsTo(references: "projectID")
+  }
+
+  type Test @model {
+    id: ID!
+  }
+  `;
+
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
+    }),
+  ).toThrowError('All references provided to @hasOne must be scalar or enum fields.');
+});
+
+test('has one references single partition key', () => {
+  const inputSchema = `
+    type Project @model {
+      name: String
+      teamId: String
+      team: Team @belongsTo(references: "teamId")
+    }
+
+    type Team @model {
+      id: String!
+      mantra: String
+      project: Project @hasOne(references: "teamId")
+    }
+  `;
+
+  const out = testTransform({
+    schema: inputSchema,
+    transformers: [new ModelTransformer(), new HasOneTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
+  });
+
+  expect(out).toBeDefined();
+  const schema = parse(out.schema);
+  validateModelSchema(schema);
+  expect(out.resolvers['Team.project.req.vtl']).toBeDefined();
+  expect(out.resolvers['Team.project.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Project.team.req.vtl']).toBeDefined();
+  expect(out.resolvers['Project.team.req.vtl']).toMatchSnapshot();
+});
+
+test('has one references with partition key + sort key', () => {
+  const inputSchema = `
+    type Project @model {
+      name: String
+      teamId: String
+      teamMantra: String
+      team: Team @belongsTo(references: ["teamId", "teamMantra"])
+    }
+
+    type Team @model {
+      id: String! @primaryKey(sortKeyFields: ["mantra"])
+      mantra: String!
+      project: Project @hasOne(references: ["teamId", "teamMantra"])
+    }
+  `;
+
+  const out = testTransform({
+    schema: inputSchema,
+    transformers: [
+      new ModelTransformer(),
+      new PrimaryKeyTransformer(),
+      new HasOneTransformer(),
+      new HasManyTransformer(),
+      new BelongsToTransformer(),
+    ],
+  });
+
+  expect(out).toBeDefined();
+  const schema = parse(out.schema);
+  validateModelSchema(schema);
+  expect(out.resolvers['Team.project.req.vtl']).toBeDefined();
+  expect(out.resolvers['Team.project.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Project.team.req.vtl']).toBeDefined();
+  expect(out.resolvers['Project.team.req.vtl']).toMatchSnapshot();
+});
+
+test('has one references with multiple sort keys', () => {
+  const inputSchema = `
+    type Project @model {
+      name: String
+      teamId: String
+      teamMantra: String
+      teamOrganization: String
+      team: Team @belongsTo(references: ["teamId", "teamMantra", "teamOrganization"])
+    }
+
+    type Team @model {
+      id: String! @primaryKey(sortKeyFields: ["mantra", "organization"])
+      mantra: String!
+      organization: String!
+      project: Project @hasOne(references: ["teamId", "teamMantra", "teamOrganization"])
+    }
+  `;
+
+  const out = testTransform({
+    schema: inputSchema,
+    transformers: [
+      new ModelTransformer(),
+      new PrimaryKeyTransformer(),
+      new HasOneTransformer(),
+      new HasManyTransformer(),
+      new BelongsToTransformer(),
+    ],
+  });
+
+  expect(out).toBeDefined();
+  const schema = parse(out.schema);
+  validateModelSchema(schema);
+  expect(out.resolvers['Team.project.req.vtl']).toBeDefined();
+  expect(out.resolvers['Team.project.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Project.team.req.vtl']).toBeDefined();
+  expect(out.resolvers['Project.team.req.vtl']).toMatchSnapshot();
+});

--- a/packages/amplify-graphql-relational-transformer/src/graphql-has-one-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-has-one-transformer.ts
@@ -159,7 +159,7 @@ export class HasOneTransformer extends TransformerPluginBase {
     this.directiveList.forEach((config) => {
       const modelName = config.object.name.value;
       const dbType = getStrategyDbTypeFromModel(context as TransformerContextProvider, modelName);
-      const dataSourceBasedTransformer = getHasOneDirectiveTransformer(dbType);
+      const dataSourceBasedTransformer = getHasOneDirectiveTransformer(dbType, config);
       dataSourceBasedTransformer.prepare(context, config);
     });
   };
@@ -169,7 +169,7 @@ export class HasOneTransformer extends TransformerPluginBase {
 
     for (const config of this.directiveList) {
       const dbType = getStrategyDbTypeFromTypeNode(config.field.type, context);
-      const dataSourceBasedTransformer = getHasOneDirectiveTransformer(dbType);
+      const dataSourceBasedTransformer = getHasOneDirectiveTransformer(dbType, config);
       dataSourceBasedTransformer.transformSchema(ctx, config);
       ensureHasOneConnectionField(config, context);
     }
@@ -180,8 +180,8 @@ export class HasOneTransformer extends TransformerPluginBase {
 
     for (const config of this.directiveList) {
       const dbType = getStrategyDbTypeFromTypeNode(config.field.type, context);
-      const generator = getGenerator(dbType);
-      generator.makeHasOneGetItemConnectionWithKeyResolver(config, context);
+      const dataSourceBasedTransformer = getHasOneDirectiveTransformer(dbType, config);
+      dataSourceBasedTransformer.generateResolvers(ctx, config);
     }
   };
 }
@@ -191,7 +191,7 @@ const validate = (config: HasOneDirectiveConfiguration, ctx: TransformerContextP
 
   const dbType = getStrategyDbTypeFromTypeNode(field.type, ctx);
   config.relatedType = getRelatedType(config, ctx);
-  const dataSourceBasedTransformer = getHasOneDirectiveTransformer(dbType);
+  const dataSourceBasedTransformer = getHasOneDirectiveTransformer(dbType, config);
   dataSourceBasedTransformer.validate(ctx, config);
   validateModelDirective(config);
 

--- a/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-ddb-fields-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-ddb-fields-transformer.ts
@@ -7,6 +7,7 @@ import {
 import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
 import { HasOneDirectiveConfiguration } from '../types';
 import { ensureFieldsArray, getFieldsNodes, getRelatedTypeIndex, registerHasOneForeignKeyMappings } from '../utils';
+import { getGenerator } from '../resolver/generator-factory';
 
 /**
  * HasOneDirectiveDDBFieldsTransformer executes transformations based on `@hasOne(fields: [String!])` configurations
@@ -32,9 +33,9 @@ export class HasOneDirectiveDDBFieldsTransformer implements DataSourceBasedDirec
     config.relatedTypeIndex = getRelatedTypeIndex(config, context as TransformerContextProvider);
   };
 
-  // TODO: Move resolver generation logic here from `HasOneTransformer`.
-  generateResolvers = (_context: TransformerContextProvider, _config: HasOneDirectiveConfiguration): void => {
-    return;
+  generateResolvers = (context: TransformerContextProvider, config: HasOneDirectiveConfiguration): void => {
+    const generator = getGenerator(this.dbType);
+    generator.makeHasOneGetItemConnectionWithKeyResolver(config, context);
   };
 
   validate = (context: TransformerContextProvider, config: HasOneDirectiveConfiguration): void => {

--- a/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-ddb-references-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-ddb-references-transformer.ts
@@ -1,0 +1,47 @@
+import { DDB_DB_TYPE } from '@aws-amplify/graphql-transformer-core';
+import {
+  TransformerContextProvider,
+  TransformerPrepareStepContextProvider,
+  TransformerTransformSchemaStepContextProvider,
+} from '@aws-amplify/graphql-transformer-interfaces';
+import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
+import { DDBRelationalReferencesResolverGenerator } from '../resolver/ddb-references-generator';
+import { setFieldMappingResolverReference, updateTableForReferencesConnection } from '../resolvers';
+import { HasOneDirectiveConfiguration } from '../types';
+import { ensureReferencesArray, getReferencesNodes, registerHasOneForeignKeyMappings, validateParentReferencesFields } from '../utils';
+
+/**
+ * HasOneDirectiveDDBFieldsTransformer executes transformations based on `@hasOne(references: [String!])` configurations
+ * and surrounding TransformerContextProviders for DynamoDB data sources.
+ *
+ * This should not be used for `@hasOne(fields: [String!])` definitions.
+ */
+export class HasOneDirectiveDDBReferencesTransformer implements DataSourceBasedDirectiveTransformer<HasOneDirectiveConfiguration> {
+  dbType = DDB_DB_TYPE;
+
+  prepare = (context: TransformerPrepareStepContextProvider, config: HasOneDirectiveConfiguration): void => {
+    const modelName = config.object.name.value;
+    setFieldMappingResolverReference(context, config.relatedType?.name?.value, modelName, config.field.name.value, true);
+    registerHasOneForeignKeyMappings({
+      transformParameters: context.transformParameters,
+      resourceHelper: context.resourceHelper,
+      thisTypeName: modelName,
+      thisFieldName: config.field.name.value,
+      relatedType: config.relatedType,
+    });
+  };
+
+  transformSchema = (context: TransformerTransformSchemaStepContextProvider, config: HasOneDirectiveConfiguration): void => {
+    validateParentReferencesFields(config, context as TransformerContextProvider);
+  };
+
+  generateResolvers = (context: TransformerContextProvider, config: HasOneDirectiveConfiguration): void => {
+    updateTableForReferencesConnection(config, context);
+    new DDBRelationalReferencesResolverGenerator().makeHasOneGetItemConnectionWithKeyResolver(config, context);
+  };
+
+  validate = (context: TransformerContextProvider, config: HasOneDirectiveConfiguration): void => {
+    ensureReferencesArray(config);
+    config.referenceNodes = getReferencesNodes(config, context);
+  };
+}

--- a/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-sql-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-sql-transformer.ts
@@ -8,6 +8,7 @@ import { DataSourceBasedDirectiveTransformer } from '../data-source-based-direct
 import { setFieldMappingResolverReference } from '../resolvers';
 import { HasOneDirectiveConfiguration } from '../types';
 import { ensureReferencesArray, getReferencesNodes, validateParentReferencesFields } from '../utils';
+import { getGenerator } from '../resolver/generator-factory';
 
 /**
  * HasOneDirectiveSQLTransformer executes transformations based on `@hasOne(references: [String!])` configurations
@@ -25,9 +26,9 @@ export class HasOneDirectiveSQLTransformer implements DataSourceBasedDirectiveTr
     validateParentReferencesFields(config, context as TransformerContextProvider);
   };
 
-  // TODO: Move resolver generation logic here from `HasOneTransformer`.
-  generateResolvers = (_context: TransformerContextProvider, _config: HasOneDirectiveConfiguration): void => {
-    return;
+  generateResolvers = (context: TransformerContextProvider, config: HasOneDirectiveConfiguration): void => {
+    const generator = getGenerator(this.dbType);
+    generator.makeHasOneGetItemConnectionWithKeyResolver(config, context);
   };
 
   validate = (context: TransformerContextProvider, config: HasOneDirectiveConfiguration): void => {

--- a/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-transformer-factory.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-transformer-factory.ts
@@ -3,13 +3,16 @@ import { HasOneDirectiveConfiguration } from '../types';
 import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
 import { HasOneDirectiveDDBFieldsTransformer } from './has-one-directive-ddb-fields-transformer';
 import { HasOneDirectiveSQLTransformer } from './has-one-directive-sql-transformer';
+import { HasOneDirectiveDDBReferencesTransformer } from './has-one-directive-ddb-references-transformer';
 
 const hasOneDirectiveMySqlTransformer = new HasOneDirectiveSQLTransformer();
 const hasOneDirectivePostgresTransformer = new HasOneDirectiveSQLTransformer();
 const hasOneDirectiveDdbFieldsTransformer = new HasOneDirectiveDDBFieldsTransformer();
+const hasOneDirectiveDdbReferencesTransformer = new HasOneDirectiveDDBReferencesTransformer();
 
 export const getHasOneDirectiveTransformer = (
   dbType: ModelDataSourceStrategyDbType,
+  config: HasOneDirectiveConfiguration,
   // eslint-disable-next-line consistent-return
 ): DataSourceBasedDirectiveTransformer<HasOneDirectiveConfiguration> => {
   switch (dbType) {
@@ -18,6 +21,22 @@ export const getHasOneDirectiveTransformer = (
     case 'POSTGRES':
       return hasOneDirectivePostgresTransformer;
     case 'DYNAMODB':
+      // If references are passed to the directive, we'll use the references relational
+      // modeling approach.
+      if (config.references) {
+        // Passing both references and fields is not supported.
+        if (config.fields) {
+          // TODO: Better error message
+          throw new Error('Something went wrong >> cannot have both references and fields.');
+        }
+        if (config.references.length < 1) {
+          throw new Error(`Invalid @hasMany directive on ${config.field.name.value} - empty references list`);
+        }
+        return hasOneDirectiveDdbReferencesTransformer;
+      }
+
+      // fields based relational modeling is the default because it supports implicit
+      // field creation / doesn't require explicitly defining the fields in the directive.
       return hasOneDirectiveDdbFieldsTransformer;
   }
 };

--- a/packages/amplify-graphql-relational-transformer/src/resolver/ddb-generator.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolver/ddb-generator.ts
@@ -221,7 +221,15 @@ export class DDBRelationalResolverGenerator extends RelationalResolverGenerator 
    * @param config The connection directive configuration.
    * @param ctx The transformer context provider.
    */
-  makeHasOneGetItemConnectionWithKeyResolver = (
+  makeHasOneGetItemConnectionWithKeyResolver = (config: HasOneDirectiveConfiguration, ctx: TransformerContextProvider): void => {
+    this.makeHasOneBelongToGetItemConnectionWithKeyResolver(config, ctx);
+  };
+
+  makeBelongsToGetItemConnectionWithKeyResolver = (config: BelongsToDirectiveConfiguration, ctx: TransformerContextProvider): void => {
+    this.makeHasOneBelongToGetItemConnectionWithKeyResolver(config, ctx);
+  };
+
+  makeHasOneBelongToGetItemConnectionWithKeyResolver = (
     config: HasOneDirectiveConfiguration | BelongsToDirectiveConfiguration,
     ctx: TransformerContextProvider,
   ): void => {
@@ -349,9 +357,5 @@ export class DDBRelationalResolverGenerator extends RelationalResolverGenerator 
         isPartitionKey ? `$${PARTITION_KEY_VALUE}` : `$ctx.source.${fieldName}`
       }, "${NONE_VALUE}")))`,
     );
-  };
-
-  makeBelongsToGetItemConnectionWithKeyResolver = (config: BelongsToDirectiveConfiguration, ctx: TransformerContextProvider): void => {
-    this.makeHasOneGetItemConnectionWithKeyResolver(config, ctx);
   };
 }

--- a/packages/amplify-graphql-relational-transformer/src/resolver/ddb-references-generator.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolver/ddb-references-generator.ts
@@ -262,6 +262,8 @@ export class DDBRelationalReferencesResolverGenerator extends DDBRelationalResol
             ifElse(
               and([not(ref('ctx.result.items.isEmpty()')), equals(ref('ctx.result.scannedCount'), int(1))]),
               toJson(ref('ctx.result.items[0]')),
+              // TODO: Should we be checking scannedCount > 0 instead of == 1 here?
+              // The current `fields` based implementation checks if scannedCount == 1
               compoundExpression([
                 iff(and([ref('ctx.result.items.isEmpty()'), equals(ref('ctx.result.scannedCount'), int(1))]), ref('util.unauthorized()')),
                 toJson(nul()),

--- a/packages/amplify-graphql-relational-transformer/src/resolver/ddb-references-generator.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolver/ddb-references-generator.ts
@@ -171,7 +171,6 @@ export class DDBRelationalReferencesResolverGenerator extends DDBRelationalResol
       // TODO: Better error message
       throw new Error('references should be populated.');
     }
-
     const primaryKeyFields: string[] = getPrimaryKeyFields(object);
     const dataSourceName = getModelDataSourceNameForTypeName(ctx, relatedType.name.value);
     const dataSource = ctx.api.host.getDataSource(dataSourceName);
@@ -187,8 +186,8 @@ export class DDBRelationalReferencesResolverGenerator extends DDBRelationalResol
 
     if (references.length > 2) {
       const rangeKeyFields = references.slice(1);
-      const sortKeyName = rangeKeyFields[0];
-      const condensedSortKeyValue = condenseRangeKey(rangeKeyFields.map((keyField) => `\${ctx.source.${keyField}}`));
+      const sortKeyName = condenseRangeKey(rangeKeyFields);
+      const condensedSortKeyValue = condenseRangeKey(primaryKeyFields.slice(1).map((keyField) => `\${ctx.source.${keyField}}`));
 
       totalExpressions.push('#sortKeyName = :sortKeyName');
       totalExpressionNames['#sortKeyName'] = str(sortKeyName);
@@ -199,7 +198,7 @@ export class DDBRelationalReferencesResolverGenerator extends DDBRelationalResol
       const sortKeyName = references[1];
       totalExpressions.push('#sortKeyName = :sortKeyName');
       totalExpressionNames['#sortKeyName'] = str(sortKeyName);
-      totalExpressionValues[':sortKeyName'] = this.buildKeyValueExpression(references[1], ctx.output.getObject(object.name.value)!);
+      totalExpressionValues[':sortKeyName'] = this.buildKeyValueExpression(primaryKeyFields[1], ctx.output.getObject(object.name.value)!);
     }
 
     const resolverResourceId = ResolverResourceIDs.ResolverResourceID(object.name.value, field.name.value);

--- a/packages/amplify-graphql-relational-transformer/src/resolver/ddb-references-generator.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolver/ddb-references-generator.ts
@@ -165,8 +165,117 @@ export class DDBRelationalReferencesResolverGenerator extends DDBRelationalResol
     ctx.resolvers.addResolver(object.name.value, field.name.value, resolver);
   };
 
-  makeHasOneGetItemConnectionWithKeyResolver = (_config: HasOneDirectiveConfiguration, _ctx: TransformerContextProvider): void => {
-    // TODO: Implement hasOne resolver -- this should be nearly identical to hasMany
+  makeHasOneGetItemConnectionWithKeyResolver = (config: HasOneDirectiveConfiguration, ctx: TransformerContextProvider): void => {
+    const { field, indexName, references, object, relatedType } = config;
+    if (references.length < 1) {
+      // TODO: Better error message
+      throw new Error('references should be populated.');
+    }
+
+    const primaryKeyFields: string[] = getPrimaryKeyFields(object);
+    const dataSourceName = getModelDataSourceNameForTypeName(ctx, relatedType.name.value);
+    const dataSource = ctx.api.host.getDataSource(dataSourceName);
+    const partitionKeyName = references[0];
+    const totalExpressions = ['#partitionKey = :partitionValue'];
+    const totalExpressionNames: Record<string, Expression> = {
+      '#partitionKey': str(partitionKeyName),
+    };
+
+    const totalExpressionValues: Record<string, Expression> = {
+      ':partitionValue': this.buildKeyValueExpression(references[0], relatedType, true),
+    };
+
+    if (references.length > 2) {
+      const rangeKeyFields = references.slice(1);
+      const sortKeyName = rangeKeyFields[0];
+      const condensedSortKeyValue = condenseRangeKey(rangeKeyFields.map((keyField) => `\${ctx.source.${keyField}}`));
+
+      totalExpressions.push('#sortKeyName = :sortKeyName');
+      totalExpressionNames['#sortKeyName'] = str(sortKeyName);
+      totalExpressionValues[':sortKeyName'] = ref(
+        `util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank("${condensedSortKeyValue}", "${NONE_VALUE}")))`,
+      );
+    } else if (references.length === 2) {
+      const sortKeyName = references[1];
+      totalExpressions.push('#sortKeyName = :sortKeyName');
+      totalExpressionNames['#sortKeyName'] = str(sortKeyName);
+      totalExpressionValues[':sortKeyName'] = this.buildKeyValueExpression(references[1], ctx.output.getObject(object.name.value)!);
+    }
+
+    const resolverResourceId = ResolverResourceIDs.ResolverResourceID(object.name.value, field.name.value);
+    const resolver = ctx.resolvers.generateQueryResolver(
+      object.name.value,
+      field.name.value,
+      resolverResourceId,
+      dataSource as any,
+      MappingTemplate.s3MappingTemplateFromString(
+        print(
+          compoundExpression([
+            iff(ref('ctx.stash.deniedField'), raw('#return($util.toJson(null))')),
+            set(
+              ref(PARTITION_KEY_VALUE),
+              methodCall(
+                ref('util.defaultIfNull'),
+                ref(`ctx.stash.connectionAttibutes.get("${primaryKeyFields[0]}")`),
+                ref(`ctx.source.${primaryKeyFields[0]}`),
+              ),
+            ),
+            ifElse(
+              or([
+                methodCall(ref('util.isNull'), ref(PARTITION_KEY_VALUE)),
+                ...primaryKeyFields.slice(1).map((f) => raw(`$util.isNull($ctx.source.${f})`)),
+              ]),
+              raw('#return'),
+              compoundExpression([
+                set(ref('GetRequest'), obj({ version: str('2018-05-29'), operation: str('Query'), index: str(indexName) })),
+                qref(
+                  methodCall(
+                    ref('GetRequest.put'),
+                    str('query'),
+                    obj({
+                      expression: str(totalExpressions.join(' AND ')),
+                      expressionNames: obj(totalExpressionNames),
+                      expressionValues: obj(totalExpressionValues),
+                    }),
+                  ),
+                ),
+                iff(
+                  not(isNullOrEmpty(authFilter)),
+                  qref(
+                    methodCall(
+                      ref('GetRequest.put'),
+                      str('filter'),
+                      methodCall(ref('util.parseJson'), methodCall(ref('util.transform.toDynamoDBFilterExpression'), authFilter)),
+                    ),
+                  ),
+                ),
+                toJson(ref('GetRequest')),
+              ]),
+            ),
+          ]),
+        ),
+        `${object.name.value}.${field.name.value}.req.vtl`,
+      ),
+      MappingTemplate.s3MappingTemplateFromString(
+        print(
+          DynamoDBMappingTemplate.dynamoDBResponse(
+            false,
+            ifElse(
+              and([not(ref('ctx.result.items.isEmpty()')), equals(ref('ctx.result.scannedCount'), int(1))]),
+              toJson(ref('ctx.result.items[0]')),
+              compoundExpression([
+                iff(and([ref('ctx.result.items.isEmpty()'), equals(ref('ctx.result.scannedCount'), int(1))]), ref('util.unauthorized()')),
+                toJson(nul()),
+              ]),
+            ),
+          ),
+        ),
+        `${object.name.value}.${field.name.value}.res.vtl`,
+      ),
+    );
+
+    resolver.setScope(ctx.stackManager.getScopeFor(resolverResourceId, CONNECTION_STACK));
+    ctx.resolvers.addResolver(object.name.value, field.name.value, resolver);
   };
 
   /**

--- a/packages/amplify-graphql-relational-transformer/src/resolver/generator.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolver/generator.ts
@@ -3,9 +3,6 @@ import { BelongsToDirectiveConfiguration, HasManyDirectiveConfiguration, HasOneD
 
 export abstract class RelationalResolverGenerator {
   abstract makeHasManyGetItemsConnectionWithKeyResolver(config: HasManyDirectiveConfiguration, ctx: TransformerContextProvider): void;
-  abstract makeHasOneGetItemConnectionWithKeyResolver(
-    config: HasOneDirectiveConfiguration | BelongsToDirectiveConfiguration,
-    ctx: TransformerContextProvider,
-  ): void;
-  abstract makeBelongsToGetItemConnectionWithKeyResolver(config: HasOneDirectiveConfiguration, ctx: TransformerContextProvider): void;
+  abstract makeHasOneGetItemConnectionWithKeyResolver(config: HasOneDirectiveConfiguration, ctx: TransformerContextProvider): void;
+  abstract makeBelongsToGetItemConnectionWithKeyResolver(config: BelongsToDirectiveConfiguration, ctx: TransformerContextProvider): void;
 }

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -5,7 +5,7 @@ import * as cdk from 'aws-cdk-lib';
 import { FieldDefinitionNode, ObjectTypeDefinitionNode } from 'graphql';
 import { ModelResourceIDs, ResourceConstants } from 'graphql-transformer-common';
 import { getSortKeyFields } from './schema';
-import { HasManyDirectiveConfiguration } from './types';
+import { HasManyDirectiveConfiguration, HasOneDirectiveConfiguration } from './types';
 import { getConnectionAttributeName, getObjectPrimaryKey } from './utils';
 
 /**
@@ -21,21 +21,22 @@ import { getConnectionAttributeName, getObjectPrimaryKey } from './utils';
  * @param ctx The `TransformerContextProvider` for DDB references.
  */
 export const updateTableForReferencesConnection = (
-  config: HasManyDirectiveConfiguration, // TODO: Add support for HasOneDirectiveConfiguration
+  config: HasManyDirectiveConfiguration | HasOneDirectiveConfiguration,
   ctx: TransformerContextProvider,
 ): void => {
   const { field, referenceNodes, indexName: incomingIndexName, object, references, relatedType } = config;
+  const mappedObjectName = ctx.resourceHelper.getModelNameMapping(object.name.value);
 
   if (incomingIndexName) {
-    // TODO: log warning or throw that indexName isn't supported for DDB references
-    // Ideally validate this further up the chain.
+    throw new Error(
+      `Invalid @hasMany directive on ${mappedObjectName}.${field.name.value} - indexName is not supported with DDB references.`,
+    );
   }
 
   if (references.length < 1 || referenceNodes.length < 1) {
     throw new Error('references should not be empty here'); // TODO: better error message
   }
 
-  const mappedObjectName = ctx.resourceHelper.getModelNameMapping(object.name.value);
   const indexName = `gsi-${mappedObjectName}.${field.name.value}`;
   config.indexName = indexName;
 

--- a/packages/amplify-graphql-relational-transformer/src/schema.ts
+++ b/packages/amplify-graphql-relational-transformer/src/schema.ts
@@ -126,7 +126,10 @@ const ensureModelSortDirectionEnum = (ctx: TransformerContextProvider): void => 
 /**
  * ensureHasOneConnectionField
  */
-export const ensureHasOneConnectionField = (config: HasOneDirectiveConfiguration, ctx: TransformerContextProvider): void => {
+export const ensureHasOneConnectionField = (
+  config: HasOneDirectiveConfiguration | BelongsToDirectiveConfiguration,
+  ctx: TransformerContextProvider,
+): void => {
   const { field, fieldNodes, references, object, relatedType } = config;
 
   // If fields were explicitly provided to the directive, there is nothing else to do here.

--- a/packages/amplify-graphql-relational-transformer/src/types.ts
+++ b/packages/amplify-graphql-relational-transformer/src/types.ts
@@ -6,9 +6,15 @@ export type HasOneDirectiveConfiguration = {
   object: ObjectTypeDefinitionNode;
   field: FieldDefinitionNode;
   directive: DirectiveNode;
+  indexName: string;
+  /** `fields` strings passed to `@hasOne(fields:)` */
   fields: string[];
+  /** `references` strings passed to `@hasOne(references:)` */
   references: string[];
+  /** `FieldDefinitionNode`s for each of the `fields` including type information from the `relatedType`. */
   fieldNodes: FieldDefinitionNode[];
+  /** `FieldDefinitionNode`s for each of the `references` including type information from the `relatedType`. */
+  referenceNodes: FieldDefinitionNode[];
   relatedType: ObjectTypeDefinitionNode;
   relatedTypeIndex: FieldDefinitionNode[];
   connectionFields: string[];

--- a/packages/amplify-graphql-relational-transformer/src/utils.ts
+++ b/packages/amplify-graphql-relational-transformer/src/utils.ts
@@ -197,6 +197,7 @@ export const ensureReferencesBidirectionality = (
   config: HasManyDirectiveConfiguration | BelongsToDirectiveConfiguration, // TODO: Add HasOnyDirectiveConfiguration
 ): void => {
   if (config.fields) {
+    // TODO: Better error message
     throw new InvalidDirectiveError('fields and references cannot be used together.');
   }
 
@@ -207,15 +208,10 @@ export const ensureReferencesBidirectionality = (
       - if belongsTo --> hasMany | hasOne
     2. find matching propertyName
       - directive.arguments[].references === config.references (order matters)
-    3. confirm matching type as sanity check
-      - field.type.name.value == config.type
-
+    3. validate matching type
+      - field.type.name.value === config.type
 
   */
-  // const related = config.relatedType;
-  // const otherSide = related.fields?.find((field) => {
-  //   const hasDirective = field?.directives?.length >= 1
-  // })
 };
 
 export const getModelDirective = (objectType: ObjectTypeDefinitionNode): DirectiveNode | undefined => {

--- a/packages/amplify-graphql-relational-transformer/src/utils.ts
+++ b/packages/amplify-graphql-relational-transformer/src/utils.ts
@@ -75,7 +75,7 @@ export const validateChildReferencesFields = (config: BelongsToDirectiveConfigur
 };
 
 export const getRelatedTypeIndex = (
-  config: HasOneDirectiveConfiguration,
+  config: HasOneDirectiveConfiguration | BelongsToDirectiveConfiguration,
   ctx: TransformerContextProvider,
   indexName?: string,
 ): FieldDefinitionNode[] => {
@@ -193,6 +193,31 @@ export const ensureReferencesArray = (
   }
 };
 
+export const ensureReferencesBidirectionality = (
+  config: HasManyDirectiveConfiguration | BelongsToDirectiveConfiguration, // TODO: Add HasOnyDirectiveConfiguration
+): void => {
+  if (config.fields) {
+    throw new InvalidDirectiveError('fields and references cannot be used together.');
+  }
+
+  /*
+    1. find related directives:
+      - if hasMany --> belongsTo
+      - if hasOne --> belongsTo
+      - if belongsTo --> hasMany | hasOne
+    2. find matching propertyName
+      - directive.arguments[].references === config.references (order matters)
+    3. confirm matching type as sanity check
+      - field.type.name.value == config.type
+
+
+  */
+  // const related = config.relatedType;
+  // const otherSide = related.fields?.find((field) => {
+  //   const hasDirective = field?.directives?.length >= 1
+  // })
+};
+
 export const getModelDirective = (objectType: ObjectTypeDefinitionNode): DirectiveNode | undefined => {
   return objectType.directives!.find((directive) => directive.name.value === 'model');
 };
@@ -254,6 +279,7 @@ export const getReferencesNodes = (
     const fieldNode = relatedType.fields!.find((field) => field.name.value === fieldName);
 
     if (!fieldNode) {
+      // TODO: include more directive / type information to help debugging.
       throw new InvalidDirectiveError(`${fieldName} is not a field in ${relatedType.name.value}`);
     }
 


### PR DESCRIPTION
#### Description of changes
Adds `references` support for DDB data sources when defining `@hasOne` relationships.
- Adds `HasOneDirectiveDDBReferencesTransformer`
- Fixes input types in `RelationalResolverGenerator` abstract class and some method signatures.
- Adds some logic in the `getHasOneDirectiveTransformer` to unlock use references implementation for `hasOne`.
- Adds `hasOne` resolver implementation.
- Adds (start of) unit test in `amplify-graphql-has-one-references-transformer.test.ts`

##### CDK / CloudFormation Parameters Changed
None

#### Issue #, if available
N/A

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
