### PR TITLE
fix: remove null timestamp fields from filter input

### DIFF
--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -8171,5 +8171,5 @@
     }
   },
   "version": "1.7.0",
-  "fingerprint": "UZL1dcaHRE1QTkM+nDhzxpi+re0E9F/sEb1Xp+ynSWM="
+  "fingerprint": "bwDzPgpuWoeGBaJYiwKc49U+YQ0YU9eMGAQ5zgfkTyY="
 }

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -4126,8 +4126,6 @@ input ModelPostConditionInput {
   or: [ModelPostConditionInput]
   not: ModelPostConditionInput
   _deleted: ModelBooleanInput
-  createdAt: ModelStringInput
-  updatedAt: ModelStringInput
 }
 
 input CreatePostInput {
@@ -4370,6 +4368,338 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **"
+`;
+
+exports[`ModelTransformer: should remove null timestamp fields from input 1`] = `
+"type Foo {
+  id: ID!
+  title: String!
+  createdAt: AWSDateTime!
+}
+
+type Bar {
+  id: ID!
+  title: String!
+  updatedAt: AWSDateTime!
+}
+
+type Baz {
+  id: ID!
+  title: String!
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelFooConnection {
+  items: [Foo]!
+  nextToken: String
+}
+
+input ModelFooFilterInput {
+  id: ModelIDInput
+  title: ModelStringInput
+  createdAt: ModelStringInput
+  and: [ModelFooFilterInput]
+  or: [ModelFooFilterInput]
+  not: ModelFooFilterInput
+}
+
+type Query {
+  getFoo(id: ID!): Foo
+  listFoos(filter: ModelFooFilterInput, limit: Int, nextToken: String): ModelFooConnection
+  getBar(id: ID!): Bar
+  listBars(filter: ModelBarFilterInput, limit: Int, nextToken: String): ModelBarConnection
+  getBaz(id: ID!): Baz
+  listBazs(filter: ModelBazFilterInput, limit: Int, nextToken: String): ModelBazConnection
+}
+
+input ModelFooConditionInput {
+  title: ModelStringInput
+  and: [ModelFooConditionInput]
+  or: [ModelFooConditionInput]
+  not: ModelFooConditionInput
+  createdAt: ModelStringInput
+}
+
+input CreateFooInput {
+  id: ID
+  title: String!
+}
+
+input UpdateFooInput {
+  id: ID!
+  title: String
+}
+
+input DeleteFooInput {
+  id: ID!
+}
+
+type Mutation {
+  createFoo(input: CreateFooInput!, condition: ModelFooConditionInput): Foo
+  updateFoo(input: UpdateFooInput!, condition: ModelFooConditionInput): Foo
+  deleteFoo(input: DeleteFooInput!, condition: ModelFooConditionInput): Foo
+  createBar(input: CreateBarInput!, condition: ModelBarConditionInput): Bar
+  updateBar(input: UpdateBarInput!, condition: ModelBarConditionInput): Bar
+  deleteBar(input: DeleteBarInput!, condition: ModelBarConditionInput): Bar
+  createBaz(input: CreateBazInput!, condition: ModelBazConditionInput): Baz
+  updateBaz(input: UpdateBazInput!, condition: ModelBazConditionInput): Baz
+  deleteBaz(input: DeleteBazInput!, condition: ModelBazConditionInput): Baz
+}
+
+input ModelSubscriptionFooFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionStringInput
+  and: [ModelSubscriptionFooFilterInput]
+  or: [ModelSubscriptionFooFilterInput]
+}
+
+type Subscription {
+  onCreateFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"createFoo\\"])
+  onUpdateFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"updateFoo\\"])
+  onDeleteFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"deleteFoo\\"])
+  onCreateBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"createBar\\"])
+  onUpdateBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"updateBar\\"])
+  onDeleteBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"deleteBar\\"])
+  onCreateBaz(filter: ModelSubscriptionBazFilterInput): Baz @aws_subscribe(mutations: [\\"createBaz\\"])
+  onUpdateBaz(filter: ModelSubscriptionBazFilterInput): Baz @aws_subscribe(mutations: [\\"updateBaz\\"])
+  onDeleteBaz(filter: ModelSubscriptionBazFilterInput): Baz @aws_subscribe(mutations: [\\"deleteBaz\\"])
+}
+
+type ModelBarConnection {
+  items: [Bar]!
+  nextToken: String
+}
+
+input ModelBarFilterInput {
+  id: ModelIDInput
+  title: ModelStringInput
+  updatedAt: ModelStringInput
+  and: [ModelBarFilterInput]
+  or: [ModelBarFilterInput]
+  not: ModelBarFilterInput
+}
+
+input ModelBarConditionInput {
+  title: ModelStringInput
+  and: [ModelBarConditionInput]
+  or: [ModelBarConditionInput]
+  not: ModelBarConditionInput
+  updatedAt: ModelStringInput
+}
+
+input CreateBarInput {
+  id: ID
+  title: String!
+}
+
+input UpdateBarInput {
+  id: ID!
+  title: String
+}
+
+input DeleteBarInput {
+  id: ID!
+}
+
+input ModelSubscriptionBarFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  updatedAt: ModelSubscriptionStringInput
+  and: [ModelSubscriptionBarFilterInput]
+  or: [ModelSubscriptionBarFilterInput]
+}
+
+type ModelBazConnection {
+  items: [Baz]!
+  nextToken: String
+}
+
+input ModelBazFilterInput {
+  id: ModelIDInput
+  title: ModelStringInput
+  and: [ModelBazFilterInput]
+  or: [ModelBazFilterInput]
+  not: ModelBazFilterInput
+}
+
+input ModelBazConditionInput {
+  title: ModelStringInput
+  and: [ModelBazConditionInput]
+  or: [ModelBazConditionInput]
+  not: ModelBazConditionInput
+}
+
+input CreateBazInput {
+  id: ID
+  title: String!
+}
+
+input UpdateBazInput {
+  id: ID!
+  title: String
+}
+
+input DeleteBazInput {
+  id: ID!
+}
+
+input ModelSubscriptionBazFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  and: [ModelSubscriptionBazFilterInput]
+  or: [ModelSubscriptionBazFilterInput]
+}
+"
 `;
 
 exports[`ModelTransformer: should successfully transform rds schema with array and object fields 1`] = `

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -225,6 +225,1098 @@ type Subscription {
 "
 `;
 
+exports[`ModelTransformer: remove null timestamp fields from input createdAt null 1`] = `
+"type Bar {
+  id: ID!
+  title: String!
+  updatedAt: AWSDateTime!
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelBarConnection {
+  items: [Bar]!
+  nextToken: String
+}
+
+input ModelBarFilterInput {
+  id: ModelIDInput
+  title: ModelStringInput
+  updatedAt: ModelStringInput
+  and: [ModelBarFilterInput]
+  or: [ModelBarFilterInput]
+  not: ModelBarFilterInput
+}
+
+type Query {
+  getBar(id: ID!): Bar
+  listBars(filter: ModelBarFilterInput, limit: Int, nextToken: String): ModelBarConnection
+}
+
+input ModelBarConditionInput {
+  title: ModelStringInput
+  and: [ModelBarConditionInput]
+  or: [ModelBarConditionInput]
+  not: ModelBarConditionInput
+  updatedAt: ModelStringInput
+}
+
+input CreateBarInput {
+  id: ID
+  title: String!
+}
+
+input UpdateBarInput {
+  id: ID!
+  title: String
+}
+
+input DeleteBarInput {
+  id: ID!
+}
+
+type Mutation {
+  createBar(input: CreateBarInput!, condition: ModelBarConditionInput): Bar
+  updateBar(input: UpdateBarInput!, condition: ModelBarConditionInput): Bar
+  deleteBar(input: DeleteBarInput!, condition: ModelBarConditionInput): Bar
+}
+
+input ModelSubscriptionBarFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  updatedAt: ModelSubscriptionStringInput
+  and: [ModelSubscriptionBarFilterInput]
+  or: [ModelSubscriptionBarFilterInput]
+}
+
+type Subscription {
+  onCreateBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"createBar\\"])
+  onUpdateBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"updateBar\\"])
+  onDeleteBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"deleteBar\\"])
+}
+"
+`;
+
+exports[`ModelTransformer: remove null timestamp fields from input createdAt null and updatedAt null 1`] = `
+"type Boo {
+  id: ID!
+  title: String!
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelBooConnection {
+  items: [Boo]!
+  nextToken: String
+}
+
+input ModelBooFilterInput {
+  id: ModelIDInput
+  title: ModelStringInput
+  and: [ModelBooFilterInput]
+  or: [ModelBooFilterInput]
+  not: ModelBooFilterInput
+}
+
+type Query {
+  getBoo(id: ID!): Boo
+  listBoos(filter: ModelBooFilterInput, limit: Int, nextToken: String): ModelBooConnection
+}
+
+input ModelBooConditionInput {
+  title: ModelStringInput
+  and: [ModelBooConditionInput]
+  or: [ModelBooConditionInput]
+  not: ModelBooConditionInput
+}
+
+input CreateBooInput {
+  id: ID
+  title: String!
+}
+
+input UpdateBooInput {
+  id: ID!
+  title: String
+}
+
+input DeleteBooInput {
+  id: ID!
+}
+
+type Mutation {
+  createBoo(input: CreateBooInput!, condition: ModelBooConditionInput): Boo
+  updateBoo(input: UpdateBooInput!, condition: ModelBooConditionInput): Boo
+  deleteBoo(input: DeleteBooInput!, condition: ModelBooConditionInput): Boo
+}
+
+input ModelSubscriptionBooFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  and: [ModelSubscriptionBooFilterInput]
+  or: [ModelSubscriptionBooFilterInput]
+}
+
+type Subscription {
+  onCreateBoo(filter: ModelSubscriptionBooFilterInput): Boo @aws_subscribe(mutations: [\\"createBoo\\"])
+  onUpdateBoo(filter: ModelSubscriptionBooFilterInput): Boo @aws_subscribe(mutations: [\\"updateBoo\\"])
+  onDeleteBoo(filter: ModelSubscriptionBooFilterInput): Boo @aws_subscribe(mutations: [\\"deleteBoo\\"])
+}
+"
+`;
+
+exports[`ModelTransformer: remove null timestamp fields from input custom createdAt and updatedAt null 1`] = `
+"type Bing {
+  id: ID!
+  title: String!
+  createdOn: AWSDateTime!
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelBingConnection {
+  items: [Bing]!
+  nextToken: String
+}
+
+input ModelBingFilterInput {
+  id: ModelIDInput
+  title: ModelStringInput
+  createdOn: ModelStringInput
+  and: [ModelBingFilterInput]
+  or: [ModelBingFilterInput]
+  not: ModelBingFilterInput
+}
+
+type Query {
+  getBing(id: ID!): Bing
+  listBings(filter: ModelBingFilterInput, limit: Int, nextToken: String): ModelBingConnection
+}
+
+input ModelBingConditionInput {
+  title: ModelStringInput
+  and: [ModelBingConditionInput]
+  or: [ModelBingConditionInput]
+  not: ModelBingConditionInput
+  createdOn: ModelStringInput
+}
+
+input CreateBingInput {
+  id: ID
+  title: String!
+}
+
+input UpdateBingInput {
+  id: ID!
+  title: String
+}
+
+input DeleteBingInput {
+  id: ID!
+}
+
+type Mutation {
+  createBing(input: CreateBingInput!, condition: ModelBingConditionInput): Bing
+  updateBing(input: UpdateBingInput!, condition: ModelBingConditionInput): Bing
+  deleteBing(input: DeleteBingInput!, condition: ModelBingConditionInput): Bing
+}
+
+input ModelSubscriptionBingFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  createdOn: ModelSubscriptionStringInput
+  and: [ModelSubscriptionBingFilterInput]
+  or: [ModelSubscriptionBingFilterInput]
+}
+
+type Subscription {
+  onCreateBing(filter: ModelSubscriptionBingFilterInput): Bing @aws_subscribe(mutations: [\\"createBing\\"])
+  onUpdateBing(filter: ModelSubscriptionBingFilterInput): Bing @aws_subscribe(mutations: [\\"updateBing\\"])
+  onDeleteBing(filter: ModelSubscriptionBingFilterInput): Bing @aws_subscribe(mutations: [\\"deleteBing\\"])
+}
+"
+`;
+
+exports[`ModelTransformer: remove null timestamp fields from input timestamps null 1`] = `
+"type Baz {
+  id: ID!
+  title: String!
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelBazConnection {
+  items: [Baz]!
+  nextToken: String
+}
+
+input ModelBazFilterInput {
+  id: ModelIDInput
+  title: ModelStringInput
+  and: [ModelBazFilterInput]
+  or: [ModelBazFilterInput]
+  not: ModelBazFilterInput
+}
+
+type Query {
+  getBaz(id: ID!): Baz
+  listBazs(filter: ModelBazFilterInput, limit: Int, nextToken: String): ModelBazConnection
+}
+
+input ModelBazConditionInput {
+  title: ModelStringInput
+  and: [ModelBazConditionInput]
+  or: [ModelBazConditionInput]
+  not: ModelBazConditionInput
+}
+
+input CreateBazInput {
+  id: ID
+  title: String!
+}
+
+input UpdateBazInput {
+  id: ID!
+  title: String
+}
+
+input DeleteBazInput {
+  id: ID!
+}
+
+type Mutation {
+  createBaz(input: CreateBazInput!, condition: ModelBazConditionInput): Baz
+  updateBaz(input: UpdateBazInput!, condition: ModelBazConditionInput): Baz
+  deleteBaz(input: DeleteBazInput!, condition: ModelBazConditionInput): Baz
+}
+
+input ModelSubscriptionBazFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  and: [ModelSubscriptionBazFilterInput]
+  or: [ModelSubscriptionBazFilterInput]
+}
+
+type Subscription {
+  onCreateBaz(filter: ModelSubscriptionBazFilterInput): Baz @aws_subscribe(mutations: [\\"createBaz\\"])
+  onUpdateBaz(filter: ModelSubscriptionBazFilterInput): Baz @aws_subscribe(mutations: [\\"updateBaz\\"])
+  onDeleteBaz(filter: ModelSubscriptionBazFilterInput): Baz @aws_subscribe(mutations: [\\"deleteBaz\\"])
+}
+"
+`;
+
+exports[`ModelTransformer: remove null timestamp fields from input updatedAt null 1`] = `
+"type Foo {
+  id: ID!
+  title: String!
+  createdAt: AWSDateTime!
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelSubscriptionStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  in: [String]
+  notIn: [String]
+}
+
+input ModelSubscriptionIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  in: [Int]
+  notIn: [Int]
+}
+
+input ModelSubscriptionFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  in: [Float]
+  notIn: [Float]
+}
+
+input ModelSubscriptionBooleanInput {
+  ne: Boolean
+  eq: Boolean
+}
+
+input ModelSubscriptionIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  in: [ID]
+  notIn: [ID]
+}
+
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelFooConnection {
+  items: [Foo]!
+  nextToken: String
+}
+
+input ModelFooFilterInput {
+  id: ModelIDInput
+  title: ModelStringInput
+  createdAt: ModelStringInput
+  and: [ModelFooFilterInput]
+  or: [ModelFooFilterInput]
+  not: ModelFooFilterInput
+}
+
+type Query {
+  getFoo(id: ID!): Foo
+  listFoos(filter: ModelFooFilterInput, limit: Int, nextToken: String): ModelFooConnection
+}
+
+input ModelFooConditionInput {
+  title: ModelStringInput
+  and: [ModelFooConditionInput]
+  or: [ModelFooConditionInput]
+  not: ModelFooConditionInput
+  createdAt: ModelStringInput
+}
+
+input CreateFooInput {
+  id: ID
+  title: String!
+}
+
+input UpdateFooInput {
+  id: ID!
+  title: String
+}
+
+input DeleteFooInput {
+  id: ID!
+}
+
+type Mutation {
+  createFoo(input: CreateFooInput!, condition: ModelFooConditionInput): Foo
+  updateFoo(input: UpdateFooInput!, condition: ModelFooConditionInput): Foo
+  deleteFoo(input: DeleteFooInput!, condition: ModelFooConditionInput): Foo
+}
+
+input ModelSubscriptionFooFilterInput {
+  id: ModelSubscriptionIDInput
+  title: ModelSubscriptionStringInput
+  createdAt: ModelSubscriptionStringInput
+  and: [ModelSubscriptionFooFilterInput]
+  or: [ModelSubscriptionFooFilterInput]
+}
+
+type Subscription {
+  onCreateFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"createFoo\\"])
+  onUpdateFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"updateFoo\\"])
+  onDeleteFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"deleteFoo\\"])
+}
+"
+`;
+
 exports[`ModelTransformer: should filter known input types from create and update input fields 1`] = `
 "type Test {
   id: ID!
@@ -4368,338 +5460,6 @@ $util.qr($update.put(\\"expression\\", \\"$expression\\"))
 #end
 $util.toJson($UpdateItem)
 ## [End] Mutation Update resolver. **"
-`;
-
-exports[`ModelTransformer: should remove null timestamp fields from input 1`] = `
-"type Foo {
-  id: ID!
-  title: String!
-  createdAt: AWSDateTime!
-}
-
-type Bar {
-  id: ID!
-  title: String!
-  updatedAt: AWSDateTime!
-}
-
-type Baz {
-  id: ID!
-  title: String!
-}
-
-input ModelStringInput {
-  ne: String
-  eq: String
-  le: String
-  lt: String
-  ge: String
-  gt: String
-  contains: String
-  notContains: String
-  between: [String]
-  beginsWith: String
-  attributeExists: Boolean
-  attributeType: ModelAttributeTypes
-  size: ModelSizeInput
-}
-
-input ModelIntInput {
-  ne: Int
-  eq: Int
-  le: Int
-  lt: Int
-  ge: Int
-  gt: Int
-  between: [Int]
-  attributeExists: Boolean
-  attributeType: ModelAttributeTypes
-}
-
-input ModelFloatInput {
-  ne: Float
-  eq: Float
-  le: Float
-  lt: Float
-  ge: Float
-  gt: Float
-  between: [Float]
-  attributeExists: Boolean
-  attributeType: ModelAttributeTypes
-}
-
-input ModelBooleanInput {
-  ne: Boolean
-  eq: Boolean
-  attributeExists: Boolean
-  attributeType: ModelAttributeTypes
-}
-
-input ModelIDInput {
-  ne: ID
-  eq: ID
-  le: ID
-  lt: ID
-  ge: ID
-  gt: ID
-  contains: ID
-  notContains: ID
-  between: [ID]
-  beginsWith: ID
-  attributeExists: Boolean
-  attributeType: ModelAttributeTypes
-  size: ModelSizeInput
-}
-
-input ModelSubscriptionStringInput {
-  ne: String
-  eq: String
-  le: String
-  lt: String
-  ge: String
-  gt: String
-  contains: String
-  notContains: String
-  between: [String]
-  beginsWith: String
-  in: [String]
-  notIn: [String]
-}
-
-input ModelSubscriptionIntInput {
-  ne: Int
-  eq: Int
-  le: Int
-  lt: Int
-  ge: Int
-  gt: Int
-  between: [Int]
-  in: [Int]
-  notIn: [Int]
-}
-
-input ModelSubscriptionFloatInput {
-  ne: Float
-  eq: Float
-  le: Float
-  lt: Float
-  ge: Float
-  gt: Float
-  between: [Float]
-  in: [Float]
-  notIn: [Float]
-}
-
-input ModelSubscriptionBooleanInput {
-  ne: Boolean
-  eq: Boolean
-}
-
-input ModelSubscriptionIDInput {
-  ne: ID
-  eq: ID
-  le: ID
-  lt: ID
-  ge: ID
-  gt: ID
-  contains: ID
-  notContains: ID
-  between: [ID]
-  beginsWith: ID
-  in: [ID]
-  notIn: [ID]
-}
-
-enum ModelAttributeTypes {
-  binary
-  binarySet
-  bool
-  list
-  map
-  number
-  numberSet
-  string
-  stringSet
-  _null
-}
-
-input ModelSizeInput {
-  ne: Int
-  eq: Int
-  le: Int
-  lt: Int
-  ge: Int
-  gt: Int
-  between: [Int]
-}
-
-enum ModelSortDirection {
-  ASC
-  DESC
-}
-
-type ModelFooConnection {
-  items: [Foo]!
-  nextToken: String
-}
-
-input ModelFooFilterInput {
-  id: ModelIDInput
-  title: ModelStringInput
-  createdAt: ModelStringInput
-  and: [ModelFooFilterInput]
-  or: [ModelFooFilterInput]
-  not: ModelFooFilterInput
-}
-
-type Query {
-  getFoo(id: ID!): Foo
-  listFoos(filter: ModelFooFilterInput, limit: Int, nextToken: String): ModelFooConnection
-  getBar(id: ID!): Bar
-  listBars(filter: ModelBarFilterInput, limit: Int, nextToken: String): ModelBarConnection
-  getBaz(id: ID!): Baz
-  listBazs(filter: ModelBazFilterInput, limit: Int, nextToken: String): ModelBazConnection
-}
-
-input ModelFooConditionInput {
-  title: ModelStringInput
-  and: [ModelFooConditionInput]
-  or: [ModelFooConditionInput]
-  not: ModelFooConditionInput
-  createdAt: ModelStringInput
-}
-
-input CreateFooInput {
-  id: ID
-  title: String!
-}
-
-input UpdateFooInput {
-  id: ID!
-  title: String
-}
-
-input DeleteFooInput {
-  id: ID!
-}
-
-type Mutation {
-  createFoo(input: CreateFooInput!, condition: ModelFooConditionInput): Foo
-  updateFoo(input: UpdateFooInput!, condition: ModelFooConditionInput): Foo
-  deleteFoo(input: DeleteFooInput!, condition: ModelFooConditionInput): Foo
-  createBar(input: CreateBarInput!, condition: ModelBarConditionInput): Bar
-  updateBar(input: UpdateBarInput!, condition: ModelBarConditionInput): Bar
-  deleteBar(input: DeleteBarInput!, condition: ModelBarConditionInput): Bar
-  createBaz(input: CreateBazInput!, condition: ModelBazConditionInput): Baz
-  updateBaz(input: UpdateBazInput!, condition: ModelBazConditionInput): Baz
-  deleteBaz(input: DeleteBazInput!, condition: ModelBazConditionInput): Baz
-}
-
-input ModelSubscriptionFooFilterInput {
-  id: ModelSubscriptionIDInput
-  title: ModelSubscriptionStringInput
-  createdAt: ModelSubscriptionStringInput
-  and: [ModelSubscriptionFooFilterInput]
-  or: [ModelSubscriptionFooFilterInput]
-}
-
-type Subscription {
-  onCreateFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"createFoo\\"])
-  onUpdateFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"updateFoo\\"])
-  onDeleteFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"deleteFoo\\"])
-  onCreateBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"createBar\\"])
-  onUpdateBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"updateBar\\"])
-  onDeleteBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"deleteBar\\"])
-  onCreateBaz(filter: ModelSubscriptionBazFilterInput): Baz @aws_subscribe(mutations: [\\"createBaz\\"])
-  onUpdateBaz(filter: ModelSubscriptionBazFilterInput): Baz @aws_subscribe(mutations: [\\"updateBaz\\"])
-  onDeleteBaz(filter: ModelSubscriptionBazFilterInput): Baz @aws_subscribe(mutations: [\\"deleteBaz\\"])
-}
-
-type ModelBarConnection {
-  items: [Bar]!
-  nextToken: String
-}
-
-input ModelBarFilterInput {
-  id: ModelIDInput
-  title: ModelStringInput
-  updatedAt: ModelStringInput
-  and: [ModelBarFilterInput]
-  or: [ModelBarFilterInput]
-  not: ModelBarFilterInput
-}
-
-input ModelBarConditionInput {
-  title: ModelStringInput
-  and: [ModelBarConditionInput]
-  or: [ModelBarConditionInput]
-  not: ModelBarConditionInput
-  updatedAt: ModelStringInput
-}
-
-input CreateBarInput {
-  id: ID
-  title: String!
-}
-
-input UpdateBarInput {
-  id: ID!
-  title: String
-}
-
-input DeleteBarInput {
-  id: ID!
-}
-
-input ModelSubscriptionBarFilterInput {
-  id: ModelSubscriptionIDInput
-  title: ModelSubscriptionStringInput
-  updatedAt: ModelSubscriptionStringInput
-  and: [ModelSubscriptionBarFilterInput]
-  or: [ModelSubscriptionBarFilterInput]
-}
-
-type ModelBazConnection {
-  items: [Baz]!
-  nextToken: String
-}
-
-input ModelBazFilterInput {
-  id: ModelIDInput
-  title: ModelStringInput
-  and: [ModelBazFilterInput]
-  or: [ModelBazFilterInput]
-  not: ModelBazFilterInput
-}
-
-input ModelBazConditionInput {
-  title: ModelStringInput
-  and: [ModelBazConditionInput]
-  or: [ModelBazConditionInput]
-  not: ModelBazConditionInput
-}
-
-input CreateBazInput {
-  id: ID
-  title: String!
-}
-
-input UpdateBazInput {
-  id: ID!
-  title: String
-}
-
-input DeleteBazInput {
-  id: ID!
-}
-
-input ModelSubscriptionBazFilterInput {
-  id: ModelSubscriptionIDInput
-  title: ModelSubscriptionStringInput
-  and: [ModelSubscriptionBazFilterInput]
-  or: [ModelSubscriptionBazFilterInput]
-}
-"
 `;
 
 exports[`ModelTransformer: should successfully transform rds schema with array and object fields 1`] = `

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -226,7 +226,7 @@ type Subscription {
 `;
 
 exports[`ModelTransformer: remove null timestamp fields from input createdAt null 1`] = `
-"type Bar {
+"type CreatedAtNull {
   id: ID!
   title: String!
   updatedAt: AWSDateTime!
@@ -382,71 +382,71 @@ enum ModelSortDirection {
   DESC
 }
 
-type ModelBarConnection {
-  items: [Bar]!
+type ModelCreatedAtNullConnection {
+  items: [CreatedAtNull]!
   nextToken: String
 }
 
-input ModelBarFilterInput {
+input ModelCreatedAtNullFilterInput {
   id: ModelIDInput
   title: ModelStringInput
   updatedAt: ModelStringInput
-  and: [ModelBarFilterInput]
-  or: [ModelBarFilterInput]
-  not: ModelBarFilterInput
+  and: [ModelCreatedAtNullFilterInput]
+  or: [ModelCreatedAtNullFilterInput]
+  not: ModelCreatedAtNullFilterInput
 }
 
 type Query {
-  getBar(id: ID!): Bar
-  listBars(filter: ModelBarFilterInput, limit: Int, nextToken: String): ModelBarConnection
+  getCreatedAtNull(id: ID!): CreatedAtNull
+  listCreatedAtNulls(filter: ModelCreatedAtNullFilterInput, limit: Int, nextToken: String): ModelCreatedAtNullConnection
 }
 
-input ModelBarConditionInput {
+input ModelCreatedAtNullConditionInput {
   title: ModelStringInput
-  and: [ModelBarConditionInput]
-  or: [ModelBarConditionInput]
-  not: ModelBarConditionInput
+  and: [ModelCreatedAtNullConditionInput]
+  or: [ModelCreatedAtNullConditionInput]
+  not: ModelCreatedAtNullConditionInput
   updatedAt: ModelStringInput
 }
 
-input CreateBarInput {
+input CreateCreatedAtNullInput {
   id: ID
   title: String!
 }
 
-input UpdateBarInput {
+input UpdateCreatedAtNullInput {
   id: ID!
   title: String
 }
 
-input DeleteBarInput {
+input DeleteCreatedAtNullInput {
   id: ID!
 }
 
 type Mutation {
-  createBar(input: CreateBarInput!, condition: ModelBarConditionInput): Bar
-  updateBar(input: UpdateBarInput!, condition: ModelBarConditionInput): Bar
-  deleteBar(input: DeleteBarInput!, condition: ModelBarConditionInput): Bar
+  createCreatedAtNull(input: CreateCreatedAtNullInput!, condition: ModelCreatedAtNullConditionInput): CreatedAtNull
+  updateCreatedAtNull(input: UpdateCreatedAtNullInput!, condition: ModelCreatedAtNullConditionInput): CreatedAtNull
+  deleteCreatedAtNull(input: DeleteCreatedAtNullInput!, condition: ModelCreatedAtNullConditionInput): CreatedAtNull
 }
 
-input ModelSubscriptionBarFilterInput {
+input ModelSubscriptionCreatedAtNullFilterInput {
   id: ModelSubscriptionIDInput
   title: ModelSubscriptionStringInput
   updatedAt: ModelSubscriptionStringInput
-  and: [ModelSubscriptionBarFilterInput]
-  or: [ModelSubscriptionBarFilterInput]
+  and: [ModelSubscriptionCreatedAtNullFilterInput]
+  or: [ModelSubscriptionCreatedAtNullFilterInput]
 }
 
 type Subscription {
-  onCreateBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"createBar\\"])
-  onUpdateBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"updateBar\\"])
-  onDeleteBar(filter: ModelSubscriptionBarFilterInput): Bar @aws_subscribe(mutations: [\\"deleteBar\\"])
+  onCreateCreatedAtNull(filter: ModelSubscriptionCreatedAtNullFilterInput): CreatedAtNull @aws_subscribe(mutations: [\\"createCreatedAtNull\\"])
+  onUpdateCreatedAtNull(filter: ModelSubscriptionCreatedAtNullFilterInput): CreatedAtNull @aws_subscribe(mutations: [\\"updateCreatedAtNull\\"])
+  onDeleteCreatedAtNull(filter: ModelSubscriptionCreatedAtNullFilterInput): CreatedAtNull @aws_subscribe(mutations: [\\"deleteCreatedAtNull\\"])
 }
 "
 `;
 
 exports[`ModelTransformer: remove null timestamp fields from input createdAt null and updatedAt null 1`] = `
-"type Boo {
+"type CreatedAtAndUpdatedAtNull {
   id: ID!
   title: String!
 }
@@ -601,68 +601,68 @@ enum ModelSortDirection {
   DESC
 }
 
-type ModelBooConnection {
-  items: [Boo]!
+type ModelCreatedAtAndUpdatedAtNullConnection {
+  items: [CreatedAtAndUpdatedAtNull]!
   nextToken: String
 }
 
-input ModelBooFilterInput {
+input ModelCreatedAtAndUpdatedAtNullFilterInput {
   id: ModelIDInput
   title: ModelStringInput
-  and: [ModelBooFilterInput]
-  or: [ModelBooFilterInput]
-  not: ModelBooFilterInput
+  and: [ModelCreatedAtAndUpdatedAtNullFilterInput]
+  or: [ModelCreatedAtAndUpdatedAtNullFilterInput]
+  not: ModelCreatedAtAndUpdatedAtNullFilterInput
 }
 
 type Query {
-  getBoo(id: ID!): Boo
-  listBoos(filter: ModelBooFilterInput, limit: Int, nextToken: String): ModelBooConnection
+  getCreatedAtAndUpdatedAtNull(id: ID!): CreatedAtAndUpdatedAtNull
+  listCreatedAtAndUpdatedAtNulls(filter: ModelCreatedAtAndUpdatedAtNullFilterInput, limit: Int, nextToken: String): ModelCreatedAtAndUpdatedAtNullConnection
 }
 
-input ModelBooConditionInput {
+input ModelCreatedAtAndUpdatedAtNullConditionInput {
   title: ModelStringInput
-  and: [ModelBooConditionInput]
-  or: [ModelBooConditionInput]
-  not: ModelBooConditionInput
+  and: [ModelCreatedAtAndUpdatedAtNullConditionInput]
+  or: [ModelCreatedAtAndUpdatedAtNullConditionInput]
+  not: ModelCreatedAtAndUpdatedAtNullConditionInput
 }
 
-input CreateBooInput {
+input CreateCreatedAtAndUpdatedAtNullInput {
   id: ID
   title: String!
 }
 
-input UpdateBooInput {
+input UpdateCreatedAtAndUpdatedAtNullInput {
   id: ID!
   title: String
 }
 
-input DeleteBooInput {
+input DeleteCreatedAtAndUpdatedAtNullInput {
   id: ID!
 }
 
 type Mutation {
-  createBoo(input: CreateBooInput!, condition: ModelBooConditionInput): Boo
-  updateBoo(input: UpdateBooInput!, condition: ModelBooConditionInput): Boo
-  deleteBoo(input: DeleteBooInput!, condition: ModelBooConditionInput): Boo
+  createCreatedAtAndUpdatedAtNull(input: CreateCreatedAtAndUpdatedAtNullInput!, condition: ModelCreatedAtAndUpdatedAtNullConditionInput): CreatedAtAndUpdatedAtNull
+  updateCreatedAtAndUpdatedAtNull(input: UpdateCreatedAtAndUpdatedAtNullInput!, condition: ModelCreatedAtAndUpdatedAtNullConditionInput): CreatedAtAndUpdatedAtNull
+  deleteCreatedAtAndUpdatedAtNull(input: DeleteCreatedAtAndUpdatedAtNullInput!, condition: ModelCreatedAtAndUpdatedAtNullConditionInput): CreatedAtAndUpdatedAtNull
 }
 
-input ModelSubscriptionBooFilterInput {
+input ModelSubscriptionCreatedAtAndUpdatedAtNullFilterInput {
   id: ModelSubscriptionIDInput
   title: ModelSubscriptionStringInput
-  and: [ModelSubscriptionBooFilterInput]
-  or: [ModelSubscriptionBooFilterInput]
+  and: [ModelSubscriptionCreatedAtAndUpdatedAtNullFilterInput]
+  or: [ModelSubscriptionCreatedAtAndUpdatedAtNullFilterInput]
 }
 
 type Subscription {
-  onCreateBoo(filter: ModelSubscriptionBooFilterInput): Boo @aws_subscribe(mutations: [\\"createBoo\\"])
-  onUpdateBoo(filter: ModelSubscriptionBooFilterInput): Boo @aws_subscribe(mutations: [\\"updateBoo\\"])
-  onDeleteBoo(filter: ModelSubscriptionBooFilterInput): Boo @aws_subscribe(mutations: [\\"deleteBoo\\"])
+  onCreateCreatedAtAndUpdatedAtNull(filter: ModelSubscriptionCreatedAtAndUpdatedAtNullFilterInput): CreatedAtAndUpdatedAtNull @aws_subscribe(mutations: [\\"createCreatedAtAndUpdatedAtNull\\"])
+  onUpdateCreatedAtAndUpdatedAtNull(filter: ModelSubscriptionCreatedAtAndUpdatedAtNullFilterInput): CreatedAtAndUpdatedAtNull @aws_subscribe(mutations: [\\"updateCreatedAtAndUpdatedAtNull\\"])
+  onDeleteCreatedAtAndUpdatedAtNull(filter: ModelSubscriptionCreatedAtAndUpdatedAtNullFilterInput): CreatedAtAndUpdatedAtNull @aws_subscribe(mutations: [\\"deleteCreatedAtAndUpdatedAtNull\\"])
 }
 "
 `;
 
 exports[`ModelTransformer: remove null timestamp fields from input custom createdAt and updatedAt null 1`] = `
-"type Bing {
+"type CustomCreatedAtAndUpdatedAtNull {
   id: ID!
   title: String!
   createdOn: AWSDateTime!
@@ -818,71 +818,71 @@ enum ModelSortDirection {
   DESC
 }
 
-type ModelBingConnection {
-  items: [Bing]!
+type ModelCustomCreatedAtAndUpdatedAtNullConnection {
+  items: [CustomCreatedAtAndUpdatedAtNull]!
   nextToken: String
 }
 
-input ModelBingFilterInput {
+input ModelCustomCreatedAtAndUpdatedAtNullFilterInput {
   id: ModelIDInput
   title: ModelStringInput
   createdOn: ModelStringInput
-  and: [ModelBingFilterInput]
-  or: [ModelBingFilterInput]
-  not: ModelBingFilterInput
+  and: [ModelCustomCreatedAtAndUpdatedAtNullFilterInput]
+  or: [ModelCustomCreatedAtAndUpdatedAtNullFilterInput]
+  not: ModelCustomCreatedAtAndUpdatedAtNullFilterInput
 }
 
 type Query {
-  getBing(id: ID!): Bing
-  listBings(filter: ModelBingFilterInput, limit: Int, nextToken: String): ModelBingConnection
+  getCustomCreatedAtAndUpdatedAtNull(id: ID!): CustomCreatedAtAndUpdatedAtNull
+  listCustomCreatedAtAndUpdatedAtNulls(filter: ModelCustomCreatedAtAndUpdatedAtNullFilterInput, limit: Int, nextToken: String): ModelCustomCreatedAtAndUpdatedAtNullConnection
 }
 
-input ModelBingConditionInput {
+input ModelCustomCreatedAtAndUpdatedAtNullConditionInput {
   title: ModelStringInput
-  and: [ModelBingConditionInput]
-  or: [ModelBingConditionInput]
-  not: ModelBingConditionInput
+  and: [ModelCustomCreatedAtAndUpdatedAtNullConditionInput]
+  or: [ModelCustomCreatedAtAndUpdatedAtNullConditionInput]
+  not: ModelCustomCreatedAtAndUpdatedAtNullConditionInput
   createdOn: ModelStringInput
 }
 
-input CreateBingInput {
+input CreateCustomCreatedAtAndUpdatedAtNullInput {
   id: ID
   title: String!
 }
 
-input UpdateBingInput {
+input UpdateCustomCreatedAtAndUpdatedAtNullInput {
   id: ID!
   title: String
 }
 
-input DeleteBingInput {
+input DeleteCustomCreatedAtAndUpdatedAtNullInput {
   id: ID!
 }
 
 type Mutation {
-  createBing(input: CreateBingInput!, condition: ModelBingConditionInput): Bing
-  updateBing(input: UpdateBingInput!, condition: ModelBingConditionInput): Bing
-  deleteBing(input: DeleteBingInput!, condition: ModelBingConditionInput): Bing
+  createCustomCreatedAtAndUpdatedAtNull(input: CreateCustomCreatedAtAndUpdatedAtNullInput!, condition: ModelCustomCreatedAtAndUpdatedAtNullConditionInput): CustomCreatedAtAndUpdatedAtNull
+  updateCustomCreatedAtAndUpdatedAtNull(input: UpdateCustomCreatedAtAndUpdatedAtNullInput!, condition: ModelCustomCreatedAtAndUpdatedAtNullConditionInput): CustomCreatedAtAndUpdatedAtNull
+  deleteCustomCreatedAtAndUpdatedAtNull(input: DeleteCustomCreatedAtAndUpdatedAtNullInput!, condition: ModelCustomCreatedAtAndUpdatedAtNullConditionInput): CustomCreatedAtAndUpdatedAtNull
 }
 
-input ModelSubscriptionBingFilterInput {
+input ModelSubscriptionCustomCreatedAtAndUpdatedAtNullFilterInput {
   id: ModelSubscriptionIDInput
   title: ModelSubscriptionStringInput
   createdOn: ModelSubscriptionStringInput
-  and: [ModelSubscriptionBingFilterInput]
-  or: [ModelSubscriptionBingFilterInput]
+  and: [ModelSubscriptionCustomCreatedAtAndUpdatedAtNullFilterInput]
+  or: [ModelSubscriptionCustomCreatedAtAndUpdatedAtNullFilterInput]
 }
 
 type Subscription {
-  onCreateBing(filter: ModelSubscriptionBingFilterInput): Bing @aws_subscribe(mutations: [\\"createBing\\"])
-  onUpdateBing(filter: ModelSubscriptionBingFilterInput): Bing @aws_subscribe(mutations: [\\"updateBing\\"])
-  onDeleteBing(filter: ModelSubscriptionBingFilterInput): Bing @aws_subscribe(mutations: [\\"deleteBing\\"])
+  onCreateCustomCreatedAtAndUpdatedAtNull(filter: ModelSubscriptionCustomCreatedAtAndUpdatedAtNullFilterInput): CustomCreatedAtAndUpdatedAtNull @aws_subscribe(mutations: [\\"createCustomCreatedAtAndUpdatedAtNull\\"])
+  onUpdateCustomCreatedAtAndUpdatedAtNull(filter: ModelSubscriptionCustomCreatedAtAndUpdatedAtNullFilterInput): CustomCreatedAtAndUpdatedAtNull @aws_subscribe(mutations: [\\"updateCustomCreatedAtAndUpdatedAtNull\\"])
+  onDeleteCustomCreatedAtAndUpdatedAtNull(filter: ModelSubscriptionCustomCreatedAtAndUpdatedAtNullFilterInput): CustomCreatedAtAndUpdatedAtNull @aws_subscribe(mutations: [\\"deleteCustomCreatedAtAndUpdatedAtNull\\"])
 }
 "
 `;
 
 exports[`ModelTransformer: remove null timestamp fields from input timestamps null 1`] = `
-"type Baz {
+"type TimeStampsNull {
   id: ID!
   title: String!
 }
@@ -1037,68 +1037,68 @@ enum ModelSortDirection {
   DESC
 }
 
-type ModelBazConnection {
-  items: [Baz]!
+type ModelTimeStampsNullConnection {
+  items: [TimeStampsNull]!
   nextToken: String
 }
 
-input ModelBazFilterInput {
+input ModelTimeStampsNullFilterInput {
   id: ModelIDInput
   title: ModelStringInput
-  and: [ModelBazFilterInput]
-  or: [ModelBazFilterInput]
-  not: ModelBazFilterInput
+  and: [ModelTimeStampsNullFilterInput]
+  or: [ModelTimeStampsNullFilterInput]
+  not: ModelTimeStampsNullFilterInput
 }
 
 type Query {
-  getBaz(id: ID!): Baz
-  listBazs(filter: ModelBazFilterInput, limit: Int, nextToken: String): ModelBazConnection
+  getTimeStampsNull(id: ID!): TimeStampsNull
+  listTimeStampsNulls(filter: ModelTimeStampsNullFilterInput, limit: Int, nextToken: String): ModelTimeStampsNullConnection
 }
 
-input ModelBazConditionInput {
+input ModelTimeStampsNullConditionInput {
   title: ModelStringInput
-  and: [ModelBazConditionInput]
-  or: [ModelBazConditionInput]
-  not: ModelBazConditionInput
+  and: [ModelTimeStampsNullConditionInput]
+  or: [ModelTimeStampsNullConditionInput]
+  not: ModelTimeStampsNullConditionInput
 }
 
-input CreateBazInput {
+input CreateTimeStampsNullInput {
   id: ID
   title: String!
 }
 
-input UpdateBazInput {
+input UpdateTimeStampsNullInput {
   id: ID!
   title: String
 }
 
-input DeleteBazInput {
+input DeleteTimeStampsNullInput {
   id: ID!
 }
 
 type Mutation {
-  createBaz(input: CreateBazInput!, condition: ModelBazConditionInput): Baz
-  updateBaz(input: UpdateBazInput!, condition: ModelBazConditionInput): Baz
-  deleteBaz(input: DeleteBazInput!, condition: ModelBazConditionInput): Baz
+  createTimeStampsNull(input: CreateTimeStampsNullInput!, condition: ModelTimeStampsNullConditionInput): TimeStampsNull
+  updateTimeStampsNull(input: UpdateTimeStampsNullInput!, condition: ModelTimeStampsNullConditionInput): TimeStampsNull
+  deleteTimeStampsNull(input: DeleteTimeStampsNullInput!, condition: ModelTimeStampsNullConditionInput): TimeStampsNull
 }
 
-input ModelSubscriptionBazFilterInput {
+input ModelSubscriptionTimeStampsNullFilterInput {
   id: ModelSubscriptionIDInput
   title: ModelSubscriptionStringInput
-  and: [ModelSubscriptionBazFilterInput]
-  or: [ModelSubscriptionBazFilterInput]
+  and: [ModelSubscriptionTimeStampsNullFilterInput]
+  or: [ModelSubscriptionTimeStampsNullFilterInput]
 }
 
 type Subscription {
-  onCreateBaz(filter: ModelSubscriptionBazFilterInput): Baz @aws_subscribe(mutations: [\\"createBaz\\"])
-  onUpdateBaz(filter: ModelSubscriptionBazFilterInput): Baz @aws_subscribe(mutations: [\\"updateBaz\\"])
-  onDeleteBaz(filter: ModelSubscriptionBazFilterInput): Baz @aws_subscribe(mutations: [\\"deleteBaz\\"])
+  onCreateTimeStampsNull(filter: ModelSubscriptionTimeStampsNullFilterInput): TimeStampsNull @aws_subscribe(mutations: [\\"createTimeStampsNull\\"])
+  onUpdateTimeStampsNull(filter: ModelSubscriptionTimeStampsNullFilterInput): TimeStampsNull @aws_subscribe(mutations: [\\"updateTimeStampsNull\\"])
+  onDeleteTimeStampsNull(filter: ModelSubscriptionTimeStampsNullFilterInput): TimeStampsNull @aws_subscribe(mutations: [\\"deleteTimeStampsNull\\"])
 }
 "
 `;
 
 exports[`ModelTransformer: remove null timestamp fields from input updatedAt null 1`] = `
-"type Foo {
+"type UpdatedAtNull {
   id: ID!
   title: String!
   createdAt: AWSDateTime!
@@ -1254,65 +1254,65 @@ enum ModelSortDirection {
   DESC
 }
 
-type ModelFooConnection {
-  items: [Foo]!
+type ModelUpdatedAtNullConnection {
+  items: [UpdatedAtNull]!
   nextToken: String
 }
 
-input ModelFooFilterInput {
+input ModelUpdatedAtNullFilterInput {
   id: ModelIDInput
   title: ModelStringInput
   createdAt: ModelStringInput
-  and: [ModelFooFilterInput]
-  or: [ModelFooFilterInput]
-  not: ModelFooFilterInput
+  and: [ModelUpdatedAtNullFilterInput]
+  or: [ModelUpdatedAtNullFilterInput]
+  not: ModelUpdatedAtNullFilterInput
 }
 
 type Query {
-  getFoo(id: ID!): Foo
-  listFoos(filter: ModelFooFilterInput, limit: Int, nextToken: String): ModelFooConnection
+  getUpdatedAtNull(id: ID!): UpdatedAtNull
+  listUpdatedAtNulls(filter: ModelUpdatedAtNullFilterInput, limit: Int, nextToken: String): ModelUpdatedAtNullConnection
 }
 
-input ModelFooConditionInput {
+input ModelUpdatedAtNullConditionInput {
   title: ModelStringInput
-  and: [ModelFooConditionInput]
-  or: [ModelFooConditionInput]
-  not: ModelFooConditionInput
+  and: [ModelUpdatedAtNullConditionInput]
+  or: [ModelUpdatedAtNullConditionInput]
+  not: ModelUpdatedAtNullConditionInput
   createdAt: ModelStringInput
 }
 
-input CreateFooInput {
+input CreateUpdatedAtNullInput {
   id: ID
   title: String!
 }
 
-input UpdateFooInput {
+input UpdateUpdatedAtNullInput {
   id: ID!
   title: String
 }
 
-input DeleteFooInput {
+input DeleteUpdatedAtNullInput {
   id: ID!
 }
 
 type Mutation {
-  createFoo(input: CreateFooInput!, condition: ModelFooConditionInput): Foo
-  updateFoo(input: UpdateFooInput!, condition: ModelFooConditionInput): Foo
-  deleteFoo(input: DeleteFooInput!, condition: ModelFooConditionInput): Foo
+  createUpdatedAtNull(input: CreateUpdatedAtNullInput!, condition: ModelUpdatedAtNullConditionInput): UpdatedAtNull
+  updateUpdatedAtNull(input: UpdateUpdatedAtNullInput!, condition: ModelUpdatedAtNullConditionInput): UpdatedAtNull
+  deleteUpdatedAtNull(input: DeleteUpdatedAtNullInput!, condition: ModelUpdatedAtNullConditionInput): UpdatedAtNull
 }
 
-input ModelSubscriptionFooFilterInput {
+input ModelSubscriptionUpdatedAtNullFilterInput {
   id: ModelSubscriptionIDInput
   title: ModelSubscriptionStringInput
   createdAt: ModelSubscriptionStringInput
-  and: [ModelSubscriptionFooFilterInput]
-  or: [ModelSubscriptionFooFilterInput]
+  and: [ModelSubscriptionUpdatedAtNullFilterInput]
+  or: [ModelSubscriptionUpdatedAtNullFilterInput]
 }
 
 type Subscription {
-  onCreateFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"createFoo\\"])
-  onUpdateFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"updateFoo\\"])
-  onDeleteFoo(filter: ModelSubscriptionFooFilterInput): Foo @aws_subscribe(mutations: [\\"deleteFoo\\"])
+  onCreateUpdatedAtNull(filter: ModelSubscriptionUpdatedAtNullFilterInput): UpdatedAtNull @aws_subscribe(mutations: [\\"createUpdatedAtNull\\"])
+  onUpdateUpdatedAtNull(filter: ModelSubscriptionUpdatedAtNullFilterInput): UpdatedAtNull @aws_subscribe(mutations: [\\"updateUpdatedAtNull\\"])
+  onDeleteUpdatedAtNull(filter: ModelSubscriptionUpdatedAtNullFilterInput): UpdatedAtNull @aws_subscribe(mutations: [\\"deleteUpdatedAtNull\\"])
 }
 "
 `;

--- a/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
@@ -1686,7 +1686,7 @@ describe('ModelTransformer:', () => {
   describe('remove null timestamp fields from input', () => {
     it('updatedAt null', () => {
       const validSchema = `
-        type Foo @model(timestamps: { updatedAt: null }) {
+        type UpdatedAtNull @model(timestamps: { updatedAt: null }) {
             id: ID!
             title: String!
         }
@@ -1704,7 +1704,7 @@ describe('ModelTransformer:', () => {
 
     it('createdAt null', () => {
       const validSchema = `
-        type Bar @model(timestamps: { createdAt: null }) {
+        type CreatedAtNull @model(timestamps: { createdAt: null }) {
             id: ID!
             title: String!
         }
@@ -1722,7 +1722,7 @@ describe('ModelTransformer:', () => {
 
     it('createdAt null and updatedAt null', () => {
       const validSchema = `
-        type Boo @model(timestamps: { createdAt: null, updatedAt: null }) {
+        type CreatedAtAndUpdatedAtNull @model(timestamps: { createdAt: null, updatedAt: null }) {
             id: ID!
             title: String!
         }
@@ -1740,7 +1740,7 @@ describe('ModelTransformer:', () => {
 
     it('timestamps null', () => {
       const validSchema = `
-        type Baz @model(timestamps: null) {
+        type TimeStampsNull @model(timestamps: null) {
             id: ID!
             title: String!
         }
@@ -1758,7 +1758,7 @@ describe('ModelTransformer:', () => {
 
     it('custom createdAt and updatedAt null', () => {
       const validSchema = `
-        type Bing @model(timestamps: { createdAt: "createdOn", updatedAt: null }) {
+        type CustomCreatedAtAndUpdatedAtNull @model(timestamps: { createdAt: "createdOn", updatedAt: null }) {
             id: ID!
             title: String!
         }

--- a/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
@@ -1682,4 +1682,33 @@ describe('ModelTransformer:', () => {
       });
     });
   });
+
+  it('should remove null timestamp fields from input', () => {
+    const validSchema = `
+      type Foo @model(timestamps: { updatedAt: null }) {
+          id: ID!
+          title: String!
+      }
+
+      type Bar @model(timestamps: { createdAt: null }) {
+          id: ID!
+          title: String!
+      }
+
+      type Baz @model(timestamps: null) {
+          id: ID!
+          title: String!
+      }
+    `;
+
+    const out = testTransform({
+      schema: validSchema,
+      transformers: [new ModelTransformer()],
+    });
+    expect(out).toBeDefined();
+
+    validateModelSchema(parse(out.schema));
+    parse(out.schema);
+    expect(out.schema).toMatchSnapshot();
+  });
 });

--- a/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
@@ -1683,32 +1683,95 @@ describe('ModelTransformer:', () => {
     });
   });
 
-  it('should remove null timestamp fields from input', () => {
-    const validSchema = `
-      type Foo @model(timestamps: { updatedAt: null }) {
-          id: ID!
-          title: String!
-      }
+  describe('remove null timestamp fields from input', () => {
+    it('updatedAt null', () => {
+      const validSchema = `
+        type Foo @model(timestamps: { updatedAt: null }) {
+            id: ID!
+            title: String!
+        }
+      `;
 
-      type Bar @model(timestamps: { createdAt: null }) {
-          id: ID!
-          title: String!
-      }
+      const out = testTransform({
+        schema: validSchema,
+        transformers: [new ModelTransformer()],
+      });
+      expect(out).toBeDefined();
 
-      type Baz @model(timestamps: null) {
-          id: ID!
-          title: String!
-      }
-    `;
-
-    const out = testTransform({
-      schema: validSchema,
-      transformers: [new ModelTransformer()],
+      validateModelSchema(parse(out.schema));
+      expect(out.schema).toMatchSnapshot();
     });
-    expect(out).toBeDefined();
 
-    validateModelSchema(parse(out.schema));
-    parse(out.schema);
-    expect(out.schema).toMatchSnapshot();
+    it('createdAt null', () => {
+      const validSchema = `
+        type Bar @model(timestamps: { createdAt: null }) {
+            id: ID!
+            title: String!
+        }
+      `;
+
+      const out = testTransform({
+        schema: validSchema,
+        transformers: [new ModelTransformer()],
+      });
+      expect(out).toBeDefined();
+
+      validateModelSchema(parse(out.schema));
+      expect(out.schema).toMatchSnapshot();
+    });
+
+    it('createdAt null and updatedAt null', () => {
+      const validSchema = `
+        type Boo @model(timestamps: { createdAt: null, updatedAt: null }) {
+            id: ID!
+            title: String!
+        }
+      `;
+
+      const out = testTransform({
+        schema: validSchema,
+        transformers: [new ModelTransformer()],
+      });
+      expect(out).toBeDefined();
+
+      validateModelSchema(parse(out.schema));
+      expect(out.schema).toMatchSnapshot();
+    });
+
+    it('timestamps null', () => {
+      const validSchema = `
+        type Baz @model(timestamps: null) {
+            id: ID!
+            title: String!
+        }
+      `;
+
+      const out = testTransform({
+        schema: validSchema,
+        transformers: [new ModelTransformer()],
+      });
+      expect(out).toBeDefined();
+
+      validateModelSchema(parse(out.schema));
+      expect(out.schema).toMatchSnapshot();
+    });
+
+    it('custom createdAt and updatedAt null', () => {
+      const validSchema = `
+        type Bing @model(timestamps: { createdAt: "createdOn", updatedAt: null }) {
+            id: ID!
+            title: String!
+        }
+      `;
+
+      const out = testTransform({
+        schema: validSchema,
+        transformers: [new ModelTransformer()],
+      });
+      expect(out).toBeDefined();
+
+      validateModelSchema(parse(out.schema));
+      expect(out.schema).toMatchSnapshot();
+    });
   });
 });

--- a/packages/amplify-graphql-model-transformer/src/graphql-types/mutation.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-types/mutation.ts
@@ -177,14 +177,16 @@ export const makeMutationConditionInput = (
 
   // add implicit timestamp fields to filter
   if (isDynamoDbModel(ctx, object.name.value)) {
-    Object.values({ createdAt: 'createdAt', updatedAt: 'updatedAt', ...(modelDirectiveConfig?.timestamps || {}) }).forEach(
-      (timeStampFieldName) => {
-        if (!input.hasField(timeStampFieldName!)) {
-          const field = InputFieldWrapper.create(timeStampFieldName, 'ModelStringInput', true);
-          input.addField(field);
-        }
-      },
-    );
+    if (!(modelDirectiveConfig?.timestamps === null)) {
+      Object.values({ createdAt: 'createdAt', updatedAt: 'updatedAt', ...(modelDirectiveConfig?.timestamps || {}) }).forEach(
+        (timeStampFieldName) => {
+          if (!!timeStampFieldName && !input.hasField(timeStampFieldName!)) {
+            const field = InputFieldWrapper.create(timeStampFieldName, 'ModelStringInput', true);
+            input.addField(field);
+          }
+        },
+      );
+    }
   }
 
   return input.serialize();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This bug was introduced in https://github.com/aws-amplify/amplify-category-api/pull/2236

* A field with null name is included when timestamps are removed with `@model(timestamps: { createdAt/updatedAt: null })`.
```
type Foo @model(timestamps: { updatedAt: null }) {
  id: ID!
  title: String!
}
```
This results in schema deploy error because of field named `null`.
```
input ModelFooConditionInput {
  title: ModelStringInput
  and: [ModelFooConditionInput]
  or: [ModelFooConditionInput]
  not: ModelFooConditionInput
  createdAt: ModelStringInput
  null: ModelStringInput // should not be included
}
```
* Bad filter inputs are added when timestamps are removed with `@model(timestamps: null)`
```
type Foo @model(timestamps: null) {
  id: ID!
  title: String!
}
```

Schema deploys fine in this case.
```
input ModelFooConditionInput {
  title: ModelStringInput
  and: [ModelFooConditionInput]
  or: [ModelFooConditionInput]
  not: ModelFooConditionInput
  createdAt: ModelStringInput // should not be included
  updatedAt: ModelStringInput // should not be included
}
```
##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

N/A

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

N/A (reported through AWS support)

#### Description of how you validated changes

* Unit tests
* E2E tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
