### PR TITLE
fix(api): add identifier to generated ts data schema

### DIFF
--- a/packages/amplify-graphql-schema-generator/API.md
+++ b/packages/amplify-graphql-schema-generator/API.md
@@ -93,6 +93,7 @@ export abstract class DataSourceAdapter {
 // @public (undocumented)
 export type DataSourceConfig = {
     secretName: string;
+    identifier: string;
     vpcConfig?: VpcConfig;
 };
 

--- a/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-ts-data-schema.test.ts.snap
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-ts-data-schema.test.ts.snap
@@ -192,7 +192,7 @@ import { secret } from \\"@aws-amplify/backend\\";
 
 export const schema = configure({
     database: {
-        identifier: \\"IDUSfpAK13zArse10XtJJWbw\\",
+        identifier: \\"IDNb9LVUQdGlNwNzYAgL6A\\",
         engine: \\"mysql\\",
         connectionUri: secret(\\"secret\\")
     }

--- a/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-ts-data-schema.test.ts.snap
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-ts-data-schema.test.ts.snap
@@ -204,15 +204,15 @@ export const schema = configure({
             ],
             subnetAvailabilityZones: [
                 {
-                    subnetId: \\"sg0\\",
+                    subnetId: \\"sb0\\",
                     availabilityZone: \\"az0\\"
                 },
                 {
-                    subnetId: \\"sg1\\",
+                    subnetId: \\"sb1\\",
                     availabilityZone: \\"az1\\"
                 },
                 {
-                    subnetId: \\"sg2\\",
+                    subnetId: \\"sb2\\",
                     availabilityZone: \\"az2\\"
                 }
             ]

--- a/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-ts-data-schema.test.ts.snap
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-ts-data-schema.test.ts.snap
@@ -77,6 +77,7 @@ import { secret } from \\"@aws-amplify/backend\\";
 
 export const schema = configure({
     database: {
+        identifier: \\"ID1234567890\\",
         engine: \\"postgresql\\",
         connectionUri: secret(\\"CONN_STR\\"),
         vpcConfig: {
@@ -111,6 +112,7 @@ import { secret } from \\"@aws-amplify/backend\\";
 
 export const schema = configure({
     database: {
+        identifier: \\"ID1234567890\\",
         engine: \\"mysql\\",
         connectionUri: secret(\\"CONN_STR\\"),
         vpcConfig: {
@@ -161,6 +163,7 @@ import { secret } from \\"@aws-amplify/backend\\";
 
 export const schema = configure({
     database: {
+        identifier: \\"ID1234567890\\",
         engine: \\"mysql\\",
         connectionUri: secret(\\"CONN_STR\\")
     }
@@ -174,6 +177,29 @@ export const schema = configure({
     \\"Profile\\": a.model({
         id: a.string().required(),
         details: a.string()
+    }).identifier([
+        \\"id\\"
+    ])
+});
+"
+`;
+
+exports[`Type name conversions ts schema generator should invoke generate schema 1`] = `
+"/* eslint-disable */
+import { a } from \\"@aws-amplify/data-schema\\";
+import { configure } from \\"@aws-amplify/data-schema/internals\\";
+import { secret } from \\"@aws-amplify/backend\\";
+
+export const schema = configure({
+    database: {
+        identifier: \\"IDUSfpAK13zArse10XtJJWbw\\",
+        engine: \\"mysql\\",
+        connectionUri: secret(\\"secret\\")
+    }
+}).schema({
+    \\"User\\": a.model({
+        id: a.string().required(),
+        name: a.string()
     }).identifier([
         \\"id\\"
     ])

--- a/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-ts-data-schema.test.ts.snap
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-ts-data-schema.test.ts.snap
@@ -194,7 +194,29 @@ export const schema = configure({
     database: {
         identifier: \\"IDNb9LVUQdGlNwNzYAgL6A\\",
         engine: \\"mysql\\",
-        connectionUri: secret(\\"secret\\")
+        connectionUri: secret(\\"secret\\"),
+        vpcConfig: {
+            vpcId: \\"abc\\",
+            securityGroupIds: [
+                \\"sb0\\",
+                \\"sb1\\",
+                \\"sb2\\"
+            ],
+            subnetAvailabilityZones: [
+                {
+                    subnetId: \\"sb1\\",
+                    availabilityZone: \\"az1\\"
+                },
+                {
+                    subnetId: \\"sb2\\",
+                    availabilityZone: \\"az2\\"
+                },
+                {
+                    subnetId: \\"sb0\\",
+                    availabilityZone: \\"az3\\"
+                }
+            ]
+        }
     }
 }).schema({
     \\"User\\": a.model({

--- a/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-ts-data-schema.test.ts.snap
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-ts-data-schema.test.ts.snap
@@ -198,22 +198,22 @@ export const schema = configure({
         vpcConfig: {
             vpcId: \\"abc\\",
             securityGroupIds: [
-                \\"sb0\\",
-                \\"sb1\\",
-                \\"sb2\\"
+                \\"sg0\\",
+                \\"sg1\\",
+                \\"sg2\\"
             ],
             subnetAvailabilityZones: [
                 {
-                    subnetId: \\"sb1\\",
+                    subnetId: \\"sg0\\",
+                    availabilityZone: \\"az0\\"
+                },
+                {
+                    subnetId: \\"sg1\\",
                     availabilityZone: \\"az1\\"
                 },
                 {
-                    subnetId: \\"sb2\\",
+                    subnetId: \\"sg2\\",
                     availabilityZone: \\"az2\\"
-                },
-                {
-                    subnetId: \\"sb0\\",
-                    availabilityZone: \\"az3\\"
                 }
             ]
         }

--- a/packages/amplify-graphql-schema-generator/src/__tests__/generate-ts-data-schema.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/generate-ts-data-schema.test.ts
@@ -10,15 +10,15 @@ jest.mock('../utils', () => ({
       securityGroupIds: ['sg0', 'sg1', 'sg2'],
       subnetAvailabilityZoneConfig: [
         {
-          subnetId: 'sg0',
+          subnetId: 'sb0',
           availabilityZone: 'az0',
         },
         {
-          subnetId: 'sg1',
+          subnetId: 'sb1',
           availabilityZone: 'az1',
         },
         {
-          subnetId: 'sg2',
+          subnetId: 'sb2',
           availabilityZone: 'az2',
         },
       ],

--- a/packages/amplify-graphql-schema-generator/src/__tests__/generate-ts-data-schema.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/generate-ts-data-schema.test.ts
@@ -3,6 +3,29 @@ import { generateTypescriptDataSchema } from '../ts-schema-generator/generate-ts
 import { DataSourceConfig } from '../ts-schema-generator/helpers';
 import { TypescriptDataSchemaGenerator } from '../ts-schema-generator/ts-schema-generator';
 
+jest.mock('../utils', () => ({
+  getHostVpc: jest.fn(() => {
+    return {
+      vpcId: 'abc',
+      securityGroupIds: ['sb0', 'sb1', 'sb2'],
+      subnetAvailabilityZoneConfig: [
+        {
+          subnetId: 'sb1',
+          availabilityZone: 'az1',
+        },
+        {
+          subnetId: 'sb2',
+          availabilityZone: 'az2',
+        },
+        {
+          subnetId: 'sb0',
+          availabilityZone: 'az3',
+        },
+      ],
+    };
+  }),
+}));
+
 describe('Type name conversions', () => {
   it('ts schema generator should invoke generate schema', async () => {
     const dbschema = new Schema(new Engine('MySQL'));

--- a/packages/amplify-graphql-schema-generator/src/__tests__/generate-ts-data-schema.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/generate-ts-data-schema.test.ts
@@ -1,8 +1,34 @@
 import { Engine, Field, Model, Schema } from '../schema-representation';
 import { generateTypescriptDataSchema } from '../ts-schema-generator/generate-ts-schema';
 import { DataSourceConfig } from '../ts-schema-generator/helpers';
+import { TypescriptDataSchemaGenerator } from '../ts-schema-generator/ts-schema-generator';
 
 describe('Type name conversions', () => {
+  it('ts schema generator should invoke generate schema', async () => {
+    const dbschema = new Schema(new Engine('MySQL'));
+    const model = new Model('User');
+    model.addField(new Field('id', { kind: 'NonNull', type: { kind: 'Scalar', name: 'String' } }));
+    model.addField(new Field('name', { kind: 'Scalar', name: 'String' }));
+    model.setPrimaryKey(['id']);
+    dbschema.addModel(model);
+
+    const buildSchemaMockMethod = jest.spyOn(TypescriptDataSchemaGenerator as any, 'buildSchema');
+    buildSchemaMockMethod.mockImplementation(() => {
+      return dbschema;
+    });
+
+    const schema = await TypescriptDataSchemaGenerator.generate({
+      engine: 'mysql',
+      host: 'host',
+      port: 3306,
+      database: 'database',
+      username: 'username',
+      password: 'password',
+      connectionUriSecretName: 'secret',
+    });
+    expect(schema).toMatchSnapshot();
+  });
+
   it('basic models should generate correct typescript data schema', () => {
     const dbschema = new Schema(new Engine('MySQL'));
     let model = new Model('User');
@@ -75,6 +101,7 @@ describe('Type name conversions', () => {
     dbschema.addModel(model);
 
     const config: DataSourceConfig = {
+      identifier: 'ID1234567890',
       secretName: 'CONN_STR',
       vpcConfig: {
         vpcId: '123',
@@ -109,6 +136,7 @@ describe('Type name conversions', () => {
     dbschema.addModel(model);
 
     const config: DataSourceConfig = {
+      identifier: 'ID1234567890',
       secretName: 'CONN_STR',
       vpcConfig: {
         vpcId: '123',
@@ -141,6 +169,7 @@ describe('Type name conversions', () => {
     dbschema.addModel(model);
 
     const config: DataSourceConfig = {
+      identifier: 'ID1234567890',
       secretName: 'CONN_STR',
     };
 

--- a/packages/amplify-graphql-schema-generator/src/__tests__/generate-ts-data-schema.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/generate-ts-data-schema.test.ts
@@ -7,19 +7,19 @@ jest.mock('../utils', () => ({
   getHostVpc: jest.fn(() => {
     return {
       vpcId: 'abc',
-      securityGroupIds: ['sb0', 'sb1', 'sb2'],
+      securityGroupIds: ['sg0', 'sg1', 'sg2'],
       subnetAvailabilityZoneConfig: [
         {
-          subnetId: 'sb1',
+          subnetId: 'sg0',
+          availabilityZone: 'az0',
+        },
+        {
+          subnetId: 'sg1',
           availabilityZone: 'az1',
         },
         {
-          subnetId: 'sb2',
+          subnetId: 'sg2',
           availabilityZone: 'az2',
-        },
-        {
-          subnetId: 'sb0',
-          availabilityZone: 'az3',
         },
       ],
     };

--- a/packages/amplify-graphql-schema-generator/src/ts-schema-generator/helpers.ts
+++ b/packages/amplify-graphql-schema-generator/src/ts-schema-generator/helpers.ts
@@ -120,6 +120,7 @@ const exportModifier = ts.factory.createModifier(ts.SyntaxKind.ExportKeyword);
 
 export type DataSourceConfig = {
   secretName: string;
+  identifier: string;
   vpcConfig?: VpcConfig;
 };
 
@@ -231,6 +232,10 @@ export const createConfigureExpression = (schema: Schema, config: DataSourceConf
     return ts.factory.createIdentifier(TYPESCRIPT_DATA_SCHEMA_CONSTANTS.REFERENCE_A);
   }
   const databaseConfig = [
+    ts.factory.createPropertyAssignment(
+      ts.factory.createIdentifier(TYPESCRIPT_DATA_SCHEMA_CONSTANTS.PROPERTY_IDENTIFIER),
+      ts.factory.createStringLiteral(config.identifier),
+    ),
     ts.factory.createPropertyAssignment(
       ts.factory.createIdentifier(TYPESCRIPT_DATA_SCHEMA_CONSTANTS.PROPERTY_ENGINE),
       ts.factory.createStringLiteral(convertDBEngineToDBProtocol(schema.getEngine().type)),

--- a/packages/amplify-graphql-schema-generator/src/ts-schema-generator/ts-schema-generator.ts
+++ b/packages/amplify-graphql-schema-generator/src/ts-schema-generator/ts-schema-generator.ts
@@ -59,6 +59,9 @@ export class TypescriptDataSchemaGenerator {
 
   private static createIdentifier = (config: TypescriptDataSchemaGeneratorConfig): string => {
     const { host, database, engine, port } = config;
+    // Do not include any secrets such as username or password to compute hash.
+    // The reason we compute the hash is to generate an unique ID for a SQL datasource that remains the same on subsequent deployments.
+    // Currently we use engine, host, database and port to generate an unique id.
     const identifierString = host.concat(engine, database, port.toString());
     const identifierHash = createHash('md5').update(identifierString).digest('base64');
     const identifier = `ID${TypescriptDataSchemaGenerator.removeNonAlphaNumericChars(identifierHash)}`;

--- a/packages/amplify-graphql-schema-generator/src/ts-schema-generator/ts-schema-generator.ts
+++ b/packages/amplify-graphql-schema-generator/src/ts-schema-generator/ts-schema-generator.ts
@@ -58,8 +58,8 @@ export class TypescriptDataSchemaGenerator {
   };
 
   private static createIdentifier = (config: TypescriptDataSchemaGeneratorConfig): string => {
-    const { host, username, database, engine, port } = config;
-    const identifierString = host.concat(engine, database, username, port.toString());
+    const { host, database, engine, port } = config;
+    const identifierString = host.concat(engine, database, port.toString());
     const identifierHash = createHash('md5').update(identifierString).digest('base64');
     const identifier = `ID${TypescriptDataSchemaGenerator.removeNonAlphaNumericChars(identifierHash)}`;
     // Identifier must contain only AlphaNumeric characters.

--- a/packages/amplify-graphql-schema-generator/src/ts-schema-generator/ts-schema-generator.ts
+++ b/packages/amplify-graphql-schema-generator/src/ts-schema-generator/ts-schema-generator.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { DataSourceAdapter, MySQLDataSourceAdapter, PostgresDataSourceAdapter } from '../datasource-adapter';
 import { DBEngineType, Engine, Schema } from '../schema-representation';
 import { getHostVpc } from '../utils';
@@ -22,6 +23,7 @@ export class TypescriptDataSchemaGenerator {
     return generateTypescriptDataSchema(schema, {
       secretName: config.connectionUriSecretName,
       vpcConfig: await getHostVpc(config.host),
+      identifier: TypescriptDataSchemaGenerator.createIdentifier(config),
     });
   };
 
@@ -53,5 +55,18 @@ export class TypescriptDataSchemaGenerator {
     adapter.cleanup();
     models.forEach((m) => schema.addModel(m));
     return schema;
+  };
+
+  private static createIdentifier = (config: TypescriptDataSchemaGeneratorConfig): string => {
+    const { host, username, database, engine, port } = config;
+    const identifierString = host.concat(engine, database, username, port.toString());
+    const identifierHash = createHash('md5').update(identifierString).digest('base64');
+    const identifier = `ID${TypescriptDataSchemaGenerator.removeNonAlphaNumericChars(identifierHash)}`;
+    // Identifier must contain only AlphaNumeric characters.
+    return identifier;
+  };
+
+  private static removeNonAlphaNumericChars = (str: string): string => {
+    return str.split(/[^A-Za-z0-9]*/).join('');
   };
 }

--- a/packages/graphql-transformer-common/API.md
+++ b/packages/graphql-transformer-common/API.md
@@ -524,6 +524,7 @@ export const TYPESCRIPT_DATA_SCHEMA_CONSTANTS: {
     PROPERTY_DATABASE: string;
     PROPERTY_CONNECTION_URI: string;
     PROPERTY_ENGINE: string;
+    PROPERTY_IDENTIFIER: string;
 };
 
 // @public (undocumented)

--- a/packages/graphql-transformer-common/src/TypescriptSchemaConstants.ts
+++ b/packages/graphql-transformer-common/src/TypescriptSchemaConstants.ts
@@ -22,4 +22,5 @@ export const TYPESCRIPT_DATA_SCHEMA_CONSTANTS = {
   PROPERTY_DATABASE: 'database',
   PROPERTY_CONNECTION_URI: 'connectionUri',
   PROPERTY_ENGINE: 'engine',
+  PROPERTY_IDENTIFIER: 'identifier',
 };


### PR DESCRIPTION
#### Description of changes

Add identifier to the generated typescript data schema file. This identifier is later used with `defineData` to construct an unique datasource strategy ID.

##### CDK / CloudFormation Parameters Changed
NA

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- New unit tests
- Manual test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
