### PR TITLE
test(function-transformer): add snapshots for chained functions

### DIFF
--- a/packages/amplify-graphql-directives/src/directives/function.ts
+++ b/packages/amplify-graphql-directives/src/directives/function.ts
@@ -1,10 +1,9 @@
 import { Directive } from './directive';
 
-const name = 'function';
-// export type FunctionInvocationType = 'RequestResponse' | 'Event'
 export type FunctionDirectiveDefaults = {
   invocationType: string;
 };
+const name = 'function';
 const defaults: FunctionDirectiveDefaults = {
   invocationType: 'RequestResponse',
 };

--- a/packages/amplify-graphql-function-transformer/src/__tests__/__snapshots__/amplify-graphql-function-transformer.test.ts.snap
+++ b/packages/amplify-graphql-function-transformer/src/__tests__/__snapshots__/amplify-graphql-function-transformer.test.ts.snap
@@ -1,5 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Event invocation type Chained directives chained @function -- Event > Event succeeds with EventInvocationResponse 1`] = `
+"## [Start] Handle error and return result for event invocation type. **
+#set( $success = true )
+#if( $ctx.error )
+  $util.appendError($ctx.error.message, $ctx.error.type)
+  #set( $success = false )
+#end
+#set( $response = {
+  \\"success\\": $success
+} )
+$util.toJson($response)
+## [End] Handle error and return result for event invocation type. **"
+`;
+
+exports[`Event invocation type Chained directives chained @function -- Event > Event succeeds with EventInvocationResponse 2`] = `
+"## [Start] Handle error and return result for event invocation type. **
+#set( $success = true )
+#if( $ctx.error )
+  $util.appendError($ctx.error.message, $ctx.error.type)
+  #set( $success = false )
+#end
+#set( $response = {
+  \\"success\\": $success
+} )
+$util.toJson($response)
+## [End] Handle error and return result for event invocation type. **"
+`;
+
+exports[`Event invocation type Chained directives chained @function -- Event > RequestResponse succeeds without EventInvocationResponse 1`] = `undefined`;
+
+exports[`Event invocation type Chained directives chained @function -- Event > RequestResponse succeeds without EventInvocationResponse 2`] = `undefined`;
+
+exports[`Event invocation type Chained directives chained @function -- RequestResponse > Event succeeds with EventInvocationResponse 1`] = `
+"## [Start] Handle error and return result for event invocation type. **
+#set( $success = true )
+#if( $ctx.error )
+  $util.appendError($ctx.error.message, $ctx.error.type)
+  #set( $success = false )
+#end
+#set( $response = {
+  \\"success\\": $success
+} )
+$util.toJson($response)
+## [End] Handle error and return result for event invocation type. **"
+`;
+
+exports[`Event invocation type Chained directives chained @function -- RequestResponse > Event succeeds with EventInvocationResponse 2`] = `
+"## [Start] Handle error or return result for request response invocation type. **
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
+$util.toJson($ctx.result)
+## [End] Handle error or return result for request response invocation type. **"
+`;
+
 exports[`Event invocation type Defined on Mutation succeeds 1`] = `
 "type Mutation {
   asyncStuff(msg: String): EventInvocationResponse
@@ -29,7 +84,7 @@ Object {
   \\"invocationType\\": \\"Event\\"
 }
 ## [End] Invoke AWS Lambda data source: AsyncstuffLambdaDataSource. **",
-  "InvokeAsyncstuffLambdaDataSource.res.vtl": "## [Start] Handle error or return result. **
+  "InvokeAsyncstuffLambdaDataSource.res.vtl": "## [Start] Handle error and return result for event invocation type. **
 #set( $success = true )
 #if( $ctx.error )
   $util.appendError($ctx.error.message, $ctx.error.type)
@@ -39,7 +94,7 @@ Object {
   \\"success\\": $success
 } )
 $util.toJson($response)
-## [End] Handle error or return result. **",
+## [End] Handle error and return result for event invocation type. **",
   "Mutation.asyncStuff.res.vtl": "$util.toJson($ctx.prev.result)",
 }
 `;
@@ -62,7 +117,7 @@ Object {
   \\"invocationType\\": \\"Event\\"
 }
 ## [End] Invoke AWS Lambda data source: AsyncstuffLambdaDataSource. **",
-  "InvokeAsyncstuffLambdaDataSource.res.vtl": "## [Start] Handle error or return result. **
+  "InvokeAsyncstuffLambdaDataSource.res.vtl": "## [Start] Handle error and return result for event invocation type. **
 #set( $success = true )
 #if( $ctx.error )
   $util.appendError($ctx.error.message, $ctx.error.type)
@@ -72,7 +127,7 @@ Object {
   \\"success\\": $success
 } )
 $util.toJson($response)
-## [End] Handle error or return result. **",
+## [End] Handle error and return result for event invocation type. **",
   "Query.asyncStuff.res.vtl": "$util.toJson($ctx.prev.result)",
 }
 `;
@@ -95,12 +150,12 @@ Object {
   \\"invocationType\\": \\"RequestResponse\\"
 }
 ## [End] Invoke AWS Lambda data source: Echofunction123123456456LambdaDataSource. **",
-  "InvokeEchofunction123123456456LambdaDataSource.res.vtl": "## [Start] Handle error or return result. **
+  "InvokeEchofunction123123456456LambdaDataSource.res.vtl": "## [Start] Handle error or return result for request response invocation type. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #end
 $util.toJson($ctx.result)
-## [End] Handle error or return result. **",
+## [End] Handle error or return result for request response invocation type. **",
   "Query.echo.res.vtl": "$util.toJson($ctx.prev.result)",
 }
 `;
@@ -123,12 +178,12 @@ Object {
   \\"invocationType\\": \\"RequestResponse\\"
 }
 ## [End] Invoke AWS Lambda data source: EchofunctionLambdaDataSource. **",
-  "InvokeEchofunctionLambdaDataSource.res.vtl": "## [Start] Handle error or return result. **
+  "InvokeEchofunctionLambdaDataSource.res.vtl": "## [Start] Handle error or return result for request response invocation type. **
 #if( $ctx.error )
   $util.error($ctx.error.message, $ctx.error.type)
 #end
 $util.toJson($ctx.result)
-## [End] Handle error or return result. **",
+## [End] Handle error or return result for request response invocation type. **",
   "Query.echo.res.vtl": "$util.toJson($ctx.prev.result)",
 }
 `;

--- a/packages/amplify-graphql-function-transformer/src/__tests__/amplify-graphql-function-transformer.test.ts
+++ b/packages/amplify-graphql-function-transformer/src/__tests__/amplify-graphql-function-transformer.test.ts
@@ -454,6 +454,8 @@ describe('Event invocation type', () => {
       `;
       const out = testTransform({ schema, transformers: [new FunctionTransformer()] });
       expect(out).toBeDefined();
+      expect(out.resolvers['InvokeAsyncstuffLambdaDataSource.res.vtl']).toMatchSnapshot();
+      expect(out.resolvers['InvokeAsyncstuff2LambdaDataSource.res.vtl']).toMatchSnapshot();
     });
 
     test('chained @function -- RequestResponse > Event fails without EventInvocationResponse', () => {
@@ -486,6 +488,8 @@ describe('Event invocation type', () => {
     `;
       const out = testTransform({ schema, transformers: [new FunctionTransformer()] });
       expect(out).toBeDefined();
+      expect(out.resolvers['InvokeAsyncstuffLambdaDataSource.res.vtl']).toMatchSnapshot();
+      expect(out.resolvers['InvokeAsyncstuff2LambdaDataSource.res.vtl']).toMatchSnapshot();
     });
 
     test('chained @function -- Event > Event fails without EventInvocationResponse', () => {
@@ -503,16 +507,18 @@ describe('Event invocation type', () => {
       expect(() => testTransform({ schema, transformers: [new FunctionTransformer()] })).toThrowError(expectedErrorMessage);
     });
 
-    test('chained @function -- RequestResponse > Event succeeds without EventInvocationResponse', () => {
+    test('chained @function -- Event > RequestResponse succeeds without EventInvocationResponse', () => {
       const schema = `
         type Mutation {
-          asyncStuff(msg: String): String
+          syncStuff(msg: String): String
           @function(name: "asyncstuff-\${env}", invocationType: Event)
           @function(name: "asyncstuff2-\${env}")
         }
       `;
       const out = testTransform({ schema, transformers: [new FunctionTransformer()] });
       expect(out).toBeDefined();
+      expect(out.resolvers['InvokeSyncstuffLambdaDataSource.res.vtl']).toMatchSnapshot();
+      expect(out.resolvers['InvokeSyncstuff2LambdaDataSource.res.vtl']).toMatchSnapshot();
     });
   });
 

--- a/packages/amplify-graphql-function-transformer/src/graphql-function-transformer.ts
+++ b/packages/amplify-graphql-function-transformer/src/graphql-function-transformer.ts
@@ -2,8 +2,9 @@ import {
   DirectiveWrapper,
   generateGetArgumentsInput,
   InvalidDirectiveError,
-  isObjectTypeDefinitionNode, MappingTemplate,
-  TransformerPluginBase
+  isObjectTypeDefinitionNode,
+  MappingTemplate,
+  TransformerPluginBase,
 } from '@aws-amplify/graphql-transformer-core';
 import { TransformerContextProvider, TransformerSchemaVisitStepContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { FunctionDirective } from '@aws-amplify/graphql-directives';

--- a/packages/amplify-graphql-function-transformer/src/graphql-function-transformer.ts
+++ b/packages/amplify-graphql-function-transformer/src/graphql-function-transformer.ts
@@ -2,9 +2,8 @@ import {
   DirectiveWrapper,
   generateGetArgumentsInput,
   InvalidDirectiveError,
-  isObjectTypeDefinitionNode,
-  MappingTemplate,
-  TransformerPluginBase,
+  isObjectTypeDefinitionNode, MappingTemplate,
+  TransformerPluginBase
 } from '@aws-amplify/graphql-transformer-core';
 import { TransformerContextProvider, TransformerSchemaVisitStepContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { FunctionDirective } from '@aws-amplify/graphql-directives';
@@ -200,37 +199,26 @@ export class FunctionTransformer extends TransformerPluginBase {
  * @returns the response mapping template used by AppSync to handle responses from the Lambda function invocation.
  */
 const responseMappingTemplate = (config: FunctionDirectiveConfiguration): string => {
-  if (config.invocationType === 'Event') {
-    /*
-      #set( $success = true )
-      #if( $ctx.error )
-        $util.appendError($ctx.error.message, $ctx.error.type)
-        #set( $success = false )
-      #end
-      #set( $response = {
-        "success": $success
-      } )
-      $util.toJson($response)
-    */
-    return printBlock('Handle error or return result')(
-      compoundExpression([
-        set(ref('success'), bool(true)),
-        iff(
-          ref('ctx.error'),
-          compoundExpression([raw('$util.appendError($ctx.error.message, $ctx.error.type)'), set(ref('success'), bool(false))]),
-        ),
-        compoundExpression([set(ref('response'), obj({ success: ref('success') })), raw('$util.toJson($response)')]),
-      ]),
-    );
-  }
+  return config.invocationType === 'Event'
+    ? responseMappingTemplateEventInvocationType()
+    : responseMappingTemplateRequestResponseInvocationType();
+};
 
-  /*
-    #if( $ctx.error )
-      $util.error($ctx.error.message, $ctx.error.type)
-    #end
-    $util.toJson($ctx.result)
-  */
-  return printBlock('Handle error or return result')(
+const responseMappingTemplateEventInvocationType = (): string => {
+  return printBlock('Handle error and return result for event invocation type')(
+    compoundExpression([
+      set(ref('success'), bool(true)),
+      iff(
+        ref('ctx.error'),
+        compoundExpression([raw('$util.appendError($ctx.error.message, $ctx.error.type)'), set(ref('success'), bool(false))]),
+      ),
+      compoundExpression([set(ref('response'), obj({ success: ref('success') })), raw('$util.toJson($response)')]),
+    ]),
+  );
+};
+
+const responseMappingTemplateRequestResponseInvocationType = (): string => {
+  return printBlock('Handle error or return result for request response invocation type')(
     compoundExpression([
       iff(ref('ctx.error'), compoundExpression([raw('$util.error($ctx.error.message, $ctx.error.type)')])),
       raw('$util.toJson($ctx.result)'),
@@ -266,7 +254,7 @@ const lambdaArnKey = (name: string, region?: string, accountId?: string): string
  */
 const validate = (config: FunctionDirectiveConfiguration, definition: FieldDefinitionNode, ctx: TransformerContextProvider): void => {
   if (config.invocationType === 'Event') {
-    // For any occurance  of 'invocationType: Event' validate:
+    // For any occurence  of 'invocationType: Event' validate:
     // is used on field where parent type is Mutation or Query.
     validateIsSupportedEventInvocationParentType(config);
 


### PR DESCRIPTION
#### Description of changes
Addresses feedback from
- https://github.com/aws-amplify/amplify-category-api/pull/2864

- Adds response mapping template snapshots for chained function directive test cases.
- misc. cleanup

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
