### PR TITLE
feat: allow subscriptions to inherit primary model auth rules for relational fields behind a feature flag

### DIFF
--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -2048,44 +2048,46 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        AuthV2ExhaustiveT2B_AuthV2ExhaustiveT2D_AuthV2ExhaustiveT2C_AuthV2TransformerIAM
+        AuthV2ExhaustiveT2B_AuthV2ExhaustiveT2D_AuthV2ExhaustiveT2C_RelationalWithAuthV2Redacted
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/AuthV2ExhaustiveT2B.test.ts|src/__tests__/AuthV2ExhaustiveT2D.test.ts|src/__tests__/AuthV2ExhaustiveT2C.test.ts|src/__tests__/AuthV2TransformerIAM.test.ts
+            src/__tests__/AuthV2ExhaustiveT2B.test.ts|src/__tests__/AuthV2ExhaustiveT2D.test.ts|src/__tests__/AuthV2ExhaustiveT2C.test.ts|src/__tests__/RelationalWithAuthV2Redacted.e2e.test.ts
           CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        AuthV2ExhaustiveT3D_AuthV2ExhaustiveT3C_AuthV2ExhaustiveT3B_AuthV2ExhaustiveT3A
+        RelationalWithAuthV2NonRedacted_AuthV2TransformerIAM_AuthV2ExhaustiveT3D_AuthV2ExhaustiveT3C
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/AuthV2ExhaustiveT3D.test.ts|src/__tests__/AuthV2ExhaustiveT3C.test.ts|src/__tests__/AuthV2ExhaustiveT3B.test.ts|src/__tests__/AuthV2ExhaustiveT3A.test.ts
+            src/__tests__/RelationalWithAuthV2NonRedacted.e2e.test.ts|src/__tests__/AuthV2TransformerIAM.test.ts|src/__tests__/AuthV2ExhaustiveT3D.test.ts|src/__tests__/AuthV2ExhaustiveT3C.test.ts
           CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        SearchableModelTransformerV2_SearchableWithAuthTests_SearchableModelTransformer_SearchableWithAuthV2WithFF
+        AuthV2ExhaustiveT3B_AuthV2ExhaustiveT3A_SearchableModelTransformerV2_SearchableWithAuthTests
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
-            src/__tests__/SearchableModelTransformerV2.e2e.test.ts|src/__tests__/SearchableWithAuthTests.e2e.test.ts|src/__tests__/SearchableModelTransformer.e2e.test.ts|src/__tests__/SearchableWithAuthV2WithFF.e2e.test.ts
+            src/__tests__/AuthV2ExhaustiveT3B.test.ts|src/__tests__/AuthV2ExhaustiveT3A.test.ts|src/__tests__/SearchableModelTransformerV2.e2e.test.ts|src/__tests__/SearchableWithAuthTests.e2e.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: SearchableWithAuthV2
+    - identifier: >-
+        SearchableModelTransformer_SearchableWithAuthV2WithFF_SearchableWithAuthV2
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
-          TEST_SUITE: src/__tests__/SearchableWithAuthV2.e2e.test.ts
+          TEST_SUITE: >-
+            src/__tests__/SearchableModelTransformer.e2e.test.ts|src/__tests__/SearchableWithAuthV2WithFF.e2e.test.ts|src/__tests__/SearchableWithAuthV2.e2e.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry

--- a/packages/amplify-category-api/src/graphql-transformer/transformer-options-v2.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transformer-options-v2.ts
@@ -278,6 +278,7 @@ const generateTransformParameters = (
     secondaryKeyAsGSI: featureFlagProvider.getBoolean('secondaryKeyAsGSI'),
     enableAutoIndexQueryNames: featureFlagProvider.getBoolean('enableAutoIndexQueryNames'),
     respectPrimaryKeyAttributesOnConnectionField: featureFlagProvider.getBoolean('respectPrimaryKeyAttributesOnConnectionField'),
+    subscriptionsInheritPrimaryAuth: featureFlagProvider.getBoolean('subscriptionsInheritPrimaryAuth'),
     suppressApiKeyGeneration: suppressApiKeyGeneration(parameters),
     disableResolverDeduping: projectConfig.DisableResolverDeduping ?? false,
     enableSearchNodeToNodeEncryption: shouldEnableNodeToNodeEncryption(

--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -3537,7 +3537,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 860
+        "line": 858
       },
       "name": "AddFunctionProps",
       "properties": [
@@ -3550,7 +3550,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 864
+            "line": 862
           },
           "name": "dataSource",
           "type": {
@@ -3566,7 +3566,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 869
+            "line": 867
           },
           "name": "name",
           "type": {
@@ -3583,7 +3583,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 904
+            "line": 902
           },
           "name": "code",
           "optional": true,
@@ -3601,7 +3601,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 876
+            "line": 874
           },
           "name": "description",
           "optional": true,
@@ -3619,7 +3619,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 883
+            "line": 881
           },
           "name": "requestMappingTemplate",
           "optional": true,
@@ -3637,7 +3637,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 890
+            "line": 888
           },
           "name": "responseMappingTemplate",
           "optional": true,
@@ -3655,7 +3655,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 897
+            "line": 895
           },
           "name": "runtime",
           "optional": true,
@@ -4585,7 +4585,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 763
+        "line": 761
       },
       "name": "AmplifyGraphqlApiCfnResources",
       "properties": [
@@ -4598,7 +4598,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 817
+            "line": 815
           },
           "name": "additionalCfnResources",
           "type": {
@@ -4619,7 +4619,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 802
+            "line": 800
           },
           "name": "amplifyDynamoDbTables",
           "type": {
@@ -4640,7 +4640,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 792
+            "line": 790
           },
           "name": "cfnDataSources",
           "type": {
@@ -4661,7 +4661,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 787
+            "line": 785
           },
           "name": "cfnFunctionConfigurations",
           "type": {
@@ -4682,7 +4682,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 812
+            "line": 810
           },
           "name": "cfnFunctions",
           "type": {
@@ -4703,7 +4703,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 767
+            "line": 765
           },
           "name": "cfnGraphqlApi",
           "type": {
@@ -4719,7 +4719,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 772
+            "line": 770
           },
           "name": "cfnGraphqlSchema",
           "type": {
@@ -4735,7 +4735,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 782
+            "line": 780
           },
           "name": "cfnResolvers",
           "type": {
@@ -4756,7 +4756,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 807
+            "line": 805
           },
           "name": "cfnRoles",
           "type": {
@@ -4777,7 +4777,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 797
+            "line": 795
           },
           "name": "cfnTables",
           "type": {
@@ -4798,7 +4798,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 777
+            "line": 775
           },
           "name": "cfnApiKey",
           "optional": true,
@@ -4821,7 +4821,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 680
+        "line": 678
       },
       "name": "AmplifyGraphqlApiProps",
       "properties": [
@@ -4835,7 +4835,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 697
+            "line": 695
           },
           "name": "authorizationModes",
           "type": {
@@ -4852,7 +4852,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 685
+            "line": 683
           },
           "name": "definition",
           "type": {
@@ -4869,7 +4869,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 691
+            "line": 689
           },
           "name": "apiName",
           "optional": true,
@@ -4888,7 +4888,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 712
+            "line": 710
           },
           "name": "conflictResolution",
           "optional": true,
@@ -4906,7 +4906,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 756
+            "line": 754
           },
           "name": "dataStoreConfiguration",
           "optional": true,
@@ -4926,7 +4926,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 705
+            "line": 703
           },
           "name": "functionNameMap",
           "optional": true,
@@ -4949,7 +4949,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 727
+            "line": 725
           },
           "name": "functionSlots",
           "optional": true,
@@ -4984,7 +4984,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 750
+            "line": 748
           },
           "name": "outputStorageStrategy",
           "optional": true,
@@ -5001,7 +5001,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 739
+            "line": 737
           },
           "name": "predictionsBucket",
           "optional": true,
@@ -5019,7 +5019,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 721
+            "line": 719
           },
           "name": "stackMappings",
           "optional": true,
@@ -5045,7 +5045,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 734
+            "line": 732
           },
           "name": "transformerPlugins",
           "optional": true,
@@ -5067,7 +5067,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 745
+            "line": 743
           },
           "name": "translationBehavior",
           "optional": true,
@@ -5090,7 +5090,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 824
+        "line": 822
       },
       "name": "AmplifyGraphqlApiResources",
       "properties": [
@@ -5103,7 +5103,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 848
+            "line": 846
           },
           "name": "cfnResources",
           "type": {
@@ -5119,7 +5119,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 843
+            "line": 841
           },
           "name": "functions",
           "type": {
@@ -5140,7 +5140,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 828
+            "line": 826
           },
           "name": "graphqlApi",
           "type": {
@@ -5156,7 +5156,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 853
+            "line": 851
           },
           "name": "nestedStacks",
           "type": {
@@ -5177,7 +5177,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 838
+            "line": 836
           },
           "name": "roles",
           "type": {
@@ -5198,7 +5198,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 833
+            "line": 831
           },
           "name": "tables",
           "type": {
@@ -6237,7 +6237,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 614
+        "line": 612
       },
       "name": "IAmplifyGraphqlDefinition",
       "properties": [
@@ -6252,7 +6252,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 639
+            "line": 637
           },
           "name": "dataSourceStrategies",
           "type": {
@@ -6286,7 +6286,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 625
+            "line": 623
           },
           "name": "functionSlots",
           "type": {
@@ -6320,7 +6320,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 619
+            "line": 617
           },
           "name": "schema",
           "type": {
@@ -6337,7 +6337,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 645
+            "line": 643
           },
           "name": "customSqlDataSourceStrategies",
           "optional": true,
@@ -6361,7 +6361,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 633
+            "line": 631
           },
           "name": "referencedLambdaFunctions",
           "optional": true,
@@ -6387,7 +6387,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 651
+        "line": 649
       },
       "name": "IBackendOutputEntry",
       "properties": [
@@ -6400,7 +6400,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 660
+            "line": 658
           },
           "name": "payload",
           "type": {
@@ -6421,7 +6421,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 655
+            "line": 653
           },
           "name": "version",
           "type": {
@@ -6441,7 +6441,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 666
+        "line": 664
       },
       "methods": [
         {
@@ -6452,7 +6452,7 @@
           },
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 673
+            "line": 671
           },
           "name": "addBackendOutputEntry",
           "parameters": [
@@ -6802,7 +6802,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 505
+        "line": 504
       },
       "name": "PartialTranslationBehavior",
       "properties": [
@@ -6817,7 +6817,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 598
+            "line": 596
           },
           "name": "allowDestructiveGraphqlSchemaUpdates",
           "optional": true,
@@ -6835,7 +6835,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 517
+            "line": 516
           },
           "name": "disableResolverDeduping",
           "optional": true,
@@ -6857,7 +6857,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 563
+            "line": 561
           },
           "name": "enableAutoIndexQueryNames",
           "optional": true,
@@ -6876,7 +6876,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 578
+            "line": 576
           },
           "name": "enableSearchNodeToNodeEncryption",
           "optional": true,
@@ -6894,7 +6894,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 584
+            "line": 582
           },
           "name": "enableTransformerCfnOutputs",
           "optional": true,
@@ -6912,7 +6912,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 543
+            "line": 541
           },
           "name": "populateOwnerFieldForStaticGroupAuth",
           "optional": true,
@@ -6931,7 +6931,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 608
+            "line": 606
           },
           "name": "replaceTableUponGsiUpdate",
           "optional": true,
@@ -6949,7 +6949,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 569
+            "line": 567
           },
           "name": "respectPrimaryKeyAttributesOnConnectionField",
           "optional": true,
@@ -6967,7 +6967,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 523
+            "line": 522
           },
           "name": "sandboxModeEnabled",
           "optional": true,
@@ -6988,7 +6988,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 556
+            "line": 554
           },
           "name": "secondaryKeyAsGSI",
           "optional": true,
@@ -7009,7 +7009,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 510
+            "line": 509
           },
           "name": "shouldDeepMergeDirectiveConfigDefaults",
           "optional": true,
@@ -7022,12 +7022,12 @@
           "docs": {
             "default": "false",
             "stability": "stable",
-            "summary": "When disabled, relational fields on the mutation response are over-redacted to protect the data from subscribed users to correctly apply the auth rules."
+            "summary": "When enabled, suppresses default behavior of redacting relational fields when auth rules do not exactly match."
           },
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 537
+            "line": 535
           },
           "name": "subscriptionsInheritPrimaryAuth",
           "optional": true,
@@ -7046,7 +7046,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 550
+            "line": 548
           },
           "name": "suppressApiKeyGeneration",
           "optional": true,
@@ -7064,7 +7064,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 530
+            "line": 529
           },
           "name": "useSubUsernameForDefaultIdentityClaim",
           "optional": true,
@@ -7979,7 +7979,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 489
+            "line": 488
           },
           "name": "allowDestructiveGraphqlSchemaUpdates",
           "type": {
@@ -8017,7 +8017,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 461
+            "line": 460
           },
           "name": "enableAutoIndexQueryNames",
           "type": {
@@ -8032,7 +8032,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 469
+            "line": 468
           },
           "name": "enableSearchNodeToNodeEncryption",
           "type": {
@@ -8049,7 +8049,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 475
+            "line": 474
           },
           "name": "enableTransformerCfnOutputs",
           "type": {
@@ -8066,7 +8066,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 441
+            "line": 440
           },
           "name": "populateOwnerFieldForStaticGroupAuth",
           "type": {
@@ -8084,7 +8084,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 499
+            "line": 498
           },
           "name": "replaceTableUponGsiUpdate",
           "type": {
@@ -8101,7 +8101,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 467
+            "line": 466
           },
           "name": "respectPrimaryKeyAttributesOnConnectionField",
           "type": {
@@ -8138,7 +8138,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 454
+            "line": 453
           },
           "name": "secondaryKeyAsGSI",
           "type": {
@@ -8170,12 +8170,12 @@
           "docs": {
             "default": "false",
             "stability": "stable",
-            "summary": "When disabled, relational fields on the mutation response are over-redacted to protect the data from subscribed users to correctly apply the auth rules."
+            "summary": "When enabled, suppresses default behavior of redacting relational fields when auth rules do not exactly match."
           },
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 435
+            "line": 434
           },
           "name": "subscriptionsInheritPrimaryAuth",
           "type": {
@@ -8193,7 +8193,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 448
+            "line": 447
           },
           "name": "suppressApiKeyGeneration",
           "type": {
@@ -8333,5 +8333,5 @@
     }
   },
   "version": "1.9.5",
-  "fingerprint": "04E9V1ISyxIheTj9oC/CrBtHvlbXSiGblIeL0L6KxH8="
+  "fingerprint": "y0dwfB9gd7pkQemctlr+PPXVPITFIxROsAhrFgNqjdY="
 }

--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -3537,7 +3537,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 846
+        "line": 860
       },
       "name": "AddFunctionProps",
       "properties": [
@@ -3550,7 +3550,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 850
+            "line": 864
           },
           "name": "dataSource",
           "type": {
@@ -3566,7 +3566,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 855
+            "line": 869
           },
           "name": "name",
           "type": {
@@ -3583,7 +3583,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 890
+            "line": 904
           },
           "name": "code",
           "optional": true,
@@ -3601,7 +3601,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 862
+            "line": 876
           },
           "name": "description",
           "optional": true,
@@ -3619,7 +3619,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 869
+            "line": 883
           },
           "name": "requestMappingTemplate",
           "optional": true,
@@ -3637,7 +3637,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 876
+            "line": 890
           },
           "name": "responseMappingTemplate",
           "optional": true,
@@ -3655,7 +3655,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 883
+            "line": 897
           },
           "name": "runtime",
           "optional": true,
@@ -4585,7 +4585,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 749
+        "line": 763
       },
       "name": "AmplifyGraphqlApiCfnResources",
       "properties": [
@@ -4598,7 +4598,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 803
+            "line": 817
           },
           "name": "additionalCfnResources",
           "type": {
@@ -4619,7 +4619,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 788
+            "line": 802
           },
           "name": "amplifyDynamoDbTables",
           "type": {
@@ -4640,7 +4640,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 778
+            "line": 792
           },
           "name": "cfnDataSources",
           "type": {
@@ -4661,7 +4661,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 773
+            "line": 787
           },
           "name": "cfnFunctionConfigurations",
           "type": {
@@ -4682,7 +4682,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 798
+            "line": 812
           },
           "name": "cfnFunctions",
           "type": {
@@ -4703,7 +4703,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 753
+            "line": 767
           },
           "name": "cfnGraphqlApi",
           "type": {
@@ -4719,7 +4719,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 758
+            "line": 772
           },
           "name": "cfnGraphqlSchema",
           "type": {
@@ -4735,7 +4735,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 768
+            "line": 782
           },
           "name": "cfnResolvers",
           "type": {
@@ -4756,7 +4756,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 793
+            "line": 807
           },
           "name": "cfnRoles",
           "type": {
@@ -4777,7 +4777,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 783
+            "line": 797
           },
           "name": "cfnTables",
           "type": {
@@ -4798,7 +4798,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 763
+            "line": 777
           },
           "name": "cfnApiKey",
           "optional": true,
@@ -4821,7 +4821,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 666
+        "line": 680
       },
       "name": "AmplifyGraphqlApiProps",
       "properties": [
@@ -4835,7 +4835,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 683
+            "line": 697
           },
           "name": "authorizationModes",
           "type": {
@@ -4852,7 +4852,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 671
+            "line": 685
           },
           "name": "definition",
           "type": {
@@ -4869,7 +4869,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 677
+            "line": 691
           },
           "name": "apiName",
           "optional": true,
@@ -4888,7 +4888,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 698
+            "line": 712
           },
           "name": "conflictResolution",
           "optional": true,
@@ -4906,7 +4906,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 742
+            "line": 756
           },
           "name": "dataStoreConfiguration",
           "optional": true,
@@ -4926,7 +4926,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 691
+            "line": 705
           },
           "name": "functionNameMap",
           "optional": true,
@@ -4949,7 +4949,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 713
+            "line": 727
           },
           "name": "functionSlots",
           "optional": true,
@@ -4984,7 +4984,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 736
+            "line": 750
           },
           "name": "outputStorageStrategy",
           "optional": true,
@@ -5001,7 +5001,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 725
+            "line": 739
           },
           "name": "predictionsBucket",
           "optional": true,
@@ -5019,7 +5019,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 707
+            "line": 721
           },
           "name": "stackMappings",
           "optional": true,
@@ -5045,7 +5045,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 720
+            "line": 734
           },
           "name": "transformerPlugins",
           "optional": true,
@@ -5067,7 +5067,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 731
+            "line": 745
           },
           "name": "translationBehavior",
           "optional": true,
@@ -5090,7 +5090,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 810
+        "line": 824
       },
       "name": "AmplifyGraphqlApiResources",
       "properties": [
@@ -5103,7 +5103,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 834
+            "line": 848
           },
           "name": "cfnResources",
           "type": {
@@ -5119,7 +5119,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 829
+            "line": 843
           },
           "name": "functions",
           "type": {
@@ -5140,7 +5140,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 814
+            "line": 828
           },
           "name": "graphqlApi",
           "type": {
@@ -5156,7 +5156,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 839
+            "line": 853
           },
           "name": "nestedStacks",
           "type": {
@@ -5177,7 +5177,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 824
+            "line": 838
           },
           "name": "roles",
           "type": {
@@ -5198,7 +5198,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 819
+            "line": 833
           },
           "name": "tables",
           "type": {
@@ -6237,7 +6237,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 600
+        "line": 614
       },
       "name": "IAmplifyGraphqlDefinition",
       "properties": [
@@ -6252,7 +6252,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 625
+            "line": 639
           },
           "name": "dataSourceStrategies",
           "type": {
@@ -6286,7 +6286,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 611
+            "line": 625
           },
           "name": "functionSlots",
           "type": {
@@ -6320,7 +6320,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 605
+            "line": 619
           },
           "name": "schema",
           "type": {
@@ -6337,7 +6337,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 631
+            "line": 645
           },
           "name": "customSqlDataSourceStrategies",
           "optional": true,
@@ -6361,7 +6361,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 619
+            "line": 633
           },
           "name": "referencedLambdaFunctions",
           "optional": true,
@@ -6387,7 +6387,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 637
+        "line": 651
       },
       "name": "IBackendOutputEntry",
       "properties": [
@@ -6400,7 +6400,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 646
+            "line": 660
           },
           "name": "payload",
           "type": {
@@ -6421,7 +6421,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 641
+            "line": 655
           },
           "name": "version",
           "type": {
@@ -6441,7 +6441,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 652
+        "line": 666
       },
       "methods": [
         {
@@ -6452,7 +6452,7 @@
           },
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 659
+            "line": 673
           },
           "name": "addBackendOutputEntry",
           "parameters": [
@@ -6802,7 +6802,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 498
+        "line": 505
       },
       "name": "PartialTranslationBehavior",
       "properties": [
@@ -6817,7 +6817,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 584
+            "line": 598
           },
           "name": "allowDestructiveGraphqlSchemaUpdates",
           "optional": true,
@@ -6835,7 +6835,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 510
+            "line": 517
           },
           "name": "disableResolverDeduping",
           "optional": true,
@@ -6857,7 +6857,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 549
+            "line": 563
           },
           "name": "enableAutoIndexQueryNames",
           "optional": true,
@@ -6876,7 +6876,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 564
+            "line": 578
           },
           "name": "enableSearchNodeToNodeEncryption",
           "optional": true,
@@ -6894,7 +6894,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 570
+            "line": 584
           },
           "name": "enableTransformerCfnOutputs",
           "optional": true,
@@ -6912,7 +6912,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 529
+            "line": 543
           },
           "name": "populateOwnerFieldForStaticGroupAuth",
           "optional": true,
@@ -6931,7 +6931,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 594
+            "line": 608
           },
           "name": "replaceTableUponGsiUpdate",
           "optional": true,
@@ -6949,7 +6949,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 555
+            "line": 569
           },
           "name": "respectPrimaryKeyAttributesOnConnectionField",
           "optional": true,
@@ -6967,7 +6967,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 516
+            "line": 523
           },
           "name": "sandboxModeEnabled",
           "optional": true,
@@ -6988,7 +6988,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 542
+            "line": 556
           },
           "name": "secondaryKeyAsGSI",
           "optional": true,
@@ -7009,9 +7009,27 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 503
+            "line": 510
           },
           "name": "shouldDeepMergeDirectiveConfigDefaults",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "false",
+            "stability": "stable",
+            "summary": "When disabled, relational fields on the mutation response are over-redacted to protect the data from subscribed users to correctly apply the auth rules."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/types.ts",
+            "line": 537
+          },
+          "name": "subscriptionsInheritPrimaryAuth",
           "optional": true,
           "type": {
             "primitive": "boolean"
@@ -7028,7 +7046,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 536
+            "line": 550
           },
           "name": "suppressApiKeyGeneration",
           "optional": true,
@@ -7046,7 +7064,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 523
+            "line": 530
           },
           "name": "useSubUsernameForDefaultIdentityClaim",
           "optional": true,
@@ -7961,7 +7979,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 482
+            "line": 489
           },
           "name": "allowDestructiveGraphqlSchemaUpdates",
           "type": {
@@ -7999,7 +8017,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 454
+            "line": 461
           },
           "name": "enableAutoIndexQueryNames",
           "type": {
@@ -8014,7 +8032,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 462
+            "line": 469
           },
           "name": "enableSearchNodeToNodeEncryption",
           "type": {
@@ -8031,7 +8049,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 468
+            "line": 475
           },
           "name": "enableTransformerCfnOutputs",
           "type": {
@@ -8048,7 +8066,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 434
+            "line": 441
           },
           "name": "populateOwnerFieldForStaticGroupAuth",
           "type": {
@@ -8066,7 +8084,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 492
+            "line": 499
           },
           "name": "replaceTableUponGsiUpdate",
           "type": {
@@ -8083,7 +8101,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 460
+            "line": 467
           },
           "name": "respectPrimaryKeyAttributesOnConnectionField",
           "type": {
@@ -8120,7 +8138,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 447
+            "line": 454
           },
           "name": "secondaryKeyAsGSI",
           "type": {
@@ -8151,6 +8169,23 @@
           "abstract": true,
           "docs": {
             "default": "false",
+            "stability": "stable",
+            "summary": "When disabled, relational fields on the mutation response are over-redacted to protect the data from subscribed users to correctly apply the auth rules."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/types.ts",
+            "line": 435
+          },
+          "name": "subscriptionsInheritPrimaryAuth",
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "false",
             "remarks": "This is a legacy parameter from the Graphql Transformer existing in Amplify CLI, not recommended to change.",
             "stability": "stable",
             "summary": "If enabled, disable api key resource generation even if specified as an auth rule on the construct."
@@ -8158,7 +8193,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 441
+            "line": 448
           },
           "name": "suppressApiKeyGeneration",
           "type": {
@@ -8298,5 +8333,5 @@
     }
   },
   "version": "1.9.5",
-  "fingerprint": "A+wg2E7QPlrj0D3/I/rihpPRMljMJmmHauIKzg4HJ1w="
+  "fingerprint": "04E9V1ISyxIheTj9oC/CrBtHvlbXSiGblIeL0L6KxH8="
 }

--- a/packages/amplify-graphql-api-construct/API.md
+++ b/packages/amplify-graphql-api-construct/API.md
@@ -324,6 +324,7 @@ export interface PartialTranslationBehavior {
     readonly sandboxModeEnabled?: boolean;
     readonly secondaryKeyAsGSI?: boolean;
     readonly shouldDeepMergeDirectiveConfigDefaults?: boolean;
+    readonly subscriptionsInheritPrimaryAuth?: boolean;
     readonly suppressApiKeyGeneration?: boolean;
     readonly useSubUsernameForDefaultIdentityClaim?: boolean;
 }
@@ -436,6 +437,7 @@ export interface TranslationBehavior {
     readonly sandboxModeEnabled: boolean;
     readonly secondaryKeyAsGSI: boolean;
     readonly shouldDeepMergeDirectiveConfigDefaults: boolean;
+    readonly subscriptionsInheritPrimaryAuth: boolean;
     readonly suppressApiKeyGeneration: boolean;
     readonly useSubUsernameForDefaultIdentityClaim: boolean;
 }

--- a/packages/amplify-graphql-api-construct/src/internal/default-parameters.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/default-parameters.ts
@@ -10,6 +10,7 @@ export const defaultTranslationBehavior: TranslationBehavior = {
   disableResolverDeduping: true,
   sandboxModeEnabled: false,
   useSubUsernameForDefaultIdentityClaim: true,
+  subscriptionsInheritPrimaryAuth: false,
   populateOwnerFieldForStaticGroupAuth: true,
   suppressApiKeyGeneration: false,
   secondaryKeyAsGSI: true,

--- a/packages/amplify-graphql-api-construct/src/types.ts
+++ b/packages/amplify-graphql-api-construct/src/types.ts
@@ -428,6 +428,13 @@ export interface TranslationBehavior {
   readonly useSubUsernameForDefaultIdentityClaim: boolean;
 
   /**
+   * When disabled, relational fields on the mutation response are over-redacted to protect the data from subscribed users
+   * to correctly apply the auth rules.
+   * @default false
+   */
+  readonly subscriptionsInheritPrimaryAuth: boolean;
+
+  /**
    * Ensure that the owner field is still populated even if a static iam or group authorization applies.
    * @default true
    */
@@ -521,6 +528,13 @@ export interface PartialTranslationBehavior {
    * @default true
    */
   readonly useSubUsernameForDefaultIdentityClaim?: boolean;
+
+  /**
+   * When disabled, relational fields on the mutation response are over-redacted to protect the data from subscribed users
+   * to correctly apply the auth rules.
+   * @default false
+   */
+  readonly subscriptionsInheritPrimaryAuth?: boolean;
 
   /**
    * Ensure that the owner field is still populated even if a static iam or group authorization applies.

--- a/packages/amplify-graphql-api-construct/src/types.ts
+++ b/packages/amplify-graphql-api-construct/src/types.ts
@@ -428,8 +428,7 @@ export interface TranslationBehavior {
   readonly useSubUsernameForDefaultIdentityClaim: boolean;
 
   /**
-   * When disabled, relational fields on the mutation response are over-redacted to protect the data from subscribed users
-   * to correctly apply the auth rules.
+   * When enabled, suppresses default behavior of redacting relational fields when auth rules do not exactly match.
    * @default false
    */
   readonly subscriptionsInheritPrimaryAuth: boolean;
@@ -530,8 +529,7 @@ export interface PartialTranslationBehavior {
   readonly useSubUsernameForDefaultIdentityClaim?: boolean;
 
   /**
-   * When disabled, relational fields on the mutation response are over-redacted to protect the data from subscribed users
-   * to correctly apply the auth rules.
+   * When enabled, suppresses default behavior of redacting relational fields when auth rules do not exactly match.
    * @default false
    */
   readonly subscriptionsInheritPrimaryAuth?: boolean;

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -818,9 +818,10 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
      * An enabled subscription is the prerequisite for relational field redaction
      */
     const hasSubsEnabled = this.modelDirectiveConfig.get(typeName) && this.modelDirectiveConfig.get(typeName).subscriptions?.level === 'on';
-    if (hasSubsEnabled && redactRelationalField) {
+    if (hasSubsEnabled && redactRelationalField && !ctx.transformParameters.subscriptionsInheritPrimaryAuth) {
       relatedAuthExpression = `${this.getVtlGenerator(ctx, def.name.value).setDeniedFieldFlag('Mutation', true)}\n${relatedAuthExpression}`;
     } else if (needsFieldResolver) {
+      /* In this case, the relational field has restricted field-level auth, so we should redact */
       relatedAuthExpression = `${this.getVtlGenerator(ctx, def.name.value).setDeniedFieldFlag(
         'Mutation',
         hasSubsEnabled,

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/transform-parameters.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/transform-parameters.ts
@@ -15,6 +15,7 @@ export const defaultTransformParameters: TransformParameters = {
   useSubUsernameForDefaultIdentityClaim: true,
   populateOwnerFieldForStaticGroupAuth: true,
   suppressApiKeyGeneration: false,
+  subscriptionsInheritPrimaryAuth: false,
 
   // Index Params
   secondaryKeyAsGSI: true,

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -898,6 +898,7 @@ export type TransformParameters = {
     useSubUsernameForDefaultIdentityClaim: boolean;
     populateOwnerFieldForStaticGroupAuth: boolean;
     suppressApiKeyGeneration: boolean;
+    subscriptionsInheritPrimaryAuth: boolean;
     secondaryKeyAsGSI: boolean;
     enableAutoIndexQueryNames: boolean;
     respectPrimaryKeyAttributesOnConnectionField: boolean;

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transform-parameters.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transform-parameters.ts
@@ -19,6 +19,7 @@ export type TransformParameters = {
   useSubUsernameForDefaultIdentityClaim: boolean;
   populateOwnerFieldForStaticGroupAuth: boolean;
   suppressApiKeyGeneration: boolean;
+  subscriptionsInheritPrimaryAuth: boolean;
 
   // Index Params
   secondaryKeyAsGSI: boolean;

--- a/packages/amplify-graphql-transformer/src/__tests__/graphql-transformer.test.ts
+++ b/packages/amplify-graphql-transformer/src/__tests__/graphql-transformer.test.ts
@@ -43,6 +43,7 @@ const defaultTransformConfig: TransformConfig = {
   transformersFactoryArgs: {},
   transformParameters: {
     shouldDeepMergeDirectiveConfigDefaults: false,
+    subscriptionsInheritPrimaryAuth: false,
     disableResolverDeduping: false,
     sandboxModeEnabled: false,
     useSubUsernameForDefaultIdentityClaim: false,

--- a/packages/amplify-util-mock/src/__e2e__/utils/index.ts
+++ b/packages/amplify-util-mock/src/__e2e__/utils/index.ts
@@ -58,6 +58,7 @@ export const defaultTransformParams: Pick<ExecuteTransformConfig, 'transformersF
     disableResolverDeduping: false,
     sandboxModeEnabled: false,
     useSubUsernameForDefaultIdentityClaim: true,
+    subscriptionsInheritPrimaryAuth: false,
     populateOwnerFieldForStaticGroupAuth: true,
     suppressApiKeyGeneration: false,
     secondaryKeyAsGSI: true,

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2NonRedacted.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2NonRedacted.e2e.test.ts
@@ -1,0 +1,506 @@
+import { IndexTransformer, PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import {
+  BelongsToTransformer,
+  HasManyTransformer,
+  HasOneTransformer,
+  ManyToManyTransformer,
+} from '@aws-amplify/graphql-relational-transformer';
+import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
+import { ResourceConstants } from 'graphql-transformer-common';
+import { Output } from 'aws-sdk/clients/cloudformation';
+import { S3, CognitoIdentityServiceProvider as CognitoClient } from 'aws-sdk';
+import { default as moment } from 'moment';
+import { CloudFormationClient } from '../CloudFormationClient';
+import { GraphQLClient } from '../GraphQLClient';
+import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
+import { S3Client } from '../S3Client';
+import {
+  addUserToGroup,
+  authenticateUser,
+  configureAmplify,
+  createGroup,
+  createUserPool,
+  createUserPoolClient,
+  signupUser,
+} from '../cognitoUtils';
+import { resolveTestRegion } from '../testSetup';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+const region = resolveTestRegion();
+
+jest.setTimeout(2000000);
+
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
+const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: region });
+const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
+const STACK_NAME = `RelationalAuthV2TransformersFFTest-${BUILD_TIMESTAMP}`;
+const BUCKET_NAME = `appsync-relational-auth-transformer-ff-test-${BUILD_TIMESTAMP}`;
+const LOCAL_FS_BUILD_DIR = '/tmp/relational_auth_transformer_ff_tests/';
+const S3_ROOT_DIR_KEY = 'deployments';
+
+let GRAPHQL_ENDPOINT = undefined;
+
+/**
+ * Client 1 is logged in and is a member of the Admin group.
+ */
+let GRAPHQL_CLIENT_1 = undefined;
+
+/**
+ * Client 2 is logged in and is a member of the Devs group.
+ */
+let GRAPHQL_CLIENT_2 = undefined;
+
+/**
+ * Client 3 is logged in and has no group memberships.
+ */
+let GRAPHQL_CLIENT_3 = undefined;
+
+let USER_POOL_ID = undefined;
+
+const USERNAME1 = 'user1@test.com';
+const USERNAME2 = 'user2@test.com';
+const USERNAME3 = 'user3@test.com';
+const TMP_PASSWORD = 'Password123!';
+const REAL_PASSWORD = 'Password1234!';
+
+const ADMIN_GROUP_NAME = 'Admin';
+const DEVS_GROUP_NAME = 'Devs';
+const PARTICIPANT_GROUP_NAME = 'Participant';
+const WATCHER_GROUP_NAME = 'Watcher';
+
+function outputValueSelector(key: string) {
+  return (outputs: Output[]) => {
+    const output = outputs.find((o: Output) => o.OutputKey === key);
+    return output ? output.OutputValue : null;
+  };
+}
+
+beforeAll(async () => {
+  const validSchema = `
+    type Post @model @auth(rules: [{allow: owner}]) {
+      id: ID!
+      title: String!
+      author: User @belongsTo(fields: ["owner"])
+      owner: ID! @index(name: "byOwner", sortKeyFields: ["id"])
+    }
+
+    type User @model @auth(rules: [{ allow: owner }]) {
+      id: ID!
+      posts: [Post] @hasMany(indexName: "byOwner", fields: ["id"])
+    }
+
+    type FieldProtected @model @auth(rules: [{ allow: private }, { allow: owner, operations: [read] }]) {
+      id: ID!
+      owner: String
+      ownerOnly: String @auth(rules: [{allow: owner}])
+    }
+
+    type OpenTopLevel @model @auth(rules: [{allow: private}]) {
+      id: ID!
+      name: String
+      owner: String
+      protected: [ConnectionProtected] @hasMany(indexName: "byTopLevel", fields: ["id"])
+    }
+
+    type ConnectionProtected @model(queries: null) @auth(rules: [{allow: owner}]) {
+      id: ID!
+      name: String
+      owner: String
+      topLevelID: ID! @index(name: "byTopLevel", sortKeyFields: ["id"])
+      topLevel: OpenTopLevel @belongsTo(fields: ["topLevelID"])
+    }
+      
+    type Case @model @auth(rules: [{allow: owner}]) {
+      id: ID!
+      name: String
+      owner: String
+      managerId: ID
+      manager: Manager @belongsTo(fields: ["managerId"])
+    }
+
+    type Manager @model @auth(rules: [{allow: owner}]) {
+      id: ID!
+      name: String
+      owner: String
+      caseId: ID
+      case: Case @hasOne(fields: ["caseId"])
+    }`;
+  let out;
+  try {
+    const modelTransformer = new ModelTransformer();
+    const indexTransformer = new IndexTransformer();
+    const hasOneTransformer = new HasOneTransformer();
+    const authTransformer = new AuthTransformer();
+    out = testTransform({
+      schema: validSchema,
+      authConfig: {
+        defaultAuthentication: {
+          authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+        },
+        additionalAuthenticationProviders: [],
+      },
+      transformParameters: {
+        subscriptionsInheritPrimaryAuth: true,
+      },
+      transformers: [
+        modelTransformer,
+        new PrimaryKeyTransformer(),
+        indexTransformer,
+        hasOneTransformer,
+        new HasManyTransformer(),
+        new BelongsToTransformer(),
+        new ManyToManyTransformer(modelTransformer, indexTransformer, hasOneTransformer, authTransformer),
+        authTransformer,
+      ],
+    });
+  } catch (e) {
+    console.error(`Failed to transform schema: ${e}`);
+    expect(true).toEqual(false);
+  }
+  try {
+    await awsS3Client
+      .createBucket({
+        Bucket: BUCKET_NAME,
+      })
+      .promise();
+  } catch (e) {
+    console.error(`Failed to create S3 bucket: ${e}`);
+    expect(true).toEqual(false);
+  }
+  const userPoolResponse = await createUserPool(cognitoClient, `UserPool${STACK_NAME}`);
+  USER_POOL_ID = userPoolResponse.UserPool.Id;
+  const userPoolClientResponse = await createUserPoolClient(cognitoClient, USER_POOL_ID, `UserPool${STACK_NAME}`);
+  const userPoolClientId = userPoolClientResponse.UserPoolClient.ClientId;
+  try {
+    const finishedStack = await deploy(
+      customS3Client,
+      cf,
+      STACK_NAME,
+      out,
+      { AuthCognitoUserPoolId: USER_POOL_ID },
+      LOCAL_FS_BUILD_DIR,
+      BUCKET_NAME,
+      S3_ROOT_DIR_KEY,
+      BUILD_TIMESTAMP,
+    );
+    expect(finishedStack).toBeDefined();
+    const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput);
+    const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput);
+    const apiKey = getApiKey(finishedStack.Outputs);
+    GRAPHQL_ENDPOINT = getApiEndpoint(finishedStack.Outputs);
+    expect(apiKey).not.toBeTruthy();
+
+    // Verify we have all the details
+    expect(GRAPHQL_ENDPOINT).toBeTruthy();
+    expect(USER_POOL_ID).toBeTruthy();
+    expect(userPoolClientId).toBeTruthy();
+
+    // Configure Amplify, create users, and sign in.
+    configureAmplify(USER_POOL_ID, userPoolClientId);
+
+    await signupUser(USER_POOL_ID, USERNAME1, TMP_PASSWORD);
+    await signupUser(USER_POOL_ID, USERNAME2, TMP_PASSWORD);
+    await signupUser(USER_POOL_ID, USERNAME3, TMP_PASSWORD);
+
+    await createGroup(USER_POOL_ID, ADMIN_GROUP_NAME);
+    await createGroup(USER_POOL_ID, PARTICIPANT_GROUP_NAME);
+    await createGroup(USER_POOL_ID, WATCHER_GROUP_NAME);
+    await createGroup(USER_POOL_ID, DEVS_GROUP_NAME);
+    await addUserToGroup(ADMIN_GROUP_NAME, USERNAME1, USER_POOL_ID);
+    await addUserToGroup(PARTICIPANT_GROUP_NAME, USERNAME1, USER_POOL_ID);
+    await addUserToGroup(WATCHER_GROUP_NAME, USERNAME1, USER_POOL_ID);
+    await addUserToGroup(DEVS_GROUP_NAME, USERNAME2, USER_POOL_ID);
+    const authResAfterGroup: any = await authenticateUser(USERNAME1, TMP_PASSWORD, REAL_PASSWORD);
+
+    const idToken = authResAfterGroup.getIdToken().getJwtToken();
+    GRAPHQL_CLIENT_1 = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: idToken });
+
+    const authRes2AfterGroup: any = await authenticateUser(USERNAME2, TMP_PASSWORD, REAL_PASSWORD);
+    const idToken2 = authRes2AfterGroup.getIdToken().getJwtToken();
+    GRAPHQL_CLIENT_2 = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: idToken2 });
+
+    const authRes3: any = await authenticateUser(USERNAME3, TMP_PASSWORD, REAL_PASSWORD);
+    const idToken3 = authRes3.getIdToken().getJwtToken();
+    GRAPHQL_CLIENT_3 = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: idToken3 });
+
+    // Wait for any propagation to avoid random
+    // "The security token included in the request is invalid" errors
+    await new Promise<void>((res) => setTimeout(() => res(), 5000));
+  } catch (e) {
+    console.error(e);
+    expect(true).toEqual(false);
+  }
+});
+
+afterAll(async () => {
+  await cleanupStackAfterTest(BUCKET_NAME, STACK_NAME, cf, { cognitoClient, userPoolId: USER_POOL_ID });
+});
+
+/**
+ * Test queries below
+ */
+test('creating a post and immediately view it via the User.posts connection.', async () => {
+  const createUser1 = await GRAPHQL_CLIENT_1.query(
+    `mutation {
+        createUser(input: { id: "user1@test.com" }) {
+            id
+            posts {
+              items {
+                id
+                title
+                owner
+              }
+            }
+        }
+    }`,
+    {},
+  );
+  expect(createUser1.data.createUser.id).toEqual('user1@test.com');
+  expect(createUser1.data.createUser.posts).toBeDefined();
+  expect(createUser1.data.createUser.posts.items).toHaveLength(0);
+
+  const response = await GRAPHQL_CLIENT_1.query(
+    `mutation {
+        createPost(input: { title: "Hello, World!", owner: "user1@test.com" }) {
+            id
+            title
+            owner
+            author {
+              id
+            }
+        }
+    }`,
+    {},
+  );
+  expect(response.data.createPost.id).toBeDefined();
+  expect(response.data.createPost.title).toEqual('Hello, World!');
+  expect(response.data.createPost.owner).toBeDefined();
+  expect(response.data.createPost.author).toBeDefined();
+  expect(response.data.createPost.author.id).toEqual(USERNAME1);
+
+  const getResponse = await GRAPHQL_CLIENT_1.query(
+    `query {
+        getUser(id: "user1@test.com") {
+            posts {
+                items {
+                    id
+                    title
+                    owner
+                    author {
+                        id
+                    }
+                }
+            }
+        }
+    }`,
+    {},
+  );
+  expect(getResponse.data.getUser.posts.items[0].id).toBeDefined();
+  expect(getResponse.data.getUser.posts.items[0].title).toEqual('Hello, World!');
+  expect(getResponse.data.getUser.posts.items[0].owner).toEqual('user1@test.com');
+  expect(getResponse.data.getUser.posts.items[0].author.id).toEqual('user1@test.com');
+});
+
+test('that hasMany and belongsTo do not redact relational fields', async () => {
+  const response1 = await GRAPHQL_CLIENT_1.query(
+    `mutation {
+        createOpenTopLevel(input: { id: "1", owner: "${USERNAME1}", name: "open" }) {
+            id
+            owner
+            name
+            protected {
+              items {
+                id
+                name
+                owner
+              }
+            }
+        }
+    }`,
+    {},
+  );
+  expect(response1.data.createOpenTopLevel.id).toEqual('1');
+  expect(response1.data.createOpenTopLevel.owner).toEqual(USERNAME1);
+  expect(response1.data.createOpenTopLevel.name).toEqual('open');
+  expect(response1.data.createOpenTopLevel.protected).toBeDefined();
+  expect(response1.data.createOpenTopLevel.protected.items).toBeDefined();
+  expect(response1.data.createOpenTopLevel.protected.items).toHaveLength(0);
+
+  const response2 = await GRAPHQL_CLIENT_1.query(
+    `mutation {
+        createConnectionProtected(input: { id: "1", owner: "${USERNAME1}", name: "closed", topLevelID: "1" }) {
+          id
+          owner
+          name
+          topLevelID
+          topLevel {
+            id
+            owner
+            name
+          }
+        }
+    }`,
+    {},
+  );
+  expect(response2.data.createConnectionProtected.id).toEqual('1');
+  expect(response2.data.createConnectionProtected.owner).toEqual(USERNAME1);
+  expect(response2.data.createConnectionProtected.name).toEqual('closed');
+  expect(response2.data.createConnectionProtected.topLevelID).toEqual('1');
+  expect(response2.data.createConnectionProtected.topLevel).toBeDefined();
+  expect(response2.data.createConnectionProtected.topLevel.id).toEqual('1');
+  expect(response2.data.createConnectionProtected.topLevel.owner).toEqual(USERNAME1);
+  expect(response2.data.createConnectionProtected.topLevel.name).toEqual('open');
+
+  const response3 = await GRAPHQL_CLIENT_1.query(
+    `query {
+        getOpenTopLevel(id: "1") {
+            id
+            protected {
+                items {
+                    id
+                    name
+                    owner
+                }
+            }
+        }
+    }`,
+    {},
+  );
+  expect(response3.data.getOpenTopLevel.id).toEqual('1');
+  expect(response3.data.getOpenTopLevel.protected.items).toHaveLength(1);
+  expect(response3.data.getOpenTopLevel.protected.items[0].id).toEqual('1');
+  expect(response3.data.getOpenTopLevel.protected.items[0].name).toEqual('closed');
+  expect(response3.data.getOpenTopLevel.protected.items[0].owner).toEqual(USERNAME1);
+
+  const response4 = await GRAPHQL_CLIENT_1.query(
+    `mutation {
+        updateOpenTopLevel(input: { id: "1", owner: "${USERNAME1}", name: "closed" }) {
+            id
+            owner
+            name
+            protected {
+              items {
+                id
+                name
+                owner
+              }
+            }
+        }
+    }`,
+    {},
+  );
+  expect(response4.data.updateOpenTopLevel.id).toEqual('1');
+  expect(response4.data.updateOpenTopLevel.owner).toEqual(USERNAME1);
+  expect(response4.data.updateOpenTopLevel.name).toEqual('closed');
+  expect(response4.data.updateOpenTopLevel.protected).toBeDefined();
+  expect(response4.data.updateOpenTopLevel.protected.items).toBeDefined();
+  expect(response4.data.updateOpenTopLevel.protected.items).toHaveLength(1);
+  expect(response4.data.updateOpenTopLevel.protected.items[0].id).toEqual('1');
+  expect(response4.data.updateOpenTopLevel.protected.items[0].name).toEqual('closed');
+  expect(response4.data.updateOpenTopLevel.protected.items[0].owner).toEqual(USERNAME1);
+});
+
+test('that @hasOne and @belongsTo do not redact relational fields', async () => {
+  const response1 = await GRAPHQL_CLIENT_2.query(
+    `mutation {
+        createManager(input: { id: "1", owner: "${USERNAME2}", name: "${USERNAME2}" }) {
+            id
+            owner
+            name
+            caseId
+            case {
+                id
+                owner
+                name
+            }
+        }
+    }`,
+    {},
+  );
+  expect(response1.data.createManager.id).toEqual('1');
+  expect(response1.data.createManager.owner).toEqual(USERNAME2);
+  expect(response1.data.createManager.name).toEqual(USERNAME2);
+  expect(response1.data.createManager.caseId).toBeNull();
+  expect(response1.data.createManager.case).toBeNull();
+
+  const response2 = await GRAPHQL_CLIENT_2.query(
+    `mutation {
+        createCase(input: { id: "1", owner: "${USERNAME2}", name: "case a", managerId: "1" }) {
+          id
+          owner
+          name
+          managerId
+          manager {
+            id
+            owner
+            name
+          }
+        }
+    }`,
+    {},
+  );
+  expect(response2.data.createCase.id).toEqual('1');
+  expect(response2.data.createCase.owner).toEqual(USERNAME2);
+  expect(response2.data.createCase.name).toEqual('case a');
+  expect(response2.data.createCase.managerId).toEqual('1');
+  expect(response2.data.createCase.manager).toBeDefined();
+  expect(response2.data.createCase.manager.id).toEqual('1');
+  expect(response2.data.createCase.manager.owner).toEqual(USERNAME2);
+  expect(response2.data.createCase.manager.name).toEqual(USERNAME2);
+
+  const response3 = await GRAPHQL_CLIENT_2.query(
+    `query {
+        getCase(id: "1") {
+            id
+            name
+            owner
+            managerId
+            manager {
+                id
+                name
+                owner
+            }
+        }
+    }`,
+    {},
+  );
+  expect(response3.data.getCase.id).toEqual('1');
+  expect(response3.data.getCase.owner).toEqual(USERNAME2);
+  expect(response3.data.getCase.name).toEqual('case a');
+  expect(response3.data.getCase.managerId).toEqual('1');
+  expect(response3.data.getCase.manager).toBeDefined();
+  expect(response3.data.getCase.manager.id).toEqual('1');
+  expect(response3.data.getCase.manager.owner).toEqual(USERNAME2);
+  expect(response3.data.getCase.manager.name).toEqual(USERNAME2);
+
+  const response4 = await GRAPHQL_CLIENT_2.query(
+    `mutation {
+        updateManager(input: { id: "1", owner: "${USERNAME2}", name: "${USERNAME2}", caseId: "1" }) {
+            id
+            owner
+            name
+            caseId
+            case {
+                id
+                owner
+                name
+            }
+        }
+    }`,
+    {},
+  );
+  expect(response4.data.updateManager.id).toEqual('1');
+  expect(response4.data.updateManager.owner).toEqual(USERNAME2);
+  expect(response4.data.updateManager.name).toEqual(USERNAME2);
+  expect(response4.data.updateManager.caseId).toEqual('1');
+  expect(response4.data.updateManager.case).toBeDefined();
+  expect(response4.data.updateManager.case.id).toEqual('1');
+  expect(response4.data.updateManager.case.owner).toEqual(USERNAME2);
+  expect(response4.data.updateManager.case.name).toEqual('case a');
+});

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2Redacted.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2Redacted.e2e.test.ts
@@ -1,0 +1,496 @@
+import { IndexTransformer, PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import {
+  BelongsToTransformer,
+  HasManyTransformer,
+  HasOneTransformer,
+  ManyToManyTransformer,
+} from '@aws-amplify/graphql-relational-transformer';
+import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
+import { ResourceConstants } from 'graphql-transformer-common';
+import { Output } from 'aws-sdk/clients/cloudformation';
+import { S3, CognitoIdentityServiceProvider as CognitoClient } from 'aws-sdk';
+import { default as moment } from 'moment';
+import { CloudFormationClient } from '../CloudFormationClient';
+import { GraphQLClient } from '../GraphQLClient';
+import { cleanupStackAfterTest, deploy } from '../deployNestedStacks';
+import { S3Client } from '../S3Client';
+import {
+  addUserToGroup,
+  authenticateUser,
+  configureAmplify,
+  createGroup,
+  createUserPool,
+  createUserPoolClient,
+  signupUser,
+} from '../cognitoUtils';
+import { resolveTestRegion } from '../testSetup';
+
+// to deal with bug in cognito-identity-js
+(global as any).fetch = require('node-fetch');
+
+const region = resolveTestRegion();
+
+jest.setTimeout(2000000);
+
+const cf = new CloudFormationClient(region);
+const customS3Client = new S3Client(region);
+const awsS3Client = new S3({ region: region });
+const cognitoClient = new CognitoClient({ apiVersion: '2016-04-19', region: region });
+const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
+const STACK_NAME = `RelationalAuthV2TransformersFFTest-${BUILD_TIMESTAMP}`;
+const BUCKET_NAME = `appsync-relational-auth-transformer-ff-test-${BUILD_TIMESTAMP}`;
+const LOCAL_FS_BUILD_DIR = '/tmp/relational_auth_transformer_ff_tests/';
+const S3_ROOT_DIR_KEY = 'deployments';
+
+let GRAPHQL_ENDPOINT = undefined;
+
+/**
+ * Client 1 is logged in and is a member of the Admin group.
+ */
+let GRAPHQL_CLIENT_1 = undefined;
+
+/**
+ * Client 2 is logged in and is a member of the Devs group.
+ */
+let GRAPHQL_CLIENT_2 = undefined;
+
+/**
+ * Client 3 is logged in and has no group memberships.
+ */
+let GRAPHQL_CLIENT_3 = undefined;
+
+let USER_POOL_ID = undefined;
+
+const USERNAME1 = 'user1@test.com';
+const USERNAME2 = 'user2@test.com';
+const USERNAME3 = 'user3@test.com';
+const TMP_PASSWORD = 'Password123!';
+const REAL_PASSWORD = 'Password1234!';
+
+const ADMIN_GROUP_NAME = 'Admin';
+const DEVS_GROUP_NAME = 'Devs';
+const PARTICIPANT_GROUP_NAME = 'Participant';
+const WATCHER_GROUP_NAME = 'Watcher';
+
+function outputValueSelector(key: string) {
+  return (outputs: Output[]) => {
+    const output = outputs.find((o: Output) => o.OutputKey === key);
+    return output ? output.OutputValue : null;
+  };
+}
+
+beforeAll(async () => {
+  const validSchema = `
+    type Post @model @auth(rules: [{allow: owner}]) {
+      id: ID!
+      title: String!
+      author: User @belongsTo(fields: ["owner"])
+      owner: ID! @index(name: "byOwner", sortKeyFields: ["id"])
+    }
+
+    type User @model @auth(rules: [{ allow: owner }]) {
+      id: ID!
+      posts: [Post] @hasMany(indexName: "byOwner", fields: ["id"])
+    }
+
+    type FieldProtected @model @auth(rules: [{ allow: private }, { allow: owner, operations: [read] }]) {
+      id: ID!
+      owner: String
+      ownerOnly: String @auth(rules: [{allow: owner}])
+    }
+
+    type OpenTopLevel @model @auth(rules: [{allow: private}]) {
+      id: ID!
+      name: String
+      owner: String
+      protected: [ConnectionProtected] @hasMany(indexName: "byTopLevel", fields: ["id"])
+    }
+
+    type ConnectionProtected @model(queries: null) @auth(rules: [{allow: owner}]) {
+      id: ID!
+      name: String
+      owner: String
+      topLevelID: ID! @index(name: "byTopLevel", sortKeyFields: ["id"])
+      topLevel: OpenTopLevel @belongsTo(fields: ["topLevelID"])
+    }
+      
+    type Case @model @auth(rules: [{allow: owner}]) {
+      id: ID!
+      name: String
+      owner: String
+      managerId: ID
+      manager: Manager @belongsTo(fields: ["managerId"])
+    }
+
+    type Manager @model @auth(rules: [{allow: owner}]) {
+      id: ID!
+      name: String
+      owner: String
+      caseId: ID
+      case: Case @hasOne(fields: ["caseId"])
+    }`;
+  let out;
+  try {
+    const modelTransformer = new ModelTransformer();
+    const indexTransformer = new IndexTransformer();
+    const hasOneTransformer = new HasOneTransformer();
+    const authTransformer = new AuthTransformer();
+    out = testTransform({
+      schema: validSchema,
+      authConfig: {
+        defaultAuthentication: {
+          authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+        },
+        additionalAuthenticationProviders: [],
+      },
+      /**
+       * No transformer parameters are provided.
+       * In that case, 'subscriptionsInheritPrimaryAuth' is set to 'false' and relational fields must be redacted
+       * when auth rules do not match between primary and related models.
+       */
+      transformers: [
+        modelTransformer,
+        new PrimaryKeyTransformer(),
+        indexTransformer,
+        hasOneTransformer,
+        new HasManyTransformer(),
+        new BelongsToTransformer(),
+        new ManyToManyTransformer(modelTransformer, indexTransformer, hasOneTransformer, authTransformer),
+        authTransformer,
+      ],
+    });
+  } catch (e) {
+    console.error(`Failed to transform schema: ${e}`);
+    expect(true).toEqual(false);
+  }
+  try {
+    await awsS3Client
+      .createBucket({
+        Bucket: BUCKET_NAME,
+      })
+      .promise();
+  } catch (e) {
+    console.error(`Failed to create S3 bucket: ${e}`);
+    expect(true).toEqual(false);
+  }
+  const userPoolResponse = await createUserPool(cognitoClient, `UserPool${STACK_NAME}`);
+  USER_POOL_ID = userPoolResponse.UserPool.Id;
+  const userPoolClientResponse = await createUserPoolClient(cognitoClient, USER_POOL_ID, `UserPool${STACK_NAME}`);
+  const userPoolClientId = userPoolClientResponse.UserPoolClient.ClientId;
+  try {
+    const finishedStack = await deploy(
+      customS3Client,
+      cf,
+      STACK_NAME,
+      out,
+      { AuthCognitoUserPoolId: USER_POOL_ID },
+      LOCAL_FS_BUILD_DIR,
+      BUCKET_NAME,
+      S3_ROOT_DIR_KEY,
+      BUILD_TIMESTAMP,
+    );
+    expect(finishedStack).toBeDefined();
+    const getApiEndpoint = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIEndpointOutput);
+    const getApiKey = outputValueSelector(ResourceConstants.OUTPUTS.GraphQLAPIApiKeyOutput);
+    const apiKey = getApiKey(finishedStack.Outputs);
+    GRAPHQL_ENDPOINT = getApiEndpoint(finishedStack.Outputs);
+    expect(apiKey).not.toBeTruthy();
+
+    // Verify we have all the details
+    expect(GRAPHQL_ENDPOINT).toBeTruthy();
+    expect(USER_POOL_ID).toBeTruthy();
+    expect(userPoolClientId).toBeTruthy();
+
+    // Configure Amplify, create users, and sign in.
+    configureAmplify(USER_POOL_ID, userPoolClientId);
+
+    await signupUser(USER_POOL_ID, USERNAME1, TMP_PASSWORD);
+    await signupUser(USER_POOL_ID, USERNAME2, TMP_PASSWORD);
+    await signupUser(USER_POOL_ID, USERNAME3, TMP_PASSWORD);
+
+    await createGroup(USER_POOL_ID, ADMIN_GROUP_NAME);
+    await createGroup(USER_POOL_ID, PARTICIPANT_GROUP_NAME);
+    await createGroup(USER_POOL_ID, WATCHER_GROUP_NAME);
+    await createGroup(USER_POOL_ID, DEVS_GROUP_NAME);
+    await addUserToGroup(ADMIN_GROUP_NAME, USERNAME1, USER_POOL_ID);
+    await addUserToGroup(PARTICIPANT_GROUP_NAME, USERNAME1, USER_POOL_ID);
+    await addUserToGroup(WATCHER_GROUP_NAME, USERNAME1, USER_POOL_ID);
+    await addUserToGroup(DEVS_GROUP_NAME, USERNAME2, USER_POOL_ID);
+    const authResAfterGroup: any = await authenticateUser(USERNAME1, TMP_PASSWORD, REAL_PASSWORD);
+
+    const idToken = authResAfterGroup.getIdToken().getJwtToken();
+    GRAPHQL_CLIENT_1 = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: idToken });
+
+    const authRes2AfterGroup: any = await authenticateUser(USERNAME2, TMP_PASSWORD, REAL_PASSWORD);
+    const idToken2 = authRes2AfterGroup.getIdToken().getJwtToken();
+    GRAPHQL_CLIENT_2 = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: idToken2 });
+
+    const authRes3: any = await authenticateUser(USERNAME3, TMP_PASSWORD, REAL_PASSWORD);
+    const idToken3 = authRes3.getIdToken().getJwtToken();
+    GRAPHQL_CLIENT_3 = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: idToken3 });
+
+    // Wait for any propagation to avoid random
+    // "The security token included in the request is invalid" errors
+    await new Promise<void>((res) => setTimeout(() => res(), 5000));
+  } catch (e) {
+    console.error(e);
+    expect(true).toEqual(false);
+  }
+});
+
+afterAll(async () => {
+  await cleanupStackAfterTest(BUCKET_NAME, STACK_NAME, cf, { cognitoClient, userPoolId: USER_POOL_ID });
+});
+
+/**
+ * Test queries below
+ */
+test('creating a post and immediately view it via the User.posts connection.', async () => {
+  const createUser1 = await GRAPHQL_CLIENT_1.query(
+    `mutation {
+        createUser(input: { id: "user1@test.com" }) {
+            id
+            posts {
+              items {
+                id
+                title
+                owner
+              }
+            }
+        }
+    }`,
+    {},
+  );
+  expect(createUser1.data.createUser.id).toEqual('user1@test.com');
+  expect(createUser1.data.createUser.posts).toBeDefined();
+  expect(createUser1.data.createUser.posts.items).toBeDefined();
+  expect(createUser1.data.createUser.posts.items).toHaveLength(0);
+
+  const response = await GRAPHQL_CLIENT_1.query(
+    `mutation {
+        createPost(input: { title: "Hello, World!", owner: "user1@test.com" }) {
+            id
+            title
+            owner
+            author {
+              id
+            }
+        }
+    }`,
+    {},
+  );
+  expect(response.data.createPost.id).toBeDefined();
+  expect(response.data.createPost.title).toEqual('Hello, World!');
+  expect(response.data.createPost.owner).toBeDefined();
+  expect(response.data.createPost.author).toBeNull();
+
+  const getResponse = await GRAPHQL_CLIENT_1.query(
+    `query {
+        getUser(id: "user1@test.com") {
+            posts {
+                items {
+                    id
+                    title
+                    owner
+                    author {
+                        id
+                    }
+                }
+            }
+        }
+    }`,
+    {},
+  );
+  expect(getResponse.data.getUser.posts.items[0].id).toBeDefined();
+  expect(getResponse.data.getUser.posts.items[0].title).toEqual('Hello, World!');
+  expect(getResponse.data.getUser.posts.items[0].owner).toEqual('user1@test.com');
+  expect(getResponse.data.getUser.posts.items[0].author.id).toEqual('user1@test.com');
+});
+
+test('that hasMany and belongsTo redact relational fields', async () => {
+  const response1 = await GRAPHQL_CLIENT_1.query(
+    `mutation {
+        createOpenTopLevel(input: { id: "1", owner: "${USERNAME1}", name: "open" }) {
+            id
+            owner
+            name
+            protected {
+              items {
+                id
+                name
+                owner
+              }
+            }
+        }
+    }`,
+    {},
+  );
+  expect(response1.data.createOpenTopLevel.id).toEqual('1');
+  expect(response1.data.createOpenTopLevel.owner).toEqual(USERNAME1);
+  expect(response1.data.createOpenTopLevel.name).toEqual('open');
+  expect(response1.data.createOpenTopLevel.protected).toBeDefined();
+  expect(response1.data.createOpenTopLevel.protected.items).toBeDefined();
+  expect(response1.data.createOpenTopLevel.protected.items).toHaveLength(0);
+
+  const response2 = await GRAPHQL_CLIENT_1.query(
+    `mutation {
+        createConnectionProtected(input: { id: "1", owner: "${USERNAME1}", name: "closed", topLevelID: "1" }) {
+          id
+          owner
+          name
+          topLevelID
+          topLevel {
+            id
+            owner
+            name
+          }
+        }
+    }`,
+    {},
+  );
+  expect(response2.data.createConnectionProtected.id).toEqual('1');
+  expect(response2.data.createConnectionProtected.owner).toEqual(USERNAME1);
+  expect(response2.data.createConnectionProtected.name).toEqual('closed');
+  expect(response2.data.createConnectionProtected.topLevelID).toEqual('1');
+  expect(response2.data.createConnectionProtected.topLevel).toBeNull();
+
+  const response3 = await GRAPHQL_CLIENT_1.query(
+    `query {
+        getOpenTopLevel(id: "1") {
+            id
+            protected {
+                items {
+                    id
+                    name
+                    owner
+                }
+            }
+        }
+    }`,
+    {},
+  );
+  expect(response3.data.getOpenTopLevel.id).toEqual('1');
+  expect(response3.data.getOpenTopLevel.protected.items).toHaveLength(1);
+  expect(response3.data.getOpenTopLevel.protected.items[0].id).toEqual('1');
+  expect(response3.data.getOpenTopLevel.protected.items[0].name).toEqual('closed');
+  expect(response3.data.getOpenTopLevel.protected.items[0].owner).toEqual(USERNAME1);
+
+  const response4 = await GRAPHQL_CLIENT_1.query(
+    `mutation {
+        updateOpenTopLevel(input: { id: "1", owner: "${USERNAME1}", name: "closed" }) {
+            id
+            owner
+            name
+            protected {
+              items {
+                id
+                name
+                owner
+              }
+            }
+        }
+    }`,
+    {},
+  );
+  expect(response4.data.updateOpenTopLevel.id).toEqual('1');
+  expect(response4.data.updateOpenTopLevel.owner).toEqual(USERNAME1);
+  expect(response4.data.updateOpenTopLevel.name).toEqual('closed');
+  expect(response4.data.updateOpenTopLevel.protected).toBeDefined();
+  expect(response4.data.updateOpenTopLevel.protected.items).toBeDefined();
+  expect(response4.data.updateOpenTopLevel.protected.items).toHaveLength(0);
+});
+
+test('that @hasOne and @belongsTo do not redact relational fields', async () => {
+  const response1 = await GRAPHQL_CLIENT_2.query(
+    `mutation {
+        createManager(input: { id: "1", owner: "${USERNAME2}", name: "${USERNAME2}" }) {
+            id
+            owner
+            name
+            caseId
+            case {
+                id
+                owner
+                name
+            }
+        }
+    }`,
+    {},
+  );
+  expect(response1.data.createManager.id).toEqual('1');
+  expect(response1.data.createManager.owner).toEqual(USERNAME2);
+  expect(response1.data.createManager.name).toEqual(USERNAME2);
+  expect(response1.data.createManager.caseId).toBeNull();
+  expect(response1.data.createManager.case).toBeNull();
+
+  const response2 = await GRAPHQL_CLIENT_2.query(
+    `mutation {
+        createCase(input: { id: "1", owner: "${USERNAME2}", name: "case a", managerId: "1" }) {
+          id
+          owner
+          name
+          managerId
+          manager {
+            id
+            owner
+            name
+          }
+        }
+    }`,
+    {},
+  );
+  expect(response2.data.createCase.id).toEqual('1');
+  expect(response2.data.createCase.owner).toEqual(USERNAME2);
+  expect(response2.data.createCase.name).toEqual('case a');
+  expect(response2.data.createCase.managerId).toEqual('1');
+  expect(response2.data.createCase.manager).toBeNull();
+
+  const response3 = await GRAPHQL_CLIENT_2.query(
+    `query {
+        getCase(id: "1") {
+            id
+            name
+            owner
+            managerId
+            manager {
+                id
+                name
+                owner
+            }
+        }
+    }`,
+    {},
+  );
+  expect(response3.data.getCase.id).toEqual('1');
+  expect(response3.data.getCase.owner).toEqual(USERNAME2);
+  expect(response3.data.getCase.name).toEqual('case a');
+  expect(response3.data.getCase.managerId).toEqual('1');
+  expect(response3.data.getCase.manager).toBeDefined();
+  expect(response3.data.getCase.manager.id).toEqual('1');
+  expect(response3.data.getCase.manager.owner).toEqual(USERNAME2);
+  expect(response3.data.getCase.manager.name).toEqual(USERNAME2);
+
+  const response4 = await GRAPHQL_CLIENT_2.query(
+    `mutation {
+        updateManager(input: { id: "1", owner: "${USERNAME2}", name: "${USERNAME2}", caseId: "1" }) {
+            id
+            owner
+            name
+            caseId
+            case {
+                id
+                owner
+                name
+            }
+        }
+    }`,
+    {},
+  );
+  expect(response4.data.updateManager.id).toEqual('1');
+  expect(response4.data.updateManager.owner).toEqual(USERNAME2);
+  expect(response4.data.updateManager.name).toEqual(USERNAME2);
+  expect(response4.data.updateManager.caseId).toEqual('1');
+  expect(response4.data.updateManager.case).toBeNull();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -21257,7 +21257,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -21274,15 +21274,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
@@ -21376,7 +21367,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -21403,13 +21394,6 @@ strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -22750,7 +22734,7 @@ workerpool@^6.5.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -22771,15 +22755,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Allow subscriptions to inherit primary model auth rules for relational fields if `subscriptionsInheritPrimaryAuth` is set to `true`.

##### CDK / CloudFormation Parameters Changed
NA
<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available
TODO: To be updated later.

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- New E2E tests
- New unit tests
- Manual testing

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
