### PR TITLE
test: remove bootstrap in test code

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/commands.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/commands.ts
@@ -122,9 +122,6 @@ export const cdkDeploy = async (cwd: string, option: string, props?: CdkDeployPr
     env: { npm_config_registry: 'https://registry.npmjs.org/' },
     noOutputTimeout,
   };
-  // This prevents us from maintaining a separate CDK account bootstrap process as we add support for new accounts, regions.
-  // Checks and succeeds early (a no-op) if the account-region combination is already bootstrapped.
-  await spawn(getNpxPath(), ['cdk', 'bootstrap'], commandOptions).runAsync();
 
   await spawn(
     getNpxPath(),

--- a/packages/graphql-transformers-e2e-tests/src/cdkUtils.ts
+++ b/packages/graphql-transformers-e2e-tests/src/cdkUtils.ts
@@ -26,15 +26,6 @@ export const deployJsonServer = () => {
     throw new Error(`'yarn' failed with exit code: ${yarnServerResult.exitCode}`);
   }
 
-  const cdkBootstrapResult = execa.sync('npx', ['cdk', 'bootstrap', '--require-approval', 'never'], {
-    cwd: jsonServerRootDirectory,
-    stdio: 'inherit',
-  });
-
-  if (cdkBootstrapResult.exitCode !== 0) {
-    throw new Error(`CDK bootstrap failed with exit code: ${cdkBootstrapResult.exitCode}`);
-  }
-
   const cdkDeployResult = execa.sync('npx', ['cdk', 'deploy', '--outputsFile', outputValuesFile, '--require-approval', 'never'], {
     cwd: jsonServerRootDirectory,
     stdio: 'inherit',


### PR DESCRIPTION
#### Description of changes

Removes CDK bootstrap step in test code, in favor of out-of-band bootstrap stack management.

#### Description of how you validated changes

E2E tests that were previously failing due to missing `iam:UpdateAssumeRolePolicy` permissions during the bootstrap phase are no longer failing due to those missing permissions.

#### Checklist

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
