### PR TITLE
fix(graphql-relational-transformer): properly create sortkey for generated gsi on related table

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -61,8 +61,9 @@ export const updateTableForReferencesConnection = (
   // -- ideally further up the chain
   const partitionKeyType = attributeTypeFromType(referenceNode.type, ctx);
 
-  // TODO: Add support for sortKey in GSI
-  const sortKey = undefined;
+  // The sortKeys are any referencesNodes following the first element.
+  const sortKeyReferenceNodes = referenceNodes.slice(1);
+  const sortKey = getReferencesBasedDDBSortKey(sortKeyReferenceNodes, ctx);
 
   addGlobalSecondaryIndex(relatedTable, {
     indexName: indexName,
@@ -71,6 +72,37 @@ export const updateTableForReferencesConnection = (
     ctx: ctx,
     relatedTypeName: relatedType.name.value,
   });
+};
+
+/**
+ * Given a list a `FieldDefinitionNode`s representing sortKeys for a references based relationship where the
+ * related model's data source is DDB, this provides the sortKey as a `KeyAttributeDefinition`.
+ * @param sortKeyNodes The `FieldDefinitionNode`s representing sortKeys of the references based relationship.
+ * @param ctx The `TransformerContextProvider` passed down the transformer chain.
+ * @returns A `KeyAttributeDefinition` representing the sort key to be added to a DDB table.
+ */
+const getReferencesBasedDDBSortKey = (
+  sortKeyNodes: FieldDefinitionNode[],
+  ctx: TransformerContextProvider,
+): KeyAttributeDefinition | undefined => {
+  if (sortKeyNodes.length === 1) {
+    // If there's only one sortKeysFields defined, we'll use its type.
+    return {
+      name: sortKeyNodes[0].name.value,
+      type: attributeTypeFromType(sortKeyNodes[0].type, ctx),
+    };
+  } else if (sortKeyNodes.length > 1) {
+    // If there's more than one sortKeysFields defined, we'll combine the names with
+    // a `#` delimiter with a type `S` (string).
+    const sortKeyFieldNames = sortKeyNodes.map((node) => node.name.value);
+    return {
+      name: condenseRangeKey(sortKeyFieldNames),
+      type: 'S',
+    };
+  }
+
+  // If no sortKeysFields are defined, the returned sortKey is `undefined`.
+  return undefined
 };
 
 /**


### PR DESCRIPTION
#### Description of changes
Adds missing support for sort keys on generated GSIs on the related model DDB table in the new `references` world.

Example schema
```graphql
type Foo @model {
  id: ID! @primaryKey(sortKeyFields: ["baz", "quux"])
  baz: String!
  quux: Int!
  bar: Bar @hasOne(references: ["fooID", "fooBaz", "fooQuux"])
}

type Bar @model {
  id: ID!
  fooID: ID
  fooBaz: String
  fooQuux: Int
  foo: Foo @belongsTo(references: ["fooID", "fooBaz", "fooQuux"])
}
```

##### CDK / CloudFormation Parameters Changed
None

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit and manual E2E testing

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] ~Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)~
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
