### PR TITLE
Revert "feat: get datasource map for migration (#2668)"

### DIFF
--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -4433,7 +4433,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 287
+            "line": 286
           },
           "name": "addDynamoDbDataSource",
           "parameters": [
@@ -4482,7 +4482,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 299
+            "line": 298
           },
           "name": "addElasticsearchDataSource",
           "parameters": [
@@ -4529,7 +4529,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 309
+            "line": 308
           },
           "name": "addEventBridgeDataSource",
           "parameters": [
@@ -4576,7 +4576,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 391
+            "line": 390
           },
           "name": "addFunction",
           "parameters": [
@@ -4611,7 +4611,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 320
+            "line": 319
           },
           "name": "addHttpDataSource",
           "parameters": [
@@ -4659,7 +4659,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 331
+            "line": 330
           },
           "name": "addLambdaDataSource",
           "parameters": [
@@ -4707,7 +4707,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 342
+            "line": 341
           },
           "name": "addNoneDataSource",
           "parameters": [
@@ -4746,7 +4746,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 353
+            "line": 352
           },
           "name": "addOpenSearchDataSource",
           "parameters": [
@@ -4794,7 +4794,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 366
+            "line": 365
           },
           "name": "addRdsDataSource",
           "parameters": [
@@ -4861,7 +4861,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 382
+            "line": 381
           },
           "name": "addResolver",
           "parameters": [
@@ -8960,5 +8960,5 @@
     }
   },
   "version": "1.13.0",
-  "fingerprint": "SvUg/laowa+2kCDSW7tShjvINY9o1V4/u3HBb9mcdYA="
+  "fingerprint": "GVOegrfILHqK5KKiknuL6p+fkV96vEguqRKbwXKS36g="
 }

--- a/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
+++ b/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
@@ -187,7 +187,6 @@ export class AmplifyGraphqlApi extends Construct {
     const transformParameters = {
       ...defaultTranslationBehavior,
       ...(translationBehavior ?? {}),
-      enableGen2Migration: false,
       allowGen1Patterns: false,
     };
     const executeTransformConfig: ExecuteTransformConfig = {

--- a/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/model-transformer.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@aws-amplify/graphql-transformer-core';
 import { InputObjectTypeDefinitionNode, InputValueDefinitionNode, NamedTypeNode, parse } from 'graphql';
 import { getBaseType } from 'graphql-transformer-common';
-import { Template, Match } from 'aws-cdk-lib/assertions';
+import { Template } from 'aws-cdk-lib/assertions';
 import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import { PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
 import { VpcConfig, ModelDataSourceStrategySqlDbType, SQLLambdaModelDataSourceStrategy } from '@aws-amplify/graphql-transformer-interfaces';
@@ -2314,101 +2314,6 @@ describe('ModelTransformer:', () => {
       expect(postType.directives!.length).toEqual(1);
       const directiveNames = postType.directives!.map((dir) => dir.name.value);
       expect(directiveNames).toContain('aws_iam');
-    });
-  });
-
-  describe('migration', () => {
-    it('should output data source mapping', async () => {
-      const validSchema = `
-        type Post @model {
-            id: ID!
-            title: String!
-        }
-      `;
-
-      const out = testTransform({
-        schema: validSchema,
-        transformers: [new ModelTransformer()],
-        transformParameters: {
-          enableGen2Migration: true,
-        },
-      });
-      expect(out).toBeDefined();
-      const template = Template.fromJSON(out.rootStack);
-      template.hasOutput('DataSourceMappingOutput', {
-        Value: Match.objectLike({
-          'Fn::Join': [
-            '',
-            [
-              '{"Post":"',
-              {
-                'Fn::GetAtt': ['Post', 'Outputs.transformerrootstackPostPostTable34CAE87BRef'],
-              },
-              '"}',
-            ],
-          ],
-        }),
-        Description: 'Mapping of model name to data source table name.',
-      });
-    });
-
-    it('should set table removal policy to retain', () => {
-      const validSchema = `
-        type Post @model {
-            id: ID!
-            title: String!
-        }
-      `;
-
-      const out = testTransform({
-        schema: validSchema,
-        transformers: [new ModelTransformer()],
-        transformParameters: {
-          enableGen2Migration: true,
-        },
-      });
-      expect(out).toBeDefined();
-      const postStack = out.stacks['Post'];
-      const template = Template.fromJSON(postStack);
-      template.hasResource('AWS::DynamoDB::Table', {
-        DeletionPolicy: 'Retain',
-        Properties: {
-          TableName: {
-            'Fn::Join': [
-              '',
-              [
-                'Post-',
-                {
-                  Ref: 'referencetotransformerrootstackGraphQLAPI20497F53ApiId',
-                },
-                '-',
-                {
-                  Ref: 'referencetotransformerrootstackenv10C5A902Ref',
-                },
-              ],
-            ],
-          },
-        },
-      });
-    });
-
-    describe('does not add SQL data sources to mapping', () => {
-      test.each(sqlDatasources)('%s', (dbType) => {
-        const validSchema = `
-            type Post @model {
-              id: ID! @primaryKey
-              title: String!
-            }
-          `;
-
-        const out = testTransform({
-          schema: validSchema,
-          transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
-          dataSourceStrategies: constructDataSourceStrategies(validSchema, makeStrategy(dbType)),
-        });
-        expect(out).toBeDefined();
-        expect(out.rootStack.Outputs?.DataSourceMappingOutput).toBeUndefined();
-      });
     });
   });
 });

--- a/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
+++ b/packages/amplify-graphql-model-transformer/src/graphql-model-transformer.ts
@@ -34,7 +34,6 @@ import {
   TransformerTransformSchemaStepContextProvider,
   TransformerValidationStepContextProvider,
   DataSourceStrategiesProvider,
-  DataSourceProvider,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import { ModelDirective } from '@aws-amplify/graphql-directives';
 import { ITable } from 'aws-cdk-lib/aws-dynamodb';
@@ -326,31 +325,9 @@ export class ModelTransformer extends TransformerModelBase implements Transforme
   };
 
   generateResolvers = (context: TransformerContextProvider): void => {
-    const dataSourceMapping: Record<string, string> = {};
     this.resourceGeneratorMap.forEach((generator) => {
       generator.generateResources(context);
-      const ddbDatasources = Object.entries(generator.getDatasourceMap()).filter(
-        ([, datasource]) => datasource.ds.type === 'AMAZON_DYNAMODB',
-      );
-      ddbDatasources.forEach(([modelName, datasource]) => {
-        if (datasource.ds.dynamoDbConfig && !cdk.isResolvableObject(datasource.ds.dynamoDbConfig)) {
-          dataSourceMapping[modelName] = datasource.ds.dynamoDbConfig.tableName;
-        }
-        // TODO: probably need a link to docs for this
-        console.warn(
-          `Could not resolve table name for ${modelName}. DataSourceMappingOutput is incomplete. Please manually add ${modelName} to the mapping for your migration.`,
-        );
-      });
     });
-    if (context.transformParameters.enableGen2Migration && context.transformParameters.enableTransformerCfnOutputs) {
-      const { scope } = context.stackManager;
-      // TODO: decide final naming before merge to main
-      new cdk.CfnOutput(cdk.Stack.of(scope), 'DataSourceMappingOutput', {
-        value: cdk.Stack.of(scope).toJsonString(dataSourceMapping),
-        description: 'Mapping of model name to data source table name.',
-        exportName: cdk.Fn.join(':', [cdk.Aws.STACK_NAME, 'DataSourceMappingOutput']),
-      });
-    }
   };
 
   generateGetResolver = (

--- a/packages/amplify-graphql-model-transformer/src/resources/dynamo-model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/dynamo-model-resource-generator.ts
@@ -68,10 +68,7 @@ export class DynamoModelResourceGenerator extends ModelResourceGenerator {
       expression: cdk.Fn.conditionEquals(pointInTimeRecovery, 'true'),
     });
 
-    const removalPolicy =
-      this.options.EnableDeletionProtection || context.transformParameters.enableGen2Migration
-        ? cdk.RemovalPolicy.RETAIN
-        : cdk.RemovalPolicy.DESTROY;
+    const removalPolicy = this.options.EnableDeletionProtection ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY;
 
     // Expose a way in context to allow proper resource naming
     const table = new Table(scope, tableLogicalName, {

--- a/packages/amplify-graphql-model-transformer/src/resources/model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/model-resource-generator.ts
@@ -730,8 +730,4 @@ export abstract class ModelResourceGenerator {
 
     return fields;
   };
-
-  getDatasourceMap(): Record<string, DataSourceProvider> {
-    return this.datasourceMap;
-  }
 }

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/transform-parameters.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/transform-parameters.ts
@@ -27,7 +27,4 @@ export const defaultTransformParameters: TransformParameters = {
 
   // Search Params
   enableSearchNodeToNodeEncryption: false,
-
-  // Migration
-  enableGen2Migration: false,
 };

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -933,7 +933,6 @@ export type TransformParameters = {
     enableAutoIndexQueryNames: boolean;
     respectPrimaryKeyAttributesOnConnectionField: boolean;
     enableSearchNodeToNodeEncryption: boolean;
-    enableGen2Migration: boolean;
 };
 
 // @public (undocumented)

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transform-parameters.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transform-parameters.ts
@@ -31,7 +31,4 @@ export type TransformParameters = {
 
   // Search Params
   enableSearchNodeToNodeEncryption: boolean;
-
-  // Migration
-  enableGen2Migration: boolean;
 };

--- a/packages/amplify-graphql-transformer/src/__tests__/graphql-transformer.test.ts
+++ b/packages/amplify-graphql-transformer/src/__tests__/graphql-transformer.test.ts
@@ -57,7 +57,6 @@ const defaultTransformConfig: TransformConfig = {
     allowDestructiveGraphqlSchemaUpdates: false,
     replaceTableUponGsiUpdate: false,
     allowGen1Patterns: true,
-    enableGen2Migration: false,
   },
 };
 

--- a/packages/graphql-transformer-common/API.md
+++ b/packages/graphql-transformer-common/API.md
@@ -349,7 +349,6 @@ export class ResourceConstants {
         AuthCognitoUserPoolIdOutput: string;
         AuthCognitoUserPoolNativeClientOutput: string;
         AuthCognitoUserPoolJSClientOutput: string;
-        DataSourceMappingOutput: string;
     };
     // (undocumented)
     static PARAMETERS: {

--- a/packages/graphql-transformer-common/src/ResourceConstants.ts
+++ b/packages/graphql-transformer-common/src/ResourceConstants.ts
@@ -164,9 +164,6 @@ export class ResourceConstants {
     AuthCognitoUserPoolIdOutput: 'AuthCognitoUserPoolIdOutput',
     AuthCognitoUserPoolNativeClientOutput: 'AuthCognitoUserPoolNativeClientId',
     AuthCognitoUserPoolJSClientOutput: 'AuthCognitoUserPoolJSClientId',
-
-    // Migration
-    DataSourceMappingOutput: 'DataSourceMappingOutput',
   };
 
   public static METADATA = {};


### PR DESCRIPTION
This reverts commit 02c7da0da0d5837ca05a8e4ff1b1536cc20ae15b.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Remove migration changes for Gen 1 CLI. The change has been moved to the stable branch: https://github.com/aws-amplify/amplify-category-api/pull/2896

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
