### PR TITLE
chore: use medium sized containers for canaries

### DIFF
--- a/codebuild_specs/amplify_ddb_canary.yml
+++ b/codebuild_specs/amplify_ddb_canary.yml
@@ -2,6 +2,8 @@ version: 0.2
 env:
   shell: bash
   compute-type: BUILD_GENERAL1_MEDIUM
+  variables:
+    NODE_OPTIONS: '--max-old-space-size=6656'
 batch:
   fast-fail: false
   build-graph:
@@ -24,7 +26,6 @@ batch:
     - identifier: amplify_ddb_canary_ap_east_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: ap-east-1
@@ -34,7 +35,6 @@ batch:
     - identifier: amplify_ddb_canary_ap_northeast_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: ap-northeast-1
@@ -44,7 +44,6 @@ batch:
     - identifier: amplify_ddb_canary_ap_northeast_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: ap-northeast-2
@@ -54,7 +53,6 @@ batch:
     - identifier: amplify_ddb_canary_ap_south_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: ap-south-1
@@ -64,7 +62,6 @@ batch:
     - identifier: amplify_ddb_canary_ap_southeast_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: ap-southeast-1
@@ -74,7 +71,6 @@ batch:
     - identifier: amplify_ddb_canary_ap_southeast_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: ap-southeast-2
@@ -84,7 +80,6 @@ batch:
     - identifier: amplify_ddb_canary_ca_central_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: ca-central-1
@@ -94,7 +89,6 @@ batch:
     - identifier: amplify_ddb_canary_eu_central_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: eu-central-1
@@ -104,7 +98,6 @@ batch:
     - identifier: amplify_ddb_canary_eu_north_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: eu-north-1
@@ -114,7 +107,6 @@ batch:
     - identifier: amplify_ddb_canary_eu_south_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: eu-south-1
@@ -124,7 +116,6 @@ batch:
     - identifier: amplify_ddb_canary_eu_west_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: eu-west-1
@@ -134,7 +125,6 @@ batch:
     - identifier: amplify_ddb_canary_eu_west_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: eu-west-2
@@ -144,7 +134,6 @@ batch:
     - identifier: amplify_ddb_canary_eu_west_3
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: eu-west-3
@@ -154,7 +143,6 @@ batch:
     - identifier: amplify_ddb_canary_me_south_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: me-south-1
@@ -164,7 +152,6 @@ batch:
     - identifier: amplify_ddb_canary_sa_east_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: sa-east-1
@@ -174,7 +161,6 @@ batch:
     - identifier: amplify_ddb_canary_us_east_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: us-east-1
@@ -184,7 +170,6 @@ batch:
     - identifier: amplify_ddb_canary_us_east_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: us-east-2
@@ -194,7 +179,6 @@ batch:
     - identifier: amplify_ddb_canary_us_west_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: us-west-1
@@ -204,7 +188,6 @@ batch:
     - identifier: amplify_ddb_canary_us_west_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: us-west-2

--- a/codebuild_specs/default_ddb_canary.yml
+++ b/codebuild_specs/default_ddb_canary.yml
@@ -2,6 +2,8 @@ version: 0.2
 env:
   shell: bash
   compute-type: BUILD_GENERAL1_MEDIUM
+  variables:
+    NODE_OPTIONS: '--max-old-space-size=6656'
 batch:
   fast-fail: false
   build-graph:
@@ -24,7 +26,6 @@ batch:
     - identifier: default_ddb_canary_ap_east_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: ap-east-1
@@ -34,7 +35,6 @@ batch:
     - identifier: default_ddb_canary_ap_northeast_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: ap-northeast-1
@@ -44,7 +44,6 @@ batch:
     - identifier: default_ddb_canary_ap_northeast_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: ap-northeast-2
@@ -54,7 +53,6 @@ batch:
     - identifier: default_ddb_canary_ap_south_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: ap-south-1
@@ -64,7 +62,6 @@ batch:
     - identifier: default_ddb_canary_ap_southeast_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: ap-southeast-1
@@ -74,7 +71,6 @@ batch:
     - identifier: default_ddb_canary_ap_southeast_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: ap-southeast-2
@@ -84,7 +80,6 @@ batch:
     - identifier: default_ddb_canary_ca_central_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: ca-central-1
@@ -94,7 +89,6 @@ batch:
     - identifier: default_ddb_canary_eu_central_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: eu-central-1
@@ -104,7 +98,6 @@ batch:
     - identifier: default_ddb_canary_eu_north_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: eu-north-1
@@ -114,7 +107,6 @@ batch:
     - identifier: default_ddb_canary_eu_south_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: eu-south-1
@@ -124,7 +116,6 @@ batch:
     - identifier: default_ddb_canary_eu_west_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: eu-west-1
@@ -134,7 +125,6 @@ batch:
     - identifier: default_ddb_canary_eu_west_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: eu-west-2
@@ -144,7 +134,6 @@ batch:
     - identifier: default_ddb_canary_eu_west_3
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: eu-west-3
@@ -154,7 +143,6 @@ batch:
     - identifier: default_ddb_canary_me_south_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: me-south-1
@@ -164,7 +152,6 @@ batch:
     - identifier: default_ddb_canary_sa_east_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: sa-east-1
@@ -174,7 +161,6 @@ batch:
     - identifier: default_ddb_canary_us_east_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: us-east-1
@@ -184,7 +170,6 @@ batch:
     - identifier: default_ddb_canary_us_east_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: us-east-2
@@ -194,7 +179,6 @@ batch:
     - identifier: default_ddb_canary_us_west_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: us-west-1
@@ -204,7 +188,6 @@ batch:
     - identifier: default_ddb_canary_us_west_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: us-west-2

--- a/codebuild_specs/sql_mysql_canary.yml
+++ b/codebuild_specs/sql_mysql_canary.yml
@@ -2,6 +2,8 @@ version: 0.2
 env:
   shell: bash
   compute-type: BUILD_GENERAL1_MEDIUM
+  variables:
+    NODE_OPTIONS: '--max-old-space-size=6656'
 batch:
   fast-fail: false
   build-graph:
@@ -24,7 +26,6 @@ batch:
     - identifier: sql_mysql_canary_ap_northeast_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: ap-northeast-1
@@ -34,7 +35,6 @@ batch:
     - identifier: sql_mysql_canary_ap_northeast_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: ap-northeast-2
@@ -44,7 +44,6 @@ batch:
     - identifier: sql_mysql_canary_ap_south_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: ap-south-1
@@ -54,7 +53,6 @@ batch:
     - identifier: sql_mysql_canary_ap_southeast_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: ap-southeast-1
@@ -64,7 +62,6 @@ batch:
     - identifier: sql_mysql_canary_ap_southeast_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: ap-southeast-2
@@ -74,7 +71,6 @@ batch:
     - identifier: sql_mysql_canary_ca_central_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: ca-central-1
@@ -84,7 +80,6 @@ batch:
     - identifier: sql_mysql_canary_eu_central_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: eu-central-1
@@ -94,7 +89,6 @@ batch:
     - identifier: sql_mysql_canary_eu_north_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: eu-north-1
@@ -104,7 +98,6 @@ batch:
     - identifier: sql_mysql_canary_eu_west_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: eu-west-1
@@ -114,7 +107,6 @@ batch:
     - identifier: sql_mysql_canary_eu_west_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: eu-west-2
@@ -124,7 +116,6 @@ batch:
     - identifier: sql_mysql_canary_eu_west_3
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: eu-west-3
@@ -134,7 +125,6 @@ batch:
     - identifier: sql_mysql_canary_sa_east_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: sa-east-1
@@ -144,7 +134,6 @@ batch:
     - identifier: sql_mysql_canary_us_east_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: us-east-1
@@ -154,7 +143,6 @@ batch:
     - identifier: sql_mysql_canary_us_east_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: us-east-2
@@ -164,7 +152,6 @@ batch:
     - identifier: sql_mysql_canary_us_west_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: us-west-1
@@ -174,7 +161,6 @@ batch:
     - identifier: sql_mysql_canary_us_west_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: us-west-2

--- a/codebuild_specs/sql_pg_canary.yml
+++ b/codebuild_specs/sql_pg_canary.yml
@@ -2,6 +2,8 @@ version: 0.2
 env:
   shell: bash
   compute-type: BUILD_GENERAL1_MEDIUM
+  variables:
+    NODE_OPTIONS: '--max-old-space-size=6656'
 batch:
   fast-fail: false
   build-graph:
@@ -24,7 +26,6 @@ batch:
     - identifier: sql_pg_canary_ap_northeast_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
           CLI_REGION: ap-northeast-1
@@ -34,7 +35,6 @@ batch:
     - identifier: sql_pg_canary_ap_northeast_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
           CLI_REGION: ap-northeast-2
@@ -44,7 +44,6 @@ batch:
     - identifier: sql_pg_canary_ap_south_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
           CLI_REGION: ap-south-1
@@ -54,7 +53,6 @@ batch:
     - identifier: sql_pg_canary_ap_southeast_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
           CLI_REGION: ap-southeast-1
@@ -64,7 +62,6 @@ batch:
     - identifier: sql_pg_canary_ap_southeast_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
           CLI_REGION: ap-southeast-2
@@ -74,7 +71,6 @@ batch:
     - identifier: sql_pg_canary_ca_central_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
           CLI_REGION: ca-central-1
@@ -84,7 +80,6 @@ batch:
     - identifier: sql_pg_canary_eu_central_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
           CLI_REGION: eu-central-1
@@ -94,7 +89,6 @@ batch:
     - identifier: sql_pg_canary_eu_north_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
           CLI_REGION: eu-north-1
@@ -104,7 +98,6 @@ batch:
     - identifier: sql_pg_canary_eu_west_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
           CLI_REGION: eu-west-1
@@ -114,7 +107,6 @@ batch:
     - identifier: sql_pg_canary_eu_west_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
           CLI_REGION: eu-west-2
@@ -124,7 +116,6 @@ batch:
     - identifier: sql_pg_canary_eu_west_3
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
           CLI_REGION: eu-west-3
@@ -134,7 +125,6 @@ batch:
     - identifier: sql_pg_canary_sa_east_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
           CLI_REGION: sa-east-1
@@ -144,7 +134,6 @@ batch:
     - identifier: sql_pg_canary_us_east_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
           CLI_REGION: us-east-1
@@ -154,7 +143,6 @@ batch:
     - identifier: sql_pg_canary_us_east_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
           CLI_REGION: us-east-2
@@ -164,7 +152,6 @@ batch:
     - identifier: sql_pg_canary_us_west_1
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
           CLI_REGION: us-west-1
@@ -174,7 +161,6 @@ batch:
     - identifier: sql_pg_canary_us_west_2
       buildspec: codebuild_specs/run_cdk_canary_e2e_tests.yml
       env:
-        compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/sql-pg-canary.test.ts
           CLI_REGION: us-west-2


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The upgraded version of `jest` consumes more memory that 3GB allocated in small sized containers. Bumping the size to medium gives upto 7GB.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Triggering canary run on top of these changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
