### PR TITLE
test: Scope auth/unauth roles created in e2e tests

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/cognitoUtils.ts
+++ b/packages/graphql-transformers-e2e-tests/src/cognitoUtils.ts
@@ -228,6 +228,9 @@ export function addIAMRolesToCFNStack(out: DeploymentResources, e2eConfig: E2Eco
           },
           Action: 'sts:AssumeRoleWithWebIdentity',
           Condition: {
+            StringEquals: {
+              'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
+            },
             'ForAnyValue:StringLike': {
               'cognito-identity.amazonaws.com:amr': 'authenticated',
             },
@@ -250,6 +253,9 @@ export function addIAMRolesToCFNStack(out: DeploymentResources, e2eConfig: E2Eco
           },
           Action: 'sts:AssumeRoleWithWebIdentity',
           Condition: {
+            StringEquals: {
+              'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
+            },
             'ForAnyValue:StringLike': {
               'cognito-identity.amazonaws.com:amr': 'unauthenticated',
             },


### PR DESCRIPTION
#### Description of changes

Adds appropriate Cognito Identity ID conditions to role trust policies for E2E test roles. These conditions mimic those created by Amplify CLI.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] [E2E test](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:6b5a2f62-45bd-4bfd-ae3c-d2fcb15c8503?region=us-east-1) passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
