### PR TITLE
fix: update ai-constructs to 0.1.2

### DIFF
--- a/packages/amplify-data-construct/.jsii
+++ b/packages/amplify-data-construct/.jsii
@@ -6,7 +6,7 @@
     ]
   },
   "bundled": {
-    "@aws-amplify/ai-constructs": "^0.1.1",
+    "@aws-amplify/ai-constructs": "^0.1.2",
     "@aws-amplify/backend-output-schemas": "^0.4.0",
     "@aws-amplify/backend-output-storage": "^0.2.2",
     "@aws-amplify/graphql-auth-transformer": "4.0.1",
@@ -3889,5 +3889,5 @@
   },
   "types": {},
   "version": "1.9.8",
-  "fingerprint": "wiYEUEClw4o+05o1RxzH2fyh79noXVm7XBCtZFB09Nc="
+  "fingerprint": "SZRkyIYCoDioT9yG2y4r9v1Ntnv0HF13abV6O7HQ/Ps="
 }

--- a/packages/amplify-data-construct/package.json
+++ b/packages/amplify-data-construct/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "@aws-amplify/backend-output-schemas": "^0.4.0",
     "@aws-amplify/backend-output-storage": "^0.2.2",
-    "@aws-amplify/ai-constructs": "^0.1.1",
+    "@aws-amplify/ai-constructs": "^0.1.2",
     "@aws-amplify/graphql-api-construct": "1.11.8",
     "@aws-amplify/graphql-auth-transformer": "4.0.1",
     "@aws-amplify/graphql-conversation-transformer": "0.1.0",

--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -6,7 +6,7 @@
     ]
   },
   "bundled": {
-    "@aws-amplify/ai-constructs": "^0.1.1",
+    "@aws-amplify/ai-constructs": "^0.1.2",
     "@aws-amplify/backend-output-schemas": "^0.4.0",
     "@aws-amplify/backend-output-storage": "^0.2.2",
     "@aws-amplify/graphql-auth-transformer": "4.0.1",
@@ -8806,5 +8806,5 @@
     }
   },
   "version": "1.11.8",
-  "fingerprint": "3XHtnC9UqaP4b4Q1zd8RPGGQTBtWhtaknlN8cwhQZ+k="
+  "fingerprint": "N7FLb/WZuBY5GGxUynWlo1ddZa6fBhr6Bwxyl347br8="
 }

--- a/packages/amplify-graphql-api-construct/package.json
+++ b/packages/amplify-graphql-api-construct/package.json
@@ -98,7 +98,7 @@
     "@aws-amplify/graphql-transformer-interfaces": "4.0.1",
     "@aws-amplify/platform-core": "^0.2.0",
     "@aws-amplify/plugin-types": "^0.4.1",
-    "@aws-amplify/ai-constructs": "^0.1.1",
+    "@aws-amplify/ai-constructs": "^0.1.2",
     "charenc": "^0.0.2",
     "crypt": "^0.0.2",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-graphql-conversation-transformer/package.json
+++ b/packages/amplify-graphql-conversation-transformer/package.json
@@ -23,7 +23,7 @@
     "extract-api": "ts-node ../../scripts/extract-api.ts"
   },
   "dependencies": {
-    "@aws-amplify/ai-constructs": "^0.1.1",
+    "@aws-amplify/ai-constructs": "^0.1.2",
     "@aws-amplify/graphql-directives": "2.0.0",
     "@aws-amplify/graphql-index-transformer": "3.0.1",
     "@aws-amplify/graphql-model-transformer": "3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,10 +15,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-amplify/ai-constructs@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/ai-constructs/-/ai-constructs-0.1.1.tgz#27bc519be9459ed1caf8068348e2b51b534a2bd1"
-  integrity sha512-PKuaocx8spTylgwpZPTsOnwTmszOgKZP74ZIriy+Ua9bqj5Uv0aetpgnusTk2qqCKV5LkiFnNImiPp4s/KNx3Q==
+"@aws-amplify/ai-constructs@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/ai-constructs/-/ai-constructs-0.1.2.tgz#572f46c308edf5823861116cd9152eb429e9453f"
+  integrity sha512-fMwCPTBrf80Lk3/fyIUqDH79NVbo+kdroYj3wOOIqFsDHAnrQbnV64UgBNHqv7PUcQD11V+tLbC5qEb30+5Emg==
   dependencies:
     "@aws-amplify/plugin-types" "^1.0.1"
     "@aws-sdk/client-bedrock-runtime" "^3.622.0"


### PR DESCRIPTION
#### Description of changes
Updates `@aws-amplify/ai-constructs` from `^0.1.1` to `^0.1.2` to pull in this fix that addresses a problem with bundledDependencies and re-exported bedrock client stuff.
- https://github.com/aws-amplify/amplify-backend/pull/1962
##### CDK / CloudFormation Parameters Changed

#### Issue #, if available

#### Description of how you validated changes

#### Checklist

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
