### PR TITLE
chore(api): increase gsi e2e test timeout to 45 minutes

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/deploy-velocity/replace-2-gsis-update-attr-100k-records.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/deploy-velocity/replace-2-gsis-update-attr-100k-records.test.ts
@@ -1,7 +1,7 @@
 import {
   API_POST_PROCESSOR_SET_PROVISIONED_THROUGHPUT_TWO_GSIS,
   COUNT_100_THOUSAND,
-  DURATION_30_MINUTES,
+  DURATION_45_MINUTES,
   MUTATION_FOUR_FIELD_CREATE,
   SCHEMA_FOUR_FIELDS_FINAL_TWO_INDEXED,
   SCHEMA_FOUR_FIELDS_INITIAL_TWO_INDEXED,
@@ -10,7 +10,7 @@ import { recordCountDataProvider, recordCountDataValidator, testManagedTableDepl
 
 testManagedTableDeployment({
   name: 'Replace 2 GSIs updated w/ attr update - 100k Records',
-  maxDeployDurationMs: DURATION_30_MINUTES,
+  maxDeployDurationMs: DURATION_45_MINUTES,
   initialSchema: SCHEMA_FOUR_FIELDS_INITIAL_TWO_INDEXED,
   updatedSchema: SCHEMA_FOUR_FIELDS_FINAL_TWO_INDEXED,
   dataSetup: recordCountDataProvider(COUNT_100_THOUSAND, MUTATION_FOUR_FIELD_CREATE),


### PR DESCRIPTION
Change the GSI 2K update E2E timeout to 45 minutes.
- replace-2-gsis-update-attr-100k-records.test.ts