### PR TITLE
fix: relational bidirectionality validation and improved error messages

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/iam-access.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/iam-access.test.ts
@@ -4,6 +4,7 @@ import { AuthTransformer } from '../graphql-auth-transformer';
 import { PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
 import { constructDataSourceStrategies } from '@aws-amplify/graphql-transformer-core';
 import { HasManyTransformer } from '@aws-amplify/graphql-relational-transformer';
+import { BelongsToTransformer } from '@aws-amplify/graphql-relational-transformer/src';
 
 const IAM_ACCESS_CHECK_DDB =
   '#if( $util.authType() == "IAM Authorization" && $util.isNull($ctx.identity.cognitoIdentityPoolId) && $util.isNull($ctx.identity.cognitoIdentityId) )';
@@ -458,6 +459,7 @@ describe('rds', () => {
       type Post @model {
         id: ID! @primaryKey
         blogId: ID!
+        blog: Blog @belongsTo(references: "blogId")
         title: String!
         createdAt: String
         updatedAt: String
@@ -476,7 +478,13 @@ describe('rds', () => {
       transformParameters: {
         sandboxModeEnabled: true,
       },
-      transformers: [new ModelTransformer(), new HasManyTransformer(), new AuthTransformer(), new PrimaryKeyTransformer()],
+      transformers: [
+        new ModelTransformer(),
+        new HasManyTransformer(),
+        new BelongsToTransformer(),
+        new AuthTransformer(),
+        new PrimaryKeyTransformer(),
+      ],
       dataSourceStrategies: constructDataSourceStrategies(validSchema, mysqlStrategy),
     });
     expect(out).toBeDefined();

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-references-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-references-transformer.test.ts.snap
@@ -804,8 +804,8 @@ type PostEditor {
   id: ID!
   postID: ID!
   editorID: ID!
-  post: Post!
-  editor: User!
+  post: Post
+  editor: User
   createdAt: AWSDateTime!
   updatedAt: AWSDateTime!
   _version: Int!

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
@@ -13,6 +13,7 @@ type Part {
   partName: String
   systemId: String!
   systemName: String!
+  system: System
 }
 
 input ModelStringInput {
@@ -362,6 +363,7 @@ type Post {
   id: String!
   content: String
   blogId: String
+  blog: Blog
 }
 
 input ModelStringInput {

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-one-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-one-transformer.test.ts.snap
@@ -11,6 +11,7 @@ type Profile {
   profileId: String!
   userFirstName: String
   userLastName: String!
+  user: User
 }
 
 input ModelStringInput {
@@ -348,6 +349,7 @@ type Profile {
   id: String!
   createdAt: AWSDateTime
   userId: String!
+  user: User
 }
 
 input ModelStringInput {

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-references-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-references-transformer.test.ts
@@ -67,7 +67,7 @@ test('fails if indexName is provided with references', () => {
       schema: inputSchema,
       transformers: [new ModelTransformer(), new IndexTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
     }),
-  ).toThrowError('Invalid @hasMany directive on Team.members - indexName is not supported with DDB references.');
+  ).toThrowError('Invalid @hasMany directive on Team.members - indexName is not supported with DynamoDB references.');
 });
 
 test('fails if property does not exist on related type with references', () => {

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-references-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-references-transformer.test.ts
@@ -171,7 +171,7 @@ test('fails if uni-directional hasMany', () => {
       transformers: [new ModelTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
     }),
   ).toThrowError(
-    'Uni-directional relationships are not supported. Expected @belongsTo in Member to match @hasMany in Team.members: Member',
+    'Uni-directional relationships are not supported. Add a @belongsTo field in Member to match the @hasMany field Team.members',
   );
 });
 

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-references-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-references-transformer.test.ts
@@ -128,7 +128,7 @@ test('fails if related type does not exist', () => {
       schema: inputSchema,
       transformers: [new ModelTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
     }),
-  ).toThrowError(); // TODO: Fix validation error messaging - 'Unknown type "Foo". Did you mean "Member"?'
+  ).toThrowError('Schema validation failed.');
 });
 
 test('fails if hasMany related type is not an array', () => {
@@ -149,7 +149,7 @@ test('fails if hasMany related type is not an array', () => {
       schema: inputSchema,
       transformers: [new ModelTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
     }),
-  ).toThrowError(); // TODO: Error message
+  ).toThrowError('@hasMany must be used with a list. Use @hasOne for non-list types.');
 });
 
 test('fails if uni-directional hasMany', () => {
@@ -165,13 +165,14 @@ test('fails if uni-directional hasMany', () => {
       team: Team
     }`;
 
-  // TODO: This should fail -- find appropriate place to validate.
-  // expect(() =>
-  //   testTransform({
-  //     schema: inputSchema,
-  //     transformers: [new ModelTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
-  //   }),
-  // ).toThrowError();
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
+    }),
+  ).toThrowError(
+    'Uni-directional relationships are not supported. Expected @belongsTo in Member to match @hasMany in Team.members: Member',
+  );
 });
 
 test('fails if used as a has one relationship', () => {
@@ -253,19 +254,19 @@ test('many to many query', () => {
       type Post @model {
         id: ID!
         title: String!
-        editors: [PostEditor] @hasMany(references: ["editorID"])
+        editors: [PostEditor] @hasMany(references: ["postID"])
       }
       type PostEditor @model(queries: null) {
         id: ID!
         postID: ID!
         editorID: ID!
-        post: Post! @belongsTo(references: ["postID"])
-        editor: User! @belongsTo(references: ["editorID"])
+        post: Post @belongsTo(references: ["postID"])
+        editor: User @belongsTo(references: ["editorID"])
       }
       type User @model {
         id: ID!
         username: String!
-        posts: [PostEditor] @hasMany(references: ["postID"])
+        posts: [PostEditor] @hasMany(references: ["editorID"])
       }`;
 
   const out = testTransform({

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
@@ -954,12 +954,13 @@ describe('@hasMany directive with RDS datasource', () => {
         id: String! @primaryKey
         content: String
         blogId: String
+        blog: Blog @belongsTo(references: ["blogId"])
       }
     `;
 
     const out = testTransform({
       schema: inputSchema,
-      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasManyTransformer()],
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
       dataSourceStrategies: constructDataSourceStrategies(inputSchema, mySqlStrategy),
     });
     expect(out).toBeDefined();
@@ -985,12 +986,13 @@ describe('@hasMany directive with RDS datasource', () => {
         partName: String
         systemId: String!
         systemName: String!
+        system: System @belongsTo(references: ["systemId", "systemName"])
       }
     `;
 
     const out = testTransform({
       schema: inputSchema,
-      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasManyTransformer()],
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasManyTransformer(), new BelongsToTransformer()],
       dataSourceStrategies: constructDataSourceStrategies(inputSchema, mySqlStrategy),
     });
     expect(out).toBeDefined();

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-one-references-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-one-references-transformer.test.ts
@@ -221,7 +221,9 @@ test('uni-directional @hasOne fails', () => {
       schema: inputSchema,
       transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
     }),
-  ).toThrowError('Uni-directional relationships are not supported. Expected @belongsTo in Test1 to match @hasOne in Test.testObj: Test1');
+  ).toThrowError(
+    'Uni-directional relationships are not supported. Add a @belongsTo field in Test1 to match the @hasOne field Test.testObj',
+  );
 });
 
 test('fails if used as a has many relation', () => {

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-one-references-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-one-references-transformer.test.ts
@@ -48,15 +48,12 @@ test('fails if @hasOne was used with a related type that is not a model', () => 
       schema: inputSchema,
       transformers: [new ModelTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
     }),
-  ).toThrowError();
-  // TODO: Fix error message
-  // Currently throws 'Cannot find datasource type for model Team'
-  // Should throw 'Object type Team must be annotated with @model.'
+  ).toThrowError('Object type Team must be annotated with @model.');
 });
 
 test('fails if the related type does not exist', () => {
   const inputSchema = `
-    type Project @Model {
+    type Project @model {
         id: ID!
         name: String
         team: Team1 @hasOne(references: ["projectID"])
@@ -80,7 +77,7 @@ test('fails if the related type does not exist', () => {
 
 test('fails if an empty list of fields is passed in', () => {
   const inputSchema = `
-    type Project @Model {
+    type Project @model {
         id: ID!
         name: String
         team: Team @hasOne(references: [])
@@ -98,7 +95,7 @@ test('fails if an empty list of fields is passed in', () => {
       schema: inputSchema,
       transformers: [new ModelTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
     }),
-  ).toThrowError(); // TODO -- Error message
+  ).toThrowError('Invalid @hasMany directive on team - empty references list');
 });
 
 test('fails if any of the fields passed in are not in the related model', () => {
@@ -136,17 +133,19 @@ test('fails if @hasOne field does not match related type primary key', () => {
     type Team @model {
         id: ID!
         name: String
-        projectID: String!
+        projectID: Int!
         project: Project @belongsTo(references: ["projectID"])
     }
   `;
-  // TODO: Currently not throwing. Need to add some validation that types match.
-  // expect(() =>
-  //   testTransform({
-  //     schema: inputSchema,
-  //     transformers: [new ModelTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
-  //   }),
-  // ).toThrowError('projectID field is not of type ID');
+
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
+    }),
+  ).toThrowError(
+    'Type mismatch between primary key field(s) of Project and reference fields of Team. Type of Project.id does not match type of Team.projectID',
+  );
 });
 
 test('fails if sort key type does not match related type sort key', () => {
@@ -162,17 +161,19 @@ test('fails if sort key type does not match related type sort key', () => {
         id: ID!
         name: String
         projectID: ID
-        projectResourceID: String
+        projectResourceID: Int
         project: Project @belongsTo(references: ["projectID", "projectResourceID"])
       }
     `;
-  // TODO: Currently not throwing. Need to add some validation that types match.
-  // expect(() =>
-  //   testTransform({
-  //     schema: inputSchema,
-  //     transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
-  //   }),
-  // ).toThrowError('projectResourceID field is not of type ID');
+
+  expect(() =>
+    testTransform({
+      schema: inputSchema,
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
+    }),
+  ).toThrowError(
+    'Type mismatch between primary key field(s) of Project and reference fields of Team. Type of Project.resourceID does not match type of Team.projectResourceID',
+  );
 });
 
 test('fails if partial sort key is provided', () => {
@@ -200,7 +201,7 @@ test('fails if partial sort key is provided', () => {
   ).toThrowError('The number of references provided to @hasOne must match the number of primary keys on Project.');
 });
 
-test('accepts @hasOne without a sort key', () => {
+test('uni-directional @hasOne fails', () => {
   const inputSchema = `
     type Test @model {
       id: ID!
@@ -209,7 +210,7 @@ test('accepts @hasOne without a sort key', () => {
     }
 
     type Test1 @model {
-      id: ID! @primaryKey(sortKeyFields: ["friendID", "name"])
+      id: ID!
       friendID: ID!
       name: String!
     }
@@ -220,7 +221,7 @@ test('accepts @hasOne without a sort key', () => {
       schema: inputSchema,
       transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
     }),
-  ).not.toThrowError();
+  ).toThrowError('Uni-directional relationships are not supported. Expected @belongsTo in Test1 to match @hasOne in Test.testObj: Test1');
 });
 
 test('fails if used as a has many relation', () => {

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-one-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-one-transformer.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@aws-amplify/graphql-transformer-core';
 import { DocumentNode, Kind, parse } from 'graphql';
 import { mockSqlDataSourceStrategy, testTransform } from '@aws-amplify/graphql-transformer-test-utils';
-import { HasManyTransformer, HasOneTransformer } from '..';
+import { BelongsToTransformer, HasManyTransformer, HasOneTransformer } from '..';
 import { hasGeneratedField } from './test-helpers';
 
 test('fails if @hasOne was used on an object that is not a model type', () => {
@@ -768,12 +768,13 @@ describe('@hasOne directive with RDS datasource', () => {
         id: String! @primaryKey
         createdAt: AWSDateTime
         userId: String!
+        user: User @belongsTo(references: ["userId"])
       }
     `;
 
     const out = testTransform({
       schema: inputSchema,
-      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasOneTransformer()],
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
       dataSourceStrategies: constructDataSourceStrategies(inputSchema, mySqlStrategy),
     });
     expect(out).toBeDefined();
@@ -797,12 +798,13 @@ describe('@hasOne directive with RDS datasource', () => {
         profileId: String! @primaryKey
         userFirstName: String
         userLastName: String!
+        user: User @belongsTo(references: ["userFirstName", "userLastName"])
       }
     `;
 
     const out = testTransform({
       schema: inputSchema,
-      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasOneTransformer()],
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasOneTransformer(), new BelongsToTransformer()],
       dataSourceStrategies: constructDataSourceStrategies(inputSchema, mySqlStrategy),
     });
     expect(out).toBeDefined();

--- a/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-ddb-references-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-ddb-references-transformer.ts
@@ -13,6 +13,7 @@ import {
   getBelongsToReferencesNodes,
   registerHasOneForeignKeyMappings,
   validateChildReferencesFields,
+  validateReferencesBidirectionality,
 } from '../utils';
 
 /**
@@ -54,5 +55,6 @@ export class BelongsToDirectiveDDBReferencesTransformer implements DataSourceBas
     ensureReferencesArray(config);
     validateChildReferencesFields(config, context as TransformerContextProvider);
     config.referenceNodes = getBelongsToReferencesNodes(config, context);
+    validateReferencesBidirectionality(config);
   };
 }

--- a/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-sql-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-sql-transformer.ts
@@ -8,7 +8,12 @@ import { DataSourceBasedDirectiveTransformer } from '../data-source-based-direct
 import { getGenerator } from '../resolver/generator-factory';
 import { setFieldMappingResolverReference } from '../resolvers';
 import { BelongsToDirectiveConfiguration } from '../types';
-import { ensureReferencesArray, getBelongsToReferencesNodes, validateChildReferencesFields } from '../utils';
+import {
+  ensureReferencesArray,
+  getBelongsToReferencesNodes,
+  validateChildReferencesFields,
+  validateReferencesBidirectionality,
+} from '../utils';
 
 /**
  * BelongsToDirectiveSQLTransformer executes transformations based on `@belongsTo(references: [String!])` configurations
@@ -34,5 +39,6 @@ export class BelongsToDirectiveSQLTransformer implements DataSourceBasedDirectiv
   validate = (context: TransformerContextProvider, config: BelongsToDirectiveConfiguration): void => {
     ensureReferencesArray(config);
     config.referenceNodes = getBelongsToReferencesNodes(config, context);
+    validateReferencesBidirectionality(config);
   };
 }

--- a/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-transformer-factory.ts
+++ b/packages/amplify-graphql-relational-transformer/src/belongs-to/belongs-to-directive-transformer-factory.ts
@@ -1,3 +1,4 @@
+import { InvalidDirectiveError } from '@aws-amplify/graphql-transformer-core';
 import { ModelDataSourceStrategyDbType } from '@aws-amplify/graphql-transformer-interfaces';
 import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
 import { BelongsToDirectiveConfiguration } from '../types';
@@ -26,8 +27,7 @@ export const getBelongsToDirectiveTransformer = (
       if (config.references) {
         // Passing both references and fields is not supported.
         if (config.fields) {
-          // TODO: Better error message
-          throw new Error('Something went wrong >> cannot have both references and fields.');
+          throw new InvalidDirectiveError(`fields and references cannot be defined in the same ${config.directiveName}. Use 'references'`);
         }
         if (config.references.length < 1) {
           throw new Error(`Invalid @belongsTo directive on ${config.field.name.value} - empty references list`);

--- a/packages/amplify-graphql-relational-transformer/src/data-source-based-directive-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/data-source-based-directive-transformer.ts
@@ -13,7 +13,7 @@ export type RelationalDirectiveConfiguration =
 
 /**
  * Represents a subset of transformer methods based on a specific
- * data source (currently SQL / DDB Fields).
+ * data source (currently SQL References / DynamoDB References / DynamoDB Fields).
  *
  * Each method is to be invoked by the applicable relational transformer when iterating through
  * its directive configurations the applicable transformer step.

--- a/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-ddb-references-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-ddb-references-transformer.ts
@@ -12,7 +12,13 @@ import {
   updateTableForReferencesConnection,
 } from '../resolvers';
 import { HasManyDirectiveConfiguration } from '../types';
-import { ensureReferencesArray, ensureReferencesBidirectionality, getReferencesNodes, registerHasManyForeignKeyMappings, validateParentReferencesFields } from '../utils';
+import {
+  ensureReferencesArray,
+  getReferencesNodes,
+  registerHasManyForeignKeyMappings,
+  validateParentReferencesFields,
+  validateReferencesBidirectionality,
+} from '../utils';
 
 /**
  * HasManyDirectiveDDBReferencesTransformer executes transformations based on `@hasMany(references: [String!])` configurations
@@ -60,12 +66,11 @@ export class HasManyDirectiveDDBReferencesTransformer implements DataSourceBased
     }
     ensureReferencesArray(config);
     validateParentReferencesFields(config, context);
-    ensureReferencesBidirectionality(config, context);
     const objectName = config.object.name.value;
     const fieldName = config.field.name.value;
     config.indexName = `gsi-${objectName}.${fieldName}`;
     config.referenceNodes = getReferencesNodes(config, context);
 
-    // TODO: validate bidirectionality
+    validateReferencesBidirectionality(config);
   };
 }

--- a/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-ddb-references-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-ddb-references-transformer.ts
@@ -12,7 +12,7 @@ import {
   updateTableForReferencesConnection,
 } from '../resolvers';
 import { HasManyDirectiveConfiguration } from '../types';
-import { ensureReferencesArray, getReferencesNodes, registerHasManyForeignKeyMappings, validateParentReferencesFields } from '../utils';
+import { ensureReferencesArray, ensureReferencesBidirectionality, getReferencesNodes, registerHasManyForeignKeyMappings, validateParentReferencesFields } from '../utils';
 
 /**
  * HasManyDirectiveDDBReferencesTransformer executes transformations based on `@hasMany(references: [String!])` configurations
@@ -55,11 +55,12 @@ export class HasManyDirectiveDDBReferencesTransformer implements DataSourceBased
     if (config.indexName) {
       const mappedObjectName = context.resourceHelper.getModelNameMapping(config.object.name.value);
       throw new Error(
-        `Invalid @hasMany directive on ${mappedObjectName}.${config.field.name.value} - indexName is not supported with DDB references.`,
+        `Invalid @hasMany directive on ${mappedObjectName}.${config.field.name.value} - indexName is not supported with DynamoDB references.`,
       );
     }
     ensureReferencesArray(config);
     validateParentReferencesFields(config, context);
+    ensureReferencesBidirectionality(config, context);
     const objectName = config.object.name.value;
     const fieldName = config.field.name.value;
     config.indexName = `gsi-${objectName}.${fieldName}`;

--- a/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-sql-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-sql-transformer.ts
@@ -8,7 +8,7 @@ import { DataSourceBasedDirectiveTransformer } from '../data-source-based-direct
 import { getGenerator } from '../resolver/generator-factory';
 import { setFieldMappingResolverReference } from '../resolvers';
 import { HasManyDirectiveConfiguration } from '../types';
-import { ensureReferencesArray, getReferencesNodes, validateParentReferencesFields } from '../utils';
+import { ensureReferencesArray, getReferencesNodes, validateParentReferencesFields, validateReferencesBidirectionality } from '../utils';
 
 /**
  * HasManyDirectiveSQLTransformer executes transformations based on `@hasMany(references: [String!])` configurations
@@ -33,6 +33,7 @@ export class HasManyDirectiveSQLTransformer implements DataSourceBasedDirectiveT
 
   validate = (context: TransformerContextProvider, config: HasManyDirectiveConfiguration): void => {
     ensureReferencesArray(config);
-    getReferencesNodes(config, context);
+    config.referenceNodes = getReferencesNodes(config, context);
+    validateReferencesBidirectionality(config);
   };
 }

--- a/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-transformer-factory.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-many/has-many-directive-transformer-factory.ts
@@ -4,6 +4,7 @@ import { DataSourceBasedDirectiveTransformer } from '../data-source-based-direct
 import { HasManyDirectiveDDBFieldsTransformer } from './has-many-directive-ddb-fields-transformer';
 import { HasManyDirectiveSQLTransformer } from './has-many-directive-sql-transformer';
 import { HasManyDirectiveDDBReferencesTransformer } from './has-many-directive-ddb-references-transformer';
+import { InvalidDirectiveError } from '@aws-amplify/graphql-transformer-core';
 
 const hasManyDirectiveMySqlTransformer = new HasManyDirectiveSQLTransformer();
 const hasManyDirectivePostgresTransformer = new HasManyDirectiveSQLTransformer();
@@ -26,11 +27,10 @@ export const getHasManyDirectiveTransformer = (
       if (config.references) {
         // Passing both references and fields is not supported.
         if (config.fields) {
-          // TODO: Better error message
-          throw new Error('Something went wrong >> cannot have both references and fields.');
+          throw new InvalidDirectiveError(`fields and references cannot be defined in the same ${config.directiveName}. Use 'references'`);
         }
         if (config.references.length < 1) {
-          throw new Error(`Invalid @hasMany directive on ${config.field.name.value} - empty references list`);
+          throw new InvalidDirectiveError(`Invalid @hasMany directive on ${config.field.name.value} - empty references list`);
         }
         return hasManyDirectiveDdbReferencesTransformer;
       }

--- a/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-ddb-references-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-ddb-references-transformer.ts
@@ -55,7 +55,7 @@ export class HasOneDirectiveDDBReferencesTransformer implements DataSourceBasedD
     if (config.indexName) {
       const mappedObjectName = context.resourceHelper.getModelNameMapping(config.object.name.value);
       throw new Error(
-        `Invalid @${config.directiveName} directive on ${mappedObjectName}.${config.field.name.value} - indexName is not supported with DDB references.`,
+        `Invalid @${config.directiveName} directive on ${mappedObjectName}.${config.field.name.value} - indexName is not supported with DynamoDB references.`,
       );
     }
     ensureReferencesArray(config);

--- a/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-ddb-references-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-ddb-references-transformer.ts
@@ -12,7 +12,13 @@ import {
   updateTableForReferencesConnection,
 } from '../resolvers';
 import { HasOneDirectiveConfiguration } from '../types';
-import { ensureReferencesArray, getReferencesNodes, registerHasOneForeignKeyMappings, validateParentReferencesFields } from '../utils';
+import {
+  ensureReferencesArray,
+  getReferencesNodes,
+  registerHasOneForeignKeyMappings,
+  validateParentReferencesFields,
+  validateReferencesBidirectionality,
+} from '../utils';
 
 /**
  * HasOneDirectiveDDBFieldsTransformer executes transformations based on `@hasOne(references: [String!])` configurations
@@ -64,5 +70,6 @@ export class HasOneDirectiveDDBReferencesTransformer implements DataSourceBasedD
     const fieldName = config.field.name.value;
     config.indexName = `gsi-${objectName}.${fieldName}`;
     config.referenceNodes = getReferencesNodes(config, context);
+    validateReferencesBidirectionality(config);
   };
 }

--- a/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-sql-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-sql-transformer.ts
@@ -7,7 +7,7 @@ import {
 import { DataSourceBasedDirectiveTransformer } from '../data-source-based-directive-transformer';
 import { setFieldMappingResolverReference } from '../resolvers';
 import { HasOneDirectiveConfiguration } from '../types';
-import { ensureReferencesArray, getReferencesNodes, validateParentReferencesFields } from '../utils';
+import { ensureReferencesArray, getReferencesNodes, validateParentReferencesFields, validateReferencesBidirectionality } from '../utils';
 import { getGenerator } from '../resolver/generator-factory';
 
 /**
@@ -33,6 +33,7 @@ export class HasOneDirectiveSQLTransformer implements DataSourceBasedDirectiveTr
 
   validate = (context: TransformerContextProvider, config: HasOneDirectiveConfiguration): void => {
     ensureReferencesArray(config);
-    getReferencesNodes(config, context);
+    config.referenceNodes = getReferencesNodes(config, context);
+    validateReferencesBidirectionality(config);
   };
 }

--- a/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-transformer-factory.ts
+++ b/packages/amplify-graphql-relational-transformer/src/has-one/has-one-directive-transformer-factory.ts
@@ -4,6 +4,7 @@ import { DataSourceBasedDirectiveTransformer } from '../data-source-based-direct
 import { HasOneDirectiveDDBFieldsTransformer } from './has-one-directive-ddb-fields-transformer';
 import { HasOneDirectiveSQLTransformer } from './has-one-directive-sql-transformer';
 import { HasOneDirectiveDDBReferencesTransformer } from './has-one-directive-ddb-references-transformer';
+import { InvalidDirectiveError } from '@aws-amplify/graphql-transformer-core';
 
 const hasOneDirectiveMySqlTransformer = new HasOneDirectiveSQLTransformer();
 const hasOneDirectivePostgresTransformer = new HasOneDirectiveSQLTransformer();
@@ -26,8 +27,7 @@ export const getHasOneDirectiveTransformer = (
       if (config.references) {
         // Passing both references and fields is not supported.
         if (config.fields) {
-          // TODO: Better error message
-          throw new Error('Something went wrong >> cannot have both references and fields.');
+          throw new InvalidDirectiveError(`fields and references cannot be defined in the same ${config.directiveName}. Use 'references'`);
         }
         if (config.references.length < 1) {
           throw new Error(`Invalid @hasMany directive on ${config.field.name.value} - empty references list`);

--- a/packages/amplify-graphql-relational-transformer/src/resolver/ddb-references-generator.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolver/ddb-references-generator.ts
@@ -1,4 +1,5 @@
 import {
+  InvalidDirectiveError,
   MappingTemplate,
   getKeySchema,
   getModelDataSourceNameForTypeName,
@@ -33,7 +34,7 @@ import {
   str,
   toJson,
 } from 'graphql-mapping-template';
-import { ModelResourceIDs, NONE_VALUE, ResolverResourceIDs, setArgs } from 'graphql-transformer-common';
+import { ModelResourceIDs, NONE_VALUE, ResolverResourceIDs, directiveExists, setArgs } from 'graphql-transformer-common';
 import { OPERATION_KEY } from '@aws-amplify/graphql-model-transformer';
 import { condenseRangeKey } from '../resolvers';
 import { BelongsToDirectiveConfiguration, HasManyDirectiveConfiguration, HasOneDirectiveConfiguration } from '../types';
@@ -93,8 +94,8 @@ export class DDBRelationalReferencesResolverGenerator extends DDBRelationalResol
     const { field, indexName, limit, object, references, relatedType } = config;
 
     if (references.length < 1) {
-      // TODO: Better error message
-      throw new Error('references should be populated.');
+      // If references is empty at this point, something has gone horribly wrong. Time to bail.
+      throw new InvalidDirectiveError(`Expected references for @${config.directiveName} on ${object.name.value}.${field.name.value}`);
     }
 
     const primaryKeyFields: string[] = getPrimaryKeyFields(object);
@@ -220,8 +221,8 @@ export class DDBRelationalReferencesResolverGenerator extends DDBRelationalResol
   makeHasOneGetItemConnectionWithKeyResolver = (config: HasOneDirectiveConfiguration, ctx: TransformerContextProvider): void => {
     const { field, indexName, references, object, relatedType } = config;
     if (references.length < 1) {
-      // TODO: Better error message
-      throw new Error('references should be populated.');
+      // If references is empty at this point, something has gone horribly wrong. Time to bail.
+      throw new InvalidDirectiveError(`Expected references for @${config.directiveName} on ${object.name.value}.${field.name.value}`);
     }
     const primaryKeyFields: string[] = getPrimaryKeyFields(object);
     const dataSourceName = getModelDataSourceNameForTypeName(ctx, relatedType.name.value);

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -38,8 +38,8 @@ import { getConnectionAttributeName, getObjectPrimaryKey } from './utils';
  *
  * Preconditions: `config.references >= 1` and `config.referenceNodes >= 1`
  *
- * @param config The `HasManyDirectiveConfiguration` for DDB references.
- * @param ctx The `TransformerContextProvider` for DDB references.
+ * @param config The `HasManyDirectiveConfiguration` for DynamoDB references.
+ * @param ctx The `TransformerContextProvider` for DynamoDB references.
  */
 export const updateTableForReferencesConnection = (
   config: HasManyDirectiveConfiguration | HasOneDirectiveConfiguration,
@@ -263,7 +263,7 @@ export const setFieldMappingResolverReference = (
 };
 
 /**
- * In a DDB references based relationship, when the Primary model has a primary key with composite
+ * In a DynamoDB references based relationship, when the Primary model has a primary key with composite
  * sort key (>= 2 sort key fields), we need to add function slots in the Mutation resolvers (create, update, delete)
  * of the Related model in order to write the composite sort key attribute to the Related model's table.
  *
@@ -290,7 +290,7 @@ export const updateRelatedModelMutationResolversForCompositeSortKeys = (
   const objectName = ctx.output.getMutationTypeName();
   if (!objectName) {
     throw new Error(`
-      Mutation type name is undefined when updated mutation resolvers for composite sortKeys used in DDB references based relationships.
+      Mutation type name is undefined when updated mutation resolvers for composite sortKeys used in DynamoDB references based relationships.
       This should not happen, please file a bug at https://github.com/aws-amplify/amplify-category-api/issues/new/choose`);
   }
 

--- a/packages/amplify-graphql-relational-transformer/src/types.ts
+++ b/packages/amplify-graphql-relational-transformer/src/types.ts
@@ -1,6 +1,14 @@
 import { DirectiveNode, FieldDefinitionNode, ObjectTypeDefinitionNode, ObjectTypeExtensionNode } from 'graphql';
 import { WritableDraft } from 'immer/dist/types/types-external';
 
+/**
+ * Relational directive configuration types that can be used with references based relationships
+ */
+export type ReferencesRelationalDirectiveConfiguration =
+  | HasManyDirectiveConfiguration
+  | HasOneDirectiveConfiguration
+  | BelongsToDirectiveConfiguration;
+
 export type HasOneDirectiveConfiguration = {
   directiveName: string;
   object: ObjectTypeDefinitionNode;

--- a/packages/amplify-graphql-relational-transformer/src/utils.ts
+++ b/packages/amplify-graphql-relational-transformer/src/utils.ts
@@ -165,7 +165,7 @@ export const ensureFieldsArray = (
   config: HasManyDirectiveConfiguration | HasOneDirectiveConfiguration | BelongsToDirectiveConfiguration,
 ): void => {
   if (config.references) {
-    throw new InvalidDirectiveError(`DynamoDB models do not support 'references' on @${config.directiveName} directive.`);
+    throw new InvalidDirectiveError(`'references' defined on ${config.object.name.value}.${config.field.name.value} @${config.directive}. Expecting 'fields' only.`);
   }
 
   if (!config.fields) {
@@ -181,7 +181,7 @@ export const ensureReferencesArray = (
   config: HasManyDirectiveConfiguration | HasOneDirectiveConfiguration | BelongsToDirectiveConfiguration,
 ): void => {
   if (config.fields) {
-    throw new InvalidDirectiveError(`Relational database models do not support 'fields' on @${config.directiveName} directive.`);
+    throw new InvalidDirectiveError(`'fields' defined on ${config.object.name.value}.${config.field.name.value} @${config.directive}. Expecting 'references' only.`);
   }
 
   if (!config.references) {
@@ -195,11 +195,15 @@ export const ensureReferencesArray = (
 
 export const ensureReferencesBidirectionality = (
   config: HasManyDirectiveConfiguration | BelongsToDirectiveConfiguration, // TODO: Add HasOnyDirectiveConfiguration
+  ctx: TransformerContextProvider,
 ): void => {
   if (config.fields) {
     // TODO: Better error message
     throw new InvalidDirectiveError('fields and references cannot be used together.');
   }
+
+  
+
 
   /*
     1. find related directives:

--- a/packages/amplify-graphql-relational-transformer/src/utils.ts
+++ b/packages/amplify-graphql-relational-transformer/src/utils.ts
@@ -27,6 +27,7 @@ import {
   toPascalCase,
   unwrapNonNull,
 } from 'graphql-transformer-common';
+import { BelongsToDirective, HasManyDirective, HasOneDirective } from '@aws-amplify/graphql-directives';
 import {
   BelongsToDirectiveConfiguration,
   HasManyDirectiveConfiguration,
@@ -225,8 +226,8 @@ const getReferencesAssociatedField = (
     const associatedDirectiveTypes = getAssociatedRelationalDirectiveTypes(config.directiveName);
     const associatedDirectiveDescription = associatedDirectiveTypes.map((directiveName) => `@${directiveName}`).join(' or ');
     return (
-      `Expected ${associatedDirectiveDescription} in ${config.relatedType.name.value} to match @${config.directiveName}` +
-      ` in ${config.object.name.value}.${config.field.name.value}: ${config.relatedType.name.value}`
+      `Add a ${associatedDirectiveDescription} field in ${config.relatedType.name.value} to match the @${config.directiveName}` +
+      ` field ${config.object.name.value}.${config.field.name.value}`
     );
   };
 
@@ -413,11 +414,11 @@ export const getFieldsNodes = (
 };
 const getAssociatedRelationalDirectiveTypes = (sourceRelationalDirectiveType: string): string[] => {
   switch (sourceRelationalDirectiveType) {
-    case 'hasOne':
-    case 'hasMany':
-      return ['belongsTo'];
-    case 'belongsTo':
-      return ['hasOne', 'hasMany'];
+    case HasOneDirective.name:
+    case HasManyDirective.name:
+      return [BelongsToDirective.name];
+    case BelongsToDirective.name:
+      return [HasOneDirective.name, HasManyDirective.name];
     default:
       throw new Error(`Unexpected directive type ${sourceRelationalDirectiveType}`);
   }


### PR DESCRIPTION
#### Description of changes
- Adds bidirectional validation for references based relationships.
- Improves error messages for invalid schema / directive scenarios.
- Updates necessary tests -- error message assertions, schemas / relevant snapshots

Docs PR: https://github.com/aws-amplify/docs/pull/7222

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
- Unit tests
- [E2E tests](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:328eb397-5107-41ee-b919-e07eca87a122?region=us-east-1)

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
