### PR TITLE
chore: set NO_ARTIFACTS in verify buildspecs

### DIFF
--- a/codebuild_specs/verify_api_extract.yml
+++ b/codebuild_specs/verify_api_extract.yml
@@ -5,3 +5,5 @@ phases:
   build:
     commands:
       - source ./shared-scripts.sh && _verifyAPIExtract
+artifacts:
+  type: NO_ARTIFACTS

--- a/codebuild_specs/verify_cdk_version.yml
+++ b/codebuild_specs/verify_cdk_version.yml
@@ -5,3 +5,5 @@ phases:
   build:
     commands:
       - source ./shared-scripts.sh && _verifyCDKVersion
+artifacts:
+  type: NO_ARTIFACTS

--- a/codebuild_specs/verify_dependency_licenses_extract.yml
+++ b/codebuild_specs/verify_dependency_licenses_extract.yml
@@ -5,3 +5,5 @@ phases:
   build:
     commands:
       - source ./shared-scripts.sh && _verifyDependencyLicensesExtract
+artifacts:
+  type: NO_ARTIFACTS

--- a/codebuild_specs/verify_yarn_lock.yml
+++ b/codebuild_specs/verify_yarn_lock.yml
@@ -5,3 +5,5 @@ phases:
   build:
     commands:
       - source ./shared-scripts.sh && _verifyYarnLock
+artifacts:
+  type: NO_ARTIFACTS


### PR DESCRIPTION
#### Description of changes

The change in #2407 set dependencies so that a `deploy` would not kick off if any of the validations fail. However, CodeBuild expects build steps to produce an artifact by default. This change defines the validation steps as producing no artifacts, which lets the deploy complete as expected.

Tested by doing a [tagged release](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-release-workflow/batch/amplify-category-api-release-workflow:f0790e4d-ea0e-4b14-ae76-991c478ef119?region=us-east-1) with this change.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
