### PR TITLE
fix: update awaiter s3 key

### DIFF
--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/__snapshots__/ecs-apigw-stack.test.ts.snap
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/__snapshots__/ecs-apigw-stack.test.ts.snap
@@ -204,7 +204,7 @@ Object {
       "Type": "String",
     },
     "awaiterS3Key": Object {
-      "Default": "custom-resource-pipeline-awaiter.zip",
+      "Default": "custom-resource-pipeline-awaiter-18.zip",
       "Type": "String",
     },
     "deploymentBucketName": Object {

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/base-api-stack.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/base-api-stack.ts
@@ -15,7 +15,7 @@ import { NETWORK_STACK_LOGICAL_ID } from '../../category-constants';
 import Container from './docker-compose/ecs-objects/container';
 import { GitHubSourceActionInfo, PipelineWithAwaiter } from './pipeline-with-awaiter';
 
-const PIPELINE_AWAITER_ZIP = 'custom-resource-pipeline-awaiter.zip';
+const PIPELINE_AWAITER_ZIP = 'custom-resource-pipeline-awaiter-18.zip';
 
 export enum DEPLOYMENT_MECHANISM {
   /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

With the CDK version upgrade the runtime version of the custom resource lambda changed from 16 to 18. With the runtime change the lambda code needed be changed to account for breaking changes between 16 and 18. However, the S3 key for the zip file containing the lambda code was not changed, even though the hash of code has changed. During the CFN deploy if the S3 key for the lambda code is unchanged the lambda code will not be updated. 

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html

> Changes to a deployment package in Amazon S3 or a container image in ECR are not detected automatically during stack updates. To update the function code, change the object key or version in the template.

This resulted in the runtime version being upgraded to 18, but the code was not updated (and stayed with the runtime version 16 compatible implementation). The lambda would then throw errors when executed.

This change updates the lambda code s3 key to append the runtime version. This will cause the next deploy to update the lambda code because the s3 key has changed.

Change in CLI repo: https://github.com/aws-amplify/amplify-cli/pull/13872

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

Awaiter function code S3 key updated to include node runtime version.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-category-api/issues/2730

#### Description of how you validated changes

Manual testing. This issue only presents itself when upgrading from an earlier version of the CLI with an existing awaiter function deployed. We do not have an E2E testing framework that allows multiple versions of the CLI to be used. Adding this testing would delay the release of this fix. The tests can be added at a later time.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
