### PR TITLE
fix(graphql-relational-transformer): ddb references hasOne returns re…

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/relationships/composite-pk/relationships-cpk.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/relationships/composite-pk/relationships-cpk.test.ts
@@ -8,6 +8,7 @@ import { TestDefinition, writeStackPrefix, writeTestDefinitions } from '../../..
 import {
   testPrimaryCpkSkOneContainsAssociated,
   testPrimaryCpkSkTwoContainAssociated,
+  testPrimaryMultipleHasOneContainsOneHasOne,
   testRelatedManyCpkSkOneContainsAssociated,
   testRelatedManypkSkTwoContainsAssociated,
   testRelatedOneCpkSkOneContainsAssociated,
@@ -79,6 +80,10 @@ describe('Relationships defined using composite primary are supported', () => {
 
       test('Associated models included in query and mutation response with two sort keys', async () => {
         await testPrimaryCpkSkTwoContainAssociated(currentId, apiEndpoint, apiKey);
+      });
+
+      test('Multiple RelatedOne associated records returns one RelatedOne record', async () => {
+        await testPrimaryMultipleHasOneContainsOneHasOne(currentId, apiEndpoint, apiKey);
       });
     });
 

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/relationships/composite-pk/test-implementations.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/relationships/composite-pk/test-implementations.ts
@@ -105,6 +105,40 @@ export const testPrimaryCpkSkTwoContainAssociated = async (currentId: number, ap
   assertPrimaryCpkTwoContainsAssociated(primaryUpdate, primaryVariables);
 };
 
+export const testPrimaryMultipleHasOneContainsOneHasOne = async (currentId: number, apiEndpoint: string, apiKey: string): Promise<void> => {
+  const primaryVariables = getPrimaryVariablesSkOne(currentId);
+  const relatedVariables = getRelatedVariablesSkOne(primaryVariables);
+  const args = {
+    apiEndpoint,
+    auth: { apiKey },
+  };
+  // Create two `RelatedOne`s
+  await doAppSyncGraphqlMutation({ ...args, query: createRelatedOneCPKSKOne, variables: relatedVariables });
+  await doAppSyncGraphqlMutation({ ...args, query: createRelatedOneCPKSKOne, variables: relatedVariables });
+
+  // Create PrimaryCPKSKOne
+  const primaryCreateResult = await doAppSyncGraphqlMutation({ ...args, query: createPrimaryCPKSKOne, variables: primaryVariables });
+  // Assert create mutation response contains one RelatedOne model
+  const primaryCreate = primaryCreateResult.body.data.createPrimaryCPKSKOne;
+  expect(primaryCreate.relatedOne).toBeDefined();
+  expect(primaryCreate.relatedOne.primaryId).toEqual(primaryVariables.id);
+  expect(primaryCreate.relatedOne.primarySkOne).toEqual(primaryVariables.skOne);
+
+  // Assert get query response contains one RelatedOne model
+  const primaryGetResult = await doAppSyncGraphqlQuery({ ...args, query: getPrimaryCPKSKOne, variables: primaryVariables });
+  const primaryGet = primaryGetResult.body.data.getPrimaryCPKSKOne;
+  expect(primaryGet.relatedOne).toBeDefined();
+  expect(primaryGet.relatedOne.primaryId).toEqual(primaryVariables.id);
+  expect(primaryGet.relatedOne.primarySkOne).toEqual(primaryVariables.skOne);
+
+  // Assert update mutation response contains one RelatedOne model
+  const primaryUpdateResult = await doAppSyncGraphqlMutation({ ...args, query: updatePrimaryCPKSKOne, variables: primaryVariables });
+  const primaryUpdate = primaryUpdateResult.body.data.updatePrimaryCPKSKOne;
+  expect(primaryUpdate.relatedOne).toBeDefined();
+  expect(primaryUpdate.relatedOne.primaryId).toEqual(primaryVariables.id);
+  expect(primaryUpdate.relatedOne.primarySkOne).toEqual(primaryVariables.skOne);
+};
+
 // #region Primary assertions
 const assertPrimaryCpkOneContainsAssociated = (
   primary: RecursiveOmit<GetPrimaryCPKSKOneQuery['getPrimaryCPKSKOne'], '__typename'>,
@@ -126,6 +160,7 @@ const assertPrimaryCpkTwoContainsAssociated = (
   expect(primary.skTwo).toEqual(expected.skTwo);
   expect(primary.relatedOne.primarySkTwo).toEqual(expected.skTwo);
 };
+
 // #endregion Primary assertions
 // #endregion Primary as source model
 

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-one-references-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-one-references-transformer.test.ts.snap
@@ -1316,7 +1316,7 @@ $util.toJson(null)
   "Team.project.res.vtl": "#if( $ctx.error )
 $util.error($ctx.error.message, $ctx.error.type)
 #else
-  #if( !$ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+  #if( !$ctx.result.items.isEmpty() )
     #set( $resultValue = $ctx.result.items[0] )
     #set( $operation = $util.defaultIfNull($ctx.source.get(\\"__operation\\"), null) )
     #if( $operation == \\"Mutation\\" )
@@ -1324,7 +1324,7 @@ $util.error($ctx.error.message, $ctx.error.type)
     #end
     $util.toJson($resultValue)
   #else
-    #if( $ctx.result.items.isEmpty() && $ctx.result.scannedCount == 1 )
+    #if( $ctx.result.items.isEmpty() && $ctx.result.scannedCount > 0 )
 $util.unauthorized()
     #end
     $util.toJson(null)

--- a/packages/graphql-mapping-template/src/ast.ts
+++ b/packages/graphql-mapping-template/src/ast.ts
@@ -111,6 +111,22 @@ export function notEquals(leftExpr: Expression, rightExpr: Expression): NotEqual
 }
 
 /**
+ * Compares to expressions with greater than (>)
+ */
+export interface GreaterThanNode {
+  kind: 'GreaterThan';
+  leftExpr: Expression;
+  rightExpr: Expression;
+}
+export function greaterThan(leftExpr: Expression, rightExpr: Expression): GreaterThanNode {
+  return {
+    kind: 'GreaterThan',
+    leftExpr,
+    rightExpr,
+  };
+}
+
+/**
  * Compares two expressions for unequality.
  */
 export interface NotNode {
@@ -407,6 +423,7 @@ export type Expression =
   | ParensNode
   | EqualsNode
   | NotEqualsNode
+  | GreaterThanNode
   | ForEachNode
   | StringNode
   | RawNode

--- a/packages/graphql-mapping-template/src/print.ts
+++ b/packages/graphql-mapping-template/src/print.ts
@@ -30,6 +30,7 @@ import {
   ReturnNode,
   parens,
   IsNullOrEmptyNode,
+  GreaterThanNode,
 } from './ast';
 
 const TAB = '  ';
@@ -68,6 +69,10 @@ function printParens(node: ParensNode, indent: string = ''): string {
 
 function printEquals(node: EqualsNode, indent: string = ''): string {
   return `${indent}${printExpr(node.leftExpr)} == ${printExpr(node.rightExpr)}`;
+}
+
+function printGreaterThan(node: GreaterThanNode, indent: string = ''): string {
+  return `${indent}${printExpr(node.leftExpr)} > ${printExpr(node.rightExpr)}`;
 }
 
 function printNotEquals(node: NotEqualsNode, indent: string = ''): string {
@@ -190,6 +195,8 @@ function printExpr(expr: Expression, indent: string = ''): string {
       return printEquals(expr, indent);
     case 'NotEquals':
       return printNotEquals(expr, indent);
+    case 'GreaterThan':
+      return printGreaterThan(expr, indent);
     case 'ForEach':
       return printForEach(expr, indent);
     case 'String':


### PR DESCRIPTION
…cord if multiple exist

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
