### PR TITLE
test: Restore modulemapper to jest config in client canary

### DIFF
--- a/client-test-apps/js/api-model-relationship-app/package.json
+++ b/client-test-apps/js/api-model-relationship-app/package.json
@@ -64,5 +64,10 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "axios": "axios/dist/node/axios.cjs"
+    }
   }
 }


### PR DESCRIPTION
#### Description of changes

Client canary failures started after the Jest 29 upgrade (#2747) was merged to `main`. I was able to resolve locally by restoring the `moduleNameMapper` config to the canary's `package.json`.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
