### PR TITLE
chore(conversation-transformer): bump ai-constructs version

### DIFF
--- a/packages/amplify-data-construct/.jsii
+++ b/packages/amplify-data-construct/.jsii
@@ -6,7 +6,7 @@
     ]
   },
   "bundled": {
-    "@aws-amplify/ai-constructs": "0.0.0-test-20240906180649",
+    "@aws-amplify/ai-constructs": "^0.1.3",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.0",
@@ -3970,5 +3970,5 @@
   },
   "types": {},
   "version": "1.10.0",
-  "fingerprint": "gmo67wGo900F+dEdfyBmdUyHaiMheWBo1qPT7I3J6wk="
+  "fingerprint": "OxMQk8JtDJq0lQi6ojXZRMgt4j2ao2i152N4Um6ykgc="
 }

--- a/packages/amplify-data-construct/.jsii
+++ b/packages/amplify-data-construct/.jsii
@@ -6,7 +6,7 @@
     ]
   },
   "bundled": {
-    "@aws-amplify/ai-constructs": "^0.1.2",
+    "@aws-amplify/ai-constructs": "0.0.0-test-20240906180649",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.0",
@@ -3970,5 +3970,5 @@
   },
   "types": {},
   "version": "1.10.0",
-  "fingerprint": "iwrIQH3hduS0+l5ULC3hEHaUiKg9p2tIkLNN/pNc0+I="
+  "fingerprint": "gmo67wGo900F+dEdfyBmdUyHaiMheWBo1qPT7I3J6wk="
 }

--- a/packages/amplify-data-construct/package.json
+++ b/packages/amplify-data-construct/package.json
@@ -157,7 +157,7 @@
     "semver"
   ],
   "dependencies": {
-    "@aws-amplify/ai-constructs": "0.0.0-test-20240906180649",
+    "@aws-amplify/ai-constructs": "^0.1.3",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-api-construct": "1.12.0",

--- a/packages/amplify-data-construct/package.json
+++ b/packages/amplify-data-construct/package.json
@@ -157,7 +157,7 @@
     "semver"
   ],
   "dependencies": {
-    "@aws-amplify/ai-constructs": "^0.1.2",
+    "@aws-amplify/ai-constructs": "0.0.0-test-20240906180649",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-api-construct": "1.12.0",

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/conversation.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/conversation.test.ts
@@ -25,7 +25,7 @@ describe('conversation', () => {
       projRoot = await createNewProjectDir(projFolderName);
       const templatePath = path.resolve(path.join(__dirname, '..', 'backends', 'configurable-stack'));
       const name = await initCDKProject(projRoot, templatePath, {
-        additionalDependencies: ['@aws-sdk/client-bedrock-runtime', 'esbuild'],
+        additionalDependencies: ['esbuild'],
       });
 
       const conversationSchemaPath = path.resolve(path.join(__dirname, 'graphql', 'schema-conversation.graphql'));

--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -6,7 +6,7 @@
     ]
   },
   "bundled": {
-    "@aws-amplify/ai-constructs": "^0.1.2",
+    "@aws-amplify/ai-constructs": "0.0.0-test-20240906180649",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.0",
@@ -8887,5 +8887,5 @@
     }
   },
   "version": "1.12.0",
-  "fingerprint": "QnCZIP8hoYcbQ1AKuNU1P5dQ8fjbJJAEQzxEkxgg0Js="
+  "fingerprint": "vrgsgERa95VdfS3Fl/dDc387Sh8EVtXT+mCHns6bLcM="
 }

--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -6,7 +6,7 @@
     ]
   },
   "bundled": {
-    "@aws-amplify/ai-constructs": "0.0.0-test-20240906180649",
+    "@aws-amplify/ai-constructs": "^0.1.3",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.0",
@@ -8887,5 +8887,5 @@
     }
   },
   "version": "1.12.0",
-  "fingerprint": "vrgsgERa95VdfS3Fl/dDc387Sh8EVtXT+mCHns6bLcM="
+  "fingerprint": "dhaZBXs5izeqSNv72KDB2qndyddYZAK2HZvMRnS3ICA="
 }

--- a/packages/amplify-graphql-api-construct/package.json
+++ b/packages/amplify-graphql-api-construct/package.json
@@ -158,7 +158,7 @@
     "semver"
   ],
   "dependencies": {
-    "@aws-amplify/ai-constructs": "0.0.0-test-20240906180649",
+    "@aws-amplify/ai-constructs": "^0.1.3",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.0",

--- a/packages/amplify-graphql-api-construct/package.json
+++ b/packages/amplify-graphql-api-construct/package.json
@@ -158,7 +158,7 @@
     "semver"
   ],
   "dependencies": {
-    "@aws-amplify/ai-constructs": "^0.1.2",
+    "@aws-amplify/ai-constructs": "0.0.0-test-20240906180649",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.0",

--- a/packages/amplify-graphql-conversation-transformer/package.json
+++ b/packages/amplify-graphql-conversation-transformer/package.json
@@ -23,7 +23,7 @@
     "extract-api": "ts-node ../../scripts/extract-api.ts"
   },
   "dependencies": {
-    "@aws-amplify/ai-constructs": "^0.1.2",
+    "@aws-amplify/ai-constructs": "0.0.0-test-20240906180649",
     "@aws-amplify/graphql-directives": "2.1.0",
     "@aws-amplify/graphql-index-transformer": "3.0.2",
     "@aws-amplify/graphql-model-transformer": "3.0.2",

--- a/packages/amplify-graphql-conversation-transformer/package.json
+++ b/packages/amplify-graphql-conversation-transformer/package.json
@@ -23,7 +23,7 @@
     "extract-api": "ts-node ../../scripts/extract-api.ts"
   },
   "dependencies": {
-    "@aws-amplify/ai-constructs": "0.0.0-test-20240906180649",
+    "@aws-amplify/ai-constructs": "^0.1.3",
     "@aws-amplify/graphql-directives": "2.1.0",
     "@aws-amplify/graphql-index-transformer": "3.0.2",
     "@aws-amplify/graphql-model-transformer": "3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,10 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aws-amplify/ai-constructs@0.0.0-test-20240906180649":
-  version "0.0.0-test-20240906180649"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/ai-constructs/-/ai-constructs-0.0.0-test-20240906180649.tgz#35498181f77d54e0f5d4027391c2c0e6bf2bfc08"
-  integrity sha512-zlR9FME/kleiTXBTTpbzwSDOjJTB64EY445isfqFlYAd3kF6McNZtS4jpWrXxzKP8D9Ko1rIPUb2844PH0GGhw==
+"@aws-amplify/ai-constructs@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/ai-constructs/-/ai-constructs-0.1.3.tgz#dc371ff76937635042d50376c233308775495e87"
+  integrity sha512-6WynWa4R6AuogXqqRncU7PXJ+ZeWEIGmJuYcFot+x+oxp3juj51oFnPwdfj65QSqNcq2TbxSUe7jE/2A0pZ5OQ==
   dependencies:
     "@aws-amplify/plugin-types" "^1.0.1"
     "@aws-sdk/client-bedrock-runtime" "^3.622.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,10 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aws-amplify/ai-constructs@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/ai-constructs/-/ai-constructs-0.1.2.tgz#572f46c308edf5823861116cd9152eb429e9453f"
-  integrity sha512-fMwCPTBrf80Lk3/fyIUqDH79NVbo+kdroYj3wOOIqFsDHAnrQbnV64UgBNHqv7PUcQD11V+tLbC5qEb30+5Emg==
+"@aws-amplify/ai-constructs@0.0.0-test-20240906180649":
+  version "0.0.0-test-20240906180649"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/ai-constructs/-/ai-constructs-0.0.0-test-20240906180649.tgz#35498181f77d54e0f5d4027391c2c0e6bf2bfc08"
+  integrity sha512-zlR9FME/kleiTXBTTpbzwSDOjJTB64EY445isfqFlYAd3kF6McNZtS4jpWrXxzKP8D9Ko1rIPUb2844PH0GGhw==
   dependencies:
     "@aws-amplify/plugin-types" "^1.0.1"
     "@aws-sdk/client-bedrock-runtime" "^3.622.0"


### PR DESCRIPTION
#### Description of changes
- Bumps `ai-constructs` dependency to `0.1.3` to **not** bundle the AWS SDK for the conversation route happy path (implicit lambda generation). This is done to prevent customers from needing to install `@aws-sdk/client-bedrock-runtime` as a dependency in their project. Here's the [backend PR for reference](https://github.com/aws-amplify/amplify-backend/pull/1969).
- Removes `@aws-sdk/client-bedrock-runtime` from `additionalDependencies` in conversation directive E2E tests.


##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
