### PR TITLE
chore: allow adding underscore (_), colon (:), comma (,), and dot(.) for the path part and underscore (_) for path parameters in addition to a-z A-Z -

### DIFF
--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/rest-api-path-utils.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/utils/rest-api-path-utils.test.ts
@@ -27,7 +27,7 @@ test('validatePathName_hasTrailingSlash', () => {
 test('validatePathName_invalidCharacters', () => {
   // setup
   const errorMessage =
-    'Each path part must use characters a-z A-Z 0-9 - and must not be empty.\nOptionally, a path part can be surrounded by { } to denote a path parameter.';
+    'Each path part must use characters a-z A-Z 0-9 - _ : , . and must not be empty.\nOptionally, a path part with characters a-z A-Z 0-9 - _ can be surrounded by { } to denote a path parameter.';
 
   // test
   expect(validatePathName('/invalid+/{char}')).toStrictEqual(errorMessage);

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rest-api-path-utils.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/utils/rest-api-path-utils.ts
@@ -20,8 +20,8 @@ export const validatePathName = (name: string) => {
 
   // Matches parameterized paths such as /book/{isbn}/page/{pageNum}
   // This regex also catches the above conditions, but those are left in to provide clearer error messages.
-  if (!/^(?:\/(?:[a-zA-Z0-9\-]+|{[a-zA-Z0-9\-]+}))+$/.test(name)) {
-    return 'Each path part must use characters a-z A-Z 0-9 - and must not be empty.\nOptionally, a path part can be surrounded by { } to denote a path parameter.';
+  if (!/^(?:\/(?:[a-zA-Z0-9\-_:,.]+|{[a-zA-Z0-9\-_]+}))+$/.test(name)) {
+    return 'Each path part must use characters a-z A-Z 0-9 - _ : , . and must not be empty.\nOptionally, a path part with characters a-z A-Z 0-9 - _ can be surrounded by { } to denote a path parameter.';
   }
 
   return true;


### PR DESCRIPTION
#### Description of changes
Updated the regex for REST API path validation to conform with the specifications from the [AWS API Gateway important notes](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-known-issues.html#api-gateway-known-issues-rest-apis). This change ensures that the API paths properly handle colons, commas, underscores, and dots in static segments without interpreting them as parameters.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
- Unit tests
- Regex101 with Unit tests
- Manually tested in AWS API Gateway via AWS Console

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
