### PR TITLE
chore: update config to avoid errors during Git operations on CI

### DIFF
--- a/codebuild_specs/publish_to_local_registry.yml
+++ b/codebuild_specs/publish_to_local_registry.yml
@@ -1,6 +1,8 @@
 version: 0.2
 env:
   shell: bash
+  variables:
+    CI: true
 phases:
   build:
     commands:

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -149,9 +149,14 @@ function _publishToLocalRegistry {
     # Store current git config settings
     httpVersion=$(git config --get http.version)
     postBufferSize=$(git config --get http.postBuffer)
+    echo "httpVersion: $httpVersion"
+    echo "postBufferSize: $postBufferSize"
     git config http.version HTTP/1.1
+    echo "set http version to 1"
+
     # Increase buffer size to avoid error when git operations return large response
     git config http.postBuffer 157286400
+    echo "set buffer size to 150MB"
 
     git checkout $BRANCH_NAME
   
@@ -161,7 +166,7 @@ function _publishToLocalRegistry {
     echo "fetching tags"
     git fetch --tags https://github.com/aws-amplify/amplify-category-api
     # Create the folder to avoid failure when no packages are published due to no change detected
-    mkdir ../verdaccio-cache
+    rm -rf ../verdaccio-cache && mkdir ../verdaccio-cache
 
     source codebuild_specs/scripts/local_publish_helpers.sh
     startLocalRegistry "$(pwd)/codebuild_specs/scripts/verdaccio.yaml"

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -146,9 +146,13 @@ function _publishToLocalRegistry {
     fi
     echo $BRANCH_NAME
 
+    # Store current git config settings
+    httpVersion=$(git config --get http.version)
+    postBufferSize=$(git config --get http.postBuffer)
     git config http.version HTTP/1.1
     # Increase buffer size to avoid error when git operations return large response
     git config http.postBuffer 157286400
+
     git checkout $BRANCH_NAME
   
     # Fetching git tags from upstream
@@ -171,6 +175,17 @@ function _publishToLocalRegistry {
       yarn lerna publish --exact --dist-tag=latest --preid=$NPM_TAG --conventional-commits --conventional-prerelease --no-verify-access --yes --no-commit-hooks --no-push --no-git-tag-version
     fi
     unsetNpmRegistryUrl
+    # Restore git config settings
+    if [ -z "$httpVersion" ]; then
+      git config --unset http.version
+    else
+      git config http.version $httpVersion
+    fi
+    if [ -z "$postBufferSize" ]; then
+      git config --unset http.postBuffer
+    else
+      git config http.postBuffer $postBufferSize
+    fi
     # copy [verdaccio-cache] to s3
     storeCache $CODEBUILD_SRC_DIR/../verdaccio-cache verdaccio-cache
 

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -145,6 +145,10 @@ function _publishToLocalRegistry {
       fi
     fi
     echo $BRANCH_NAME
+
+    git config http.version HTTP/1.1
+    # Increase buffer size to avoid error when git operations return large response
+    git config http.postBuffer 157286400
     git checkout $BRANCH_NAME
   
     # Fetching git tags from upstream


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

We've seen the below error during Git operations like fetching tags on CI:
```
error: RPC failed; curl 92 HTTP/2 stream 0 was not closed cleanly: CANCEL (err 8)
```
There is a [community recommended workaround](https://gist.github.com/daopk/0a95772d582cafb202142ff7871da2fc) by changing the Http version and increasing the max buffer size to receive larger response payloads.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
