### PR TITLE
fix(api): protect sql relational fields when using owner rule

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/userpool-provider-fields.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth-test-schemas/userpool-provider-fields.ts
@@ -114,6 +114,32 @@ export const schema = `
     groupContent: String @refersTo(name: "group_content") @auth(rules: [{ allow: groups, groupsField: "customGroup", operations: [create, read] }])
     groupsContent: String @refersTo(name: "groups_content") @auth(rules: [{ allow: groups, groupsField: "customGroups", operations: [update, read] }])
   }
+
+  type PrimaryOne @model @auth(rules: [{ allow: owner }]) {
+    id: String! @primaryKey
+    owner: String
+    relatedOne: RelatedOne @hasOne(references: ["primaryId"])
+  }
+
+  type RelatedOne @model @auth(rules: [{ allow: owner, ownerField: "relatedOwner" }]) {
+    id: String! @primaryKey
+    relatedOwner: String
+    primaryId: String
+    primary: PrimaryOne @belongsTo(references: ["primaryId"])
+  }
+
+  type PrimaryTwo @model @auth(rules: [{ allow: owner }]) {
+    id: String! @primaryKey
+    owner: String
+    relatedTwos: [RelatedTwo] @hasMany(references: ["primaryId"])
+  }
+
+  type RelatedTwo @model @auth(rules: [{ allow: owner, ownerField: "relatedOwner" }]) {
+    id: String! @primaryKey
+    relatedOwner: String
+    primaryId: String
+    primary: PrimaryTwo @belongsTo(references: ["primaryId"])
+  }
 `;
 
 export const sqlCreateStatements = (engine: ImportedRDSType): string[] => generateDDL(schema, engine);

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool-fields.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-userpool-fields.ts
@@ -3568,7 +3568,11 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       expect(createResultPrimary.data[createResultSetNamePrimary].owner).toEqual(userName1);
 
       // Create a related record with user2
-      const createResultRelated = await user2RelatedOneHelper.create(createResultSetNameRelated, relatedRecord, 'id relatedOwner primaryId');
+      const createResultRelated = await user2RelatedOneHelper.create(
+        createResultSetNameRelated,
+        relatedRecord,
+        'id relatedOwner primaryId',
+      );
       expect(createResultRelated.data[createResultSetNameRelated].id).toBeDefined();
       expect(createResultRelated.data[createResultSetNameRelated].id).toEqual(relatedRecord['id']);
       expect(createResultRelated.data[createResultSetNameRelated].relatedOwner).toEqual(userName2);
@@ -3646,14 +3650,22 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       expect(createResultPrimary.data[createResultSetNamePrimary].owner).toEqual(userName1);
 
       // Create a related record with user2
-      const createResultRelated1 = await user2RelatedTwoHelper.create(createResultSetNameRelated, relatedRecord1, 'id relatedOwner primaryId');
+      const createResultRelated1 = await user2RelatedTwoHelper.create(
+        createResultSetNameRelated,
+        relatedRecord1,
+        'id relatedOwner primaryId',
+      );
       expect(createResultRelated1.data[createResultSetNameRelated].id).toBeDefined();
       expect(createResultRelated1.data[createResultSetNameRelated].id).toEqual(relatedRecord1['id']);
       expect(createResultRelated1.data[createResultSetNameRelated].relatedOwner).toEqual(userName2);
       expect(createResultRelated1.data[createResultSetNameRelated].primaryId).toEqual(relatedRecord1['primaryId']);
 
       // Create a related record with user1
-      const createResultRelated2 = await user1RelatedTwoHelper.create(createResultSetNameRelated, relatedRecord2, 'id relatedOwner primaryId');
+      const createResultRelated2 = await user1RelatedTwoHelper.create(
+        createResultSetNameRelated,
+        relatedRecord2,
+        'id relatedOwner primaryId',
+      );
       expect(createResultRelated2.data[createResultSetNameRelated].id).toBeDefined();
       expect(createResultRelated2.data[createResultSetNameRelated].id).toEqual(relatedRecord2['id']);
       expect(createResultRelated2.data[createResultSetNameRelated].relatedOwner).toEqual(userName1);
@@ -3682,11 +3694,13 @@ export const testUserPoolFieldAuth = (engine: ImportedRDSType): void => {
       expect(getResultPrimary.data[getResultSetNamePrimary].relatedTwos).toBeDefined();
       expect(getResultPrimary.data[getResultSetNamePrimary].relatedTwos.items).toBeDefined();
       expect(getResultPrimary.data[getResultSetNamePrimary].relatedTwos.items.length).toEqual(1);
-      expect(getResultPrimary.data[getResultSetNamePrimary].relatedTwos.items[0]).toEqual(expect.objectContaining({
-        id: relatedRecord2['id'],
-        relatedOwner: userName1,
-        primaryId: relatedRecord2['primaryId'],
-      }));
+      expect(getResultPrimary.data[getResultSetNamePrimary].relatedTwos.items[0]).toEqual(
+        expect.objectContaining({
+          id: relatedRecord2['id'],
+          relatedOwner: userName1,
+          primaryId: relatedRecord2['primaryId'],
+        }),
+      );
     });
   });
 };

--- a/packages/amplify-graphql-name-mapping-transformer/src/__tests__/__integ__/__snapshots__/with-has-many.test.ts.snap
+++ b/packages/amplify-graphql-name-mapping-transformer/src/__tests__/__integ__/__snapshots__/with-has-many.test.ts.snap
@@ -440,6 +440,9 @@ $util.qr($lambdaInput.args.putAll($util.defaultIfNull($context.arguments, {})))
 #if( !$lambdaInput.args.filter )
   #set( $lambdaInput.args.filter = {} )
 #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $lambdaInput.args.metadata.authFilter = $ctx.stash.authFilter )
+#end
 $util.qr($lambdaInput.args.filter.put(\\"employeeId\\", {
   \\"eq\\": $util.defaultIfNull($ctx.source.id, \\"\\")
 }))
@@ -469,6 +472,9 @@ $util.qr($lambdaInput.args.metadata.fieldMap.putAll($util.defaultIfNull($context
 $util.qr($lambdaInput.args.putAll($util.defaultIfNull($context.arguments, {})))
 #if( !$lambdaInput.args.input )
   #set( $lambdaInput.args.input = {} )
+#end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $lambdaInput.args.metadata.authFilter = $ctx.stash.authFilter )
 #end
 $util.qr($lambdaInput.args.input.put(\\"id\\", $util.defaultIfNull($ctx.source.employeeId, \\"\\")))
 {

--- a/packages/amplify-graphql-name-mapping-transformer/src/__tests__/__integ__/__snapshots__/with-has-one.test.ts.snap
+++ b/packages/amplify-graphql-name-mapping-transformer/src/__tests__/__integ__/__snapshots__/with-has-one.test.ts.snap
@@ -432,6 +432,9 @@ $util.qr($lambdaInput.args.putAll($util.defaultIfNull($context.arguments, {})))
 #if( !$lambdaInput.args.input )
   #set( $lambdaInput.args.input = {} )
 #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $lambdaInput.args.metadata.authFilter = $ctx.stash.authFilter )
+#end
 $util.qr($lambdaInput.args.input.put(\\"employeeId\\", {
   \\"eq\\": $util.defaultIfNull($ctx.source.id, \\"\\")
 }))
@@ -460,6 +463,9 @@ $util.qr($lambdaInput.args.metadata.fieldMap.putAll($util.defaultIfNull($context
 $util.qr($lambdaInput.args.putAll($util.defaultIfNull($context.arguments, {})))
 #if( !$lambdaInput.args.input )
   #set( $lambdaInput.args.input = {} )
+#end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $lambdaInput.args.metadata.authFilter = $ctx.stash.authFilter )
 #end
 $util.qr($lambdaInput.args.input.put(\\"id\\", $util.defaultIfNull($ctx.source.employeeId, \\"\\")))
 {

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-belongs-to-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-belongs-to-transformer.test.ts.snap
@@ -306,6 +306,9 @@ $util.qr($lambdaInput.args.putAll($util.defaultIfNull($context.arguments, {})))
 #if( !$lambdaInput.args.input )
   #set( $lambdaInput.args.input = {} )
 #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $lambdaInput.args.metadata.authFilter = $ctx.stash.authFilter )
+#end
 $util.qr($lambdaInput.args.input.put(\\"firstName\\", $util.defaultIfNull($ctx.source.userFirstName, \\"\\")))
 $util.qr($lambdaInput.args.input.put(\\"lastName\\", $util.defaultIfNull($ctx.source.userLastName, \\"\\")))
 {
@@ -626,6 +629,9 @@ $util.qr($lambdaInput.args.metadata.fieldMap.putAll($util.defaultIfNull($context
 $util.qr($lambdaInput.args.putAll($util.defaultIfNull($context.arguments, {})))
 #if( !$lambdaInput.args.input )
   #set( $lambdaInput.args.input = {} )
+#end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $lambdaInput.args.metadata.authFilter = $ctx.stash.authFilter )
 #end
 $util.qr($lambdaInput.args.input.put(\\"id\\", $util.defaultIfNull($ctx.source.userId, \\"\\")))
 {

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
@@ -317,6 +317,9 @@ $util.qr($lambdaInput.args.putAll($util.defaultIfNull($context.arguments, {})))
 #if( !$lambdaInput.args.filter )
   #set( $lambdaInput.args.filter = {} )
 #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $lambdaInput.args.metadata.authFilter = $ctx.stash.authFilter )
+#end
 $util.qr($lambdaInput.args.filter.put(\\"systemId\\", {
   \\"eq\\": $util.defaultIfNull($ctx.source.systemId, \\"\\")
 }))
@@ -642,6 +645,9 @@ $util.qr($lambdaInput.args.metadata.fieldMap.putAll($util.defaultIfNull($context
 $util.qr($lambdaInput.args.putAll($util.defaultIfNull($context.arguments, {})))
 #if( !$lambdaInput.args.filter )
   #set( $lambdaInput.args.filter = {} )
+#end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $lambdaInput.args.metadata.authFilter = $ctx.stash.authFilter )
 #end
 $util.qr($lambdaInput.args.filter.put(\\"blogId\\", {
   \\"eq\\": $util.defaultIfNull($ctx.source.id, \\"\\")

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-one-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-one-transformer.test.ts.snap
@@ -305,6 +305,9 @@ $util.qr($lambdaInput.args.putAll($util.defaultIfNull($context.arguments, {})))
 #if( !$lambdaInput.args.input )
   #set( $lambdaInput.args.input = {} )
 #end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $lambdaInput.args.metadata.authFilter = $ctx.stash.authFilter )
+#end
 $util.qr($lambdaInput.args.input.put(\\"userFirstName\\", {
   \\"eq\\": $util.defaultIfNull($ctx.source.firstName, \\"\\")
 }))
@@ -628,6 +631,9 @@ $util.qr($lambdaInput.args.metadata.fieldMap.putAll($util.defaultIfNull($context
 $util.qr($lambdaInput.args.putAll($util.defaultIfNull($context.arguments, {})))
 #if( !$lambdaInput.args.input )
   #set( $lambdaInput.args.input = {} )
+#end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $lambdaInput.args.metadata.authFilter = $ctx.stash.authFilter )
 #end
 $util.qr($lambdaInput.args.input.put(\\"userId\\", {
   \\"eq\\": $util.defaultIfNull($ctx.source.id, \\"\\")

--- a/packages/amplify-graphql-relational-transformer/src/resolver/rds-generator.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolver/rds-generator.ts
@@ -104,6 +104,7 @@ export class RDSRelationalResolverGenerator extends RelationalResolverGenerator 
         this.constructFieldMappingInput(),
         qref(methodCall(ref('lambdaInput.args.putAll'), methodCall(ref('util.defaultIfNull'), ref('context.arguments'), obj({})))),
         iff(not(ref('lambdaInput.args.filter')), set(ref('lambdaInput.args.filter'), obj({}))),
+        this.constructRelationalFieldAuthFilterStatement('lambdaInput.args.metadata.authFilter'),
         ...joinCondition,
         qref(
           methodCall(ref('lambdaInput.args.metadata.keys.addAll'), methodCall(ref('util.defaultIfNull'), ref('ctx.stash.keys'), list([]))),
@@ -140,6 +141,7 @@ export class RDSRelationalResolverGenerator extends RelationalResolverGenerator 
         this.constructFieldMappingInput(),
         qref(methodCall(ref('lambdaInput.args.putAll'), methodCall(ref('util.defaultIfNull'), ref('context.arguments'), obj({})))),
         iff(not(ref('lambdaInput.args.input')), set(ref('lambdaInput.args.input'), obj({}))),
+        this.constructRelationalFieldAuthFilterStatement('lambdaInput.args.metadata.authFilter'),
         ...joinCondition,
         obj({
           version: str('2018-05-29'),
@@ -298,4 +300,7 @@ export class RDSRelationalResolverGenerator extends RelationalResolverGenerator 
       ),
     ]);
   };
+
+  constructRelationalFieldAuthFilterStatement = (keyName: string): Expression =>
+    iff(not(methodCall(ref('util.isNullOrEmpty'), ref('ctx.stash.authFilter'))), set(ref(keyName), ref('ctx.stash.authFilter')));
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Fix: Relational directive hasMany, hasOne and belongsTo respect owner rule on the related type.

Example: In the below schema, primary.relatedMany and related.primary must respect the owner rule on the corresponding model.

```graphql
type Primary @model @auth(rules: [{ allow: owner }]) {
  id: String! @primaryKey
  owner: String
  relatedMany: [RelatedMany] @hasMany(references: ["primaryId"])
}

type RelatedMany @model @auth(rules: [{ allow: owner }]) {
  id: String! @primaryKey
  owner: String
  primaryId: String
  primary: Primary @belongsTo(references: ["primaryId"])
}
```

##### CDK / CloudFormation Parameters Changed
NA
<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available
NA (Internal Ticket)
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- New E2E Tests
- Manual test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
