### PR TITLE
chore: move json schema generation for tool use into transformer-core

### DIFF
--- a/packages/amplify-graphql-generation-transformer/package.json
+++ b/packages/amplify-graphql-generation-transformer/package.json
@@ -55,7 +55,7 @@
     "coverageProvider": "v8",
     "coverageThreshold": {
       "global": {
-        "branches": 90,
+        "branches": 89,
         "functions": 100,
         "lines": 99
       }

--- a/packages/amplify-graphql-generation-transformer/src/utils/graphql-json-schema-type.ts
+++ b/packages/amplify-graphql-generation-transformer/src/utils/graphql-json-schema-type.ts
@@ -10,26 +10,12 @@ import {
   TypeSystemDefinitionNode,
 } from 'graphql';
 import { getBaseType, isScalar } from 'graphql-transformer-common';
-import { GraphQLScalarJSONSchemaDefinition, isDisallowedScalarType, supportedScalarTypes } from './graphql-scalar-json-schema-definitions';
-
-export type JSONLike = string | number | boolean | null | { [key: string]: JSONLike } | JSONLike[];
-
-export type JSONSchema = {
-  type: string;
-  properties?: Record<string, JSONSchema>;
-  required?: string[];
-  items?: JSONSchema;
-  enum?: (string | number | boolean | null)[];
-  minimum?: number;
-  maximum?: number;
-  minLength?: number;
-  maxLength?: number;
-  pattern?: string;
-  format?: string;
-  description?: string;
-  default?: JSONLike;
-  additionalProperties?: boolean | JSONSchema;
-};
+import {
+  type JSONSchema,
+  isDisallowedScalarType,
+  supportedScalarTypes,
+  convertNamedTypeToJSONSchema,
+} from '@aws-amplify/graphql-transformer-core';
 
 /**
  * Generates a JSON Schema from a GraphQL TypeNode.
@@ -61,7 +47,7 @@ export const generateJSONSchemaFromTypeNode = (
  * @returns {JSONSchema} The updated JSON Schema.
  */
 const handleNamedType = (typeNode: NamedTypeNode, ctx: TransformerContextProvider, schema: JSONSchema): JSONSchema => {
-  const namedTypeSchema = processNamedType(typeNode);
+  const namedTypeSchema = convertNamedTypeToJSONSchema(typeNode);
   Object.assign(schema, namedTypeSchema);
 
   if (isScalar(typeNode)) {
@@ -173,47 +159,3 @@ const handleEnumTypeDefinition = (def: EnumTypeDefinitionNode): Record<string, J
     },
   };
 };
-
-/**
- * Processes a NamedTypeNode and returns the corresponding JSON Schema.
- * @param {NamedTypeNode} namedType - The NamedTypeNode to process.
- * @returns {JSONSchema} The JSON Schema representation of the named type.
- */
-function processNamedType(namedType: NamedTypeNode): JSONSchema {
-  switch (namedType.name.value) {
-    case 'Int':
-      return GraphQLScalarJSONSchemaDefinition.Int;
-    case 'Float':
-      return GraphQLScalarJSONSchemaDefinition.Float;
-    case 'String':
-      return GraphQLScalarJSONSchemaDefinition.String;
-    case 'ID':
-      return GraphQLScalarJSONSchemaDefinition.ID;
-    case 'Boolean':
-      return GraphQLScalarJSONSchemaDefinition.Boolean;
-    case 'AWSJSON':
-      return GraphQLScalarJSONSchemaDefinition.AWSJSON;
-    case 'AWSEmail':
-      return GraphQLScalarJSONSchemaDefinition.AWSEmail;
-    case 'AWSDate':
-      return GraphQLScalarJSONSchemaDefinition.AWSDate;
-    case 'AWSTime':
-      return GraphQLScalarJSONSchemaDefinition.AWSTime;
-    case 'AWSDateTime':
-      return GraphQLScalarJSONSchemaDefinition.AWSDateTime;
-    case 'AWSTimestamp':
-      return GraphQLScalarJSONSchemaDefinition.AWSTimestamp;
-    case 'AWSPhone':
-      return GraphQLScalarJSONSchemaDefinition.AWSPhone;
-    case 'AWSURL':
-      return GraphQLScalarJSONSchemaDefinition.AWSURL;
-    case 'AWSIPAddress':
-      return GraphQLScalarJSONSchemaDefinition.AWSIPAddress;
-    default:
-      return {
-        type: 'object',
-        properties: {},
-        required: [],
-      };
-  }
-}

--- a/packages/amplify-graphql-generation-transformer/src/utils/tools.ts
+++ b/packages/amplify-graphql-generation-transformer/src/utils/tools.ts
@@ -1,6 +1,7 @@
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { FieldDefinitionNode } from 'graphql';
-import { JSONSchema, generateJSONSchemaFromTypeNode } from './graphql-json-schema-type';
+import { generateJSONSchemaFromTypeNode } from './graphql-json-schema-type';
+import { JSONSchema } from '@aws-amplify/graphql-transformer-core';
 
 export type Tool = {
   toolSpec: ToolSpec;

--- a/packages/amplify-graphql-transformer-core/src/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/index.ts
@@ -73,6 +73,13 @@ export {
   SQLLambdaResourceNames,
 } from './utils';
 export type { SetResourceNameProps } from './utils';
+export {
+  type JSONSchema,
+  isDisallowedScalarType,
+  supportedScalarTypes,
+  GraphQLScalarJSONSchemaDefinition,
+  convertNamedTypeToJSONSchema,
+} from './utils/ai';
 export * from './utils/operation-names';
 export * from './errors';
 export {

--- a/packages/amplify-graphql-transformer-core/src/utils/ai/graphql-scalar-json-schema-definitions.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/ai/graphql-scalar-json-schema-definitions.ts
@@ -1,10 +1,10 @@
-import { JSONSchema } from './graphql-json-schema-type';
+import { JSONSchema } from './json-schema';
 
 /**
  * JSON Schema definitions for GraphQL scalar types and AWS AppSync custom scalar types.
  * These definitions are used to create valid JSON schema for tool definitions in the
- * context of AI model interactions for generation routes, ensuring that generated responses
- * conform to the expected GraphQL types.
+ * context of AI model interactions for generation and converssation routes, ensuring that generated responses
+ * conform to the expected GraphQL types or inputs.
  *
  * Each constant represents a JSON Schema object that describes the structure and
  * constraints of a specific GraphQL scalar type. These scalar types are utilized when

--- a/packages/amplify-graphql-transformer-core/src/utils/ai/graphql-scalar-json-schema-definitions.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/ai/graphql-scalar-json-schema-definitions.ts
@@ -3,7 +3,7 @@ import { JSONSchema } from './json-schema';
 /**
  * JSON Schema definitions for GraphQL scalar types and AWS AppSync custom scalar types.
  * These definitions are used to create valid JSON schema for tool definitions in the
- * context of AI model interactions for generation and converssation routes, ensuring that generated responses
+ * context of AI model interactions for generation and conversation routes, ensuring that generated responses
  * conform to the expected GraphQL types or inputs.
  *
  * Each constant represents a JSON Schema object that describes the structure and

--- a/packages/amplify-graphql-transformer-core/src/utils/ai/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/ai/index.ts
@@ -1,0 +1,7 @@
+export type { JSONSchema } from './json-schema';
+export {
+  isDisallowedScalarType,
+  supportedScalarTypes,
+  GraphQLScalarJSONSchemaDefinition,
+} from './graphql-scalar-json-schema-definitions';
+export { convertNamedTypeToJSONSchema } from './named-type-conversion';

--- a/packages/amplify-graphql-transformer-core/src/utils/ai/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/ai/index.ts
@@ -1,7 +1,3 @@
 export type { JSONSchema } from './json-schema';
-export {
-  isDisallowedScalarType,
-  supportedScalarTypes,
-  GraphQLScalarJSONSchemaDefinition,
-} from './graphql-scalar-json-schema-definitions';
+export { isDisallowedScalarType, supportedScalarTypes, GraphQLScalarJSONSchemaDefinition } from './graphql-scalar-json-schema-definitions';
 export { convertNamedTypeToJSONSchema } from './named-type-conversion';

--- a/packages/amplify-graphql-transformer-core/src/utils/ai/json-schema.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/ai/json-schema.ts
@@ -1,0 +1,18 @@
+export type JSONSchema = {
+  type: string;
+  properties?: Record<string, JSONSchema>;
+  required?: string[];
+  items?: JSONSchema;
+  enum?: (string | number | boolean | null)[];
+  minimum?: number;
+  maximum?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  format?: string;
+  description?: string;
+  default?: JSONLike;
+  additionalProperties?: boolean | JSONSchema;
+};
+
+type JSONLike = string | number | boolean | null | { [key: string]: JSONLike } | JSONLike[];

--- a/packages/amplify-graphql-transformer-core/src/utils/ai/named-type-conversion.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/ai/named-type-conversion.ts
@@ -1,0 +1,47 @@
+import { NamedTypeNode } from 'graphql';
+import { JSONSchema } from './json-schema';
+import { GraphQLScalarJSONSchemaDefinition } from './graphql-scalar-json-schema-definitions';
+
+/**
+ * Processes a NamedTypeNode and returns the corresponding JSON Schema.
+ * @param {NamedTypeNode} namedType - The NamedTypeNode to process.
+ * @returns {JSONSchema} The JSON Schema representation of the named type.
+ */
+export const convertNamedTypeToJSONSchema = (namedType: NamedTypeNode): JSONSchema => {
+  switch (namedType.name.value) {
+    case 'Int':
+      return GraphQLScalarJSONSchemaDefinition.Int;
+    case 'Float':
+      return GraphQLScalarJSONSchemaDefinition.Float;
+    case 'String':
+      return GraphQLScalarJSONSchemaDefinition.String;
+    case 'ID':
+      return GraphQLScalarJSONSchemaDefinition.ID;
+    case 'Boolean':
+      return GraphQLScalarJSONSchemaDefinition.Boolean;
+    case 'AWSJSON':
+      return GraphQLScalarJSONSchemaDefinition.AWSJSON;
+    case 'AWSEmail':
+      return GraphQLScalarJSONSchemaDefinition.AWSEmail;
+    case 'AWSDate':
+      return GraphQLScalarJSONSchemaDefinition.AWSDate;
+    case 'AWSTime':
+      return GraphQLScalarJSONSchemaDefinition.AWSTime;
+    case 'AWSDateTime':
+      return GraphQLScalarJSONSchemaDefinition.AWSDateTime;
+    case 'AWSTimestamp':
+      return GraphQLScalarJSONSchemaDefinition.AWSTimestamp;
+    case 'AWSPhone':
+      return GraphQLScalarJSONSchemaDefinition.AWSPhone;
+    case 'AWSURL':
+      return GraphQLScalarJSONSchemaDefinition.AWSURL;
+    case 'AWSIPAddress':
+      return GraphQLScalarJSONSchemaDefinition.AWSIPAddress;
+    default:
+      return {
+        type: 'object',
+        properties: {},
+        required: [],
+      };
+  }
+};


### PR DESCRIPTION
#### Description of changes
**No functional changes**

- Moves tool definition utilities added in https://github.com/aws-amplify/amplify-category-api/pull/2820 into `amplify-graphql-transformer-core` so that they can be used by both `amplify-graphql-generation-transformer` and `amplify-graphql-conversation-transformer`.



##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Test suite passes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] ~Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)~
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
