### PR TITLE
chore: fix publish:tag script to interpolate NPM_TAG

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "publish:beta": "lerna publish --exact --dist-tag=beta --preid=beta --conventional-commits --conventional-prerelease --message 'chore(release): Publish [ci skip]' --no-verify-access --yes",
     "publish:main": "lerna publish --canary --force-publish --preid=alpha --exact --include-merged-tags --conventional-prerelease --no-verify-access --yes",
     "publish:release": "lerna publish --conventional-commits --conventional-graduate --exact --yes --message 'chore(release): Publish [ci skip]' --no-verify-access",
-    "publish:tag": "lerna publish --exact --dist-tag=$NPM_TAG --preid=$NPM_TAG --conventional-commits --conventional-prerelease --message 'chore(release): Publish tagged release $NPM_TAG [ci skip]' --no-verify-access --yes",
+    "publish:tag": "lerna publish --exact --dist-tag=$NPM_TAG --preid=$NPM_TAG --conventional-commits --conventional-prerelease --message \"chore(release): Publish tagged release $NPM_TAG [ci skip]\" --no-verify-access --yes",
     "refresh-lockfile": "rimraf yarn.lock && yarn",
     "rm-dev-link": "rimraf -f \"$(yarn global bin)/amplify-dev\"",
     "setup-dev-win": "(yarn && lerna run build) && yarn add-cli-no-save && (yarn hoist-cli-win && yarn rm-dev-link && yarn link-win)",


### PR DESCRIPTION
#### Description of changes

Fixes the `publish:tag` script in package.json to allow the `$NPM_TAG` env var to be correctly interpolated into the commit message.

#### Description of how you validated changes

Run a tagged release from [a branch containing this commit](https://github.com/aws-amplify/amplify-category-api/tree/palpatim.chore.fix-publish-tag) and ensure the commit message is correct. See that b32d1359c has the commit message: `chore(release): Publish tagged release fix-publish-tag [ci skip]` rather than the previous `chore(release): Publish tagged release $NPM_TAG [ci skip]`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
