### PR TITLE
chore: bump private package versions

### DIFF
--- a/packages/amplify-e2e-core/package.json
+++ b/packages/amplify-e2e-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-category-api-e2e-core",
-  "version": "4.9.1",
+  "version": "5.0.0",
   "description": "Core testing library",
   "repository": {
     "type": "git",

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-category-api-e2e-tests",
-  "version": "3.22.11",
+  "version": "4.0.0",
   "description": "E2e test suite",
   "repository": {
     "type": "git",
@@ -27,7 +27,7 @@
     "@aws-amplify/amplify-app": "^5.0.35",
     "@aws-amplify/graphql-schema-generator": "0.10.1",
     "@aws-amplify/graphql-transformer-core": "3.0.1",
-    "amplify-category-api-e2e-core": "4.9.1",
+    "amplify-category-api-e2e-core": "5.0.0",
     "aws-amplify": "^4.2.8",
     "aws-appsync": "^4.1.1",
     "aws-sdk": "^2.1113.0",

--- a/packages/amplify-graphql-api-construct-tests/package.json
+++ b/packages/amplify-graphql-api-construct-tests/package.json
@@ -31,7 +31,7 @@
     "@aws-sdk/client-ssm": "3.624.0",
     "@aws-sdk/client-sts": "3.624.0",
     "@faker-js/faker": "^8.2.0",
-    "amplify-category-api-e2e-core": "4.9.1",
+    "amplify-category-api-e2e-core": "5.0.0",
     "aws-amplify": "^4.2.8",
     "aws-appsync": "^4.1.1",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-graphql-api-construct/package.json
+++ b/packages/amplify-graphql-api-construct/package.json
@@ -114,7 +114,7 @@
     "zod": "^3.22.3"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.6.1",
+    "@aws-amplify/graphql-transformer-test-utils": "1.0.0",
     "@types/fs-extra": "^8.0.1",
     "@types/node": "^18.0.0",
     "aws-cdk-lib": "2.152.0",

--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -46,7 +46,7 @@
     "@aws-amplify/graphql-index-transformer": "3.0.1",
     "@aws-amplify/graphql-searchable-transformer": "3.0.1",
     "@aws-amplify/graphql-sql-transformer": "0.4.1",
-    "@aws-amplify/graphql-transformer-test-utils": "0.6.1",
+    "@aws-amplify/graphql-transformer-test-utils": "1.0.0",
     "@types/node": "^18.0.0"
   },
   "peerDependencies": {

--- a/packages/amplify-graphql-default-value-transformer/package.json
+++ b/packages/amplify-graphql-default-value-transformer/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@aws-amplify/graphql-model-transformer": "3.0.1",
-    "@aws-amplify/graphql-transformer-test-utils": "0.6.1"
+    "@aws-amplify/graphql-transformer-test-utils": "1.0.0"
   },
   "jest": {
     "transform": {

--- a/packages/amplify-graphql-function-transformer/package.json
+++ b/packages/amplify-graphql-function-transformer/package.json
@@ -37,7 +37,7 @@
     "graphql-transformer-common": "5.0.0"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.6.1"
+    "@aws-amplify/graphql-transformer-test-utils": "1.0.0"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.152.0",

--- a/packages/amplify-graphql-http-transformer/package.json
+++ b/packages/amplify-graphql-http-transformer/package.json
@@ -37,7 +37,7 @@
     "graphql-transformer-common": "5.0.0"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.6.1"
+    "@aws-amplify/graphql-transformer-test-utils": "1.0.0"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.152.0",

--- a/packages/amplify-graphql-index-transformer/package.json
+++ b/packages/amplify-graphql-index-transformer/package.json
@@ -38,7 +38,7 @@
     "graphql-transformer-common": "5.0.0"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.6.1"
+    "@aws-amplify/graphql-transformer-test-utils": "1.0.0"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.152.0",

--- a/packages/amplify-graphql-model-transformer/package.json
+++ b/packages/amplify-graphql-model-transformer/package.json
@@ -45,7 +45,7 @@
     "constructs": "^10.3.0"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.6.1",
+    "@aws-amplify/graphql-transformer-test-utils": "1.0.0",
     "@aws-sdk/client-dynamodb": "^3.624.0",
     "@aws-sdk/client-lambda": "^3.624.0",
     "@aws-sdk/client-sfn": "^3.624.0",

--- a/packages/amplify-graphql-name-mapping-transformer/package.json
+++ b/packages/amplify-graphql-name-mapping-transformer/package.json
@@ -46,7 +46,7 @@
     "@aws-amplify/graphql-model-transformer": "3.0.1",
     "@aws-amplify/graphql-relational-transformer": "3.0.1",
     "@aws-amplify/graphql-searchable-transformer": "3.0.1",
-    "@aws-amplify/graphql-transformer-test-utils": "0.6.1",
+    "@aws-amplify/graphql-transformer-test-utils": "1.0.0",
     "graphql": "^15.5.0"
   },
   "jest": {

--- a/packages/amplify-graphql-predictions-transformer/package.json
+++ b/packages/amplify-graphql-predictions-transformer/package.json
@@ -41,7 +41,7 @@
     "constructs": "^10.3.0"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.6.1",
+    "@aws-amplify/graphql-transformer-test-utils": "1.0.0",
     "bestzip": "^2.1.5"
   },
   "jest": {

--- a/packages/amplify-graphql-relational-transformer/package.json
+++ b/packages/amplify-graphql-relational-transformer/package.json
@@ -40,7 +40,7 @@
     "immer": "^9.0.12"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.6.1"
+    "@aws-amplify/graphql-transformer-test-utils": "1.0.0"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.152.0",

--- a/packages/amplify-graphql-schema-test-library/package.json
+++ b/packages/amplify-graphql-schema-test-library/package.json
@@ -40,7 +40,7 @@
     "@aws-amplify/graphql-searchable-transformer": "3.0.1",
     "@aws-amplify/graphql-transformer-core": "3.0.1",
     "@aws-amplify/graphql-transformer-interfaces": "4.0.1",
-    "@aws-amplify/graphql-transformer-test-utils": "0.6.1"
+    "@aws-amplify/graphql-transformer-test-utils": "1.0.0"
   },
   "jest": {
     "transform": {

--- a/packages/amplify-graphql-searchable-transformer/package.json
+++ b/packages/amplify-graphql-searchable-transformer/package.json
@@ -42,7 +42,7 @@
     "constructs": "^10.3.0"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.6.1",
+    "@aws-amplify/graphql-transformer-test-utils": "1.0.0",
     "@types/node": "^18.0.0"
   },
   "jest": {

--- a/packages/amplify-graphql-sql-transformer/package.json
+++ b/packages/amplify-graphql-sql-transformer/package.json
@@ -38,7 +38,7 @@
     "graphql-transformer-common": "5.0.0"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.6.1"
+    "@aws-amplify/graphql-transformer-test-utils": "1.0.0"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.152.0",

--- a/packages/amplify-graphql-transformer-test-utils/package.json
+++ b/packages/amplify-graphql-transformer-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/graphql-transformer-test-utils",
-  "version": "0.6.1",
+  "version": "1.0.0",
   "description": "Test utils for graphql transformers",
   "repository": {
     "type": "git",

--- a/packages/amplify-graphql-transformer/package.json
+++ b/packages/amplify-graphql-transformer/package.json
@@ -44,7 +44,7 @@
     "@aws-amplify/graphql-transformer-interfaces": "4.0.1"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.6.1",
+    "@aws-amplify/graphql-transformer-test-utils": "1.0.0",
     "@types/node": "^18.0.0",
     "fs-extra": "^8.1.0",
     "rimraf": "^3.0.0",

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-category-api-graphql-transformers-e2e-tests",
-  "version": "8.8.7",
+  "version": "9.0.0",
   "description": "End to end functional tests for appsync supported transformers.",
   "private": true,
   "repository": {
@@ -40,7 +40,7 @@
     "@aws-amplify/graphql-model-transformer": "3.0.1",
     "@aws-amplify/graphql-transformer-core": "3.0.1",
     "@aws-amplify/graphql-transformer-interfaces": "4.0.1",
-    "@aws-amplify/graphql-transformer-test-utils": "0.6.1",
+    "@aws-amplify/graphql-transformer-test-utils": "1.0.0",
     "@types/node": "^18.0.0",
     "aws-amplify": "^4.2.8",
     "aws-appsync": "^4.1.1",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The following private packages used for unit/E2E testing are cause clashes of git tags published during the release from `main` and `release-api-plugin-stable` branches. Bumping the major versions for these to be able to deploy from both branches.
- amplify-category-api-e2e-core
- amplify-category-api-e2e-tests
- @aws-amplify/graphql-transformer-test-utils
- amplify-category-api-graphql-transformers-e2e-tests

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
CI checks

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
