### PR TITLE
chore: use current branch for triggering release flow

### DIFF
--- a/codebuild_specs/scripts/publish.sh
+++ b/codebuild_specs/scripts/publish.sh
@@ -31,7 +31,7 @@ else
   git config --global user.name $GITHUB_USER
 fi
 
-RESERVED_TAGS=(alpha beta dev latest main)
+RESERVED_TAGS=(alpha beta dev latest main api-plugin-stable)
 
 if [[ "$BRANCH_NAME" =~ ^tagged-release ]]; then
   if [[ "$BRANCH_NAME" =~ ^tagged-release-without-e2e-tests\/.* ]]; then

--- a/scripts/cloud-release.sh
+++ b/scripts/cloud-release.sh
@@ -6,7 +6,8 @@ export RELEASE_PROJECT_NAME=amplify-category-api-release-workflow
 export DEPRECATE_PROJECT_NAME=amplify-category-api-deprecate-workflow
 
 function triggerRelease {
-  triggerProjectBatch $RELEASE_ACCOUNT_PROD $RELEASE_ROLE_NAME "${RELEASE_PROFILE_NAME}Prod" $RELEASE_PROJECT_NAME "release"
+  branch_name=$(git branch --show-current)
+  triggerProjectBatch $RELEASE_ACCOUNT_PROD $RELEASE_ROLE_NAME "${RELEASE_PROFILE_NAME}Prod" $RELEASE_PROJECT_NAME $branch_name
 }
 
 function triggerTagRelease {
@@ -26,7 +27,8 @@ function deprecateRelease {
   DEPRECATION_MESSAGE=$1
   SEARCH_FOR_RELEASE_STARTING_FROM=$2
   USE_NPM_REGISTRY=$3
-  triggerProjectBatchWithEnvOverrides $RELEASE_ACCOUNT_PROD $RELEASE_ROLE_NAME "${RELEASE_PROFILE_NAME}Prod" $DEPRECATE_PROJECT_NAME "release" \
+  branch_name=$(git branch --show-current)
+  triggerProjectBatchWithEnvOverrides $RELEASE_ACCOUNT_PROD $RELEASE_ROLE_NAME "${RELEASE_PROFILE_NAME}Prod" $DEPRECATE_PROJECT_NAME $branch_name \
     name=DEPRECATION_MESSAGE,value=\""$DEPRECATION_MESSAGE"\",type=PLAINTEXT \
     name=SEARCH_FOR_RELEASE_STARTING_FROM,value=$SEARCH_FOR_RELEASE_STARTING_FROM,type=PLAINTEXT \
     name=USE_NPM_REGISTRY,value=$USE_NPM_REGISTRY,type=PLAINTEXT


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Update triggering codebuild projects from current branch instead of using fixed branch names.
Add `api-plugin-stable` as known reserved tag so we prevent developers from using it during tag release workflows.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
