### PR TITLE
chore: only require team approval for scripts/split-e2e-tests.ts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,20 @@
 # Data team has general approval permissions
 * @aws-amplify/amplify-data
 
+# Changes to this file requires admin approval
+/.github/CODEOWNERS @aws-amplify/amplify-data-admins
+
 # API approval - public surface and dependencies.
 **/API.md @aws-amplify/amplify-data-admins
 
 # Dependency Licensing approval
 dependency_licenses.txt @aws-amplify/amplify-data-admins
 
-# Changes to CI/CD scripts/buildspecs need admin approval
+# Changes to CI/CD scripts/buildspecs need admin approval, except as noted
+/codebuild_specs/ @aws-amplify/amplify-data-admins
 /scripts/ @aws-amplify/amplify-data-admins
 /shared-scripts.sh @aws-amplify/amplify-data-admins
-/codebuild_specs/ @aws-amplify/amplify-data-admins
+
+# Exceptions to CI/CD scripts/buildspecs
 /codebuild_specs/e2e_workflow.yml @aws-amplify/amplify-data
+/scripts/split-e2e-tests.ts @aws-amplify/amplify-data


### PR DESCRIPTION
#### Description of changes

Adjust some of the CODEOWNERS rules:
- We already allow `e2e_workflow.yml` to be approved by team rather than admin, so also allow team approval for changes to `scripts/split-e2e-tests.ts`
- Require admin approval for CODEOWNERS file
- Sorted the CI/CD scripts section

#### Checklist

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
