### PR TITLE
feat: support multiple connection Uris for SQL databases

### DIFF
--- a/packages/amplify-e2e-core/src/utils/rds.ts
+++ b/packages/amplify-e2e-core/src/utils/rds.ts
@@ -458,17 +458,15 @@ export const storeDbConnectionStringConfig = async (options: {
       connectionUriSsmPath: `${options.pathPrefix}/connectionUri`,
     };
   } else {
-    options.connectionUri.forEach(async (connectionUri, index) => {
-      await storeSSMParameters({
-        region: options.region,
-        pathPrefix: options.pathPrefix,
-        parameters: {
-          [`connectionUri${index}`]: connectionUri,
-        },
-      });
+    await storeSSMParameters({
+      region: options.region,
+      pathPrefix: options.pathPrefix,
+      parameters: {
+        connectionUri: options.connectionUri[1],
+      },
     });
     return {
-      connectionUriSsmPath: options.connectionUri.map((_, index) => `${options.pathPrefix}/connectionUri${index}`),
+      connectionUriSsmPath: [`${options.pathPrefix}/connectionUri/doesnotexist`, `${options.pathPrefix}/connectionUri`],
     };
   }
 };

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-models-2.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-models-2.test.ts
@@ -59,8 +59,12 @@ describe('CDK GraphQL Transformer deployments with SQL datasources', () => {
     await testGraphQLAPI(constructTestOptions('ssm'));
   });
 
-  test('creates a GraphQL API from SQL-based models using Connection String SSM parameter', async () => {
+  test('creates a GraphQL API from SQL-based models using Connection Uri SSM path', async () => {
     await testGraphQLAPI(constructTestOptions('connectionUri'));
+  });
+
+  test('creates a GraphQL API from SQL-based models using multiple Connection Uri SSM paths', async () => {
+    await testGraphQLAPI(constructTestOptions('connectionUriMultiple'));
   });
 
   const constructTestOptions = (connectionConfigName: string) => ({

--- a/packages/amplify-graphql-api-construct-tests/src/sql-datatabase-controller.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/sql-datatabase-controller.ts
@@ -119,7 +119,7 @@ export class SqlDatatabaseController {
       region: this.options.region,
       pathPrefix,
       connectionUri: [
-        'dummy connection uri',
+        'mysql://username:password@host:3306/dbname',
         this.getConnectionUri(engine, this.options.username, dbConfig.password, dbConfig.endpoint, dbConfig.port, this.options.dbname),
       ],
     });

--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -7610,7 +7610,21 @@
           },
           "name": "connectionUriSsmPath",
           "type": {
-            "primitive": "string"
+            "union": {
+              "types": [
+                {
+                  "primitive": "string"
+                },
+                {
+                  "collection": {
+                    "elementtype": {
+                      "primitive": "string"
+                    },
+                    "kind": "array"
+                  }
+                }
+              ]
+            }
           }
         }
       ],
@@ -8171,5 +8185,5 @@
     }
   },
   "version": "1.8.1",
-  "fingerprint": "RYLDuPcXrKkJVdyr+N3cvr80/DnbRL4kKh9QZAl4lUY="
+  "fingerprint": "hF3IhO8jnMvruVK74WA/JcSZ7FQvl6/6Sl4Y84Vq1qw="
 }

--- a/packages/amplify-graphql-api-construct/API.md
+++ b/packages/amplify-graphql-api-construct/API.md
@@ -370,7 +370,7 @@ export interface SqlModelDataSourceSsmDbConnectionConfig {
 
 // @public
 export interface SqlModelDataSourceSsmDbConnectionStringConfig {
-    readonly connectionUriSsmPath: string;
+    readonly connectionUriSsmPath: string | string[];
 }
 
 // @public

--- a/packages/amplify-graphql-api-construct/src/__tests__/__functional__/sql-model-strategy.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/__functional__/sql-model-strategy.test.ts
@@ -62,6 +62,13 @@ describe('SQL bound API definitions', () => {
       expect(isSqlModelDataSourceDbConnectionConfig(dbConfig)).toBe(true);
     });
 
+    it('accepts multiple connection uri SSM paths in DB configuration', () => {
+      const dbConfig = {
+        connectionUriSsmPath: ['/ssm/path/connectionUri/1', '/ssm/path/connectionUri/2'],
+      };
+      expect(isSqlModelDataSourceDbConnectionConfig(dbConfig)).toBe(true);
+    });
+
     it('does not accept a connection uri object in DB configuration', () => {
       const dbConfig = {
         connectionUriSsmPath: {},

--- a/packages/amplify-graphql-api-construct/src/__tests__/internal/data-source-config.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/internal/data-source-config.test.ts
@@ -281,5 +281,43 @@ describe('datasource config', () => {
         'Invalid data source strategy "mysqlStrategy". Following SSM paths must start with \'/\' in dbConnectionConfig: connectionUriPath.',
       );
     });
+
+    it('validateDataSourceStrategy passes when multiple valid connection string SSM Paths are passed', () => {
+      expect(() =>
+        validateDataSourceStrategy({
+          name: 'mysqlStrategy',
+          dbType: 'MYSQL',
+          dbConnectionConfig: {
+            connectionUriSsmPath: ['/test/connectionUri/1', '/test/connectionUri/2'],
+          },
+        }),
+      ).not.toThrow();
+    });
+
+    it('validateDataSourceStrategy fails when any of the connection string SSM Paths is not valid', () => {
+      expect(() =>
+        validateDataSourceStrategy({
+          name: 'mysqlStrategy',
+          dbType: 'MYSQL',
+          dbConnectionConfig: {
+            connectionUriSsmPath: ['/test/connectionUri/1', 'connectionUriPath'],
+          },
+        }),
+      ).toThrow(
+        'Invalid data source strategy "mysqlStrategy". Following SSM paths must start with \'/\' in dbConnectionConfig: connectionUriPath.',
+      );
+    });
+
+    it('validateDataSourceStrategy fails the connection string SSM Path is an empty array', () => {
+      expect(() =>
+        validateDataSourceStrategy({
+          name: 'mysqlStrategy',
+          dbType: 'MYSQL',
+          dbConnectionConfig: {
+            connectionUriSsmPath: [],
+          },
+        }),
+      ).toThrow('Invalid data source strategy "mysqlStrategy". connectionUriSsmPath must be a string or non-empty array.');
+    });
   });
 });

--- a/packages/amplify-graphql-api-construct/src/internal/data-source-config.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/data-source-config.ts
@@ -200,7 +200,18 @@ export const validateDataSourceStrategy = (strategy: ConstructModelDataSourceStr
     isSqlModelDataSourceSsmDbConnectionConfig(dbConnectionConfig) ||
     isSqlModelDataSourceSsmDbConnectionStringConfig(dbConnectionConfig)
   ) {
-    const invalidSSMPaths = Object.values(dbConnectionConfig).filter((value) => typeof value === 'string' && !isValidSSMPath(value));
+    const ssmPaths = Object.values(dbConnectionConfig).filter((value) => typeof value === 'string');
+    if (isSqlModelDataSourceSsmDbConnectionStringConfig(dbConnectionConfig)) {
+      const hasMultipleSSMPaths = Array.isArray(dbConnectionConfig?.connectionUriSsmPath);
+      if (hasMultipleSSMPaths) {
+        if (dbConnectionConfig?.connectionUriSsmPath?.length < 1) {
+          throw new Error(`Invalid data source strategy "${strategy.name}". connectionUriSsmPath must be a string or non-empty array.`);
+        }
+        ssmPaths.push(...dbConnectionConfig.connectionUriSsmPath);
+      }
+    }
+
+    const invalidSSMPaths = ssmPaths.filter((value) => !isValidSSMPath(value));
     if (invalidSSMPaths.length > 0) {
       throw new Error(
         `Invalid data source strategy "${

--- a/packages/amplify-graphql-api-construct/src/model-datasource-strategy-types.ts
+++ b/packages/amplify-graphql-api-construct/src/model-datasource-strategy-types.ts
@@ -131,7 +131,12 @@ export type SqlModelDataSourceDbConnectionConfig =
  * @experimental
  */
 export interface SqlModelDataSourceSsmDbConnectionStringConfig {
-  /** The SSM Path to the secure connection string used for connecting to the database. **/
+  /**
+   * The SSM Path to the secure connection string used for connecting to the database. If more than one path is provided,
+   * the SQL Lambda will attempt to retrieve connection information from each path in order until it finds a valid
+   * path entry, then stop. If the connection information contained in that path is invalid, the SQL Lambda will not
+   * attempt to retrieve connection information from subsequent paths in the array.
+   **/
   readonly connectionUriSsmPath: string | string[];
 }
 

--- a/packages/amplify-graphql-api-construct/src/model-datasource-strategy-types.ts
+++ b/packages/amplify-graphql-api-construct/src/model-datasource-strategy-types.ts
@@ -132,7 +132,7 @@ export type SqlModelDataSourceDbConnectionConfig =
  */
 export interface SqlModelDataSourceSsmDbConnectionStringConfig {
   /** The SSM Path to the secure connection string used for connecting to the database. **/
-  readonly connectionUriSsmPath: string;
+  readonly connectionUriSsmPath: string | string[];
 }
 
 /**

--- a/packages/amplify-graphql-api-construct/src/sql-model-datasource-strategy.ts
+++ b/packages/amplify-graphql-api-construct/src/sql-model-datasource-strategy.ts
@@ -76,7 +76,10 @@ export const isSqlModelDataSourceSecretsManagerDbConnectionConfig = (
  * @returns true if the object is shaped like a SqlModelDataSourceSsmDbConnectionStringConfig
  */
 export const isSqlModelDataSourceSsmDbConnectionStringConfig = (obj: any): obj is SqlModelDataSourceSsmDbConnectionStringConfig => {
-  return (typeof obj === 'object' || typeof obj === 'function') && typeof obj.connectionUriSsmPath === 'string';
+  return (
+    (typeof obj === 'object' || typeof obj === 'function') &&
+    (typeof obj.connectionUriSsmPath === 'string' || Array.isArray(obj.connectionUriSsmPath))
+  );
 };
 
 /**

--- a/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
+++ b/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
@@ -148,10 +148,8 @@ const resolveConnectionStringValue = async (jsonConnectionString: string): Promi
   const parsedJsonConnectionString = JSON.parse(jsonConnectionString);
   const ssmRequestError = 'Unable to connect to the database. Check the logs for more details.';
   const ssmLoggedError = 'Unable to fetch the connection Uri from SSM for the provided paths.';
-  console.log(`connection uri SSM paths: ${parsedJsonConnectionString}`);
   if (Array.isArray(parsedJsonConnectionString)) {
     for (const connectionUriSsmPath of parsedJsonConnectionString) {
-      console.log(`Trying to fetch connection string from SSM path: ${connectionUriSsmPath}`);
       try {
         return await getSSMValue(connectionUriSsmPath);
       }

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/amplify-sql-resource-generator.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/amplify-sql-resource-generator.test.ts.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ModelTransformer with SQL data sources: should accept multiple connection uris as input 1`] = `
+Object {
+  "Statement": Array [
+    Object {
+      "Action": Array [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:logs:*:*:*",
+    },
+    Object {
+      "Action": Array [
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+      ],
+      "Effect": "Allow",
+      "Resource": Array [
+        "arn:aws:ssm:*:*:parameter/test/connectionUri/1",
+        "arn:aws:ssm:*:*:parameter/test/connectionUri/2",
+      ],
+    },
+  ],
+  "Version": "2012-10-17",
+}
+`;
+
 exports[`ModelTransformer with SQL data sources: should assign SSM permissions 1`] = `
 Object {
   "Statement": Array [

--- a/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
@@ -373,11 +373,14 @@ export const createRdsLambdaRole = (
         );
       }
     } else if (isSqlModelDataSourceSsmDbConnectionStringConfig(secretEntry)) {
+      const connectionUriSsmPaths = Array.isArray(secretEntry.connectionUriSsmPath)
+        ? secretEntry.connectionUriSsmPath
+        : [secretEntry.connectionUriSsmPath];
       policyStatements.push(
         new PolicyStatement({
           actions: ['ssm:GetParameter', 'ssm:GetParameters'],
           effect: Effect.ALLOW,
-          resources: [`arn:aws:ssm:*:*:parameter${secretEntry.connectionUriSsmPath}`],
+          resources: connectionUriSsmPaths.map((ssmPath) => `arn:aws:ssm:*:*:parameter${ssmPath}`),
         }),
       );
     } else {

--- a/packages/amplify-graphql-model-transformer/src/resources/rds-model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/rds-model-resource-generator.ts
@@ -136,7 +136,7 @@ export class RdsModelResourceGenerator extends ModelResourceGenerator {
       credentialStorageMethod = CredentialStorageMethod.SECRETS_MANAGER;
     } else if (isSqlModelDataSourceSsmDbConnectionStringConfig(secretEntry)) {
       environment.CREDENTIAL_STORAGE_METHOD = 'SSM';
-      environment.connectionString = secretEntry.connectionUriSsmPath;
+      environment.connectionString = JSON.stringify(secretEntry.connectionUriSsmPath);
       credentialStorageMethod = CredentialStorageMethod.SSM;
     }
 

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -434,7 +434,7 @@ export interface SqlModelDataSourceSsmDbConnectionConfig {
 // @public (undocumented)
 export interface SqlModelDataSourceSsmDbConnectionStringConfig {
     // (undocumented)
-    readonly connectionUriSsmPath: string;
+    readonly connectionUriSsmPath: string | string[];
 }
 
 // @public (undocumented)

--- a/packages/amplify-graphql-transformer-interfaces/src/model-datasource/types.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/model-datasource/types.ts
@@ -130,7 +130,7 @@ export type SqlModelDataSourceDbConnectionConfig =
  */
 export interface SqlModelDataSourceSsmDbConnectionStringConfig {
   /** The SSM Path to the secure connection string used for connecting to the database. **/
-  readonly connectionUriSsmPath: string;
+  readonly connectionUriSsmPath: string | string[];
 }
 
 /*
@@ -304,5 +304,8 @@ export const isSqlModelDataSourceSecretsManagerDbConnectionConfig = (
  * @returns true if the object is shaped like a SqlModelDataSourceSsmDbConnectionStringConfig
  */
 export const isSqlModelDataSourceSsmDbConnectionStringConfig = (obj: any): obj is SqlModelDataSourceSsmDbConnectionStringConfig => {
-  return (typeof obj === 'object' || typeof obj === 'function') && typeof obj.connectionUriSsmPath === 'string';
+  return (
+    (typeof obj === 'object' || typeof obj === 'function') &&
+    (typeof obj.connectionUriSsmPath === 'string' || Array.isArray(obj.connectionUriSsmPath))
+  );
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
With this feature, we will allow the customers of Amplify GraphQL CDK construct to specify more than one SSM paths that hold the connection URI for the SQL database. This enables customers of Amplify Console to have both shared and branch specific secrets for database connection URIs.
The provided SSM paths are resolved in the order that is specified in the array by the customer and based on the availability to read them at runtime during execution of the SQL Lambda datasource.
This PR also updates the error messages to make them more readable.
The change is backwards compatible since existing customers can continue to specify the connection URI SSM path as a single string.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Added unit and E2E tests. The added E2E test runs successfully on CI.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
