### PR TITLE
test: use pre provisioned cluster

### DIFF
--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -1066,7 +1066,8 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: us-east-1
+          USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
     - identifier: sql_mysql_canary

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-pg-canary.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-pg-canary.test.ts
@@ -13,7 +13,7 @@ describe('Canary using Postgres lambda model datasource strategy', () => {
   const projFolderName = 'pgcanary';
   // sufficient password length that meets the requirements for RDS cluster/instance
   const [username, password, identifier] = generator.generateMultiple(3, { length: 11 });
-  const region = 'us-east-1';
+  const region = process.env.CLI_REGION ?? 'us-west-2';
   const engine = 'postgres';
 
   const databaseController: SqlDatatabaseController = new SqlDatatabaseController(

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-pg-canary.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-pg-canary.test.ts
@@ -13,7 +13,7 @@ describe('Canary using Postgres lambda model datasource strategy', () => {
   const projFolderName = 'pgcanary';
   // sufficient password length that meets the requirements for RDS cluster/instance
   const [username, password, identifier] = generator.generateMultiple(3, { length: 11 });
-  const region = process.env.CLI_REGION ?? 'us-west-2';
+  const region = 'us-east-1';
   const engine = 'postgres';
 
   const databaseController: SqlDatatabaseController = new SqlDatatabaseController(

--- a/packages/amplify-graphql-api-construct-tests/src/sql-datatabase-controller.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/sql-datatabase-controller.ts
@@ -25,7 +25,8 @@ import {
   isSqlModelDataSourceSsmDbConnectionConfig,
   isSqlModelDataSourceSsmDbConnectionStringConfig,
 } from '@aws-amplify/graphql-transformer-interfaces';
-import { getClusterIdentifier } from './utils/sql-local-testing';
+import { getClusterIdFromLocalConfig } from './utils/sql-local-testing';
+import { getPreProvisionedClusterInfo } from './utils/sql-pre-provisioned-cluster';
 
 export interface SqlDatabaseDetails {
   dbConfig: {
@@ -55,12 +56,13 @@ export class SqlDatatabaseController {
   private databaseDetails: SqlDatabaseDetails | undefined;
   private useDataAPI: boolean;
   private enableLocalTesting: boolean;
+  private usePreProvisionedCluster: boolean;
 
   constructor(private readonly setupQueries: Array<string>, private options: RDSConfig) {
     // Data API is not supported in opted-in regions
     if (options.engine === 'postgres' && isDataAPISupported(options.region)) {
       this.useDataAPI = true;
-      this.enableLocalTesting = !isCI() && getClusterIdentifier(options.region, options.engine) !== undefined;
+      this.enableLocalTesting = !isCI() && getClusterIdFromLocalConfig(options.region, options.engine) !== undefined;
     } else {
       this.useDataAPI = false;
     }
@@ -75,9 +77,13 @@ export class SqlDatatabaseController {
     let dbConfig;
 
     if (this.useDataAPI) {
-      if (this.enableLocalTesting) {
-        const identifier = getClusterIdentifier(this.options.region, this.options.engine);
-        dbConfig = await setupDataInExistingCluster(identifier, this.options, this.setupQueries);
+      const preProvisionedClusterInfo = await getPreProvisionedClusterInfo(this.options.region, this.options.engine);
+      this.usePreProvisionedCluster = preProvisionedClusterInfo !== undefined;
+      if (this.enableLocalTesting || this.usePreProvisionedCluster) {
+        const identifier = this.usePreProvisionedCluster
+          ? preProvisionedClusterInfo.clusterIdentifier
+          : getClusterIdFromLocalConfig(this.options.region, this.options.engine);
+        dbConfig = await setupDataInExistingCluster(identifier, this.options, this.setupQueries, preProvisionedClusterInfo.secretArn);
         this.options.username = dbConfig.username;
         this.options.dbname = dbConfig.dbName;
       } else {

--- a/packages/amplify-graphql-api-construct-tests/src/sql-datatabase-controller.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/sql-datatabase-controller.ts
@@ -206,7 +206,7 @@ export class SqlDatatabaseController {
   };
 
   cleanupDatabase = async (): Promise<void> => {
-    if (!this.databaseDetails) {
+    if (this.usePreProvisionedCluster || !this.databaseDetails) {
       return;
     }
 

--- a/packages/amplify-graphql-api-construct-tests/src/utils/sql-local-testing.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/utils/sql-local-testing.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import * as fs from 'fs-extra';
 import { SqlEngine } from 'amplify-category-api-e2e-core';
 
-export const getClusterIdentifier = (region: string, engine: SqlEngine): string | undefined => {
+export const getClusterIdFromLocalConfig = (region: string, engine: SqlEngine): string | undefined => {
   const repoRoot = path.join(__dirname, '..', '..', '..', '..');
   const localClusterPath = path.join(repoRoot, 'scripts', 'e2e-test-local-cluster-config.json');
   if (!fs.existsSync(localClusterPath)) {

--- a/packages/amplify-graphql-api-construct-tests/src/utils/sql-pre-provisioned-cluster.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/utils/sql-pre-provisioned-cluster.ts
@@ -16,14 +16,17 @@ export const getPreProvisionedClusterInfo = async (region: string, engine: SqlEn
     const callerIdentity = await stsClient.send(new GetCallerIdentityCommand({}));
     const accountId = callerIdentity?.Account;
     if (!accountId) {
-      throw new Error('cannot get the current account Id');
+      throw new Error('Cannot get the current account Id');
     }
-    // const clusterManifestPrefix = process.env.RDS_CLUSTER_MANIFEST_BUCKET_PREFIX;
-    const clusterManifestPrefix = 'rdsmanifestbucket';
+    const clusterManifestPrefix = process.env.RDS_CLUSTER_MANIFEST_BUCKET_PREFIX;
+    if (!clusterManifestPrefix) {
+      throw new Error('Cannot get the cluster manifest prefix');
+    }
     const command = new GetObjectCommand({
       Bucket: `${clusterManifestPrefix}${accountId}`,
       Key: `${engine}/${region}`,
     });
+
     const response = await s3Client.send(command);
     const clusterInfo: PreProvisionedClusterInfo = JSON.parse(await response.Body.transformToString());
     console.log(JSON.stringify(clusterInfo));

--- a/packages/amplify-graphql-api-construct-tests/src/utils/sql-pre-provisioned-cluster.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/utils/sql-pre-provisioned-cluster.ts
@@ -1,0 +1,35 @@
+import { SqlEngine } from 'amplify-category-api-e2e-core';
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
+
+export type PreProvisionedClusterInfo = {
+  clusterArn: string;
+  secretArn: string;
+  clusterIdentifier: string;
+};
+
+export const getPreProvisionedClusterInfo = async (region: string, engine: SqlEngine): Promise<PreProvisionedClusterInfo | undefined> => {
+  const s3Client = new S3Client({ region });
+  const stsClient = new STSClient({ region });
+
+  try {
+    const callerIdentity = await stsClient.send(new GetCallerIdentityCommand({}));
+    const accountId = callerIdentity?.Account;
+    if (!accountId) {
+      throw new Error('cannot get the current account Id');
+    }
+    // const clusterManifestPrefix = process.env.RDS_CLUSTER_MANIFEST_BUCKET_PREFIX;
+    const clusterManifestPrefix = 'rdsmanifestbucket';
+    const command = new GetObjectCommand({
+      Bucket: `${clusterManifestPrefix}${accountId}`,
+      Key: `${engine}/${region}`,
+    });
+    const response = await s3Client.send(command);
+    const clusterInfo: PreProvisionedClusterInfo = JSON.parse(await response.Body.transformToString());
+    console.log(JSON.stringify(clusterInfo));
+    return clusterInfo;
+  } catch (err) {
+    console.error(err);
+    return;
+  }
+};

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -75,6 +75,7 @@ type CandidateJob = {
 const FORCE_REGION_MAP = {
   interactions: 'us-west-2',
   containers: 'us-east-1',
+  'sql-pg-canary': 'us-east-1',
 };
 
 // some tests require additional time, the parent account can handle longer tests (up to 90 minutes)
@@ -82,6 +83,7 @@ const USE_PARENT_ACCOUNT = [
   'src/__tests__/graphql-v2/searchable-datastore',
   'src/__tests__/schema-searchable',
   'src/__tests__/FunctionTransformerTestsV2.e2e.test.ts',
+  'src/__tests__/sql-pg-canary.test.ts',
 ];
 const TEST_TIMINGS_PATH = join(REPO_ROOT, 'scripts', 'test-timings.data.json');
 const CODEBUILD_CONFIG_BASE_PATH = join(REPO_ROOT, 'codebuild_specs', 'e2e_workflow_base.yml');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Update the SQL E2E test setup to be able to use the pre-provisioned cluster. Use `sql-pg-canary` test to run in parent account and `us-east-1` region that has the pre-provisioned cluster.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Ran the updated test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
