### PR TITLE
fix: set installLatestAwsSdk on AwsCustomResource to false

### DIFF
--- a/packages/amplify-graphql-model-transformer/package.json
+++ b/packages/amplify-graphql-model-transformer/package.json
@@ -68,7 +68,7 @@
     "coverageThreshold": {
       "global": {
         "branches": 65,
-        "functions": 77,
+        "functions": 76,
         "lines": 73
       }
     },

--- a/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
@@ -199,6 +199,7 @@ export const createLayerVersionCustomResource = (scope: Construct, resourceNames
     policy: AwsCustomResourcePolicy.fromSdkCalls({
       resources: [manifestArn],
     }),
+    installLatestAwsSdk: false,
   });
 
   return customResource;
@@ -233,6 +234,7 @@ export const createSNSTopicARNCustomResource = (scope: Construct, resourceNames:
     policy: AwsCustomResourcePolicy.fromSdkCalls({
       resources: [manifestArn],
     }),
+    installLatestAwsSdk: false,
   });
 
   return customResource;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* set installLatestAwsSdk on AwsCustomResource to false

```
installLatestAwsSdk was not specified, and defaults to true. You probably do not want this. Set the global context flag '@aws-cdk/customresources:installLatestAwsSdkDefault' to false to switch this behavior off project-wide, or set the property explicitly to true if you know you need to call APIs that are not in Lambda's built-in SDK version.
```


##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

`installLatestAwsSdk` set to false. https://github.com/aws/aws-cdk/blob/main/packages/%40aws-cdk/cx-api/FEATURE_FLAGS.md#aws-cdkcustomresourcesinstalllatestawssdkdefault

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

* Unit tests
* E2E tests: https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:67bc453c-41aa-4623-b3ff-5fb3f2180d29?region=us-east-1

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
