### PR TITLE
fix(amplify-category-api): data api call print the full error object

### DIFF
--- a/packages/amplify-e2e-core/src/utils/rds.ts
+++ b/packages/amplify-e2e-core/src/utils/rds.ts
@@ -350,7 +350,7 @@ export const setupRDSClusterAndData = async (config: RDSConfig, queries?: string
       const executeStatementResponse = await client.send(new ExecuteStatementCommand(executeStatementInput));
       console.log('Create table response: ' + JSON.stringify(executeStatementResponse));
     } catch (err) {
-      throw new Error(`Error in creating tables in test database: ${err.response.json}`);
+      throw new Error(`Error in creating tables in test database: ${JSON.stringify(err, null, 4)}`);
     }
   });
 


### PR DESCRIPTION
Print the full error object while making a call to the data api.