### PR TITLE
chore(ai): bump ai-constructs to 0.1.4

### DIFF
--- a/packages/amplify-data-construct/.jsii
+++ b/packages/amplify-data-construct/.jsii
@@ -6,7 +6,7 @@
     ]
   },
   "bundled": {
-    "@aws-amplify/ai-constructs": "^0.1.3",
+    "@aws-amplify/ai-constructs": "^0.1.4",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.0",
@@ -3970,5 +3970,5 @@
   },
   "types": {},
   "version": "1.10.0",
-  "fingerprint": "OxMQk8JtDJq0lQi6ojXZRMgt4j2ao2i152N4Um6ykgc="
+  "fingerprint": "QWdydzCj6LkvRatJAureGb8gN9ROP+DfWzUSJrr3idc="
 }

--- a/packages/amplify-data-construct/package.json
+++ b/packages/amplify-data-construct/package.json
@@ -157,7 +157,7 @@
     "semver"
   ],
   "dependencies": {
-    "@aws-amplify/ai-constructs": "^0.1.3",
+    "@aws-amplify/ai-constructs": "^0.1.4",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-api-construct": "1.12.0",

--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -6,7 +6,7 @@
     ]
   },
   "bundled": {
-    "@aws-amplify/ai-constructs": "^0.1.3",
+    "@aws-amplify/ai-constructs": "^0.1.4",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.0",
@@ -8887,5 +8887,5 @@
     }
   },
   "version": "1.12.0",
-  "fingerprint": "dhaZBXs5izeqSNv72KDB2qndyddYZAK2HZvMRnS3ICA="
+  "fingerprint": "WQe8bESYXwkHuayA70K/y1utQFCo4AT58swUXMJSDuc="
 }

--- a/packages/amplify-graphql-api-construct/package.json
+++ b/packages/amplify-graphql-api-construct/package.json
@@ -158,7 +158,7 @@
     "semver"
   ],
   "dependencies": {
-    "@aws-amplify/ai-constructs": "^0.1.3",
+    "@aws-amplify/ai-constructs": "^0.1.4",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.0",

--- a/packages/amplify-graphql-conversation-transformer/package.json
+++ b/packages/amplify-graphql-conversation-transformer/package.json
@@ -23,7 +23,7 @@
     "extract-api": "ts-node ../../scripts/extract-api.ts"
   },
   "dependencies": {
-    "@aws-amplify/ai-constructs": "^0.1.3",
+    "@aws-amplify/ai-constructs": "^0.1.4",
     "@aws-amplify/graphql-directives": "2.1.0",
     "@aws-amplify/graphql-index-transformer": "3.0.2",
     "@aws-amplify/graphql-model-transformer": "3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,10 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aws-amplify/ai-constructs@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/ai-constructs/-/ai-constructs-0.1.3.tgz#dc371ff76937635042d50376c233308775495e87"
-  integrity sha512-6WynWa4R6AuogXqqRncU7PXJ+ZeWEIGmJuYcFot+x+oxp3juj51oFnPwdfj65QSqNcq2TbxSUe7jE/2A0pZ5OQ==
+"@aws-amplify/ai-constructs@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/ai-constructs/-/ai-constructs-0.1.4.tgz#043ca7793cb4a97ad7864797bd70dbfa323329f4"
+  integrity sha512-BGLBFs/pt6JrNgUo+QD0Szt/ssHMa6EyEE45yLoHemwPHRuJPpnFmxIbbxgxaqJP0mWK6QMs9Wh3IsdJ/6XhDA==
   dependencies:
     "@aws-amplify/plugin-types" "^1.0.1"
     "@aws-sdk/client-bedrock-runtime" "^3.622.0"


### PR DESCRIPTION
#### Description of changes

Bumps `ai-constructs` dependency to 0.1.4 to pull in this change:
- https://github.com/aws-amplify/amplify-backend/pull/1988

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
See linked backend PR for description of issue.

#### Description of how you validated changes
[E2E run](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:1a0e7580-1d94-41ce-a1eb-1f41fe7447a1?region=us-east-1)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] ~Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)~
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
