### PR TITLE
fix(api): handle attribute type change on gsi

### DIFF
--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -1108,68 +1108,67 @@ batch:
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
-    - identifier: utils_ddb_iam_access_data_construct_custom_logic
+    - identifier: add_resources_amplify_table_5_custom_logic_data_construct
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/utils.test.ts|src/__tests__/ddb-iam-access.test.ts|src/__tests__/data-construct.test.ts|src/__tests__/custom-logic.test.ts
-          CLI_REGION: eu-west-1
+            src/__tests__/add-resources.test.ts|src/__tests__/amplify-table-5.test.ts|src/__tests__/custom-logic.test.ts|src/__tests__/data-construct.test.ts
+          CLI_REGION: ap-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: >-
-        add_resources_single_gsi_single_record_single_gsi_empty_table_single_gsi_1k_records
+    - identifier: ddb_iam_access_3_gsis_10k_records_3_gsis_1k_records_3_gsis_empty_table
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/add-resources.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-1k-records.test.ts
+            src/__tests__/ddb-iam-access.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-1k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-empty-table.test.ts
           CLI_REGION: eu-north-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        single_gsi_10k_records_replace_2_gsis_update_attr_single_record_replace_2_gsis_update_attr_empty_table_replace_2_gsis_update_at
+        3_gsis_single_record_replace_2_gsis_10k_records_replace_2_gsis_1k_records_replace_2_gsis_empty_table
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-1k-records.test.ts
-          CLI_REGION: ap-northeast-1
+            src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-1k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-empty-table.test.ts
+          CLI_REGION: eu-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        replace_2_gsis_update_attr_10k_records_replace_2_gsis_single_record_replace_2_gsis_empty_table_replace_2_gsis_1k_records
+        replace_2_gsis_single_record_replace_2_gsis_update_attr_10k_records_replace_2_gsis_update_attr_1k_records_replace_2_gsis_update
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-1k-records.test.ts
-          CLI_REGION: ap-northeast-2
+            src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-1k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-empty-table.test.ts
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        replace_2_gsis_10k_records_3_gsis_single_record_3_gsis_empty_table_3_gsis_1k_records
+        replace_2_gsis_update_attr_single_record_single_gsi_10k_records_single_gsi_1k_records_single_gsi_empty_table
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-empty-table.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-1k-records.test.ts
-          CLI_REGION: ap-south-1
+            src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-single-record.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-10k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-1k-records.test.ts|src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-empty-table.test.ts
+          CLI_REGION: eu-west-3
       depend-on:
         - publish_to_local_registry
-    - identifier: 3_gsis_10k_records
+    - identifier: single_gsi_single_record_utils
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-10k-records.test.ts
-          CLI_REGION: ap-southeast-1
+            src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-single-record.test.ts|src/__tests__/utils.test.ts
+          CLI_REGION: me-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: sql_pg_models

--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -60,88 +60,87 @@ batch:
         compute-type: BUILD_GENERAL1_MEDIUM
       depend-on:
         - build_linux
-    - identifier: auth_2_datastore_modelgen_mock_api_amplify_app
+    - identifier: auth_2_datastore_modelgen_amplify_app_custom_transformers
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/auth_2.test.ts|src/__tests__/datastore-modelgen.test.ts|src/__tests__/mock-api.test.ts|src/__tests__/amplify-app.test.ts
+            src/__tests__/auth_2.test.ts|src/__tests__/datastore-modelgen.test.ts|src/__tests__/amplify-app.test.ts|src/__tests__/graphql-v2/custom-transformers.test.ts
           CLI_REGION: ap-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        custom_transformers_schema_versioned_invalid_input_arguments_schema_data_access_patterns
+        mock_api_invalid_input_arguments_schema_versioned_schema_data_access_patterns
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/graphql-v2/custom-transformers.test.ts|src/__tests__/schema-versioned.test.ts|src/__tests__/graphql-v2/invalid-input-arguments.test.ts|src/__tests__/schema-data-access-patterns.test.ts
+            src/__tests__/mock-api.test.ts|src/__tests__/graphql-v2/invalid-input-arguments.test.ts|src/__tests__/schema-versioned.test.ts|src/__tests__/schema-data-access-patterns.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: predictions_migration_schema_predictions_function_10_api_7
+    - identifier: predictions_migration_function_10_schema_predictions_api_7
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/transformer-migrations/predictions-migration.test.ts|src/__tests__/schema-predictions.test.ts|src/__tests__/function_10.test.ts|src/__tests__/api_7.test.ts
+            src/__tests__/transformer-migrations/predictions-migration.test.ts|src/__tests__/function_10.test.ts|src/__tests__/schema-predictions.test.ts|src/__tests__/api_7.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
-    - identifier: http_migration_schema_function_2_global_sandbox_api_connection_migration
+    - identifier: http_migration_global_sandbox_schema_function_2_api_connection_migration
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/transformer-migrations/http-migration.test.ts|src/__tests__/schema-function-2.test.ts|src/__tests__/global_sandbox.test.ts|src/__tests__/migration/api.connection.migration.test.ts
+            src/__tests__/transformer-migrations/http-migration.test.ts|src/__tests__/global_sandbox.test.ts|src/__tests__/schema-function-2.test.ts|src/__tests__/migration/api.connection.migration.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
-    - identifier: >-
-        schema_iterative_update_3_api_8_auth_migration_schema_iterative_update_locking
+    - identifier: api_8_schema_iterative_update_3_auth_migration_lambda_conflict_handler
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/schema-iterative-update-3.test.ts|src/__tests__/api_8.test.ts|src/__tests__/transformer-migrations/auth-migration.test.ts|src/__tests__/schema-iterative-update-locking.test.ts
-          CLI_REGION: eu-west-2
+            src/__tests__/api_8.test.ts|src/__tests__/schema-iterative-update-3.test.ts|src/__tests__/transformer-migrations/auth-migration.test.ts|src/__tests__/graphql-v2/lambda-conflict-handler.test.ts
+          CLI_REGION: eu-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        schema_iterative_update_1_lambda_conflict_handler_index_with_stack_mappings_schema_iterative_update_2
+        schema_iterative_update_1_schema_iterative_update_locking_index_with_stack_mappings_api_4
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/schema-iterative-update-1.test.ts|src/__tests__/graphql-v2/lambda-conflict-handler.test.ts|src/__tests__/graphql-v2/index-with-stack-mappings.test.ts|src/__tests__/schema-iterative-update-2.test.ts
+            src/__tests__/schema-iterative-update-1.test.ts|src/__tests__/schema-iterative-update-locking.test.ts|src/__tests__/graphql-v2/index-with-stack-mappings.test.ts|src/__tests__/api_4.test.ts
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        custom_policies_container_api_4_api_connection_migration2_containers_api_secrets
+        custom_policies_container_schema_iterative_update_2_api_connection_migration2_api_5
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/custom_policies_container.test.ts|src/__tests__/api_4.test.ts|src/__tests__/migration/api.connection.migration2.test.ts|src/__tests__/containers-api-secrets.test.ts
-          CLI_REGION: us-east-1
+            src/__tests__/custom_policies_container.test.ts|src/__tests__/schema-iterative-update-2.test.ts|src/__tests__/migration/api.connection.migration2.test.ts|src/__tests__/api_5.test.ts
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: api_5_schema_function_1_api_3_generate_ts_data_schema
+    - identifier: containers_api_secrets_schema_function_1_api_3_generate_ts_data_schema
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/api_5.test.ts|src/__tests__/schema-function-1.test.ts|src/__tests__/api_3.test.ts|src/__tests__/generate_ts_data_schema.test.ts
-          CLI_REGION: ca-central-1
+            src/__tests__/containers-api-secrets.test.ts|src/__tests__/schema-function-1.test.ts|src/__tests__/api_3.test.ts|src/__tests__/generate_ts_data_schema.test.ts
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: resolvers_sync_query_datastore_api_6_api_lambda_auth
@@ -151,7 +150,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts|src/__tests__/api_6.test.ts|src/__tests__/graphql-v2/api_lambda_auth.test.ts
-          CLI_REGION: ap-east-1
+          CLI_REGION: sa-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: api_9
@@ -163,21 +162,21 @@ batch:
           CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
-    - identifier: rds_v2
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-v2.test.ts
-          CLI_REGION: ap-south-1
-      depend-on:
-        - publish_to_local_registry
     - identifier: api_10
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/api_10.test.ts
+          CLI_REGION: ap-south-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_v2
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-v2.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
@@ -200,23 +199,23 @@ batch:
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_iterative_update_5
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/schema-iterative-update-5.test.ts
-          CLI_REGION: eu-north-1
-      depend-on:
-        - publish_to_local_registry
     - identifier: api_key_migration5
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/migration/api.key.migration5.test.ts
-          CLI_REGION: eu-west-3
+          CLI_REGION: eu-north-1
           USE_PARENT_ACCOUNT: 1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: schema_iterative_update_5
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/schema-iterative-update-5.test.ts
+          CLI_REGION: eu-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: model_migration
@@ -225,16 +224,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/model-migration.test.ts
-          CLI_REGION: eu-west-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: schema_auth_2
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/schema-auth-2.test.ts
-          CLI_REGION: eu-west-3
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_10
@@ -243,6 +233,15 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-10.test.ts
+          CLI_REGION: eu-west-3
+      depend-on:
+        - publish_to_local_registry
+    - identifier: schema_auth_2
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/schema-auth-2.test.ts
           CLI_REGION: me-south-1
       depend-on:
         - publish_to_local_registry
@@ -255,31 +254,22 @@ batch:
           CLI_REGION: sa-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_auth_13
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/schema-auth-13.test.ts
-          CLI_REGION: us-east-2
-      depend-on:
-        - publish_to_local_registry
     - identifier: schema_auth_12
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-12.test.ts
-          CLI_REGION: us-west-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_auth_3
+    - identifier: schema_auth_13
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/schema-auth-3.test.ts
-          CLI_REGION: us-west-2
+          TEST_SUITE: src/__tests__/schema-auth-13.test.ts
+          CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_15
@@ -288,16 +278,16 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-15.test.ts
-          CLI_REGION: ap-east-1
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_iterative_rollback_1
+    - identifier: schema_auth_3
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/schema-iterative-rollback-1.test.ts
-          CLI_REGION: ap-northeast-2
+          TEST_SUITE: src/__tests__/schema-auth-3.test.ts
+          CLI_REGION: ap-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: api_key_migration4
@@ -306,17 +296,17 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/migration/api.key.migration4.test.ts
-          CLI_REGION: ap-south-1
+          CLI_REGION: ap-northeast-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_key
+    - identifier: schema_iterative_rollback_1
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/schema-key.test.ts
-          CLI_REGION: ap-southeast-1
+          TEST_SUITE: src/__tests__/schema-iterative-rollback-1.test.ts
+          CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_iterative_rollback_2
@@ -325,25 +315,16 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-rollback-2.test.ts
+          CLI_REGION: ap-southeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: schema_key
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/schema-key.test.ts
           CLI_REGION: ap-southeast-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: schema_auth_8
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/schema-auth-8.test.ts
-          CLI_REGION: eu-central-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: schema_auth_4
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/schema-auth-4.test.ts
-          CLI_REGION: eu-north-1
       depend-on:
         - publish_to_local_registry
     - identifier: containers_api_1
@@ -355,13 +336,22 @@ batch:
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_auth_11
+    - identifier: schema_auth_4
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/schema-auth-11.test.ts
-          CLI_REGION: eu-west-1
+          TEST_SUITE: src/__tests__/schema-auth-4.test.ts
+          CLI_REGION: eu-north-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: schema_auth_8
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/schema-auth-8.test.ts
+          CLI_REGION: eu-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: api_key_migration2
@@ -370,8 +360,17 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/migration/api.key.migration2.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: eu-west-1
           USE_PARENT_ACCOUNT: 1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: schema_auth_11
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/schema-auth-11.test.ts
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: api_key_migration1
@@ -383,400 +382,13 @@ batch:
           CLI_REGION: eu-west-3
       depend-on:
         - publish_to_local_registry
-    - identifier: sql_generate_unauth
+    - identifier: api_11
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/sql-generate-unauth.test.ts
-          CLI_REGION: ap-northeast-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: schema_model
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/schema-model.test.ts
-          CLI_REGION: sa-east-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_v2_test_utils
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-v2-test-utils.test.ts
-          CLI_REGION: us-east-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_relational_directives
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-relational-directives.test.ts
-          CLI_REGION: us-east-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_v2_generate_schema
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-v2-generate-schema.test.ts
-          CLI_REGION: us-west-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_userpool_auth
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-userpool-auth.test.ts
-          CLI_REGION: us-west-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_userpool_auth_fields
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-userpool-auth-fields.test.ts
-          CLI_REGION: eu-north-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_relational_directives
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-relational-directives.test.ts
-          CLI_REGION: ap-northeast-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_refers_to
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-refers-to.test.ts
-          CLI_REGION: ap-northeast-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_refers_to_fields
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-refers-to-fields.test.ts
-          CLI_REGION: ap-south-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_oidc_auth
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-oidc-auth.test.ts
-          CLI_REGION: ap-southeast-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_oidc_auth_fields
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-oidc-auth-fields.test.ts
-          CLI_REGION: ap-southeast-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_model_v2
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-model-v2.test.ts
-          CLI_REGION: ca-central-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_import
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-import.test.ts
-          CLI_REGION: eu-central-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_field_auth_userpool_static_dynamic
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-field-auth-userpool-static-dynamic.test.ts
-          CLI_REGION: eu-north-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_field_auth_userpool_iam
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-field-auth-userpool-iam.test.ts
-          CLI_REGION: ap-northeast-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_field_auth_lambda
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-field-auth-lambda.test.ts
-          CLI_REGION: eu-west-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_field_auth_identityPool
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-field-auth-identityPool.test.ts
-          CLI_REGION: eu-west-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_field_auth_iam
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-field-auth-iam.test.ts
-          CLI_REGION: eu-west-3
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_field_auth_apikey
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-field-auth-apikey.test.ts
-          CLI_REGION: ap-southeast-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_custom_claims_refersto_auth
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-custom-claims-refersto-auth.test.ts
-          CLI_REGION: sa-east-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_auth_iam
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-auth-iam.test.ts
-          CLI_REGION: us-east-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_auth_iam_apikey_lambda_subscription
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-auth-iam-apikey-lambda-subscription.test.ts
-          CLI_REGION: us-east-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_auth_apikey_lambda
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-auth-apikey-lambda.test.ts
-          CLI_REGION: us-west-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_pg_array_objects
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-pg-array-objects.test.ts
-          CLI_REGION: us-west-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_v2_generate_schema
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-v2-generate-schema.test.ts
-          CLI_REGION: eu-west-3
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_userpool_auth
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-userpool-auth.test.ts
-          CLI_REGION: ap-northeast-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_userpool_auth_fields
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-userpool-auth-fields.test.ts
-          CLI_REGION: ap-northeast-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_refers_to
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-refers-to.test.ts
-          CLI_REGION: ap-south-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_refers_to_fields
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-refers-to-fields.test.ts
-          CLI_REGION: ap-southeast-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_oidc_auth
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-oidc-auth.test.ts
-          CLI_REGION: ap-southeast-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_oidc_auth_fields
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-oidc-auth-fields.test.ts
-          CLI_REGION: ca-central-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_multi_auth_1
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-multi-auth-1.test.ts
-          CLI_REGION: eu-central-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_model_v2
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-model-v2.test.ts
-          CLI_REGION: eu-north-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_field_auth_userpool_static_dynamic
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-field-auth-userpool-static-dynamic.test.ts
-          CLI_REGION: ap-southeast-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_field_auth_userpool_iam
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-field-auth-userpool-iam.test.ts
-          CLI_REGION: eu-west-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_field_auth_lambda
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-field-auth-lambda.test.ts
-          CLI_REGION: eu-west-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_field_auth_identityPool
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-field-auth-identityPool.test.ts
-          CLI_REGION: eu-west-3
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_field_auth_iam
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-field-auth-iam.test.ts
-          CLI_REGION: eu-north-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_field_auth_apikey
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-field-auth-apikey.test.ts
-          CLI_REGION: sa-east-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_custom_claims_refersto_auth
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-custom-claims-refersto-auth.test.ts
-          CLI_REGION: us-east-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_auth_iam
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-auth-iam.test.ts
-          CLI_REGION: us-east-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_auth_iam_apikey_lambda_subscription
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts
-          CLI_REGION: us-west-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: rds_mysql_auth_apikey_lambda
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/rds-mysql-auth-apikey-lambda.test.ts
-          CLI_REGION: us-west-2
+          TEST_SUITE: src/__tests__/api_11.test.ts
+          CLI_REGION: me-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: api_canary_ap_east_1
@@ -950,12 +562,399 @@ batch:
           CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: api_11
+    - identifier: rds_mysql_auth_apikey_lambda
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/api_11.test.ts
+          TEST_SUITE: src/__tests__/rds-mysql-auth-apikey-lambda.test.ts
+          CLI_REGION: us-east-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_auth_iam_apikey_lambda_subscription
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts
+          CLI_REGION: us-east-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_auth_iam
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-auth-iam.test.ts
+          CLI_REGION: us-west-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_custom_claims_refersto_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-custom-claims-refersto-auth.test.ts
+          CLI_REGION: us-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_field_auth_apikey
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-field-auth-apikey.test.ts
+          CLI_REGION: eu-west-3
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_field_auth_iam
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-field-auth-iam.test.ts
+          CLI_REGION: ap-northeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_field_auth_identityPool
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-field-auth-identityPool.test.ts
+          CLI_REGION: ap-northeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_field_auth_lambda
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-field-auth-lambda.test.ts
+          CLI_REGION: ap-south-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_field_auth_userpool_iam
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-field-auth-userpool-iam.test.ts
+          CLI_REGION: ap-southeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_field_auth_userpool_static_dynamic
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-field-auth-userpool-static-dynamic.test.ts
+          CLI_REGION: ap-southeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_model_v2
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-model-v2.test.ts
+          CLI_REGION: ca-central-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_multi_auth_1
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-multi-auth-1.test.ts
+          CLI_REGION: eu-central-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_oidc_auth_fields
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-oidc-auth-fields.test.ts
+          CLI_REGION: eu-north-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_oidc_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-oidc-auth.test.ts
+          CLI_REGION: ap-southeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_refers_to_fields
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-refers-to-fields.test.ts
+          CLI_REGION: eu-west-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_refers_to
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-refers-to.test.ts
+          CLI_REGION: eu-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_userpool_auth_fields
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-userpool-auth-fields.test.ts
+          CLI_REGION: eu-west-3
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_userpool_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-userpool-auth.test.ts
+          CLI_REGION: eu-north-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_mysql_v2_generate_schema
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-mysql-v2-generate-schema.test.ts
+          CLI_REGION: sa-east-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_array_objects
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-array-objects.test.ts
+          CLI_REGION: us-east-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_auth_apikey_lambda
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-auth-apikey-lambda.test.ts
+          CLI_REGION: us-east-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_auth_iam_apikey_lambda_subscription
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-auth-iam-apikey-lambda-subscription.test.ts
+          CLI_REGION: us-west-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_auth_iam
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-auth-iam.test.ts
+          CLI_REGION: us-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_custom_claims_refersto_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-custom-claims-refersto-auth.test.ts
+          CLI_REGION: us-east-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_field_auth_apikey
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-field-auth-apikey.test.ts
+          CLI_REGION: ap-northeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_field_auth_iam
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-field-auth-iam.test.ts
+          CLI_REGION: ap-northeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_field_auth_identityPool
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-field-auth-identityPool.test.ts
+          CLI_REGION: ap-south-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_field_auth_lambda
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-field-auth-lambda.test.ts
+          CLI_REGION: ap-southeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_field_auth_userpool_iam
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-field-auth-userpool-iam.test.ts
+          CLI_REGION: ap-southeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_field_auth_userpool_static_dynamic
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-field-auth-userpool-static-dynamic.test.ts
+          CLI_REGION: ca-central-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_import
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-import.test.ts
+          CLI_REGION: eu-central-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_model_v2
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-model-v2.test.ts
+          CLI_REGION: eu-north-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_oidc_auth_fields
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-oidc-auth-fields.test.ts
+          CLI_REGION: eu-central-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_oidc_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-oidc-auth.test.ts
+          CLI_REGION: eu-west-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_refers_to_fields
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-refers-to-fields.test.ts
+          CLI_REGION: eu-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_refers_to
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-refers-to.test.ts
+          CLI_REGION: eu-west-3
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_relational_directives
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-relational-directives.test.ts
+          CLI_REGION: eu-west-3
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_userpool_auth_fields
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-userpool-auth-fields.test.ts
+          CLI_REGION: sa-east-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_userpool_auth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-userpool-auth.test.ts
+          CLI_REGION: us-east-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_pg_v2_generate_schema
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-pg-v2-generate-schema.test.ts
+          CLI_REGION: us-east-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_relational_directives
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-relational-directives.test.ts
+          CLI_REGION: us-west-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: rds_v2_test_utils
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/rds-v2-test-utils.test.ts
+          CLI_REGION: us-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: schema_model
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/schema-model.test.ts
+          CLI_REGION: ap-east-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: sql_generate_unauth
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/sql-generate-unauth.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
@@ -968,22 +967,13 @@ batch:
           CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_auth_9
+    - identifier: containers_api_2
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/schema-auth-9.test.ts
-          CLI_REGION: ap-south-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: schema_auth_7
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/schema-auth-7.test.ts
-          CLI_REGION: ap-southeast-1
+          TEST_SUITE: src/__tests__/containers-api-2.test.ts
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_14
@@ -992,16 +982,25 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-14.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: containers_api_2
+    - identifier: schema_auth_7
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/containers-api-2.test.ts
-          CLI_REGION: us-east-1
+          TEST_SUITE: src/__tests__/schema-auth-7.test.ts
+          CLI_REGION: ap-southeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: schema_auth_9
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/schema-auth-9.test.ts
+          CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: api_1
@@ -1022,13 +1021,13 @@ batch:
           CLI_REGION: eu-north-1
       depend-on:
         - publish_to_local_registry
-    - identifier: schema_searchable
+    - identifier: searchable_datastore
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/schema-searchable.test.ts
-          CLI_REGION: us-east-1
+          TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts
+          CLI_REGION: eu-west-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -1041,23 +1040,14 @@ batch:
           CLI_REGION: eu-west-1
       depend-on:
         - publish_to_local_registry
-    - identifier: searchable_datastore
+    - identifier: schema_searchable
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts
-          CLI_REGION: eu-west-2
+          TEST_SUITE: src/__tests__/schema-searchable.test.ts
+          CLI_REGION: us-west-2
           USE_PARENT_ACCOUNT: 1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: schema_connection
-      buildspec: codebuild_specs/run_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/schema-connection.test.ts
-          CLI_REGION: eu-west-3
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_6
@@ -1066,6 +1056,15 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-6.test.ts
+          CLI_REGION: eu-west-3
+      depend-on:
+        - publish_to_local_registry
+    - identifier: schema_connection
+      buildspec: codebuild_specs/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/schema-connection.test.ts
           CLI_REGION: me-south-1
       depend-on:
         - publish_to_local_registry
@@ -1171,66 +1170,66 @@ batch:
           CLI_REGION: me-south-1
       depend-on:
         - publish_to_local_registry
-    - identifier: sql_pg_models
+    - identifier: admin_role
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/sql-pg-models.test.ts
+          TEST_SUITE: src/__tests__/admin-role.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: sql_pg_canary
+    - identifier: all_auth_modes
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
+          TEST_SUITE: src/__tests__/all-auth-modes.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
-    - identifier: sql_mysql_canary
+    - identifier: amplify_ddb_canary
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
+          TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
-    - identifier: sql_models_2
+    - identifier: amplify_table_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/sql-models-2.test.ts
+          TEST_SUITE: src/__tests__/amplify-table-1.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: sql_models_1
+    - identifier: amplify_table_2
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/sql-models-1.test.ts
+          TEST_SUITE: src/__tests__/amplify-table-2.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
-    - identifier: sql_iam_access
+    - identifier: amplify_table_3
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/sql-iam-access.test.ts
+          TEST_SUITE: src/__tests__/amplify-table-3.test.ts
           CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
-    - identifier: default_ddb_canary
+    - identifier: amplify_table_4
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
+          TEST_SUITE: src/__tests__/amplify-table-4.test.ts
           CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
@@ -1405,186 +1404,147 @@ batch:
           CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: amplify_table_4
+    - identifier: default_ddb_canary
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/amplify-table-4.test.ts
+          TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: eu-south-1
       depend-on:
         - publish_to_local_registry
-    - identifier: amplify_table_3
+    - identifier: 3_gsis_100k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/amplify-table-3.test.ts
-          CLI_REGION: eu-west-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: amplify_table_2
-      buildspec: codebuild_specs/run_cdk_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/amplify-table-2.test.ts
-          CLI_REGION: eu-west-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: amplify_table_1
-      buildspec: codebuild_specs/run_cdk_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/amplify-table-1.test.ts
-          CLI_REGION: eu-west-3
-      depend-on:
-        - publish_to_local_registry
-    - identifier: amplify_ddb_canary
-      buildspec: codebuild_specs/run_cdk_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
-          CLI_REGION: me-south-1
-      depend-on:
-        - publish_to_local_registry
-    - identifier: all_auth_modes
-      buildspec: codebuild_specs/run_cdk_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/all-auth-modes.test.ts
+          TEST_SUITE: src/__tests__/deploy-velocity/3-gsis-100k-records.test.ts
           CLI_REGION: sa-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: admin_role
+    - identifier: replace_2_gsis_100k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/admin-role.test.ts
+          TEST_SUITE: src/__tests__/deploy-velocity/replace-2-gsis-100k-records.test.ts
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: restricted_field_auth_gen2
+    - identifier: replace_2_gsis_update_attr_100k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: >-
-            src/__tests__/restricted-field-auth/restricted-field-auth-gen2.test.ts
+            src/__tests__/deploy-velocity/replace-2-gsis-update-attr-100k-records.test.ts
           CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
-    - identifier: restricted_field_auth_gen1
+    - identifier: single_gsi_100k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: >-
-            src/__tests__/restricted-field-auth/restricted-field-auth-gen1.test.ts
+          TEST_SUITE: src/__tests__/deploy-velocity/single-gsi-100k-records.test.ts
           CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
-    - identifier: references_sqlprimary_sqlrelated
+    - identifier: dynamic_group_auth_ddbprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: >-
-            src/__tests__/relationships/references/references-sqlprimary-sqlrelated.test.ts
+            src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-ddbprimary-ddbrelated.test.ts
           CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: references_sqlprimary_ddbrelated
+    - identifier: dynamic_group_auth_ddbprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: >-
-            src/__tests__/relationships/references/references-sqlprimary-ddbrelated.test.ts
-          CLI_REGION: us-east-1
+            src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-ddbprimary-sqlrelated.test.ts
+          CLI_REGION: ap-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: references_ddbprimary_sqlrelated
+    - identifier: dynamic_group_auth_sqlprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: >-
-            src/__tests__/relationships/references/references-ddbprimary-sqlrelated.test.ts
+            src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-sqlprimary-ddbrelated.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: references_ddbprimary_ddbrelated
+    - identifier: dynamic_group_auth_sqlprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: >-
-            src/__tests__/relationships/references/references-ddbprimary-ddbrelated.test.ts
+            src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-sqlprimary-sqlrelated.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
-    - identifier: recursive_relationships_sql
+    - identifier: static_group_auth_ddbprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: >-
-            src/__tests__/relationships/recursive/recursive-relationships-sql.test.ts
+            src/__tests__/group-auth/static-group-auth/static-group-auth-ddbprimary-ddbrelated.test.ts
           CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
-    - identifier: recursive_relationships_ddb
+    - identifier: static_group_auth_ddbprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: >-
-            src/__tests__/relationships/recursive/recursive-relationships-ddb.test.ts
+            src/__tests__/group-auth/static-group-auth/static-group-auth-ddbprimary-sqlrelated.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: multi_relationship_sqlprimary_sqlrelated
+    - identifier: static_group_auth_sqlprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: >-
-            src/__tests__/relationships/multi-relationship/multi-relationship-sqlprimary-sqlrelated.test.ts
+            src/__tests__/group-auth/static-group-auth/static-group-auth-sqlprimary-ddbrelated.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
-    - identifier: multi_relationship_sqlprimary_ddbrelated
+    - identifier: static_group_auth_sqlprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: >-
-            src/__tests__/relationships/multi-relationship/multi-relationship-sqlprimary-ddbrelated.test.ts
+            src/__tests__/group-auth/static-group-auth/static-group-auth-sqlprimary-sqlrelated.test.ts
           CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
-    - identifier: multi_relationship_ddbprimary_sqlrelated
+    - identifier: assoc_field
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: >-
-            src/__tests__/relationships/multi-relationship/multi-relationship-ddbprimary-sqlrelated.test.ts
+          TEST_SUITE: src/__tests__/owner-auth/assoc-field/assoc-field.test.ts
           CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
-    - identifier: multi_relationship_ddbprimary_ddbrelated
+    - identifier: bind_sql_ids
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: >-
-            src/__tests__/relationships/multi-relationship/multi-relationship-ddbprimary-ddbrelated.test.ts
+          TEST_SUITE: src/__tests__/owner-auth/bind-sql-ids/bind-sql-ids.test.ts
           CLI_REGION: eu-north-1
       depend-on:
         - publish_to_local_registry
@@ -1597,323 +1557,362 @@ batch:
           CLI_REGION: eu-south-1
       depend-on:
         - publish_to_local_registry
-    - identifier: bind_sql_ids
+    - identifier: multi_relationship_ddbprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/owner-auth/bind-sql-ids/bind-sql-ids.test.ts
+          TEST_SUITE: >-
+            src/__tests__/relationships/multi-relationship/multi-relationship-ddbprimary-ddbrelated.test.ts
           CLI_REGION: eu-west-1
       depend-on:
         - publish_to_local_registry
-    - identifier: assoc_field
+    - identifier: multi_relationship_ddbprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/owner-auth/assoc-field/assoc-field.test.ts
+          TEST_SUITE: >-
+            src/__tests__/relationships/multi-relationship/multi-relationship-ddbprimary-sqlrelated.test.ts
           CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: static_group_auth_sqlprimary_sqlrelated
+    - identifier: multi_relationship_sqlprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: >-
-            src/__tests__/group-auth/static-group-auth/static-group-auth-sqlprimary-sqlrelated.test.ts
+            src/__tests__/relationships/multi-relationship/multi-relationship-sqlprimary-ddbrelated.test.ts
           CLI_REGION: eu-west-3
       depend-on:
         - publish_to_local_registry
-    - identifier: static_group_auth_sqlprimary_ddbrelated
+    - identifier: multi_relationship_sqlprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: >-
-            src/__tests__/group-auth/static-group-auth/static-group-auth-sqlprimary-ddbrelated.test.ts
+            src/__tests__/relationships/multi-relationship/multi-relationship-sqlprimary-sqlrelated.test.ts
           CLI_REGION: me-south-1
       depend-on:
         - publish_to_local_registry
-    - identifier: static_group_auth_ddbprimary_sqlrelated
+    - identifier: recursive_relationships_ddb
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: >-
-            src/__tests__/group-auth/static-group-auth/static-group-auth-ddbprimary-sqlrelated.test.ts
+            src/__tests__/relationships/recursive/recursive-relationships-ddb.test.ts
           CLI_REGION: sa-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: static_group_auth_ddbprimary_ddbrelated
+    - identifier: recursive_relationships_sql
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: >-
-            src/__tests__/group-auth/static-group-auth/static-group-auth-ddbprimary-ddbrelated.test.ts
+            src/__tests__/relationships/recursive/recursive-relationships-sql.test.ts
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: dynamic_group_auth_sqlprimary_sqlrelated
+    - identifier: references_ddbprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: >-
-            src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-sqlprimary-sqlrelated.test.ts
+            src/__tests__/relationships/references/references-ddbprimary-ddbrelated.test.ts
           CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
-    - identifier: dynamic_group_auth_sqlprimary_ddbrelated
+    - identifier: references_ddbprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: >-
-            src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-sqlprimary-ddbrelated.test.ts
+            src/__tests__/relationships/references/references-ddbprimary-sqlrelated.test.ts
           CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
-    - identifier: dynamic_group_auth_ddbprimary_sqlrelated
+    - identifier: references_sqlprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: >-
-            src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-ddbprimary-sqlrelated.test.ts
+            src/__tests__/relationships/references/references-sqlprimary-ddbrelated.test.ts
           CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: dynamic_group_auth_ddbprimary_ddbrelated
+    - identifier: references_sqlprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: >-
-            src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-ddbprimary-ddbrelated.test.ts
-          CLI_REGION: us-east-1
+            src/__tests__/relationships/references/references-sqlprimary-sqlrelated.test.ts
+          CLI_REGION: ap-east-1
       depend-on:
         - publish_to_local_registry
-    - identifier: single_gsi_100k_records
+    - identifier: restricted_field_auth_gen1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/deploy-velocity/single-gsi-100k-records.test.ts
+          TEST_SUITE: >-
+            src/__tests__/restricted-field-auth/restricted-field-auth-gen1.test.ts
+          CLI_REGION: ap-northeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: restricted_field_auth_gen2
+      buildspec: codebuild_specs/run_cdk_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/restricted-field-auth/restricted-field-auth-gen2.test.ts
+          CLI_REGION: ap-northeast-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: sql_iam_access
+      buildspec: codebuild_specs/run_cdk_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/sql-iam-access.test.ts
+          CLI_REGION: ap-south-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: sql_models_1
+      buildspec: codebuild_specs/run_cdk_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/sql-models-1.test.ts
+          CLI_REGION: ap-southeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: sql_models_2
+      buildspec: codebuild_specs/run_cdk_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/sql-models-2.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
-    - identifier: replace_2_gsis_update_attr_100k_records
+    - identifier: sql_mysql_canary
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: >-
-            src/__tests__/deploy-velocity/replace-2-gsis-update-attr-100k-records.test.ts
+          TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
-    - identifier: replace_2_gsis_100k_records
+    - identifier: sql_pg_canary
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/deploy-velocity/replace-2-gsis-100k-records.test.ts
+          TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
           CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
-    - identifier: 3_gsis_100k_records
+    - identifier: sql_pg_models
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
-          TEST_SUITE: src/__tests__/deploy-velocity/3-gsis-100k-records.test.ts
+          TEST_SUITE: src/__tests__/sql-pg-models.test.ts
           CLI_REGION: eu-north-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        TestComplexStackMappingsLocal_NestedStacksTest_KeyTransformerLocal_CustomRoots
+        CustomRoots_KeyTransformerLocal_NestedStacksTest_TestComplexStackMappingsLocal
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/TestComplexStackMappingsLocal.e2e.test.ts|src/__tests__/NestedStacksTest.e2e.test.ts|src/__tests__/KeyTransformerLocal.e2e.test.ts|src/__tests__/CustomRoots.e2e.test.ts
+            src/__tests__/CustomRoots.e2e.test.ts|src/__tests__/KeyTransformerLocal.e2e.test.ts|src/__tests__/NestedStacksTest.e2e.test.ts|src/__tests__/TestComplexStackMappingsLocal.e2e.test.ts
           CLI_REGION: ap-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        NonModelAuthV2Function_VersionedModelTransformer_TransformerOptionsV2_PredictionsTransformerV2Tests
+        NonModelAuthV2Function_FunctionTransformerTests_KeyWithAuth_MutationCondition
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/NonModelAuthV2Function.e2e.test.ts|src/__tests__/VersionedModelTransformer.e2e.test.ts|src/__tests__/TransformerOptionsV2.e2e.test.ts|src/__tests__/PredictionsTransformerV2Tests.e2e.test.ts
+            src/__tests__/NonModelAuthV2Function.e2e.test.ts|src/__tests__/FunctionTransformerTests.e2e.test.ts|src/__tests__/KeyWithAuth.e2e.test.ts|src/__tests__/MutationCondition.e2e.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        PredictionsTransformerTests_PerFieldAuthTests_NoneEnvFunctionTransformer_NonModelAuthFunction
+        NoneEnvFunctionTransformer_NonModelAuthFunction_PerFieldAuthTests_PredictionsTransformerTests
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/PredictionsTransformerTests.e2e.test.ts|src/__tests__/PerFieldAuthTests.e2e.test.ts|src/__tests__/NoneEnvFunctionTransformer.e2e.test.ts|src/__tests__/NonModelAuthFunction.e2e.test.ts
-          CLI_REGION: ap-northeast-2
-      depend-on:
-        - publish_to_local_registry
-    - identifier: >-
-        MutationCondition_KeyWithAuth_FunctionTransformerTests_DynamoDBModelTransformer
-      buildspec: codebuild_specs/graphql_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_MEDIUM
-        variables:
-          TEST_SUITE: >-
-            src/__tests__/MutationCondition.e2e.test.ts|src/__tests__/KeyWithAuth.e2e.test.ts|src/__tests__/FunctionTransformerTests.e2e.test.ts|src/__tests__/DynamoDBModelTransformer.e2e.test.ts
+            src/__tests__/NoneEnvFunctionTransformer.e2e.test.ts|src/__tests__/NonModelAuthFunction.e2e.test.ts|src/__tests__/PerFieldAuthTests.e2e.test.ts|src/__tests__/PredictionsTransformerTests.e2e.test.ts
           CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        DefaultValueTransformer_ConnectionsWithAuthTests_RelationalWithOwnerFieldAsKeySchemaAuth_NewConnectionWithAuth
+        PredictionsTransformerV2Tests_TransformerOptionsV2_VersionedModelTransformer_ConnectionsWithAuthTests
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/DefaultValueTransformer.e2e.test.ts|src/__tests__/ConnectionsWithAuthTests.e2e.test.ts|src/__tests__/RelationalWithOwnerFieldAsKeySchemaAuth.e2e.test.ts|src/__tests__/NewConnectionWithAuth.e2e.test.ts
+            src/__tests__/PredictionsTransformerV2Tests.e2e.test.ts|src/__tests__/TransformerOptionsV2.e2e.test.ts|src/__tests__/VersionedModelTransformer.e2e.test.ts|src/__tests__/ConnectionsWithAuthTests.e2e.test.ts
+          CLI_REGION: ap-southeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: >-
+        DefaultValueTransformer_DynamoDBModelTransformer_ModelConnectionTransformer_NewConnectionTransformer
+      buildspec: codebuild_specs/graphql_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          TEST_SUITE: >-
+            src/__tests__/DefaultValueTransformer.e2e.test.ts|src/__tests__/DynamoDBModelTransformer.e2e.test.ts|src/__tests__/ModelConnectionTransformer.e2e.test.ts|src/__tests__/NewConnectionTransformer.e2e.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        NewConnectionTransformer_ModelConnectionTransformer_SubscriptionsWithAuthTest_PerFieldAuthV2TransformerWithFF
+        NewConnectionWithAuth_RelationalWithOwnerFieldAsKeySchemaAuth_BelongsToTransformerV2_KeyTransformer
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/NewConnectionTransformer.e2e.test.ts|src/__tests__/ModelConnectionTransformer.e2e.test.ts|src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts|src/__tests__/PerFieldAuthV2TransformerWithFF.e2e.test.ts
-          CLI_REGION: ca-central-1
+            src/__tests__/NewConnectionWithAuth.e2e.test.ts|src/__tests__/RelationalWithOwnerFieldAsKeySchemaAuth.e2e.test.ts|src/__tests__/BelongsToTransformerV2.e2e.test.ts|src/__tests__/KeyTransformer.e2e.test.ts
+          CLI_REGION: eu-north-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        PerFieldAuthV2Transformer_ModelAuthTransformer_KeyTransformer_BelongsToTransformerV2
+        ModelAuthTransformer_PerFieldAuthV2Transformer_PerFieldAuthV2TransformerWithFF_SubscriptionsWithAuthTest
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/PerFieldAuthV2Transformer.e2e.test.ts|src/__tests__/ModelAuthTransformer.e2e.test.ts|src/__tests__/KeyTransformer.e2e.test.ts|src/__tests__/BelongsToTransformerV2.e2e.test.ts
+            src/__tests__/ModelAuthTransformer.e2e.test.ts|src/__tests__/PerFieldAuthV2Transformer.e2e.test.ts|src/__tests__/PerFieldAuthV2TransformerWithFF.e2e.test.ts|src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts
           CLI_REGION: eu-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        RelationalWithAuthV2WithFF_ModelConnectionWithKeyTransformer_IndexWithAuthV2_MultiAuthModelAuthTransformer
+        IndexWithAuthV2_ModelConnectionWithKeyTransformer_RelationalWithAuthV2WithFF_IndexWithAuthV2WithFF
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/RelationalWithAuthV2WithFF.e2e.test.ts|src/__tests__/ModelConnectionWithKeyTransformer.e2e.test.ts|src/__tests__/IndexWithAuthV2.e2e.test.ts|src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
+            src/__tests__/IndexWithAuthV2.e2e.test.ts|src/__tests__/ModelConnectionWithKeyTransformer.e2e.test.ts|src/__tests__/RelationalWithAuthV2WithFF.e2e.test.ts|src/__tests__/IndexWithAuthV2WithFF.e2e.test.ts
           CLI_REGION: eu-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        IndexWithAuthV2WithFF_SubscriptionsWithAuthV2WithFF_MultiAuthV2Transformer_ModelTransformer
+        MultiAuthModelAuthTransformer_IndexWithClaimFieldAsSortKeyAuth_ModelTransformer_MultiAuthV2Transformer
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/IndexWithAuthV2WithFF.e2e.test.ts|src/__tests__/SubscriptionsWithAuthV2WithFF.e2e.test.ts|src/__tests__/MultiAuthV2Transformer.e2e.test.ts|src/__tests__/ModelTransformer.e2e.test.ts
+            src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts|src/__tests__/IndexWithClaimFieldAsSortKeyAuth.e2e.test.ts|src/__tests__/ModelTransformer.e2e.test.ts|src/__tests__/MultiAuthV2Transformer.e2e.test.ts
           CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        IndexWithClaimFieldAsSortKeyAuth_SubscriptionsWithAuthV2_RelationalWithAuthV2_MapsToTransformer
+        SubscriptionsWithAuthV2WithFF_MapsToTransformer_RelationalWithAuthV2_SubscriptionsWithAuthV2
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/IndexWithClaimFieldAsSortKeyAuth.e2e.test.ts|src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts|src/__tests__/RelationalWithAuthV2.e2e.test.ts|src/__tests__/MapsToTransformer.e2e.test.ts
+            src/__tests__/SubscriptionsWithAuthV2WithFF.e2e.test.ts|src/__tests__/MapsToTransformer.e2e.test.ts|src/__tests__/RelationalWithAuthV2.e2e.test.ts|src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts
           CLI_REGION: eu-west-3
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        MultiAuthV2TransformerWithFF_IndexTransformer_AuthV2Transformer_AuthV2ExhaustiveT1B
+        IndexTransformer_MultiAuthV2TransformerWithFF_AuthV2Transformer_AuthV2ExhaustiveT1A
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/MultiAuthV2TransformerWithFF.e2e.test.ts|src/__tests__/IndexTransformer.e2e.test.ts|src/__tests__/AuthV2Transformer.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT1B.test.ts
+            src/__tests__/IndexTransformer.e2e.test.ts|src/__tests__/MultiAuthV2TransformerWithFF.e2e.test.ts|src/__tests__/AuthV2Transformer.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT1A.test.ts
           CLI_REGION: me-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        AuthV2ExhaustiveT1A_IndexWithAutoQueryField_AuthV2TransformerWithFF_SubscriptionsRuntimeFiltering
+        AuthV2ExhaustiveT1B_AuthV2TransformerWithFF_IndexWithAutoQueryField_AuthV2ExhaustiveT1C
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/AuthV2ExhaustiveT1A.test.ts|src/__tests__/IndexWithAutoQueryField.e2e.test.ts|src/__tests__/AuthV2TransformerWithFF.e2e.test.ts|src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts
+            src/__tests__/AuthV2ExhaustiveT1B.test.ts|src/__tests__/AuthV2TransformerWithFF.e2e.test.ts|src/__tests__/IndexWithAutoQueryField.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT1C.test.ts
           CLI_REGION: sa-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        RelationalTransformers_AuthV2ExhaustiveT2A_AuthV2ExhaustiveT1C_AuthV2ExhaustiveT1D
+        AuthV2ExhaustiveT2A_RelationalTransformers_SubscriptionsRuntimeFiltering_AuthV2ExhaustiveT1D
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/RelationalTransformers.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT2A.test.ts|src/__tests__/AuthV2ExhaustiveT1C.test.ts|src/__tests__/AuthV2ExhaustiveT1D.test.ts
+            src/__tests__/AuthV2ExhaustiveT2A.test.ts|src/__tests__/RelationalTransformers.e2e.test.ts|src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT1D.test.ts
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        AuthV2ExhaustiveT2B_AuthV2ExhaustiveT2D_AuthV2ExhaustiveT2C_AuthV2TransformerIAM
+        AuthV2ExhaustiveT2B_AuthV2ExhaustiveT2D_AuthV2ExhaustiveT2C_AuthV2ExhaustiveT3A
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/AuthV2ExhaustiveT2B.test.ts|src/__tests__/AuthV2ExhaustiveT2D.test.ts|src/__tests__/AuthV2ExhaustiveT2C.test.ts|src/__tests__/AuthV2TransformerIAM.test.ts
+            src/__tests__/AuthV2ExhaustiveT2B.test.ts|src/__tests__/AuthV2ExhaustiveT2D.test.ts|src/__tests__/AuthV2ExhaustiveT2C.test.ts|src/__tests__/AuthV2ExhaustiveT3A.test.ts
           CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        AuthV2ExhaustiveT3D_AuthV2ExhaustiveT3C_AuthV2ExhaustiveT3B_AuthV2ExhaustiveT3A
+        AuthV2ExhaustiveT3B_AuthV2ExhaustiveT3C_AuthV2ExhaustiveT3D_AuthV2TransformerIAM
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/AuthV2ExhaustiveT3D.test.ts|src/__tests__/AuthV2ExhaustiveT3C.test.ts|src/__tests__/AuthV2ExhaustiveT3B.test.ts|src/__tests__/AuthV2ExhaustiveT3A.test.ts
+            src/__tests__/AuthV2ExhaustiveT3B.test.ts|src/__tests__/AuthV2ExhaustiveT3C.test.ts|src/__tests__/AuthV2ExhaustiveT3D.test.ts|src/__tests__/AuthV2TransformerIAM.test.ts
           CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        SearchableModelTransformerV2_SearchableWithAuthTests_SearchableModelTransformer_SearchableWithAuthV2WithFF
+        SearchableModelTransformerV2_SearchableWithAuthTests_SearchableModelTransformer_SearchableWithAuthV2
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/SearchableModelTransformerV2.e2e.test.ts|src/__tests__/SearchableWithAuthTests.e2e.test.ts|src/__tests__/SearchableModelTransformer.e2e.test.ts|src/__tests__/SearchableWithAuthV2WithFF.e2e.test.ts
+            src/__tests__/SearchableModelTransformerV2.e2e.test.ts|src/__tests__/SearchableWithAuthTests.e2e.test.ts|src/__tests__/SearchableModelTransformer.e2e.test.ts|src/__tests__/SearchableWithAuthV2.e2e.test.ts
           CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
-    - identifier: SearchableWithAuthV2
+    - identifier: SearchableWithAuthV2WithFF
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
-          TEST_SUITE: src/__tests__/SearchableWithAuthV2.e2e.test.ts
+          TEST_SUITE: src/__tests__/SearchableWithAuthV2WithFF.e2e.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
@@ -1923,8 +1922,17 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/FunctionTransformerTestsV2.e2e.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-northeast-2
           USE_PARENT_ACCOUNT: 1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: HttpTransformer
+      buildspec: codebuild_specs/graphql_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          TEST_SUITE: src/__tests__/HttpTransformer.e2e.test.ts
+          CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: HttpTransformerV2
@@ -1936,18 +1944,9 @@ batch:
           CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
-    - identifier: HttpTransformer
-      buildspec: codebuild_specs/graphql_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          TEST_SUITE: src/__tests__/HttpTransformer.e2e.test.ts
-          CLI_REGION: eu-north-1
-      depend-on:
-        - publish_to_local_registry
     - identifier: cleanup_e2e_resources
       buildspec: codebuild_specs/cleanup_e2e_resources.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
       depend-on:
-        - auth_2_datastore_modelgen_mock_api_amplify_app
+        - auth_2_datastore_modelgen_amplify_app_custom_transformers

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/amplify-table-5.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/amplify-table-5.test.ts
@@ -1,0 +1,59 @@
+import * as path from 'path';
+import { createNewProjectDir, deleteProjectDir, getDDBTable } from 'amplify-category-api-e2e-core';
+import { cdkDestroy, initCDKProject, cdkDeploy, updateCDKAppWithTemplate } from '../commands';
+
+jest.setTimeout(1000 * 60 * 60 /* 1 hour */);
+
+describe('CDK amplify table 5', () => {
+  let projRoot: string;
+  let projFolderName: string;
+
+  beforeEach(async () => {
+    projFolderName = 'cdkamplifytable5';
+    projRoot = await createNewProjectDir(projFolderName);
+  });
+
+  afterEach(async () => {
+    try {
+      await cdkDestroy(projRoot, '--all');
+    } catch (_) {
+      /* No-op */
+    }
+
+    deleteProjectDir(projRoot);
+  });
+
+  test('datatype change on indexed field should replace the index', async () => {
+    const templatePath = path.resolve(path.join(__dirname, 'backends', 'amplify-table', 'simple-todo'));
+    const name = await initCDKProject(projRoot, templatePath);
+    const outputs = await cdkDeploy(projRoot, '--all');
+    const { awsAppsyncApiId: apiId, awsAppsyncRegion: region } = outputs[name];
+    const tableName = `Todo-${apiId}-NONE`;
+    const table = await getDDBTable(tableName, region);
+    expect(table.Table.AttributeDefinitions).toHaveLength(2);
+    const nameAttr = table.Table.AttributeDefinitions.find((attr) => attr.AttributeName === 'name');
+    expect(nameAttr.AttributeType).toEqual('S');
+    expect(table.Table.GlobalSecondaryIndexes).toHaveLength(1);
+    expect(table.Table.GlobalSecondaryIndexes[0].IndexName).toEqual('byName');
+
+    // deploy with modified attribute type
+    const updateTemplatePath = path.resolve(path.join(__dirname, 'backends', 'amplify-table', 'simple-todo', 'attributeTypeChange'));
+    updateCDKAppWithTemplate(projRoot, updateTemplatePath);
+    await expect(cdkDeploy(projRoot, '--all')).resolves.not.toThrow();
+    const modifiedTable = await getDDBTable(tableName, region);
+    expect(modifiedTable.Table.AttributeDefinitions).toHaveLength(3);
+    const modifiedNameAttr = modifiedTable.Table.AttributeDefinitions.find((attr) => attr.AttributeName === 'name');
+    expect(modifiedNameAttr.AttributeType).toEqual('N');
+    expect(modifiedTable.Table.GlobalSecondaryIndexes).toHaveLength(2);
+    expect(modifiedTable.Table.GlobalSecondaryIndexes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          IndexName: 'byNameDescription',
+        }),
+        expect.objectContaining({
+          IndexName: 'byName',
+        }),
+      ]),
+    );
+  });
+});

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/amplify-table/simple-todo/attributeTypeChange/app.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/amplify-table/simple-todo/attributeTypeChange/app.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import { App, Stack, Duration } from 'aws-cdk-lib';
+// @ts-ignore
+import { AmplifyGraphqlApi, AmplifyGraphqlDefinition } from '@aws-amplify/graphql-api-construct';
+
+const packageJson = require('../package.json');
+
+const app = new App();
+const stack = new Stack(app, packageJson.name.replace(/_/g, '-'), {
+  env: { region: process.env.CLI_REGION || 'us-west-2' },
+});
+
+new AmplifyGraphqlApi(stack, 'GraphqlApi', {
+  apiName: 'MyGraphQLApi',
+  definition: AmplifyGraphqlDefinition.fromString(
+    /* GraphQL */ `
+      type Todo @model @auth(rules: [{ allow: public }]) {
+        id: ID!
+        description: String!
+        name: Int! @index(name: "byName") @index(name: "byNameDescription", sortKeyFields: ["description"])
+      }
+    `,
+    {
+      dbType: 'DYNAMODB',
+      provisionStrategy: 'AMPLIFY_TABLE',
+    },
+  ),
+  authorizationModes: {
+    apiKeyConfig: { expires: Duration.days(7) },
+  },
+});

--- a/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-table-manager-lambda/amplify-table-manager-handler.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-table-manager-lambda/amplify-table-manager-handler.ts
@@ -1147,9 +1147,9 @@ const getIndexesContainingAttributes = (
 ): string[] => {
   if (!currentSchema) return [];
   const result = currentSchema
-  .filter((index) => index.IndexStatus === 'ACTIVE') // This is important. You do not want to update a GSI that is not active.
-  .filter((index) => index.KeySchema?.some((key) => attributes.includes(key.AttributeName!)))
-  .map((index) => index.IndexName!);
+    .filter((index) => index.IndexStatus === 'ACTIVE') // This is important. You do not want to update a GSI that is not active.
+    .filter((index) => index.KeySchema?.some((key) => attributes.includes(key.AttributeName!)))
+    .map((index) => index.IndexName!);
   return result ?? [];
 };
 

--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -226,9 +226,6 @@ export const getConnectionName: (modelName: string) => string;
 // @public (undocumented)
 export const getDefaultStrategyNameForDbType: (dbType: ModelDataSourceStrategySqlDbType) => string;
 
-// @public (undocumented)
-export const getField: (obj: ObjectTypeDefinitionNode, fieldName: string) => FieldDefinitionNode | undefined;
-
 // Warning: (ae-forgotten-export) The symbol "Operation" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -259,9 +256,6 @@ export const getNonScalarFields: (object: ObjectTypeDefinitionNode | undefined, 
 export const getParameterStoreSecretPath: (secret: string, secretsKey: string, apiName: string, environmentName: string, appId: string) => string;
 
 // @public (undocumented)
-export const getPrimaryKeyFieldNodes: (type: ObjectTypeDefinitionNode) => FieldDefinitionNode[];
-
-// @public (undocumented)
 export const getPrimaryKeyFields: (type: ObjectTypeDefinitionNode) => string[];
 
 // @public (undocumented)
@@ -290,9 +284,6 @@ function getSyncConfig(ctx: TransformerTransformSchemaStepContextProvider, typeN
 
 // @public (undocumented)
 export const getTable: (ctx: TransformerContextProvider, object: ObjectTypeDefinitionNode) => any;
-
-// @public (undocumented)
-export const getType: (schema: DocumentNode_2, typeName: string) => ObjectTypeDefinitionNode | undefined;
 
 // @public (undocumented)
 export class GraphQLTransform {

--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -226,6 +226,9 @@ export const getConnectionName: (modelName: string) => string;
 // @public (undocumented)
 export const getDefaultStrategyNameForDbType: (dbType: ModelDataSourceStrategySqlDbType) => string;
 
+// @public (undocumented)
+export const getField: (obj: ObjectTypeDefinitionNode, fieldName: string) => FieldDefinitionNode | undefined;
+
 // Warning: (ae-forgotten-export) The symbol "Operation" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -256,6 +259,9 @@ export const getNonScalarFields: (object: ObjectTypeDefinitionNode | undefined, 
 export const getParameterStoreSecretPath: (secret: string, secretsKey: string, apiName: string, environmentName: string, appId: string) => string;
 
 // @public (undocumented)
+export const getPrimaryKeyFieldNodes: (type: ObjectTypeDefinitionNode) => FieldDefinitionNode[];
+
+// @public (undocumented)
 export const getPrimaryKeyFields: (type: ObjectTypeDefinitionNode) => string[];
 
 // @public (undocumented)
@@ -284,6 +290,9 @@ function getSyncConfig(ctx: TransformerTransformSchemaStepContextProvider, typeN
 
 // @public (undocumented)
 export const getTable: (ctx: TransformerContextProvider, object: ObjectTypeDefinitionNode) => any;
+
+// @public (undocumented)
+export const getType: (schema: DocumentNode_2, typeName: string) => ObjectTypeDefinitionNode | undefined;
 
 // @public (undocumented)
 export class GraphQLTransform {


### PR DESCRIPTION
#### Description of changes

Fix the bug: Attribute type changes are not reflected in amplify managed tables.

To resolve this, we will delete all the indexes referencing the attribute with type changes and recreate them.

##### CDK / CloudFormation Parameters Changed
NA
<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Manual test
- New E2E test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
