### PR TITLE
fix(model-transformer) IndexName -> index in query list resolver

### DIFF
--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-index-transformer.test.ts.snap
@@ -431,7 +431,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -1251,7 +1251,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -1750,7 +1750,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -3577,7 +3577,7 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -4558,7 +4558,7 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -5424,7 +5424,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -6219,7 +6219,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -7385,7 +7385,7 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",

--- a/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/__snapshots__/amplify-graphql-primary-key-transformer.test.ts.snap
@@ -2060,7 +2060,7 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -2654,7 +2654,7 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -3201,7 +3201,7 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -3795,7 +3795,7 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -4860,7 +4860,7 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/model-transformer.test.ts.snap
@@ -2579,7 +2579,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -3166,7 +3166,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -3753,7 +3753,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",

--- a/packages/amplify-graphql-model-transformer/src/resolvers/dynamodb/query.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/dynamodb/query.ts
@@ -160,7 +160,7 @@ export const generateListRequestTemplate = (): string => {
       ]),
       qref(methodCall(ref(`${requestVariable}.put`), str('operation'), str('Scan'))),
     ),
-    iff(not(methodCall(ref('util.isNull'), ref(indexNameVariable))), set(ref(`${requestVariable}.IndexName`), ref(indexNameVariable))),
+    iff(not(methodCall(ref('util.isNull'), ref(indexNameVariable))), set(ref(`${requestVariable}.index`), ref(indexNameVariable))),
     toJson(ref(requestVariable)),
   ]);
   return printBlock('List Request')(expression);

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-many-transformer.test.ts.snap
@@ -16925,7 +16925,7 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -16988,7 +16988,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -17051,7 +17051,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -17114,7 +17114,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -17177,7 +17177,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -17240,7 +17240,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -17365,7 +17365,7 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -17536,7 +17536,7 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-one-references-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-has-one-references-transformer.test.ts.snap
@@ -1576,7 +1576,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -1747,7 +1747,7 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
@@ -1897,7 +1897,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -2022,7 +2022,7 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -2147,7 +2147,7 @@ $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -5884,7 +5884,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -5947,7 +5947,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",
@@ -6010,7 +6010,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",

--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
@@ -1174,7 +1174,7 @@ $util.toJson({})
   $util.qr($ListRequest.put(\\"operation\\", \\"Scan\\"))
 #end
 #if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
 #end
 $util.toJson($ListRequest)
 ## [End] List Request. **",


### PR DESCRIPTION
## Description of changes

Renames invalid `IndexName` key to valid `index` for generated model list queries.

The VTL data resolver for DynamoDB data sources in generated model list queries contains a code path that (as far as I can tell) is never hit. 

```vtl
#if( !$util.isNull($ctx.stash.metadata.index) )
  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
#end
```

I'm confident it's never hit because `IndexName` is an invalid key to include in the request function evaluation for the only two DDB operations this resolver function can initiate -- Scan and Query. The correct key is `index`.

### Mapping Document Structure

AppSync Documentation References
- [Query](https://docs.aws.amazon.com/appsync/latest/devguide/aws-appsync-resolver-mapping-template-reference-dynamodb-query.html)
- [Scan](https://docs.aws.amazon.com/appsync/latest/devguide/aws-appsync-resolver-mapping-template-reference-dynamodb-scan.html)

The linked AppSync documentation shows that the correct key name for this purpose is `index`, not `IndexName`. 

<details>
<summary>Query Mapping Document Structure</summary>

```js
{
    "version" : "2017-02-28",
    "operation" : "Query",
    "query" : {
        "expression" : "some expression",
        "expressionNames" : {
            "#foo" : "foo"
        },
        "expressionValues" : {
            ":bar" : ... typed value
        }
    },
    "index" : "fooIndex", // <--- 👀 
    "nextToken" : "a pagination token",
    "limit" : 10,
    "scanIndexForward" : true,
    "consistentRead" : false,
    "select" : "ALL_ATTRIBUTES" | "ALL_PROJECTED_ATTRIBUTES" | "SPECIFIC_ATTRIBUTES",
    "filter" : {
        ...
    },
    "projection" : {
        ...
    }
}
```
</details>

<details>
<summary>Scan Mapping Document Structure</summary>

```js
{
    "version" : "2017-02-28",
    "operation" : "Scan",
    "index" : "fooIndex", // <--- 👀 
    "limit" : 10,
    "consistentRead" : false,
    "nextToken" : "aPaginationToken",
    "totalSegments" : 10,
    "segment" : 1,
    "filter" : {
        ...
    },
    "projection" : {
        ...
    }
}
```
</details>


For completeness sake, here's the error message if `ctx.stash.metadata.index` exists and `$ListRequest.IndexName` is set.
```json
{
  "data": {
    "listThings": null
  },
  "errors": [
    {
      "path": [
        "listThings"
      ],
      "data": null,
      "errorType": "MappingTemplate",
      "errorInfo": null,
      "locations": [
        {
          "line": 2,
          "column": 3,
          "sourceName": null
        }
      ],
      "message": "Unsupported element '$[IndexName]'."
    }
  ]
}
```

### Q&A

**If this code path is never hit, why are you making this change?**

I'd like to use it 😄 
For the conversation transformer, we use the model generated list query to surface conversation messages. It's important that message history be returned in sorted order. By fixing this issue, I can insert a simple resolver function into the existing list query pipeline to set `ctx.stash.metadata.index`.

**Ok, but why is it `IndexName` now if that doesn't work?**

As far as I can tell, it's been `IndexName` since this [feat: transformer redesign](https://github.com/aws-amplify/amplify-cli/pull/5534) PR in the `aws-amplify/amplify-cli` repo. I wasn't able to find any relevant commit or PR descriptions, or discussions from reviewers around this line. My assumptions are that `IndexName` was always incorrect, was added back then as a _we might want this one day_ thing, and we've just never supported a code path that hits it.

It looks like this is the specific [commit](https://github.com/aws-amplify/amplify-cli/pull/5534/files#diff-ba3bd32e49021e1312122a970768b68def09c9dddf46d184b1bf4a7824051437R89) that added it back then.

I was unable to find anywhere in the transformer where `ctx.stash.metadata.index` is actually being set. Doing this exhaustively is hard though, so I can't make any assurances that it's not being done.

### Model List Query Diff
```diff
## [Start] List Request. **
#set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
#set( $limit = $util.defaultIfNull($args.limit, 100) )
#set( $ListRequest = {
  "version": "2018-05-29",
  "limit": $limit
} )
#if( $args.nextToken )
  #set( $ListRequest.nextToken = $args.nextToken )
#end
#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
  #set( $filter = $ctx.stash.authFilter )
  #if( !$util.isNullOrEmpty($args.filter) )
    #set( $filter = {
  "and":   [$filter, $args.filter]
} )
  #end
#else
  #if( !$util.isNullOrEmpty($args.filter) )
    #set( $filter = $args.filter )
  #end
#end
#if( !$util.isNullOrEmpty($filter) )
  #set( $filterExpression = $util.parseJson($util.transform.toDynamoDBFilterExpression($filter)) )
  #if( $util.isNullOrEmpty($filterExpression) )
    $util.error("Unable to process the filter expression", "Unrecognized Filter")
  #end
  #if( !$util.isNullOrBlank($filterExpression.expression) )
    #if( $filterExpression.expressionValues.size() == 0 )
      $util.qr($filterExpression.remove("expressionValues"))
    #end
    #set( $ListRequest.filter = $filterExpression )
  #end
#end
#if( !$util.isNull($ctx.stash.modelQueryExpression) && !$util.isNullOrEmpty($ctx.stash.modelQueryExpression.expression) )
  $util.qr($ListRequest.put("operation", "Query"))
  $util.qr($ListRequest.put("query", $ctx.stash.modelQueryExpression))
  #if( !$util.isNull($args.sortDirection) && $args.sortDirection == "DESC" )
    #set( $ListRequest.scanIndexForward = false )
  #else
    #set( $ListRequest.scanIndexForward = true )
  #end
#else
  $util.qr($ListRequest.put("operation", "Scan"))
#end
#if( !$util.isNull($ctx.stash.metadata.index) )
-  #set( $ListRequest.IndexName = $ctx.stash.metadata.index )
+  #set( $ListRequest.index = $ctx.stash.metadata.index )
#end
$util.toJson($ListRequest)
## [End] List Request. **
```

## CDK / CloudFormation Parameters Changed

## Issue #, if available

## Description of how you validated changes
- PR CI job
- [E2E tests](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow%3A4c86819a-088f-4a86-aa7b-6cf7b92f317e?region=us-east-1)
- Lots of manual testing

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [ ] ~Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)~
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
