### PR TITLE
chore: update private package versions

### DIFF
--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -79,7 +79,7 @@
     "constructs": "^10.3.0"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.5.6",
+    "@aws-amplify/graphql-transformer-test-utils": "0.6.1",
     "@types/js-yaml": "^4.0.0",
     "@types/node": "^12.12.6",
     "amplify-util-headless-input": "^1.9.18",

--- a/packages/amplify-e2e-core/package.json
+++ b/packages/amplify-e2e-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amplify-category-api-e2e-core",
-  "version": "4.8.6",
-  "description": "Core testing library",
+  "version": "4.9.1",
+  "description": "Core testing library ",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws-amplify/amplify-category-api.git",

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amplify-category-api-e2e-tests",
-  "version": "3.22.9",
-  "description": "E2e test suite",
+  "version": "3.22.11",
+  "description": "E2e test suite ",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws-amplify/amplify-category-api.git",
@@ -27,7 +27,7 @@
     "@aws-amplify/amplify-app": "^5.0.35",
     "@aws-amplify/graphql-schema-generator": "^0.9.4",
     "@aws-amplify/graphql-transformer-core": "2.9.3",
-    "amplify-category-api-e2e-core": "4.8.6",
+    "amplify-category-api-e2e-core": "4.9.1",
     "aws-amplify": "^4.2.8",
     "aws-appsync": "^4.1.1",
     "aws-sdk": "^2.1113.0",

--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -45,7 +45,7 @@
     "@aws-amplify/graphql-index-transformer": "2.4.9",
     "@aws-amplify/graphql-searchable-transformer": "2.7.9",
     "@aws-amplify/graphql-sql-transformer": "^0.3.9",
-    "@aws-amplify/graphql-transformer-test-utils": "0.5.6",
+    "@aws-amplify/graphql-transformer-test-utils": "0.6.1",
     "@types/node": "^12.12.6"
   },
   "peerDependencies": {

--- a/packages/amplify-graphql-default-value-transformer/package.json
+++ b/packages/amplify-graphql-default-value-transformer/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@aws-amplify/graphql-model-transformer": "2.11.4",
-    "@aws-amplify/graphql-transformer-test-utils": "0.5.6"
+    "@aws-amplify/graphql-transformer-test-utils": "0.6.1"
   },
   "jest": {
     "transform": {

--- a/packages/amplify-graphql-function-transformer/package.json
+++ b/packages/amplify-graphql-function-transformer/package.json
@@ -36,7 +36,7 @@
     "graphql-transformer-common": "4.31.1"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.5.6"
+    "@aws-amplify/graphql-transformer-test-utils": "0.6.1"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.129.0",

--- a/packages/amplify-graphql-http-transformer/package.json
+++ b/packages/amplify-graphql-http-transformer/package.json
@@ -36,7 +36,7 @@
     "graphql-transformer-common": "4.31.1"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.5.6"
+    "@aws-amplify/graphql-transformer-test-utils": "0.6.1"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.129.0",

--- a/packages/amplify-graphql-index-transformer/package.json
+++ b/packages/amplify-graphql-index-transformer/package.json
@@ -37,7 +37,7 @@
     "graphql-transformer-common": "4.31.1"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.5.6"
+    "@aws-amplify/graphql-transformer-test-utils": "0.6.1"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.129.0",

--- a/packages/amplify-graphql-migration-tests/package.json
+++ b/packages/amplify-graphql-migration-tests/package.json
@@ -66,7 +66,7 @@
     "@aws-amplify/graphql-transformer-core": "2.9.3",
     "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
     "@aws-amplify/graphql-transformer-migrator": "2.2.27",
-    "@aws-amplify/graphql-transformer-test-utils": "0.5.6",
+    "@aws-amplify/graphql-transformer-test-utils": "0.6.1",
     "@aws-cdk/cloudformation-diff": "~2.80.0",
     "aws-cdk-lib": "~2.129.0",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-graphql-model-transformer/package.json
+++ b/packages/amplify-graphql-model-transformer/package.json
@@ -44,7 +44,7 @@
     "constructs": "^10.3.0"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.5.6",
+    "@aws-amplify/graphql-transformer-test-utils": "0.6.1",
     "@aws-sdk/client-dynamodb": "^3.624.0",
     "@aws-sdk/client-lambda": "^3.624.0",
     "@aws-sdk/client-sfn": "^3.624.0",

--- a/packages/amplify-graphql-name-mapping-transformer/package.json
+++ b/packages/amplify-graphql-name-mapping-transformer/package.json
@@ -45,7 +45,7 @@
     "@aws-amplify/graphql-model-transformer": "2.11.4",
     "@aws-amplify/graphql-relational-transformer": "2.5.11",
     "@aws-amplify/graphql-searchable-transformer": "2.7.9",
-    "@aws-amplify/graphql-transformer-test-utils": "0.5.6",
+    "@aws-amplify/graphql-transformer-test-utils": "0.6.1",
     "graphql": "^15.5.0"
   },
   "jest": {

--- a/packages/amplify-graphql-predictions-transformer/package.json
+++ b/packages/amplify-graphql-predictions-transformer/package.json
@@ -40,7 +40,7 @@
     "constructs": "^10.3.0"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.5.6",
+    "@aws-amplify/graphql-transformer-test-utils": "0.6.1",
     "bestzip": "^2.1.5"
   },
   "jest": {

--- a/packages/amplify-graphql-relational-transformer/package.json
+++ b/packages/amplify-graphql-relational-transformer/package.json
@@ -39,7 +39,7 @@
     "immer": "^9.0.12"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.5.6"
+    "@aws-amplify/graphql-transformer-test-utils": "0.6.1"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.129.0",

--- a/packages/amplify-graphql-searchable-transformer/package.json
+++ b/packages/amplify-graphql-searchable-transformer/package.json
@@ -41,7 +41,7 @@
     "constructs": "^10.3.0"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "0.5.6",
+    "@aws-amplify/graphql-transformer-test-utils": "0.6.1",
     "@types/node": "^12.12.6"
   },
   "jest": {

--- a/packages/amplify-graphql-transformer-test-utils/package.json
+++ b/packages/amplify-graphql-transformer-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws-amplify/graphql-transformer-test-utils",
-  "version": "0.5.6",
-  "description": "Test utils for graphql transformers",
+  "version": "0.6.1",
+  "description": "Test utils for graphql transformers ",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws-amplify/amplify-category-api.git",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -62,7 +62,7 @@
     "@aws-amplify/graphql-searchable-transformer": "2.7.9",
     "@aws-amplify/graphql-transformer-core": "2.9.3",
     "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
-    "@aws-amplify/graphql-transformer-test-utils": "0.5.6",
+    "@aws-amplify/graphql-transformer-test-utils": "0.6.1",
     "@types/detect-port": "^1.3.0",
     "@types/lodash": "^4.14.149",
     "@types/node": "^12.12.6",

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amplify-category-api-graphql-transformers-e2e-tests",
-  "version": "8.8.5",
-  "description": "End to end functional tests for appsync supported transformers.",
+  "version": "8.8.7",
+  "description": "End to end functional tests for appsync supported transformers ",
   "private": true,
   "repository": {
     "type": "git",
@@ -39,7 +39,7 @@
     "@aws-amplify/graphql-model-transformer": "2.11.4",
     "@aws-amplify/graphql-transformer-core": "2.9.3",
     "@aws-amplify/graphql-transformer-interfaces": "3.10.1",
-    "@aws-amplify/graphql-transformer-test-utils": "0.5.6",
+    "@aws-amplify/graphql-transformer-test-utils": "0.6.1",
     "@types/node": "^12.12.6",
     "aws-amplify": "^4.2.8",
     "aws-appsync": "^4.1.1",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Update the versions for private packages common b/w main and stable branches to the latest versions already published from `main` previously. This was identified when the `lerna publish` flow tried to push the git tags for these packages.
Following Git tags that were published for versions that don't yet exist on NPM as part of this old commit - https://github.com/aws-amplify/amplify-category-api/commit/f3ec4c4bdd1e9780b05878448031b6557403907b are deleted from Github.
- [graphql-mapping-template@4.21.0](https://github.com/aws-amplify/amplify-category-api/releases/tag/graphql-mapping-template%404.21.0)
- [graphql-auth-transformer@8.0.0](https://github.com/aws-amplify/amplify-category-api/releases/tag/graphql-auth-transformer%408.0.0)
- [graphql-connection-transformer@5.3.0](https://github.com/aws-amplify/amplify-category-api/releases/tag/graphql-connection-transformer%405.3.0)
- [graphql-dynamodb-transformer@8.0.0](https://github.com/aws-amplify/amplify-category-api/releases/tag/graphql-dynamodb-transformer%408.0.0)
- [graphql-elasticsearch-transformer@5.3.0](https://github.com/aws-amplify/amplify-category-api/releases/tag/graphql-elasticsearch-transformer%405.3.0)
- [graphql-function-transformer@3.4.0](https://github.com/aws-amplify/amplify-category-api/releases/tag/graphql-function-transformer%403.4.0)
- [graphql-http-transformer@5.3.0](https://github.com/aws-amplify/amplify-category-api/releases/tag/graphql-http-transformer%405.3.0)
- [graphql-key-transformer@3.3.0](https://github.com/aws-amplify/amplify-category-api/releases/tag/graphql-key-transformer%403.3.0)
- [graphql-relational-schema-transformer@2.22.0](https://github.com/aws-amplify/amplify-category-api/releases/tag/graphql-relational-schema-transformer%402.22.0)
- [graphql-versioned-transformer@5.3.0](https://github.com/aws-amplify/amplify-category-api/releases/tag/graphql-versioned-transformer%405.3.0)

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Full E2E suite passed

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
