### PR TITLE
fix(amplify-category-api): ssl cert api name change

### DIFF
--- a/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-ts-data-schema.test.ts.snap
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/__snapshots__/generate-ts-data-schema.test.ts.snap
@@ -226,7 +226,7 @@ export const schema = configure({
         identifier: \\"ID1234567890\\",
         engine: \\"mysql\\",
         connectionUri: secret(\\"CONN_STR\\"),
-        sslCertificate: secret(\\"SSL_CERT\\")
+        sslCert: secret(\\"SSL_CERT\\")
     }
 }).schema({
     \\"User\\": a.model({
@@ -303,7 +303,7 @@ export const schema = configure({
         identifier: \\"IDNb9LVUQdGlNwNzYAgL6A\\",
         engine: \\"mysql\\",
         connectionUri: secret(\\"connectionUriSecret\\"),
-        sslCertificate: secret(\\"mySqlSslSecret\\"),
+        sslCert: secret(\\"mySqlSslSecret\\"),
         vpcConfig: {
             vpcId: \\"abc\\",
             securityGroupIds: [
@@ -350,7 +350,7 @@ export const schema = configure({
         identifier: \\"IDbQzyUQqaWhcfRhqPkRBA\\",
         engine: \\"postgresql\\",
         connectionUri: secret(\\"connectionUriSecret\\"),
-        sslCertificate: secret(\\"postgresSslSecret\\"),
+        sslCert: secret(\\"postgresSslSecret\\"),
         vpcConfig: {
             vpcId: \\"abc\\",
             securityGroupIds: [

--- a/packages/graphql-transformer-common/src/TypescriptSchemaConstants.ts
+++ b/packages/graphql-transformer-common/src/TypescriptSchemaConstants.ts
@@ -21,7 +21,7 @@ export const TYPESCRIPT_DATA_SCHEMA_CONSTANTS = {
   PROPERTY_AZ: 'availabilityZone',
   PROPERTY_DATABASE: 'database',
   PROPERTY_CONNECTION_URI: 'connectionUri',
-  PROPERTY_SSL_CERTIFICATE: 'sslCertificate',
+  PROPERTY_SSL_CERTIFICATE: 'sslCert',
   PROPERTY_ENGINE: 'engine',
   PROPERTY_IDENTIFIER: 'identifier',
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Change the SSL certificate property in the generated typescript data schema to `sslCert`.

##### CDK / CloudFormation Parameters Changed
NA
<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Updated unit tests
- Manual testing

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
