### PR TITLE
feat: add tag to SQL datasource function

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
@@ -145,6 +145,7 @@ export const createRdsLambda = (
     Duration.seconds(30),
     scope,
     sqlLambdaVpcConfig,
+    'Amplify-managed SQL function',
   );
 
   if (sqlLambdaProvisionedConcurrencyConfig) {

--- a/packages/amplify-graphql-model-transformer/src/resources/rds-model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/rds-model-resource-generator.ts
@@ -1,4 +1,4 @@
-import { Fn } from 'aws-cdk-lib';
+import { Fn, Tags } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Topic, SubscriptionFilter } from 'aws-cdk-lib/aws-sns';
 import { LambdaSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
@@ -151,6 +151,9 @@ export class RdsModelResourceGenerator extends ModelResourceGenerator {
       strategy.vpcConfiguration,
       strategy.sqlLambdaProvisionedConcurrencyConfig,
     );
+
+    // Note that this tag will be added to either the bare function, or the alias created to handle provisioned concurrency
+    Tags.of(lambda).add('amplify:function-type', 'sql-data-source');
 
     const patchingLambdaRoleScope = context.stackManager.getScopeFor(resourceNames.sqlPatchingLambdaExecutionRole, resourceNames.sqlStack);
     const patchingLambdaRole = createRdsPatchingLambdaRole(

--- a/packages/amplify-graphql-transformer-core/src/transform-host.ts
+++ b/packages/amplify-graphql-transformer-core/src/transform-host.ts
@@ -249,6 +249,7 @@ export class DefaultTransformHost implements TransformHostProvider {
     timeout?: Duration,
     scope?: Construct,
     vpc?: VpcConfig,
+    description?: string,
   ): IFunction => {
     const dummyCode = 'if __name__ == "__main__":'; // assing dummy code so as to be overriden later
     const fn = new Function(scope || this.api, functionName, {
@@ -259,6 +260,7 @@ export class DefaultTransformHost implements TransformHostProvider {
       layers,
       environment,
       timeout,
+      description,
     });
     fn.addLayers();
     const cfnFn = fn.node.defaultChild as CfnFunction;

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -862,7 +862,7 @@ export interface TransformHostProvider {
     // (undocumented)
     addLambdaFunction: (functionName: string, functionKey: string, handlerName: string, filePath: string, runtime: Runtime, layers?: ILayerVersion[], role?: IRole, environment?: {
         [key: string]: string;
-    }, timeout?: Duration, scope?: Construct, vpc?: VpcConfig) => IFunction;
+    }, timeout?: Duration, scope?: Construct, vpc?: VpcConfig, description?: string) => IFunction;
     // (undocumented)
     addNoneDataSource(name: string, options?: DataSourceOptions, scope?: Construct): NoneDataSource;
     // (undocumented)

--- a/packages/amplify-graphql-transformer-interfaces/src/transform-host-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transform-host-provider.ts
@@ -73,6 +73,7 @@ export interface TransformHostProvider {
     timeout?: Duration,
     scope?: Construct,
     vpc?: VpcConfig,
+    description?: string,
   ) => IFunction;
 
   getDataSource: (name: string) => BaseDataSource | void;


### PR DESCRIPTION
#### Description of changes

Adds a tag and a description to the Lambda function provisioned for SQL data sources.

We will use the description field in an upcoming PR to override the Lambda Layer version for CDK-based tests.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
