### PR TITLE
chore: quote log references in verdaccio scripts

### DIFF
--- a/codebuild_specs/scripts/local_publish_helpers.sh
+++ b/codebuild_specs/scripts/local_publish_helpers.sh
@@ -7,9 +7,9 @@ function startLocalRegistry {
     # Start local registry
     tmp_registry_log="$(mktemp)"
     echo "Registry output file: $tmp_registry_log"
-    (cd && nohup npx ${VERDACCIO_PACKAGE:-$default_verdaccio_package} -c $1 &>$tmp_registry_log &)
+    (cd && nohup npx "${VERDACCIO_PACKAGE:-$default_verdaccio_package}" -c $1 &>"${tmp_registry_log}" &)
     # Wait for Verdaccio to boot
-    grep -q 'http address' <(tail -f $tmp_registry_log)
+    grep -q 'http address' <(tail -f "${tmp_registry_log}")
 }
 
 function setNpmTag {


### PR DESCRIPTION
#### Description of changes

This adds some quoting to the Verdaccio publish helper script to work around shell errors in log inspection that I encountered on my local workstation.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
