### PR TITLE
chore: add stale rds instances cleanup in scheduled workflow

### DIFF
--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -54,7 +54,7 @@ type IamRoleInfo = {
 };
 
 type RdsInstanceInfo = {
-  name: string;
+  identifier: string;
   region: string;
 };
 
@@ -163,7 +163,7 @@ const getOrphanRdsInstances = async (account: AWSAccountInfo, region: string): P
     const rdsClient = new aws.RDS(getAWSConfig(account, region));
     const listRdsInstanceResponse = await rdsClient.describeDBInstances().promise();
     const staleInstances = listRdsInstanceResponse.DBInstances.filter(testInstanceStalenessFilter);
-    return staleInstances.map((i) => ({ name: i.DBInstanceIdentifier, region }));
+    return staleInstances.map((i) => ({ identifier: i.DBInstanceIdentifier, region }));
   } catch (e) {
     if (e?.code === 'InvalidClientTokenId') {
       // Do not fail the cleanup and continue
@@ -626,11 +626,11 @@ const deleteRdsInstances = async (account: AWSAccountInfo, accountIndex: number,
 };
 
 const deleteRdsInstance = async (account: AWSAccountInfo, accountIndex: number, instance: RdsInstanceInfo): Promise<void> => {
-  const { name, region } = instance;
+  const { identifier, region } = instance;
   console.log(`${generateAccountInfo(account, accountIndex)} Deleting RDS instance ${name}`);
   try {
     const rdsClient = new aws.RDS(getAWSConfig(account, region));
-    await rdsClient.deleteDBInstance({ DBInstanceIdentifier: name, SkipFinalSnapshot: true }).promise();
+    await rdsClient.deleteDBInstance({ DBInstanceIdentifier: identifier, SkipFinalSnapshot: true }).promise();
   } catch (e) {
     console.log(`${generateAccountInfo(account, accountIndex)} Deleting instance ${name} failed with error ${e.message}`);
     if (e.code === 'ExpiredTokenException') {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Added stale RDS instance cleanup steps in the scheduled cleanup workflow
The stale instances meet the following requirements:

- DB identifier contains `integtest`
- Status is `available`
- Has been created more than 2 hours

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Run cleanup script locally with temp credential from e2e parent account
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
