### PR TITLE
test: restrict auth and unauth role conditions on e2e

### DIFF
--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
@@ -304,6 +304,9 @@ beforeAll(async () => {
             },
             Action: 'sts:AssumeRoleWithWebIdentity',
             Condition: {
+              'StringEquals': {
+                'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
+              },
               'ForAnyValue:StringLike': {
                 'cognito-identity.amazonaws.com:amr': 'authenticated',
               },
@@ -326,6 +329,9 @@ beforeAll(async () => {
             },
             Action: 'sts:AssumeRoleWithWebIdentity',
             Condition: {
+              'StringEquals': {
+                'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
+              },
               'ForAnyValue:StringLike': {
                 'cognito-identity.amazonaws.com:amr': 'unauthenticated',
               },

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MultiAuthModelAuthTransformer.e2e.test.ts
@@ -304,7 +304,7 @@ beforeAll(async () => {
             },
             Action: 'sts:AssumeRoleWithWebIdentity',
             Condition: {
-              'StringEquals': {
+              StringEquals: {
                 'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
               },
               'ForAnyValue:StringLike': {
@@ -329,7 +329,7 @@ beforeAll(async () => {
             },
             Action: 'sts:AssumeRoleWithWebIdentity',
             Condition: {
-              'StringEquals': {
+              StringEquals: {
                 'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
               },
               'ForAnyValue:StringLike': {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MutationCondition.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MutationCondition.e2e.test.ts
@@ -671,7 +671,7 @@ describe(`Deployed Mutation Condition tests`, () => {
               },
               Action: 'sts:AssumeRoleWithWebIdentity',
               Condition: {
-                'StringEquals': {
+                StringEquals: {
                   'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
                 },
                 'ForAnyValue:StringLike': {
@@ -696,7 +696,7 @@ describe(`Deployed Mutation Condition tests`, () => {
               },
               Action: 'sts:AssumeRoleWithWebIdentity',
               Condition: {
-                'StringEquals': {
+                StringEquals: {
                   'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
                 },
                 'ForAnyValue:StringLike': {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/MutationCondition.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/MutationCondition.e2e.test.ts
@@ -671,6 +671,9 @@ describe(`Deployed Mutation Condition tests`, () => {
               },
               Action: 'sts:AssumeRoleWithWebIdentity',
               Condition: {
+                'StringEquals': {
+                  'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
+                },
                 'ForAnyValue:StringLike': {
                   'cognito-identity.amazonaws.com:amr': 'authenticated',
                 },
@@ -693,6 +696,9 @@ describe(`Deployed Mutation Condition tests`, () => {
               },
               Action: 'sts:AssumeRoleWithWebIdentity',
               Condition: {
+                'StringEquals': {
+                  'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
+                },
                 'ForAnyValue:StringLike': {
                   'cognito-identity.amazonaws.com:amr': 'unauthenticated',
                 },

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/NonModelAuthFunction.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/NonModelAuthFunction.e2e.test.ts
@@ -151,7 +151,7 @@ beforeAll(async () => {
           },
           Action: 'sts:AssumeRoleWithWebIdentity',
           Condition: {
-            'StringEquals': {
+            StringEquals: {
               'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
             },
             'ForAnyValue:StringLike': {
@@ -176,7 +176,7 @@ beforeAll(async () => {
           },
           Action: 'sts:AssumeRoleWithWebIdentity',
           Condition: {
-            'StringEquals': {
+            StringEquals: {
               'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
             },
             'ForAnyValue:StringLike': {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/NonModelAuthFunction.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/NonModelAuthFunction.e2e.test.ts
@@ -151,6 +151,9 @@ beforeAll(async () => {
           },
           Action: 'sts:AssumeRoleWithWebIdentity',
           Condition: {
+            'StringEquals': {
+              'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
+            },
             'ForAnyValue:StringLike': {
               'cognito-identity.amazonaws.com:amr': 'authenticated',
             },
@@ -173,6 +176,9 @@ beforeAll(async () => {
           },
           Action: 'sts:AssumeRoleWithWebIdentity',
           Condition: {
+            'StringEquals': {
+              'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
+            },
             'ForAnyValue:StringLike': {
               'cognito-identity.amazonaws.com:amr': 'unauthenticated',
             },

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts
@@ -297,6 +297,9 @@ beforeAll(async () => {
             },
             Action: 'sts:AssumeRoleWithWebIdentity',
             Condition: {
+              'StringEquals': {
+                'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
+              },
               'ForAnyValue:StringLike': {
                 'cognito-identity.amazonaws.com:amr': 'authenticated',
               },
@@ -319,6 +322,9 @@ beforeAll(async () => {
             },
             Action: 'sts:AssumeRoleWithWebIdentity',
             Condition: {
+              'StringEquals': {
+                'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
+              },
               'ForAnyValue:StringLike': {
                 'cognito-identity.amazonaws.com:amr': 'unauthenticated',
               },

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SubscriptionsWithAuthTest.e2e.test.ts
@@ -297,7 +297,7 @@ beforeAll(async () => {
             },
             Action: 'sts:AssumeRoleWithWebIdentity',
             Condition: {
-              'StringEquals': {
+              StringEquals: {
                 'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
               },
               'ForAnyValue:StringLike': {
@@ -322,7 +322,7 @@ beforeAll(async () => {
             },
             Action: 'sts:AssumeRoleWithWebIdentity',
             Condition: {
-              'StringEquals': {
+              StringEquals: {
                 'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
               },
               'ForAnyValue:StringLike': {


### PR DESCRIPTION
Add the below condition to the auth and unauth roles created by E2E tests. This restricts the role to be assumed only by the users authenticated by the identity pool which was created as part of the same test project.

```
'StringEquals': {
   'cognito-identity.amazonaws.com:aud': { Ref: 'IdentityPool' },
}
```