### PR TITLE
Revert "chore: fix release workflow build dependencies (#2407)"

### DIFF
--- a/codebuild_specs/release_workflow.yml
+++ b/codebuild_specs/release_workflow.yml
@@ -53,7 +53,3 @@ batch:
         - test
         - mock_e2e_tests
         - build_windows
-        - verify_api_extract
-        - verify_cdk_version
-        - verify_dependency_licenses_extract
-        - verify_yarn_lock


### PR DESCRIPTION
This reverts commit f671eca05c0b5ab1ae703f230bd8242e674728d4.

The change in https://github.com/aws-amplify/amplify-category-api/pull/2407 set dependencies so that a deploy would not kick off if any of the validations fail. However, CodeBuild expects build steps to produce an artifact by default, so deployments now fail with an error:

```
[no objects found under S3 prefix for dependency artifact verify_yarn_lock verify_yarn_lock no objects found under S3 prefix for dependency artifact verify_dependency_licenses_extract verify_dependency_licenses_extract no objects found under S3 prefix for dependency artifact verify_cdk_version verify_cdk_version no objects found under S3 prefix for dependency artifact verify_api_extract verify_api_extract]
```

I attempted to defines the validation steps as producing no artifacts in #2412, but that experiment was unsuccessful. Since the dependency fix really only impacts tagged releases, I'm reverting the original dependency PR.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
