### PR TITLE
chore: fix release workflow build dependencies

### DIFF
--- a/codebuild_specs/release_workflow.yml
+++ b/codebuild_specs/release_workflow.yml
@@ -53,3 +53,7 @@ batch:
         - test
         - mock_e2e_tests
         - build_windows
+        - verify_api_extract
+        - verify_cdk_version
+        - verify_dependency_licenses_extract
+        - verify_yarn_lock


### PR DESCRIPTION
#### Description of changes

Our current release workflow allows a `deploy` even if prior steps fail. In a production release this isn't of practical concern since we have prior flows that correctly check things like API consistency, license files, and yarn.lock. However in a tagged release, we intentionally bypass a lot of those previous steps, so it's possible to deploy a tagged release even if prior steps failed.

This change makes the `deploy` step depend on all previous steps.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
