### PR TITLE
allow specifying JS runtime when creating resolver functions within transformer

### DIFF
--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -13,6 +13,7 @@ import { AssetProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { AuthorizationConfig } from 'aws-cdk-lib/aws-appsync';
 import { AuthorizationType } from 'aws-cdk-lib/aws-appsync';
 import { CfnApiKey } from 'aws-cdk-lib/aws-appsync';
+import { CfnFunctionConfiguration } from 'aws-cdk-lib/aws-appsync';
 import { CfnGraphQLSchema } from 'aws-cdk-lib/aws-appsync';
 import { CfnParameter } from 'aws-cdk-lib';
 import { CfnResource } from 'aws-cdk-lib';
@@ -768,9 +769,9 @@ export abstract class TransformerPluginBase implements TransformerPluginProvider
 
 // @public (undocumented)
 export class TransformerResolver implements TransformerResolverProvider {
-    constructor(typeName: string, fieldName: string, resolverLogicalId: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider, requestSlots: string[], responseSlots: string[], datasource?: DataSourceProvider | undefined);
+    constructor(typeName: string, fieldName: string, resolverLogicalId: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider, requestSlots: string[], responseSlots: string[], datasource?: DataSourceProvider | undefined, runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty | undefined);
     // (undocumented)
-    addToSlot: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider, dataSource?: DataSourceProvider) => void;
+    addToSlot: (slotName: string, requestMappingTemplate?: MappingTemplateProvider, responseMappingTemplate?: MappingTemplateProvider, dataSource?: DataSourceProvider, runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty) => void;
     // Warning: (ae-forgotten-export) The symbol "Slot" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/packages/amplify-graphql-transformer-core/src/__tests__/utils/function-runtime-test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/utils/function-runtime-test.ts
@@ -1,0 +1,61 @@
+import { MappingTemplate } from '@aws-amplify/graphql-transformer-core';
+import { getRuntimeSpecificFunctionProps } from '../../utils/function-runtime';
+import { App, Stack } from 'aws-cdk-lib';
+import { GraphQLApi } from '../../graphql-api';
+import { AssetProvider } from '../../../../amplify-graphql-api-construct/src/internal';
+
+describe('Function Runtime Util Tests', () => {
+  const app = new App();
+  const stack = new Stack(app, 'test-root-stack');
+  const api = new GraphQLApi(stack, 'testId', { name: 'testApiName', assetProvider: new AssetProvider(stack) });
+
+  it('should return the correct CfnFunctionConfiguration props for APPSYNC_JS runtime', () => {
+    const request = `
+        export function request(ctx) {
+            return {}
+        }
+    `;
+
+    const response = `
+        export function response(ctx) {
+            return {}
+        }
+    `;
+    const requestMappingTemplate = MappingTemplate.inlineTemplateFromString(request);
+    const responseMappingTemplate = MappingTemplate.inlineTemplateFromString(response);
+
+    const props = {
+      requestMappingTemplate,
+      responseMappingTemplate,
+      runtime: { name: 'APPSYNC_JS', runtimeVersion: '1.0.0' },
+      api,
+    };
+
+    const runtimeSpecificProps = getRuntimeSpecificFunctionProps(stack, props);
+    expect(runtimeSpecificProps).toEqual({
+      runtime: { name: 'APPSYNC_JS', runtimeVersion: '1.0.0' },
+      code: request + '\n\n' + response,
+    });
+  });
+
+  it('should return the correct CfnFunctionConfiguration props for default (VTL) runtime', () => {
+    const request = '$util.toJson({})';
+    const response = '$util.toJson({})';
+
+    const requestMappingTemplate = MappingTemplate.inlineTemplateFromString(request);
+    const responseMappingTemplate = MappingTemplate.inlineTemplateFromString(response);
+
+    const props = {
+      requestMappingTemplate,
+      responseMappingTemplate,
+      api,
+    };
+
+    const runtimeSpecificProps = getRuntimeSpecificFunctionProps(stack, props);
+    expect(runtimeSpecificProps.runtime).toBeUndefined();
+    expect(runtimeSpecificProps).toEqual({
+      requestMappingTemplateS3Location: request,
+      responseMappingTemplateS3Location: response,
+    });
+  });
+});

--- a/packages/amplify-graphql-transformer-core/src/appsync-function.ts
+++ b/packages/amplify-graphql-transformer-core/src/appsync-function.ts
@@ -4,6 +4,7 @@ import { Construct } from 'constructs';
 import { InlineTemplate } from './cdk-compat/template-asset';
 import { GraphQLApi } from './graphql-api';
 import { setResourceName } from './utils';
+import { getRuntimeSpecificFunctionProps } from './utils/function-runtime';
 
 export interface BaseFunctionConfigurationProps {
   /**
@@ -36,6 +37,15 @@ export interface FunctionConfigurationProps extends BaseFunctionConfigurationPro
    * @default - No datasource
    */
   readonly dataSource: BaseDataSource | string;
+
+  /**
+   * Describes a runtime used by an AWS AppSync resolver or AWS AppSync function.
+   *
+   * Specifies the name and version of the runtime to use. Note that if a runtime is specified, code must also be specified.
+   *
+   * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-runtime
+   */
+  readonly runtime: CfnFunctionConfiguration.AppSyncRuntimeProperty | undefined;
 }
 
 export class AppSyncFunctionConfiguration extends Construct {
@@ -51,20 +61,14 @@ export class AppSyncFunctionConfiguration extends Construct {
   constructor(scope: Construct, id: string, props: FunctionConfigurationProps) {
     super(scope, id);
 
-    const requestTemplate = props.requestMappingTemplate.bind(this, props.api.assetProvider);
-    const responseTemplate = props.responseMappingTemplate.bind(this, props.api.assetProvider);
+    const runtimeSpecificProps = getRuntimeSpecificFunctionProps(this, props);
     this.function = new CfnFunctionConfiguration(this, `${id}.AppSyncFunction`, {
       name: id,
       apiId: props.api.apiId,
       functionVersion: '2018-05-29',
       description: props.description,
       dataSourceName: props.dataSource instanceof BaseDataSource ? props.dataSource.ds.attrName : props.dataSource,
-      ...(props.requestMappingTemplate instanceof InlineTemplate
-        ? { requestMappingTemplate: requestTemplate }
-        : { requestMappingTemplateS3Location: requestTemplate }),
-      ...(props.responseMappingTemplate instanceof InlineTemplate
-        ? { responseMappingTemplate: responseTemplate }
-        : { responseMappingTemplateS3Location: responseTemplate }),
+      ...runtimeSpecificProps,
     });
     setResourceName(this.function, { name: id });
     props.api.addSchemaDependency(this.function);

--- a/packages/amplify-graphql-transformer-core/src/transform-host.ts
+++ b/packages/amplify-graphql-transformer-core/src/transform-host.ts
@@ -15,6 +15,7 @@ import {
   LambdaDataSource,
   NoneDataSource,
   CfnResolver,
+  CfnFunctionConfiguration,
 } from 'aws-cdk-lib/aws-appsync';
 import { ITable } from 'aws-cdk-lib/aws-dynamodb';
 import { IRole } from 'aws-cdk-lib/aws-iam';
@@ -25,9 +26,10 @@ import hash from 'object-hash';
 import { Construct } from 'constructs';
 import { AppSyncFunctionConfiguration } from './appsync-function';
 import { SearchableDataSource } from './cdk-compat/searchable-datasource';
-import { InlineTemplate, S3MappingFunctionCode } from './cdk-compat/template-asset';
+import { S3MappingFunctionCode } from './cdk-compat/template-asset';
 import { GraphQLApi } from './graphql-api';
 import { setResourceName } from './utils';
+import { getRuntimeSpecificFunctionProps } from './utils/function-runtime';
 
 type Slot = {
   requestMappingTemplate?: string;
@@ -138,6 +140,7 @@ export class DefaultTransformHost implements TransformHostProvider {
     responseMappingTemplate: MappingTemplateProvider,
     dataSourceName: string,
     scope?: Construct,
+    runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty,
   ): AppSyncFunctionConfiguration => {
     if (dataSourceName && !Token.isUnresolved(dataSourceName) && !this.dataSources.has(dataSourceName)) {
       throw new Error(`DataSource ${dataSourceName} is missing in the API`);
@@ -168,6 +171,7 @@ export class DefaultTransformHost implements TransformHostProvider {
       dataSource: dataSource || dataSourceName,
       requestMappingTemplate,
       responseMappingTemplate,
+      runtime,
     });
     this.appsyncFunctions.set(slotHash, fn);
     return fn;
@@ -182,15 +186,20 @@ export class DefaultTransformHost implements TransformHostProvider {
     dataSourceName?: string,
     pipelineConfig?: string[],
     scope?: Construct,
+    runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty,
   ): CfnResolver => {
     if (dataSourceName && !Token.isUnresolved(dataSourceName) && !this.dataSources.has(dataSourceName)) {
       throw new Error(`DataSource ${dataSourceName} is missing in the API`);
     }
 
-    const requestTemplateLocation = requestMappingTemplate.bind(this.api, this.api.assetProvider);
-    const responseTemplateLocation = responseMappingTemplate.bind(this.api, this.api.assetProvider);
     const resolverName = toCamelCase([resourceName(typeName), resourceName(fieldName), 'Resolver']);
     const resourceId = resolverLogicalId ?? ResolverResourceIDs.ResolverResourceID(typeName, fieldName);
+    const runtimeSpecificProps = getRuntimeSpecificFunctionProps(this.api, {
+      requestMappingTemplate,
+      responseMappingTemplate,
+      runtime,
+      api: this.api,
+    });
 
     if (dataSourceName) {
       const dataSource = this.dataSources.get(dataSourceName);
@@ -200,12 +209,7 @@ export class DefaultTransformHost implements TransformHostProvider {
         typeName,
         kind: 'UNIT',
         dataSourceName: dataSource?.ds.attrName || dataSourceName,
-        ...(requestMappingTemplate instanceof InlineTemplate
-          ? { requestMappingTemplate: requestTemplateLocation }
-          : { requestMappingTemplateS3Location: requestTemplateLocation }),
-        ...(responseMappingTemplate instanceof InlineTemplate
-          ? { responseMappingTemplate: responseTemplateLocation }
-          : { responseMappingTemplateS3Location: responseTemplateLocation }),
+        ...runtimeSpecificProps,
       });
       resolver.overrideLogicalId(resourceId);
       setResourceName(resolver, { name: `${typeName}.${fieldName}` });
@@ -218,16 +222,12 @@ export class DefaultTransformHost implements TransformHostProvider {
         fieldName,
         typeName,
         kind: 'PIPELINE',
-        ...(requestMappingTemplate instanceof InlineTemplate
-          ? { requestMappingTemplate: requestTemplateLocation }
-          : { requestMappingTemplateS3Location: requestTemplateLocation }),
-        ...(responseMappingTemplate instanceof InlineTemplate
-          ? { responseMappingTemplate: responseTemplateLocation }
-          : { responseMappingTemplateS3Location: responseTemplateLocation }),
         pipelineConfig: {
           functions: pipelineConfig,
         },
+        ...runtimeSpecificProps,
       });
+
       resolver.overrideLogicalId(resourceId);
       setResourceName(resolver, { name: `${typeName}.${fieldName}` });
       this.api.addSchemaDependency(resolver);

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -23,6 +23,7 @@ type Slot = {
   requestMappingTemplate?: MappingTemplateProvider;
   responseMappingTemplate?: MappingTemplateProvider;
   dataSource?: DataSourceProvider;
+  runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty;
 };
 
 // Name of the None Data source used for pipeline resolver
@@ -142,6 +143,7 @@ export class TransformerResolver implements TransformerResolverProvider {
     private requestSlots: string[],
     private responseSlots: string[],
     private datasource?: DataSourceProvider,
+    private runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty,
   ) {
     if (!typeName) {
       throw new InvalidDirectiveError('typeName is required');
@@ -179,6 +181,7 @@ export class TransformerResolver implements TransformerResolverProvider {
     requestMappingTemplate?: MappingTemplateProvider,
     responseMappingTemplate?: MappingTemplateProvider,
     dataSource?: DataSourceProvider,
+    runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty,
   ): void => {
     if (!this.slotNames.has(slotName)) {
       throw new Error(`Resolver is missing slot ${slotName}`);
@@ -197,6 +200,7 @@ export class TransformerResolver implements TransformerResolverProvider {
         requestMappingTemplate,
         responseMappingTemplate,
         dataSource,
+        runtime,
       });
     }
     this.slotMap.set(slotName, slotEntry);
@@ -272,7 +276,10 @@ export class TransformerResolver implements TransformerResolverProvider {
       this.responseMappingTemplate,
       this.datasource?.name || NONE_DATA_SOURCE_NAME,
       scope,
+      this.runtime,
     );
+
+    const stashStatement = this.stashStatementGenerator(this.runtime);
 
     let dataSourceType = 'NONE';
     let dataSource = '';
@@ -282,7 +289,7 @@ export class TransformerResolver implements TransformerResolverProvider {
         case 'AMAZON_DYNAMODB':
           if (this.datasource.ds.dynamoDbConfig && !isResolvableObject(this.datasource.ds.dynamoDbConfig)) {
             const tableName = this.datasource.ds.dynamoDbConfig?.tableName;
-            dataSource = `$util.qr($ctx.stash.put("tableName", "${tableName}"))`;
+            dataSource = stashStatement('tableName', `"${tableName}"`);
             if (
               this.datasource.ds.dynamoDbConfig?.deltaSyncConfig &&
               !isResolvableObject(this.datasource.ds.dynamoDbConfig?.deltaSyncConfig)
@@ -302,7 +309,7 @@ export class TransformerResolver implements TransformerResolverProvider {
                   return SyncUtils.syncDataSourceConfig().DeltaSyncTableTTL.toString();
                 },
               });
-              dataSource += `\n$util.qr($ctx.stash.put("deltaSyncTableTtl", ${deltaSyncTableTtl}))`;
+              dataSource += '\n' + stashStatement('deltaSyncTableTtl', `"${deltaSyncTableTtl}"`);
             }
           }
 
@@ -334,19 +341,19 @@ export class TransformerResolver implements TransformerResolverProvider {
         case 'AMAZON_ELASTICSEARCH':
           if (this.datasource.ds.elasticsearchConfig && !isResolvableObject(this.datasource.ds.elasticsearchConfig)) {
             const endpoint = this.datasource.ds.elasticsearchConfig?.endpoint;
-            dataSource = `$util.qr($ctx.stash.put("endpoint", "${endpoint}"))`;
+            dataSource = stashStatement('endpoint', `"${endpoint}"`);
           }
           break;
         case 'AWS_LAMBDA':
           if (this.datasource.ds.lambdaConfig && !isResolvableObject(this.datasource.ds.lambdaConfig)) {
             const lambdaFunctionArn = this.datasource.ds.lambdaConfig?.lambdaFunctionArn;
-            dataSource = `$util.qr($ctx.stash.put("lambdaFunctionArn", "${lambdaFunctionArn}"))`;
+            dataSource = stashStatement('lambdaFunctionArn', `"${lambdaFunctionArn}"`);
           }
           break;
         case 'HTTP':
           if (this.datasource.ds.httpConfig && !isResolvableObject(this.datasource.ds.httpConfig)) {
             const endpoint = this.datasource.ds.httpConfig?.endpoint;
-            dataSource = `$util.qr($ctx.stash.put("endpoint", "${endpoint}"))`;
+            dataSource = stashStatement('endpoint', `"${endpoint}"`);
           }
           break;
         case 'RELATIONAL_DATABASE':
@@ -356,7 +363,7 @@ export class TransformerResolver implements TransformerResolverProvider {
             !isResolvableObject(this.datasource.ds.relationalDatabaseConfig?.rdsHttpEndpointConfig)
           ) {
             const databaseName = this.datasource.ds.relationalDatabaseConfig?.rdsHttpEndpointConfig!.databaseName;
-            dataSource = `$util.qr($ctx.stash.metadata.put("databaseName", "${databaseName}"))`;
+            dataSource = stashStatement('databaseName', `"${databaseName}"`);
           }
           break;
         default:
@@ -364,48 +371,77 @@ export class TransformerResolver implements TransformerResolverProvider {
       }
     }
     let initResolver = dedent`
-      $util.qr($ctx.stash.put("typeName", "${this.typeName}"))
-      $util.qr($ctx.stash.put("fieldName", "${this.fieldName}"))
-      $util.qr($ctx.stash.put("conditions", []))
-      $util.qr($ctx.stash.put("metadata", {}))
-      $util.qr($ctx.stash.metadata.put("dataSourceType", "${dataSourceType}"))
-      $util.qr($ctx.stash.metadata.put("apiId", "${api.apiId}"))
-      $util.qr($ctx.stash.put("connectionAttributes", {}))
+      ${stashStatement('typeName', `"${this.typeName}"`)}
+      ${stashStatement('fieldName', `"${this.fieldName}"`)}
+      ${stashStatement('conditions', '[]')}
+      ${stashStatement('metadata', '{}')}
+      ${stashStatement('dataSourceType', `"${dataSourceType}"`, 'metadata')}
+      ${stashStatement('apiId', `"${api.apiId}"`, 'metadata')}
+      ${stashStatement('connectionAttributes', '{}')}
       ${dataSource}
     `;
     const account = Stack.of(context.stackManager.scope).account;
     const authRole = context.synthParameters.authenticatedUserRoleName;
     if (authRole) {
+      const authRoleStatement = stashStatement('authRole', `"arn:aws:sts::${account}:assumed-role/${authRole}/CognitoIdentityCredentials"`);
+
       initResolver += dedent`\n
-      $util.qr($ctx.stash.put("authRole", "arn:aws:sts::${account}:assumed-role/${authRole}/CognitoIdentityCredentials"))
+        ${authRoleStatement}
       `;
     }
     const unauthRole = context.synthParameters.unauthenticatedUserRoleName;
     if (unauthRole) {
+      const unauthRoleStatement = stashStatement(
+        'unauthRole',
+        `"arn:aws:sts::${account}:assumed-role/${unauthRole}/CognitoIdentityCredentials"`,
+      );
       initResolver += dedent`\n
-      $util.qr($ctx.stash.put("unauthRole", "arn:aws:sts::${account}:assumed-role/${unauthRole}/CognitoIdentityCredentials"))
+        ${unauthRoleStatement}
       `;
     }
     const identityPoolId = context.synthParameters.identityPoolId;
     if (identityPoolId) {
+      const identityPoolStatement = stashStatement('identityPoolId', `"${identityPoolId}"`);
       initResolver += dedent`\n
-        $util.qr($ctx.stash.put("identityPoolId", "${identityPoolId}"))
+        ${identityPoolStatement}
       `;
     }
     const adminRoles = context.synthParameters.adminRoles ?? [];
+    const adminRolesStatement = stashStatement('adminRoles', `${JSON.stringify(adminRoles)}`);
     initResolver += dedent`\n
-      $util.qr($ctx.stash.put("adminRoles", ${JSON.stringify(adminRoles)}))
+      ${adminRolesStatement}
     `;
-    initResolver += '\n$util.toJson({})';
+
+    if (this.runtime?.name === 'APPSYNC_JS') {
+      initResolver = dedent`
+        export const request = (ctx) => {
+          ${initResolver}
+          return {};
+        }
+      `;
+    } else {
+      initResolver += '\n$util.toJson({})';
+    }
+
+    const initResponseResolver =
+      this.runtime?.name === 'APPSYNC_JS'
+        ? dedent`
+        export const response = (ctx) => {
+          return ctx.prev.result;
+        };
+      `
+        : '$util.toJson($ctx.prev.result)';
+
     api.host.addResolver(
       this.typeName,
       this.fieldName,
       MappingTemplate.inlineTemplateFromString(initResolver),
-      MappingTemplate.inlineTemplateFromString('$util.toJson($ctx.prev.result)'),
+      MappingTemplate.inlineTemplateFromString(initResponseResolver),
       this.resolverLogicalId,
       undefined,
       [...requestFns, dataSourceProviderFn, ...responseFns].map((fn) => fn.functionId),
       scope,
+      this.runtime,
     );
   };
 
@@ -430,6 +466,7 @@ export class TransformerResolver implements TransformerResolverProvider {
             responseMappingTemplate || MappingTemplate.inlineTemplateFromString('$util.toJson({})'),
             dataSource?.name || NONE_DATA_SOURCE_NAME,
             scope,
+            slotItem.runtime,
           );
           appSyncFunctions.push(fn);
         }
@@ -465,5 +502,19 @@ export class TransformerResolver implements TransformerResolverProvider {
         description: 'None Data Source for Pipeline functions',
       });
     }
+  }
+
+  private stashStatementGenerator(
+    runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty,
+  ): (name: string, value?: string, object?: string) => string {
+    const jsStashStatement = (name: string, value?: string, object?: string): string => {
+      const objectPrefix = object ? `.${object}` : '';
+      return `ctx.stash${objectPrefix}.${name} = ${value};`;
+    };
+    const vtlStashStatement = (name: string, value?: string, object?: string): string => {
+      const objectPrefix = object ? `.${object}` : '';
+      return `$util.qr($ctx.stash${objectPrefix}.put("${name}", ${value}))`;
+    };
+    return runtime?.name === 'APPSYNC_JS' ? jsStashStatement : vtlStashStatement;
   }
 }

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -280,7 +280,7 @@ export class TransformerResolver implements TransformerResolverProvider {
       this.runtime,
     );
 
-    const { stashString, stashExpression } = this.generateStashStatementGenerator(this.runtime);
+    const { stashString, stashExpression } = this.createStashStatementGenerator(this.runtime);
 
     let dataSourceType = 'NONE';
     let dataSource = '';
@@ -509,7 +509,7 @@ export class TransformerResolver implements TransformerResolverProvider {
    * @param {CfnFunctionConfiguration.AppSyncRuntimeProperty} runtime - The AppSync runtime configuration.
    * @returns {StashStatementGenerator} An object with methods to generate stash statements.
    */
-  private generateStashStatementGenerator(runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty): StashStatementGenerator {
+  private createStashStatementGenerator(runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty): StashStatementGenerator {
     const jsStash = (props: StashStatementGeneratorProps): string => {
       const { name, value, object } = props;
       const objectPrefix = object ? `.${object}` : '';

--- a/packages/amplify-graphql-transformer-core/src/utils/function-runtime.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/function-runtime.ts
@@ -4,15 +4,42 @@ import { GraphQLApi } from '../graphql-api';
 import { InlineTemplate } from '../cdk-compat';
 import { Construct } from 'constructs';
 
+/**
+ * Checks if the given runtime is a JavaScript resolver function runtime.
+ * @param runtime - The AppSync runtime configuration.
+ * @returns True if the runtime is JavaScript, false otherwise.
+ */
+export const isJsResolverFnRuntime = (runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty): boolean => runtime?.name === 'APPSYNC_JS';
+
+/**
+ * Represents the runtime-specific properties for an AppSync function.
+ */
 type RuntimeSpecificFunctionProps = {
+  /** The request mapping template as a string. Used for VTL runtimes. */
   requestMappingTemplate?: string;
+  /** The response mapping template as a string. Used for VTL runtimes. */
   responseMappingTemplate?: string;
+  /** The S3 location of the request mapping template. Used for VTL runtimes with S3-stored templates. */
   requestMappingTemplateS3Location?: string;
+  /** The S3 location of the response mapping template. Used for VTL runtimes with S3-stored templates. */
   responseMappingTemplateS3Location?: string;
+  /** The AppSync runtime configuration. */
   runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty;
+  /** The function code as a string. Used for JavaScript runtimes. */
   code?: string;
 };
 
+/**
+ * Retrieves the runtime-specific function properties based on the provided configuration.
+ *
+ * @param scope - The construct scope.
+ * @param props - An object containing the function configuration properties.
+ * @param props.requestMappingTemplate - The request mapping template provider.
+ * @param props.responseMappingTemplate - The response mapping template provider.
+ * @param props.runtime - AppSync resolver function runtime configuration.
+ * @param props.api - The GraphQL API instance.
+ * @returns An object with runtime-specific function properties.
+ */
 export const getRuntimeSpecificFunctionProps = (
   scope: Construct,
   props: {
@@ -27,7 +54,7 @@ export const getRuntimeSpecificFunctionProps = (
   const requestTemplateLocation = requestMappingTemplate.bind(scope, api.assetProvider);
   const responseTemplateLocation = responseMappingTemplate.bind(scope, api.assetProvider);
 
-  if (runtime?.name === 'APPSYNC_JS') {
+  if (isJsResolverFnRuntime(runtime)) {
     return {
       runtime,
       code: requestTemplateLocation + '\n\n' + responseTemplateLocation,

--- a/packages/amplify-graphql-transformer-core/src/utils/function-runtime.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/function-runtime.ts
@@ -1,0 +1,45 @@
+import { MappingTemplateProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { CfnFunctionConfiguration } from 'aws-cdk-lib/aws-appsync';
+import { GraphQLApi } from '../graphql-api';
+import { InlineTemplate } from '../cdk-compat';
+import { Construct } from 'constructs';
+
+type RuntimeSpecificFunctionProps = {
+  requestMappingTemplate?: string;
+  responseMappingTemplate?: string;
+  requestMappingTemplateS3Location?: string;
+  responseMappingTemplateS3Location?: string;
+  runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty;
+  code?: string;
+};
+
+export const getRuntimeSpecificFunctionProps = (
+  scope: Construct,
+  props: {
+    requestMappingTemplate: MappingTemplateProvider;
+    responseMappingTemplate: MappingTemplateProvider;
+    runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty;
+    api: GraphQLApi;
+  },
+): RuntimeSpecificFunctionProps => {
+  const { requestMappingTemplate, responseMappingTemplate, runtime, api } = props;
+
+  const requestTemplateLocation = requestMappingTemplate.bind(scope, api.assetProvider);
+  const responseTemplateLocation = responseMappingTemplate.bind(scope, api.assetProvider);
+
+  if (runtime?.name === 'APPSYNC_JS') {
+    return {
+      runtime,
+      code: requestTemplateLocation + '\n\n' + responseTemplateLocation,
+    };
+  }
+
+  return {
+    ...(requestMappingTemplate instanceof InlineTemplate
+      ? { requestMappingTemplate: requestTemplateLocation }
+      : { requestMappingTemplateS3Location: requestTemplateLocation }),
+    ...(responseMappingTemplate instanceof InlineTemplate
+      ? { responseMappingTemplate: responseTemplateLocation }
+      : { responseMappingTemplateS3Location: responseTemplateLocation }),
+  };
+};

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -7,6 +7,7 @@
 import { BackedDataSource } from 'aws-cdk-lib/aws-appsync';
 import { BaseDataSource } from 'aws-cdk-lib/aws-appsync';
 import { CfnDomain } from 'aws-cdk-lib/aws-elasticsearch';
+import { CfnFunctionConfiguration } from 'aws-cdk-lib/aws-appsync';
 import { CfnParameter } from 'aws-cdk-lib';
 import { CfnResolver } from 'aws-cdk-lib/aws-appsync';
 import { CfnResource } from 'aws-cdk-lib';
@@ -869,7 +870,7 @@ export type TransformerValidationStepContextProvider = Pick<TransformerContextPr
 // @public (undocumented)
 export interface TransformHostProvider {
     // (undocumented)
-    addAppSyncFunction: (name: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider, dataSourceName: string, scope?: Construct) => AppSyncFunctionConfigurationProvider;
+    addAppSyncFunction: (name: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider, dataSourceName: string, scope?: Construct, runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty) => AppSyncFunctionConfigurationProvider;
     // (undocumented)
     addDynamoDbDataSource(name: string, table: ITable, options?: DynamoDbDataSourceOptions, scope?: Construct): DynamoDbDataSource;
     // (undocumented)
@@ -883,7 +884,7 @@ export interface TransformHostProvider {
     // (undocumented)
     addNoneDataSource(name: string, options?: DataSourceOptions, scope?: Construct): NoneDataSource;
     // (undocumented)
-    addResolver: (typeName: string, fieldName: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider, resolverLogicalId?: string, dataSourceName?: string, pipelineConfig?: string[], scope?: Construct) => CfnResolver;
+    addResolver: (typeName: string, fieldName: string, requestMappingTemplate: MappingTemplateProvider, responseMappingTemplate: MappingTemplateProvider, resolverLogicalId?: string, dataSourceName?: string, pipelineConfig?: string[], scope?: Construct, runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty) => CfnResolver;
     // (undocumented)
     addSearchableDataSource(name: string, endpoint: string, region: string, options?: SearchableDataSourceOptions, scope?: Construct): BaseDataSource;
     // (undocumented)

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -205,6 +205,8 @@ export interface GraphQLAPIProvider extends IConstruct {
     // (undocumented)
     grantSubscription: (grantee: IGrantable, ...fields: string[]) => Grant;
     // (undocumented)
+    readonly graphqlUrl: string;
+    // (undocumented)
     readonly host: TransformHostProvider;
     // (undocumented)
     readonly name: string;

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -206,8 +206,6 @@ export interface GraphQLAPIProvider extends IConstruct {
     // (undocumented)
     grantSubscription: (grantee: IGrantable, ...fields: string[]) => Grant;
     // (undocumented)
-    readonly graphqlUrl: string;
-    // (undocumented)
     readonly host: TransformHostProvider;
     // (undocumented)
     readonly name: string;

--- a/packages/amplify-graphql-transformer-interfaces/src/graphql-api-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/graphql-api-provider.ts
@@ -128,6 +128,7 @@ export type MappingTemplateProvider = InlineMappingTemplateProvider | S3MappingT
 
 export interface GraphQLAPIProvider extends IConstruct {
   readonly apiId: string;
+  readonly graphqlUrl: string;
   readonly host: TransformHostProvider;
   readonly name: string;
   readonly assetProvider: AssetProvider;

--- a/packages/amplify-graphql-transformer-interfaces/src/graphql-api-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/graphql-api-provider.ts
@@ -128,7 +128,6 @@ export type MappingTemplateProvider = InlineMappingTemplateProvider | S3MappingT
 
 export interface GraphQLAPIProvider extends IConstruct {
   readonly apiId: string;
-  readonly graphqlUrl: string;
   readonly host: TransformHostProvider;
   readonly name: string;
   readonly assetProvider: AssetProvider;

--- a/packages/amplify-graphql-transformer-interfaces/src/transform-host-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transform-host-provider.ts
@@ -7,6 +7,7 @@ import {
   LambdaDataSource,
   NoneDataSource,
   CfnResolver,
+  CfnFunctionConfiguration,
 } from 'aws-cdk-lib/aws-appsync';
 import { ITable } from 'aws-cdk-lib/aws-dynamodb';
 import { IFunction, ILayerVersion, Runtime } from 'aws-cdk-lib/aws-lambda';
@@ -48,6 +49,7 @@ export interface TransformHostProvider {
     responseMappingTemplate: MappingTemplateProvider,
     dataSourceName: string,
     scope?: Construct,
+    runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty,
   ) => AppSyncFunctionConfigurationProvider;
 
   addResolver: (
@@ -59,6 +61,7 @@ export interface TransformHostProvider {
     dataSourceName?: string,
     pipelineConfig?: string[],
     scope?: Construct,
+    runtime?: CfnFunctionConfiguration.AppSyncRuntimeProperty,
   ) => CfnResolver;
 
   addLambdaFunction: (


### PR DESCRIPTION
## Description of changes

### Allows specifying JS runtime for resolver functions
This change is only applicable to the transformer internals -- it does not expose a way for customers to specify the runtime of a resolver function.

Note: The changes made to accomplish this are the minimal changes necessary, not necessarily the best way. A more appropriate way of supporting JS runtime would be adding overloads or additional optional properties specifying `code` / `codeS3Location`. This is likely what we should do when adding support for handling `a.handler.custom({})` in the transformer. In the meantime, I favored minimal risk over ideal approach for this change.

##### CDK / CloudFormation Parameters Changed

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
