### PR TITLE
test(api): increase no output time for gsi 100k records e2e test

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/deploy-velocity/3-gsis-100k-records.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/deploy-velocity/3-gsis-100k-records.test.ts
@@ -1,6 +1,6 @@
 import {
   COUNT_100_THOUSAND,
-  DURATION_30_MINUTES,
+  DURATION_45_MINUTES,
   MUTATION_THREE_FIELD_CREATE,
   SCHEMA_THREE_FIELDS_ALL_INDEXED,
   SCHEMA_THREE_FIELDS_NO_INDEX,
@@ -9,7 +9,7 @@ import { recordCountDataProvider, recordCountDataValidator, testManagedTableDepl
 
 testManagedTableDeployment({
   name: '3 GSIs updated - 100k Records',
-  maxDeployDurationMs: DURATION_30_MINUTES,
+  maxDeployDurationMs: DURATION_45_MINUTES,
   initialSchema: SCHEMA_THREE_FIELDS_NO_INDEX,
   updatedSchema: SCHEMA_THREE_FIELDS_ALL_INDEXED,
   dataSetup: recordCountDataProvider(COUNT_100_THOUSAND, MUTATION_THREE_FIELD_CREATE),

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/deploy-velocity/deploy-velocity-constants.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/deploy-velocity/deploy-velocity-constants.ts
@@ -5,6 +5,7 @@ const ONE_MINUTE = 60 * 1000;
 export const DURATION_10_MINUTES = 10 * ONE_MINUTE;
 export const DURATION_20_MINUTES = 20 * ONE_MINUTE;
 export const DURATION_30_MINUTES = 30 * ONE_MINUTE;
+export const DURATION_45_MINUTES = 45 * ONE_MINUTE;
 export const DURATION_1_HOUR = 60 * ONE_MINUTE;
 
 export const COUNT_1_THOUSAND = 1000;


### PR DESCRIPTION
Increase the timeout of `3-gsis-100k-records.test.ts` test to 45 minutes.

Adjusting the timeout for `3-gsis-100k-records.test.ts` E2E test based on local testing. This test took anywhere between 23 - 38 while testing in local. Based on this data, adjusting the no output timeout to 45 minutes.