### PR TITLE
fix: don't print deprecation warning when pattern is not used

### DIFF
--- a/packages/amplify-graphql-api-construct/src/__tests__/__functional__/disable-gen1-patterns.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/__functional__/disable-gen1-patterns.test.ts
@@ -38,6 +38,19 @@ describe('Deprecate Gen 1 patterns', () => {
     );
   });
 
+  test('does not print @manyToMany warning when @manyToMany is not used', () => {
+    const stack = verifySchema(/* GraphQL */ `
+      type Post @model {
+        title: String
+      }
+    `);
+
+    Annotations.fromStack(stack).hasNoWarning(
+      '/Default/TestApi/GraphQLAPI',
+      '@manyToMany is deprecated. This functionality will be removed in the next major release.',
+    );
+  });
+
   test('does not allow @searchable', () => {
     const stack = verifySchema(/* GraphQL */ `
       type Post @model @searchable {
@@ -46,6 +59,19 @@ describe('Deprecate Gen 1 patterns', () => {
     `);
 
     Annotations.fromStack(stack).hasWarning(
+      '/Default/TestApi/GraphQLAPI',
+      '@searchable is deprecated. This functionality will be removed in the next major release.',
+    );
+  });
+
+  test('does not print @searchable warning when @searchable is not used', () => {
+    const stack = verifySchema(/* GraphQL */ `
+      type Post @model {
+        title: String
+      }
+    `);
+
+    Annotations.fromStack(stack).hasNoWarning(
       '/Default/TestApi/GraphQLAPI',
       '@searchable is deprecated. This functionality will be removed in the next major release.',
     );
@@ -71,6 +97,19 @@ describe('Deprecate Gen 1 patterns', () => {
     );
   });
 
+  test('does not print @predictions warning when @predictions is not used', () => {
+    const stack = verifySchema(/* GraphQL */ `
+      type Post @model {
+        title: String
+      }
+    `);
+
+    Annotations.fromStack(stack).hasNoWarning(
+      '/Default/TestApi/GraphQLAPI',
+      '@predictions is deprecated. This functionality will be removed in the next major release.',
+    );
+  });
+
   test('does not allow fields on @belongsTo', () => {
     const stack = verifySchema(/* GraphQL */ `
       type Post @model {
@@ -83,6 +122,23 @@ describe('Deprecate Gen 1 patterns', () => {
       }
     `);
     Annotations.fromStack(stack).hasWarning(
+      '/Default/TestApi/GraphQLAPI',
+      'fields argument on @belongsTo is deprecated. Modify Post.author to use references instead. This functionality will be removed in the next major release.',
+    );
+  });
+
+  test('does not print warning when fields is not used on @belongsTo', () => {
+    const stack = verifySchema(/* GraphQL */ `
+      type Post @model {
+        authorID: ID
+        author: Author @belongsTo(references: "authorID")
+      }
+
+      type Author @model {
+        posts: [Post] @hasMany(references: "authorID")
+      }
+    `);
+    Annotations.fromStack(stack).hasNoWarning(
       '/Default/TestApi/GraphQLAPI',
       'fields argument on @belongsTo is deprecated. Modify Post.author to use references instead. This functionality will be removed in the next major release.',
     );
@@ -105,6 +161,23 @@ describe('Deprecate Gen 1 patterns', () => {
     );
   });
 
+  test('does not print warning when fields is not used on @hasMany', () => {
+    const stack = verifySchema(/* GraphQL */ `
+      type Post @model {
+        authorID: ID
+        author: Author @belongsTo(references: "authorID")
+      }
+
+      type Author @model {
+        posts: [Post] @hasMany(references: "authorID")
+      }
+    `);
+    Annotations.fromStack(stack).hasNoWarning(
+      '/Default/TestApi/GraphQLAPI',
+      'fields argument on @hasMany is deprecated. Modify Author.posts to use references instead. This functionality will be removed in the next major release.',
+    );
+  });
+
   test('does not allow fields on @hasOne', () => {
     const stack = verifySchema(/* GraphQL */ `
       type Profile @model {
@@ -122,6 +195,23 @@ describe('Deprecate Gen 1 patterns', () => {
     );
   });
 
+  test('does not print warning when fields is not used on @hasOne', () => {
+    const stack = verifySchema(/* GraphQL */ `
+      type Profile @model {
+        authorID: ID
+        author: Author @belongsTo(references: "authorID")
+      }
+
+      type Author @model {
+        profile: Profile @hasOne(references: "authorID")
+      }
+    `);
+    Annotations.fromStack(stack).hasNoWarning(
+      '/Default/TestApi/GraphQLAPI',
+      'fields argument on @hasOne is deprecated. Modify Author.profile to use references instead. This functionality will be removed in the next major release.',
+    );
+  });
+
   test('does not allow required @belongsTo fields', () => {
     const stack = verifySchema(/* GraphQL */ `
       type Post @model {
@@ -134,7 +224,23 @@ describe('Deprecate Gen 1 patterns', () => {
     `);
     Annotations.fromStack(stack).hasWarning(
       '/Default/TestApi/GraphQLAPI',
-      'fields argument on @belongsTo is deprecated. Modify Post.author to use references instead. This functionality will be removed in the next major release.',
+      '@belongsTo on required fields is deprecated. Modify Post.author to be optional. This functionality will be removed in the next major release.',
+    );
+  });
+
+  test('does not print when not using required @belongsTo fields', () => {
+    const stack = verifySchema(/* GraphQL */ `
+      type Post @model {
+        author: Author @belongsTo
+      }
+
+      type Author @model {
+        posts: [Post] @hasMany
+      }
+    `);
+    Annotations.fromStack(stack).hasNoWarning(
+      '/Default/TestApi/GraphQLAPI',
+      '@belongsTo on required fields is deprecated. Modify Author.posts to be optional. This functionality will be removed in the next major release.',
     );
   });
 
@@ -154,6 +260,22 @@ describe('Deprecate Gen 1 patterns', () => {
     );
   });
 
+  test('does not print warning when not using required @hasMany fields', () => {
+    const stack = verifySchema(/* GraphQL */ `
+      type Post @model {
+        author: Author @belongsTo
+      }
+
+      type Author @model {
+        posts: [Post] @hasMany
+      }
+    `);
+    Annotations.fromStack(stack).hasNoWarning(
+      '/Default/TestApi/GraphQLAPI',
+      '@hasMany on required fields is deprecated. Modify Author.posts to be optional. This functionality will be removed in the next major release.',
+    );
+  });
+
   test('does not allow required @hasOne fields', () => {
     const stack = verifySchema(/* GraphQL */ `
       type Profile @model {
@@ -165,6 +287,22 @@ describe('Deprecate Gen 1 patterns', () => {
       }
     `);
     Annotations.fromStack(stack).hasWarning(
+      '/Default/TestApi/GraphQLAPI',
+      '@hasOne on required fields is deprecated. Modify Author.profile to be optional. This functionality will be removed in the next major release.',
+    );
+  });
+
+  test('does not print warning when not using required @hasOne fields', () => {
+    const stack = verifySchema(/* GraphQL */ `
+      type Profile @model {
+        author: Author @belongsTo
+      }
+
+      type Author @model {
+        profile: Profile @hasOne
+      }
+    `);
+    Annotations.fromStack(stack).hasNoWarning(
       '/Default/TestApi/GraphQLAPI',
       '@hasOne on required fields is deprecated. Modify Author.profile to be optional. This functionality will be removed in the next major release.',
     );

--- a/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
+++ b/packages/amplify-graphql-predictions-transformer/src/graphql-predictions-transformer.ts
@@ -153,14 +153,15 @@ export class PredictionsTransformer extends TransformerPluginBase {
   };
 
   generateResolvers = (context: TransformerContextProvider): void => {
+    if (this.directiveList.length === 0) {
+      return;
+    }
+
     // This validation can't occur in validate because the api has not been initialized until generateResolvers
     if (!context.transformParameters.allowGen1Patterns) {
       cdk.Annotations.of(context.api).addWarning(
         `@${PredictionsDirective.name} is deprecated. This functionality will be removed in the next major release.`,
       );
-    }
-    if (this.directiveList.length === 0) {
-      return;
     }
 
     const stack: cdk.Stack = context.stackManager.createStack(PREDICTIONS_DIRECTIVE_STACK);

--- a/packages/amplify-graphql-relational-transformer/src/graphql-many-to-many-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-many-to-many-transformer.ts
@@ -510,6 +510,10 @@ export class ManyToManyTransformer extends TransformerPluginBase {
   };
 
   generateResolvers = (ctx: TransformerContextProvider): void => {
+    if (this.directiveList.length === 0) {
+      return;
+    }
+
     const context = ctx as TransformerContextProvider;
     // This validation can't occur in validate because the api has not been initialized until generateResolvers
     if (!context.transformParameters.allowGen1Patterns) {

--- a/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
@@ -281,15 +281,15 @@ export class SearchableModelTransformer extends TransformerPluginBase {
   }
 
   generateResolvers = (context: TransformerContextProvider): void => {
+    if (!this.isSearchableConfigured()) {
+      return;
+    }
+
     // This validation can't occur in validate because the api has not been initialized until generateResolvers
     if (!context.transformParameters.allowGen1Patterns) {
       Annotations.of(context.api).addWarning(
         `@${SearchableDirective.name} is deprecated. This functionality will be removed in the next major release.`,
       );
-    }
-
-    if (!this.isSearchableConfigured()) {
-      return;
     }
 
     const { HasEnvironmentParameter } = ResourceConstants.CONDITIONS;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* don't print deprecation warning when pattern is not used

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

N/A

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-category-api/issues/2803

#### Description of how you validated changes

* Unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
