### PR TITLE
test(graphql-relational-transformer): add some more unit tests for has-many references ddb

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-references-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-references-transformer.test.ts.snap
@@ -388,6 +388,161 @@ exports[`has many query 3`] = `
 #end"
 `;
 
+exports[`hasMany / hasOne - belongsTo across data source type boundary 1`] = `
+"#if( $ctx.stash.deniedField )
+  #return($util.toJson(null))
+#end
+#set( $partitionKeyValue = $util.defaultIfNull($ctx.stash.connectionAttibutes.get(\\"id\\"), $ctx.source.id) )
+#if( $util.isNull($partitionKeyValue) )
+  #return
+#else
+  #set( $GetRequest = {
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Query\\",
+  \\"index\\": \\"gsi-Team.project\\"
+} )
+  $util.qr($GetRequest.put(\\"query\\", {
+  \\"expression\\": \\"#partitionKey = :partitionValue\\",
+  \\"expressionNames\\": {
+      \\"#partitionKey\\": \\"teamId\\"
+  },
+  \\"expressionValues\\": {
+      \\":partitionValue\\": $util.parseJson($util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($partitionKeyValue, \\"___xamznone____\\")))
+  }
+}))
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    $util.qr($GetRequest.put(\\"filter\\", $util.parseJson($util.transform.toDynamoDBFilterExpression($ctx.stash.authFilter))))
+  #end
+  $util.toJson($GetRequest)
+#end"
+`;
+
+exports[`hasMany / hasOne - belongsTo across data source type boundary 2`] = `
+"#if( $ctx.stash.deniedField )
+  #return($util.toJson(null))
+#end
+#set( $partitionKeyValue = $util.defaultIfNull($ctx.stash.connectionAttributes.get(\\"id\\"), $ctx.source.id) )
+#if( $util.isNull($partitionKeyValue) )
+  #set( $result = {
+  \\"items\\":   []
+} )
+  #return($result)
+#else
+  #set( $limit = $util.defaultIfNull($context.args.limit, 100) )
+  #set( $query = {
+  \\"expression\\": \\"#partitionKey = :partitionKey\\",
+  \\"expressionNames\\": {
+      \\"#partitionKey\\": \\"teamId\\"
+  },
+  \\"expressionValues\\": {
+      \\":partitionKey\\": $util.dynamodb.toDynamoDB($partitionKeyValue)
+  }
+} )
+  #set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+  #if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+    #set( $filter = $ctx.stash.authFilter )
+    #if( !$util.isNullOrEmpty($args.filter) )
+      #set( $filter = {
+  \\"and\\":   [$filter, $args.filter]
+} )
+    #end
+  #else
+    #if( !$util.isNullOrEmpty($args.filter) )
+      #set( $filter = $args.filter )
+    #end
+  #end
+  #if( !$util.isNullOrEmpty($filter) )
+    #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
+    #if( !$util.isNullOrBlank($filterExpression.expression) )
+      #if( $filterExpression.expressionValues.size() == 0 )
+        $util.qr($filterExpression.remove(\\"expressionValues\\"))
+      #end
+      #set( $filter = $filterExpression )
+    #end
+  #end
+{
+      \\"version\\": \\"2018-05-29\\",
+      \\"operation\\": \\"Query\\",
+      \\"query\\":     $util.toJson($query),
+      \\"scanIndexForward\\":     #if( $context.args.sortDirection )
+      #if( $context.args.sortDirection == \\"ASC\\" )
+true
+      #else
+false
+      #end
+    #else
+true
+    #end,
+      \\"filter\\":     #if( $filter )
+$util.toJson($filter)
+    #else
+null
+    #end,
+      \\"limit\\": $limit,
+      \\"nextToken\\":     #if( $context.args.nextToken )
+$util.toJson($context.args.nextToken)
+    #else
+null
+    #end,
+      \\"index\\": \\"gsi-Team.members\\"
+  }
+#end"
+`;
+
+exports[`hasMany / hasOne - belongsTo across data source type boundary 3`] = `
+"## [Start] Invoke RDS Lambda data source. **
+#if( $ctx.stash.deniedField )
+  #return($util.toJson(null))
+#end
+#set( $lambdaInput = {} )
+#set( $lambdaInput.args = {} )
+#set( $lambdaInput.table = \\"Team\\" )
+#set( $lambdaInput.operation = \\"GET\\" )
+#set( $lambdaInput.operationName = \\"BelongsToConnectionQuery\\" )
+#set( $lambdaInput.args.metadata = {} )
+#set( $lambdaInput.args.metadata.keys = [\\"id\\"] )
+#set( $lambdaInput.args.metadata.fieldMap = {} )
+$util.qr($lambdaInput.args.metadata.fieldMap.putAll($util.defaultIfNull($context.stash.fieldMap, {})))
+$util.qr($lambdaInput.args.putAll($util.defaultIfNull($context.arguments, {})))
+#if( !$lambdaInput.args.input )
+  #set( $lambdaInput.args.input = {} )
+#end
+$util.qr($lambdaInput.args.input.put(\\"id\\", $util.defaultIfNull($ctx.source.teamId, \\"\\")))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Invoke\\",
+  \\"payload\\":   $util.toJson($lambdaInput)
+}
+## [End] Invoke RDS Lambda data source. **"
+`;
+
+exports[`hasMany / hasOne - belongsTo across data source type boundary 4`] = `
+"## [Start] Invoke RDS Lambda data source. **
+#if( $ctx.stash.deniedField )
+  #return($util.toJson(null))
+#end
+#set( $lambdaInput = {} )
+#set( $lambdaInput.args = {} )
+#set( $lambdaInput.table = \\"Team\\" )
+#set( $lambdaInput.operation = \\"GET\\" )
+#set( $lambdaInput.operationName = \\"BelongsToConnectionQuery\\" )
+#set( $lambdaInput.args.metadata = {} )
+#set( $lambdaInput.args.metadata.keys = [\\"id\\"] )
+#set( $lambdaInput.args.metadata.fieldMap = {} )
+$util.qr($lambdaInput.args.metadata.fieldMap.putAll($util.defaultIfNull($context.stash.fieldMap, {})))
+$util.qr($lambdaInput.args.putAll($util.defaultIfNull($context.arguments, {})))
+#if( !$lambdaInput.args.input )
+  #set( $lambdaInput.args.input = {} )
+#end
+$util.qr($lambdaInput.args.input.put(\\"id\\", $util.defaultIfNull($ctx.source.teamId, \\"\\")))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"Invoke\\",
+  \\"payload\\":   $util.toJson($lambdaInput)
+}
+## [End] Invoke RDS Lambda data source. **"
+`;
+
 exports[`many to many query 1`] = `
 "type Post {
   id: ID!

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-references-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-references-transformer.test.ts
@@ -1,8 +1,8 @@
 import { IndexTransformer, PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
-import { ConflictHandlerType, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
+import { ConflictHandlerType, DDB_DEFAULT_DATASOURCE_STRATEGY, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
 import { Kind, parse } from 'graphql';
-import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
+import { mockSqlDataSourceStrategy, testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import { BelongsToTransformer, HasManyTransformer, HasOneTransformer } from '..';
 
 test('has many query', () => {
@@ -49,6 +49,205 @@ test('has many query', () => {
   expect(out.resolvers['Member.team.req.vtl']).toMatchSnapshot();
 });
 
+test('fails if indexName is provided with references', () => {
+  const inputSchema = `
+    type Team @model {
+      id: ID!
+      name: String!
+      members: [Member] @hasMany(indexName: "foo", references: ["teamID"])
+    }
+    type Member @model {
+      id: ID!
+      teamID: ID! @index(name: "foo")
+      team: Team @belongsTo(references: ["teamID"])
+    }`;
+
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new IndexTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
+    }),
+  ).toThrowError('Invalid @hasMany directive on Team.members - indexName is not supported with DDB references.');
+});
+
+test('fails if property does not exist on related type with references', () => {
+  const inputSchema = `
+    type Team @model {
+      id: ID!
+      name: String!
+      members: [Member] @hasMany(references: ["teamID"])
+    }
+    type Member @model {
+      id: ID!
+      team: Team @belongsTo(references: ["teamID"])
+    }`;
+
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new IndexTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
+    }),
+  ).toThrowError('teamID is not a field in Member');
+});
+
+test('fails if an empty list of references is passed in', () => {
+  const inputSchema = `
+    type Team @model {
+      id: ID!
+      name: String!
+      members: [Member] @hasMany(references: [])
+    }
+    type Member @model {
+      id: ID!
+      team: Team @belongsTo(references: [])
+    }`;
+
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
+    }),
+  ).toThrowError('Invalid @hasMany directive on members - empty references list');
+});
+
+test('fails if related type does not exist', () => {
+  const inputSchema = `
+    type Team @model {
+      id: ID!
+      name: String!
+      members: [Foo] @hasMany(references: ["teamID"])
+    }
+    type Member @model {
+      id: ID!
+      teamID: String
+      team: Team @belongsTo(references: ["teamID"])
+    }`;
+
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
+    }),
+  ).toThrowError(); // TODO: Fix validation error messaging - 'Unknown type "Foo". Did you mean "Member"?'
+});
+
+test('fails if hasMany related type is not an array', () => {
+  const inputSchema = `
+    type Team @model {
+      id: ID!
+      name: String!
+      members: Member @hasMany(references: ["teamID"])
+    }
+    type Member @model {
+      id: ID!
+      teamID: String
+      team: Team @belongsTo(references: ["teamID"])
+    }`;
+
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
+    }),
+  ).toThrowError(); // TODO: Error message
+});
+
+test('fails if uni-directional hasMany', () => {
+  const inputSchema = `
+    type Team @model {
+      id: ID!
+      name: String!
+      members: [Member] @hasMany(references: ["teamID"])
+    }
+    type Member @model {
+      id: ID!
+      teamID: String
+      team: Team
+    }`;
+
+  // TODO: This should fail -- find appropriate place to validate.
+  // expect(() =>
+  //   testTransform({
+  //     schema: inputSchema,
+  //     transformers: [new ModelTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
+  //   }),
+  // ).toThrowError();
+});
+
+test('fails if used as a has one relationship', () => {
+  const inputSchema = `
+    type Team @model {
+      id: ID!
+      name: String!
+      members: Member @hasMany(references: ["teamID"])
+    }
+    type Member @model {
+      id: ID!
+      teamID: String
+      team: Team @belongsTo(fields: ["teamID"])
+    }`;
+
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
+    }),
+  ).toThrowError('@hasMany must be used with a list. Use @hasOne for non-list types.');
+});
+
+test('hasMany / hasOne - belongsTo across data source type boundary', () => {
+  const mockSqlStrategy = mockSqlDataSourceStrategy();
+
+  const inputDdbSchema = `
+    type Member @model {
+      name: String
+      team: Team @belongsTo(references: "teamId")
+      teamId: String
+    }
+
+    type Project @model {
+      name: String
+      teamId: String
+      team: Team @belongsTo(references: "teamId")
+    }
+
+    type Team @model {
+      id: String! @primaryKey
+      mantra: String
+      members: [Member!] @hasMany(references: "teamId")
+      project: Project @hasOne(references: "teamId")
+    }
+  `;
+
+  const out = testTransform({
+    schema: inputDdbSchema,
+    transformers: [
+      new ModelTransformer(),
+      new PrimaryKeyTransformer(),
+      new HasOneTransformer(),
+      new HasManyTransformer(),
+      new BelongsToTransformer(),
+    ],
+    dataSourceStrategies: {
+      Member: DDB_DEFAULT_DATASOURCE_STRATEGY,
+      Project: DDB_DEFAULT_DATASOURCE_STRATEGY,
+      Team: mockSqlStrategy,
+    },
+  });
+
+  expect(out).toBeDefined();
+  const schema = parse(out.schema);
+  validateModelSchema(schema);
+  expect(out.resolvers['Team.project.req.vtl']).toBeDefined();
+  expect(out.resolvers['Team.project.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Team.members.req.vtl']).toBeDefined();
+  expect(out.resolvers['Team.members.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Project.team.req.vtl']).toBeDefined();
+  expect(out.resolvers['Project.team.req.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Member.team.req.vtl']).toBeDefined();
+  expect(out.resolvers['Member.team.req.vtl']).toMatchSnapshot();
+});
+
 test('many to many query', () => {
   const inputSchema = `
       type Post @model {
@@ -83,12 +282,7 @@ test('many to many query', () => {
       new HasOneTransformer(),
       new HasManyTransformer(),
       new BelongsToTransformer(),
-    ],
-    transformParameters: {
-      enableAutoIndexQueryNames: false,
-      respectPrimaryKeyAttributesOnConnectionField: false,
-      secondaryKeyAsGSI: false,
-    },
+    ]
   });
 
   expect(out).toBeDefined();


### PR DESCRIPTION
#### Description of changes
Adds some more unit tests for has-many references based relationships with DDB data sources.

##### CDK / CloudFormation Parameters Changed
None

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit tests passing.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
