### PR TITLE
fix(graphql-relational-transformer): fix references vs fields branching logic

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-ddb-references-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-ddb-references-transformer.ts
@@ -46,6 +46,6 @@ export class BelongsToDirectiveDDBReferencesTransformer implements DataSourceBas
 
   validate = (context: TransformerContextProvider, config: BelongsToDirectiveConfiguration): void => {
     ensureReferencesArray(config);
-    config.fieldNodes = getBelongsToReferencesNodes(config, context);
+    config.referenceNodes = getBelongsToReferencesNodes(config, context);
   };
 }

--- a/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-transformer-factory.ts
+++ b/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-transformer-factory.ts
@@ -21,18 +21,22 @@ export const getBelongsToDirectiveTransformer = (
     case 'POSTGRES':
       return belongsToDirectivePostgresTransformer;
     case 'DYNAMODB':
-      // If `references` are passed to the directive, we'll use the references relational
+    // If references are passed to the directive, we'll use the references relational
       // modeling approach.
-      if (config.references?.length >= 1) {
-        // Passing both `references` and `fields` is not supported.
-        if (config.fields?.length > 0) {
+      if (config.references) {
+        // Passing both references and fields is not supported.
+        if (config.fields) {
           // TODO: Better error message
           throw new Error('Something went wrong >> cannot have both references and fields.');
         }
+        if (config.references.length < 1) {
+          throw new Error(`Invalid @belongsTo directive on ${config.field.name.value} - empty references list`);
+        }
         return belongsToDirectiveDdbReferencesTransformer;
       }
-      // `fields` based relational modeling is the default because it supports implicit
-      // field creation / doesn't require explicitly defining the `fields` in the directive.
+
+      // fields based relational modeling is the default because it supports implicit
+      // field creation / doesn't require explicitly defining the fields in the directive.
       return belongsToDirectiveDdbFieldsTransformer;
   }
 };

--- a/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-ddb-references-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-ddb-references-transformer.ts
@@ -43,5 +43,6 @@ export class HasManyDirectiveDDBReferencesTransformer implements DataSourceBased
   validate = (context: TransformerContextProvider, config: HasManyDirectiveConfiguration): void => {
     ensureReferencesArray(config);
     config.referenceNodes = getReferencesNodes(config, context);
+    // TODO: validate bidirectionality
   };
 }

--- a/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-transformer-factory.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-transformer-factory.ts
@@ -23,14 +23,18 @@ export const getHasManyDirectiveTransformer = (
     case 'DYNAMODB':
       // If references are passed to the directive, we'll use the references relational
       // modeling approach.
-      if (config.references?.length >= 1) {
+      if (config.references) {
         // Passing both references and fields is not supported.
-        if (config.fields?.length > 0) {
+        if (config.fields) {
           // TODO: Better error message
           throw new Error('Something went wrong >> cannot have both references and fields.');
         }
+        if (config.references.length < 1) {
+          throw new Error(`Invalid @hasMany directive on ${config.field.name.value} - empty references list`);
+        }
         return hasManyDirectiveDdbReferencesTransformer;
       }
+
       // fields based relational modeling is the default because it supports implicit
       // field creation / doesn't require explicitly defining the fields in the directive.
       return hasManyDirectiveDdbFieldsTransformer;


### PR DESCRIPTION
#### Description of changes
Small fix to branching logic when determining fields vs references in relational transformers.
Dependent on https://github.com/aws-amplify/amplify-category-api/pull/2380

##### CDK / CloudFormation Parameters Changed
None

#### Issue #, if available
N/A

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
