### PR TITLE
feat: adds a default none data source

### DIFF
--- a/packages/amplify-graphql-api-construct/src/__tests__/__functional__/resources.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/__functional__/resources.test.ts
@@ -238,8 +238,49 @@ describe('generated resource access', () => {
           },
         });
 
-        expect(Object.values(cfnDataSources).length).toEqual(1);
+        expect(Object.values(cfnDataSources).length).toEqual(2);
         expect(cfnDataSources.EchoLambdaDataSource).toBeDefined();
+      });
+
+      it('re-uses a none datasource if one already exists', () => {
+        const apiResources = new AmplifyGraphqlApi(new cdk.Stack(), 'TestApi', {
+          definition: AmplifyGraphqlDefinition.fromString(/* GraphQL */ `
+            type Todo @model @auth(rules: [{ allow: public }]) {
+              description: String!
+            }
+          `),
+          authorizationModes: {
+            apiKeyConfig: { expires: cdk.Duration.days(7) },
+          },
+        });
+        const {
+          resources: {
+            cfnResources: { cfnDataSources },
+          },
+        } = apiResources;
+
+        expect(cfnDataSources.NONE_DS).toBeDefined();
+        expect(Object.values(cfnDataSources).length).toEqual(2); // NONE_DS + model data source
+      });
+
+      it('adds a none datasource when there are no models in the schema', () => {
+        const {
+          resources: {
+            cfnResources: { cfnDataSources },
+          },
+        } = new AmplifyGraphqlApi(new cdk.Stack(), 'TestApi', {
+          definition: AmplifyGraphqlDefinition.fromString(/* GraphQL */ `
+            type Query {
+              echo(message: String!): String!
+            }
+          `),
+          authorizationModes: {
+            apiKeyConfig: { expires: cdk.Duration.days(7) },
+          },
+        });
+
+        expect(Object.values(cfnDataSources).length).toEqual(1);
+        expect(cfnDataSources.NONE_DS).toBeDefined();
       });
     });
 

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -38,7 +38,7 @@ import { Construct } from 'constructs';
 import { ResolverConfig } from '../config/transformer-config';
 import { InvalidTransformerError, SchemaValidationError, UnknownDirectiveError } from '../errors';
 import { GraphQLApi } from '../graphql-api';
-import { TransformerContext } from '../transformer-context';
+import { TransformerContext, NONE_DATA_SOURCE_NAME } from '../transformer-context';
 import { TransformerOutput } from '../transformer-context/output';
 import { adoptAuthModes } from '../utils/authType';
 import { MappingTemplate } from '../cdk-compat';
@@ -327,6 +327,7 @@ export class GraphQLTransform {
       }
     }
     this.collectResolvers(context, context.api);
+    this.ensureNoneDataSource(context.api);
   }
 
   protected generateGraphQlApi(
@@ -720,5 +721,14 @@ export class GraphQLTransform {
 
   public getLogs(): TransformerLog[] {
     return this.logs;
+  }
+
+  private ensureNoneDataSource(api: GraphQLAPIProvider): void {
+    if (!api.host.hasDataSource(NONE_DATA_SOURCE_NAME)) {
+      api.host.addNoneDataSource(NONE_DATA_SOURCE_NAME, {
+        name: NONE_DATA_SOURCE_NAME,
+        description: 'None Data Source for Pipeline functions',
+      });
+    }
   }
 }

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/index.ts
@@ -29,7 +29,7 @@ import { TransformerResourceHelper } from './resource-helper';
 import { StackManager } from './stack-manager';
 import { assetManager } from './asset-manager';
 
-export { TransformerResolver } from './resolver';
+export { TransformerResolver, NONE_DATA_SOURCE_NAME } from './resolver';
 export { StackManager } from './stack-manager';
 export class TransformerContextMetadata implements TransformerContextMetadataProvider {
   /**

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -26,7 +26,7 @@ type Slot = {
 };
 
 // Name of the None Data source used for pipeline resolver
-const NONE_DATA_SOURCE_NAME = 'NONE_DS';
+export const NONE_DATA_SOURCE_NAME = 'NONE_DS';
 
 /**
  * ResolverManager


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The Amplify customers can have a schema like that is shown below, 
```
type Query {
    generateRandomNumber: Int
}
```
where they only have custom GraphQL operations. These custom GraphQL operations do not use any lambda function as their datasource but have their computation logic within the custom AppSync resolvers. These custom resolvers need a `NONE` type datasource which we do not generate by default. This leads to failures in Gen2 deployments for customers following [this guide](https://docs.amplify.aws/gen2/build-a-backend/data/custom-business-logic/#step-2---configure-custom-business-logic-handler-code) since we [default to a datasource](https://github.com/aws-amplify/amplify-api-next/blob/7d9865b72123e5d714ead5e3f82df5f49da24208/packages/data-schema/src/Handler.ts#L64) named `NONE_DS` if the customers don't explicitly pass a datasource in Gen2.
Similar issue exists for Gen1 customers following [this guide](https://docs.amplify.aws/react/build-a-backend/graphqlapi/custom-business-logic/#appsync-javascript-or-vtl-resolver) and if they haven't explicitly created this datasource in their custom CDK stack.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Added unit and E2E tests.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
