### PR TITLE
docs(contributing): ✏️ require node v18.x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ This section should get you running with **Amplify API Category** and get you fa
 
    > If you are using Yarn v2, run `yarn set version classic` to change to Yarn Classic.
    >
-   > Note: Ensure that the version of Node installed is < 17.0.0 and >= 14.17.0. During the installation process, some modules may not be compatible with other versions of Node.
+   > Note: Ensure that the version of Node installed is v18.x. During the installation process, some modules may not be compatible with other versions of Node.
 
 1. Ensure you are using the npm registry, even with yarn by running `yarn config set registry https://registry.npmjs.org`
 


### PR DESCRIPTION
#### Description of changes
Update CONTRIBUTING.md to specify Node version v18.x. 

`yarn && yarn build && yarn test` yields `error jsii@5.4.23: The engine "node" is incompatible with this module. Expected version ">= 18.12.0". Got "16.20.2"` on Node version v16.x

##### CDK / CloudFormation Parameters Changed
n/a

#### Issue #, if available
n/a

#### Description of how you validated changes
ran this by @phani-srikar

#### Checklist

- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
