### PR TITLE
fix(conversation): use functionMap for custom handler IFunction reference

### DIFF
--- a/dependency_licenses.txt
+++ b/dependency_licenses.txt
@@ -14486,6 +14486,32 @@ SOFTWARE.
 
 -----
 
+The following software may be included in this product: esbuild. A copy of the source code may be downloaded from git+https://github.com/evanw/esbuild.git. This software contains the following license and notice below:
+
+MIT License
+
+Copyright (c) 2020 Evan Wallace
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----
+
 The following software may be included in this product: escalade. A copy of the source code may be downloaded from https://github.com/lukeed/escalade.git. This software contains the following license and notice below:
 
 MIT License

--- a/packages/amplify-graphql-conversation-transformer/API.md
+++ b/packages/amplify-graphql-conversation-transformer/API.md
@@ -9,6 +9,7 @@ import { DirectiveNode } from 'graphql';
 import { FieldDefinitionNode } from 'graphql';
 import { HasManyTransformer } from '@aws-amplify/graphql-relational-transformer';
 import { InterfaceTypeDefinitionNode } from 'graphql';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { ObjectTypeDefinitionNode } from 'graphql';
 import { TransformerAuthProvider } from '@aws-amplify/graphql-transformer-interfaces';
@@ -19,7 +20,7 @@ import { TransformerSchemaVisitStepContextProvider } from '@aws-amplify/graphql-
 
 // @public (undocumented)
 export class ConversationTransformer extends TransformerPluginBase {
-    constructor(modelTransformer: ModelTransformer, hasManyTransformer: HasManyTransformer, belongsToTransformer: BelongsToTransformer, authProvider: TransformerAuthProvider);
+    constructor(modelTransformer: ModelTransformer, hasManyTransformer: HasManyTransformer, belongsToTransformer: BelongsToTransformer, authProvider: TransformerAuthProvider, functionNameMap?: Record<string, lambda.IFunction>);
     // (undocumented)
     field: (parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode, definition: FieldDefinitionNode, directive: DirectiveNode, context: TransformerSchemaVisitStepContextProvider) => void;
     // (undocumented)

--- a/packages/amplify-graphql-conversation-transformer/package.json
+++ b/packages/amplify-graphql-conversation-transformer/package.json
@@ -37,7 +37,8 @@
     "immer": "^9.0.12"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-transformer-test-utils": "1.0.3"
+    "@aws-amplify/graphql-transformer-test-utils": "1.0.3",
+    "esbuild": "^0.24.0"
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.158.0",

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -22,11 +22,9 @@ exports[`ConversationTransformer valid schemas should transform conversation rou
   ctx.stash.connectionAttributes = {};
   ctx.stash.lambdaFunctionArn = "",
       {
-        "Fn::Sub": [
-          "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:\${name}",
-          {
-            "name": "conversation-handler",
-          },
+        "Fn::GetAtt": [
+          "PirateChatConversationDirectiveLambdaStack",
+          "Outputs.transformerrootstackPirateChatConversationDirectiveLambdaStackPirateChatDefaultConversationHandlerconversationHandlerFunction2B526F1AArn",
         ],
       },
       "";
@@ -144,11 +142,9 @@ exports[`ConversationTransformer valid schemas should transform conversation rou
   ctx.stash.connectionAttributes = {};
   ctx.stash.lambdaFunctionArn = "",
       {
-        "Fn::Sub": [
-          "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:\${name}",
-          {
-            "name": "conversation-handler",
-          },
+        "Fn::GetAtt": [
+          "PirateChatConversationDirectiveLambdaStack",
+          "Outputs.transformerrootstackPirateChatConversationDirectiveLambdaStackPirateChatDefaultConversationHandlerconversationHandlerFunction2B526F1AArn",
         ],
       },
       "";
@@ -268,11 +264,9 @@ exports[`ConversationTransformer valid schemas should transform conversation rou
   ctx.stash.connectionAttributes = {};
   ctx.stash.lambdaFunctionArn = "",
       {
-        "Fn::Sub": [
-          "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:\${name}",
-          {
-            "name": "conversation-handler",
-          },
+        "Fn::GetAtt": [
+          "PirateChatConversationDirectiveLambdaStack",
+          "Outputs.transformerrootstackPirateChatConversationDirectiveLambdaStackPirateChatDefaultConversationHandlerconversationHandlerFunction2B526F1AArn",
         ],
       },
       "";
@@ -392,11 +386,9 @@ exports[`ConversationTransformer valid schemas should transform conversation rou
   ctx.stash.connectionAttributes = {};
   ctx.stash.lambdaFunctionArn = "",
       {
-        "Fn::Sub": [
-          "arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:\${name}",
-          {
-            "name": "conversation-handler",
-          },
+        "Fn::GetAtt": [
+          "PirateChatConversationDirectiveLambdaStack",
+          "Outputs.transformerrootstackPirateChatConversationDirectiveLambdaStackPirateChatDefaultConversationHandlerconversationHandlerFunction2B526F1AArn",
         ],
       },
       "";

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
@@ -3,12 +3,13 @@ import { IndexTransformer, PrimaryKeyTransformer } from '@aws-amplify/graphql-in
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { validateModelSchema } from '@aws-amplify/graphql-transformer-core';
 import { AppSyncAuthConfiguration, ModelDataSourceStrategy } from '@aws-amplify/graphql-transformer-interfaces';
-import { DeploymentResources, testTransform } from '@aws-amplify/graphql-transformer-test-utils';
+import { DeploymentResources, testTransform, TransformManager } from '@aws-amplify/graphql-transformer-test-utils';
 import { parse } from 'graphql';
 import { ConversationTransformer } from '..';
 import { BelongsToTransformer, HasManyTransformer, HasOneTransformer } from '@aws-amplify/graphql-relational-transformer';
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { Code, Function, IFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { GenerationTransformer } from '@aws-amplify/graphql-generation-transformer';
 import { toUpper } from 'graphql-transformer-common';
 
@@ -43,6 +44,35 @@ describe('ConversationTransformer', () => {
 
       const schema = parse(out.schema);
       validateModelSchema(schema);
+    });
+
+    it('uses functionMap for custom handler', () => {
+      const routeName = 'pirateChat';
+      const inputSchema = getSchema('conversation-route-custom-handler.graphql', { ROUTE_NAME: routeName });
+
+      const transformerManager = new TransformManager();
+      const stack = transformerManager.getTransformScope();
+      const customHandler = new Function(stack, 'conversation-handler', {
+        runtime: Runtime.NODEJS_18_X,
+        code: Code.fromInline('exports.handler = async (event) => { return "Hello World"; }'),
+        handler: 'index.handler',
+      });
+
+      const functionMap = {
+        [`Fn${routeName}`]: customHandler,
+      };
+
+      const out = transform(inputSchema, {}, defaultAuthConfig, functionMap, transformerManager);
+      expect(out).toBeDefined();
+
+      const expectedCustomHandlerArn = out.rawRootStack.resolve(customHandler.functionArn);
+      const conversationLambdaStackName = `${toUpper(routeName)}ConversationDirectiveLambdaStack`;
+      const conversationLambdaDataSourceName = `Fn${routeName}LambdaDataSource`;
+      const conversationLambdaDataSourceFunctionArnRef =
+        out.stacks[conversationLambdaStackName].Resources?.[conversationLambdaDataSourceName].Properties.LambdaConfig.LambdaFunctionArn.Ref;
+      const lambdaDataSourceFunctionArn =
+        out.rootStack.Resources?.[conversationLambdaStackName].Properties?.Parameters?.[conversationLambdaDataSourceFunctionArnRef];
+      expect(lambdaDataSourceFunctionArn).toEqual(expectedCustomHandlerArn);
     });
   });
 
@@ -114,6 +144,8 @@ function transform(
   inputSchema: string,
   dataSourceStrategies?: Record<string, ModelDataSourceStrategy>,
   authConfig: AppSyncAuthConfiguration = defaultAuthConfig,
+  functionMap?: Record<string, IFunction>,
+  transformerManager?: TransformManager,
 ): DeploymentResources {
   const modelTransformer = new ModelTransformer();
   const authTransformer = new AuthTransformer();
@@ -129,7 +161,7 @@ function transform(
     hasManyTransformer,
     hasOneTransformer,
     belongsToTransformer,
-    new ConversationTransformer(modelTransformer, hasManyTransformer, belongsToTransformer, authTransformer),
+    new ConversationTransformer(modelTransformer, hasManyTransformer, belongsToTransformer, authTransformer, functionMap),
     new GenerationTransformer(),
     authTransformer,
   ];
@@ -139,6 +171,7 @@ function transform(
     authConfig,
     transformers,
     dataSourceStrategies,
+    transformerManager,
   });
 
   return out;

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-handler.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-handler.graphql
@@ -1,0 +1,13 @@
+type Mutation {
+  ROUTE_NAME(
+    conversationId: ID!,
+    content: [ContentBlockInput],
+    aiContext: AWSJSON,
+    toolConfiguration: ToolConfigurationInput
+  ): ConversationMessage
+  @conversation(
+    aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
+    functionName: "FnROUTE_NAME",
+    systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
+  )
+}

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-query-tool.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-query-tool.graphql
@@ -17,7 +17,6 @@ type Mutation {
   ): ConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
-    functionName: "conversation-handler",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
     tools: [{ name: "getTemperature", description: "does a thing" }, { name: "plus", description: "does a different thing" }]
   )

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-inference-configuration-template.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-inference-configuration-template.graphql
@@ -7,7 +7,6 @@ type Mutation {
   ): ConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
-    functionName: "conversation-handler",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
     INFERENENCE_CONFIGURATION
   )

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-missing-ai-model.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-missing-ai-model.graphql
@@ -6,7 +6,6 @@ type Mutation {
     toolConfiguration: ToolConfigurationInput
   ): ConversationMessage
   @conversation(
-    functionName: "conversation-handler",
     systemPrompt: "You are a helpful chatbot."
   )
 }

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-return-type.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-return-type.graphql
@@ -7,7 +7,6 @@ type Mutation {
   ): String
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
-    functionName: "conversation-handler",
     systemPrompt: "You are a helpful chatbot."
   )
 }

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool-with-relationships.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool-with-relationships.graphql
@@ -31,7 +31,6 @@ type Mutation {
   ): ConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
-    functionName: "conversation-handler",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
     tools: [{ name: "listCustomers", description: "Provides data about the customer sending a message" }]
   )

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool.graphql
@@ -12,7 +12,6 @@ type Mutation {
   ): ConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
-    functionName: "conversation-handler",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
     tools: [{ name: "listTodos", description: "lists todos" }]
   )

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-with-inference-configuration.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-with-inference-configuration.graphql
@@ -8,7 +8,6 @@ type Mutation {
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
-    functionName: "conversation-handler",
     inferenceConfiguration: {
         temperature: 0.5,
         topP: 0.9,

--- a/packages/amplify-graphql-conversation-transformer/src/grapqhl-conversation-transformer.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/grapqhl-conversation-transformer.ts
@@ -59,7 +59,7 @@ export class ConversationTransformer extends TransformerPluginBase {
     hasManyTransformer: HasManyTransformer,
     belongsToTransformer: BelongsToTransformer,
     authProvider: TransformerAuthProvider,
-    functionNameMap?: Record<string, lambda.IFunction>
+    functionNameMap?: Record<string, lambda.IFunction>,
   ) {
     super('amplify-conversation-transformer', ConversationDirective.definition);
     this.fieldHandler = new ConversationFieldHandler();

--- a/packages/amplify-graphql-conversation-transformer/src/grapqhl-conversation-transformer.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/grapqhl-conversation-transformer.ts
@@ -15,6 +15,7 @@ import { type ToolDefinition, type Tools } from './utils/tools';
 import { ConversationPrepareHandler } from './transformer-steps/conversation-prepare-handler';
 import { ConversationResolverGenerator } from './transformer-steps/conversation-resolver-generator';
 import { ConversationFieldHandler } from './transformer-steps/conversation-field-handler';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
 
 /**
  * Configuration for the Conversation Directive
@@ -58,11 +59,12 @@ export class ConversationTransformer extends TransformerPluginBase {
     hasManyTransformer: HasManyTransformer,
     belongsToTransformer: BelongsToTransformer,
     authProvider: TransformerAuthProvider,
+    functionNameMap?: Record<string, lambda.IFunction>
   ) {
     super('amplify-conversation-transformer', ConversationDirective.definition);
     this.fieldHandler = new ConversationFieldHandler();
     this.prepareHandler = new ConversationPrepareHandler(modelTransformer, hasManyTransformer, belongsToTransformer, authProvider);
-    this.resolverGenerator = new ConversationResolverGenerator();
+    this.resolverGenerator = new ConversationResolverGenerator(functionNameMap);
   }
 
   /**

--- a/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
@@ -103,9 +103,7 @@ export class ConversationResolverGenerator {
    * @param functionStack - The CDK stack to add the function to
    * @returns An object containing the function data source ID and the referenced function
    */
-  private setupExistingFunctionDataSource(
-    functionName: string,
-  ): { functionDataSourceId: string; referencedFunction: IFunction } {
+  private setupExistingFunctionDataSource(functionName: string): { functionDataSourceId: string; referencedFunction: IFunction } {
     const functionDataSourceId = FunctionResourceIDs.FunctionDataSourceID(functionName);
     if (!this.functionNameMap) {
       throw new Error('Function name map is not provided');

--- a/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
@@ -5,7 +5,7 @@ import { APPSYNC_JS_RUNTIME, TransformerResolver } from '@aws-amplify/graphql-tr
 import { ResolverResourceIDs, FunctionResourceIDs, ResourceConstants, toUpper } from 'graphql-transformer-common';
 import * as cdk from 'aws-cdk-lib';
 import { conversation } from '@aws-amplify/ai-constructs';
-import { IFunction, Function } from 'aws-cdk-lib/aws-lambda';
+import { IFunction } from 'aws-cdk-lib/aws-lambda';
 import { getModelDataSourceNameForTypeName, getTable } from '@aws-amplify/graphql-transformer-core';
 import { initMappingTemplate } from '../resolvers/init-resolver';
 import { authMappingTemplate } from '../resolvers/auth-resolver';
@@ -24,6 +24,8 @@ type KeyAttributeDefinition = {
 
 // TODO: add explanation for the tool model queries
 export class ConversationResolverGenerator {
+  constructor(private readonly functionNameMap?: Record<string, IFunction>) {}
+
   generateResolvers(directives: ConversationDirectiveConfiguration[], ctx: TransformerContextProvider): void {
     for (const directive of directives) {
       this.processToolsForDirective(directive, ctx);
@@ -89,7 +91,7 @@ export class ConversationResolverGenerator {
     capitalizedFieldName: string,
   ): { functionDataSourceId: string; referencedFunction: IFunction } {
     if (directive.functionName) {
-      return this.setupExistingFunctionDataSource(directive.functionName, functionStack);
+      return this.setupExistingFunctionDataSource(directive.functionName);
     } else {
       return this.setupDefaultConversationHandler(functionStack, capitalizedFieldName, directive.aiModel);
     }
@@ -103,24 +105,16 @@ export class ConversationResolverGenerator {
    */
   private setupExistingFunctionDataSource(
     functionName: string,
-    functionStack: cdk.Stack,
   ): { functionDataSourceId: string; referencedFunction: IFunction } {
     const functionDataSourceId = FunctionResourceIDs.FunctionDataSourceID(functionName);
-    const referencedFunction = Function.fromFunctionAttributes(functionStack, `${functionDataSourceId}Function`, {
-      functionArn: this.lambdaArnResource(functionName),
-    });
-
+    if (!this.functionNameMap) {
+      throw new Error('Function name map is not provided');
+    }
+    const referencedFunction = this.functionNameMap[functionName];
+    if (!referencedFunction) {
+      throw new Error(`Function ${functionName} not found in function name map`);
+    }
     return { functionDataSourceId, referencedFunction };
-  }
-
-  /**
-   * Generates the Lambda ARN resource string
-   * @param name - The name of the Lambda function
-   * @returns The Lambda ARN resource string
-   */
-  private lambdaArnResource(name: string): string {
-    // eslint-disable-next-line no-template-curly-in-string
-    return cdk.Fn.sub('arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${name}', { name });
   }
 
   /**

--- a/packages/amplify-graphql-transformer-test-utils/API.md
+++ b/packages/amplify-graphql-transformer-test-utils/API.md
@@ -226,6 +226,7 @@ export type TestTransformParameters = RDSLayerMappingProvider & RDSSNSTopicMappi
     transformers: TransformerPluginProvider[];
     transformParameters?: Partial<TransformParameters>;
     userDefinedSlots?: Record<string, UserDefinedSlot[]>;
+    transformerManager?: TransformManager;
 };
 
 // @public (undocumented)

--- a/packages/amplify-graphql-transformer-test-utils/src/test-transform.ts
+++ b/packages/amplify-graphql-transformer-test-utils/src/test-transform.ts
@@ -31,6 +31,7 @@ export type TestTransformParameters = RDSLayerMappingProvider &
     transformers: TransformerPluginProvider[];
     transformParameters?: Partial<TransformParameters>;
     userDefinedSlots?: Record<string, UserDefinedSlot[]>;
+    transformerManager?: TransformManager;
   };
 
 /**
@@ -52,6 +53,7 @@ export const testTransform = (params: TestTransformParameters): DeploymentResour
     transformers,
     transformParameters,
     userDefinedSlots,
+    transformerManager,
   } = params;
 
   const transform = new GraphQLTransform({
@@ -63,7 +65,7 @@ export const testTransform = (params: TestTransformParameters): DeploymentResour
     resolverConfig,
   });
 
-  const transformManager = new TransformManager(overrideConfig);
+  const transformManager = transformerManager ?? new TransformManager(overrideConfig);
 
   const authConfigTypes = [authConfig?.defaultAuthentication, ...(authConfig?.additionalAuthenticationProviders ?? [])].map(
     (authConfigEntry) => authConfigEntry?.authenticationType,

--- a/packages/amplify-graphql-transformer/src/graphql-transformer.ts
+++ b/packages/amplify-graphql-transformer/src/graphql-transformer.ts
@@ -78,7 +78,7 @@ export const constructTransformerChain = (options?: TransformerFactoryArgs): Tra
     hasOneTransformer,
     new ManyToManyTransformer(modelTransformer, indexTransformer, hasOneTransformer, authTransformer),
     belongsToTransformer,
-    new ConversationTransformer(modelTransformer, hasManyTransformer, belongsToTransformer, authTransformer),
+    new ConversationTransformer(modelTransformer, hasManyTransformer, belongsToTransformer, authTransformer, options?.functionNameMap),
     new GenerationTransformer(),
     new DefaultValueTransformer(),
     authTransformer,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4961,6 +4961,126 @@
     esquery "^1.5.0"
     jsdoc-type-pratt-parser "~4.0.0"
 
+"@esbuild/aix-ppc64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.24.0.tgz#b57697945b50e99007b4c2521507dc613d4a648c"
+  integrity sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==
+
+"@esbuild/android-arm64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.24.0.tgz#1add7e0af67acefd556e407f8497e81fddad79c0"
+  integrity sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==
+
+"@esbuild/android-arm@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.24.0.tgz#ab7263045fa8e090833a8e3c393b60d59a789810"
+  integrity sha512-arAtTPo76fJ/ICkXWetLCc9EwEHKaeya4vMrReVlEIUCAUncH7M4bhMQ+M9Vf+FFOZJdTNMXNBrWwW+OXWpSew==
+
+"@esbuild/android-x64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.24.0.tgz#e8f8b196cfdfdd5aeaebbdb0110983460440e705"
+  integrity sha512-t8GrvnFkiIY7pa7mMgJd7p8p8qqYIz1NYiAoKc75Zyv73L3DZW++oYMSHPRarcotTKuSs6m3hTOa5CKHaS02TQ==
+
+"@esbuild/darwin-arm64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.24.0.tgz#2d0d9414f2acbffd2d86e98253914fca603a53dd"
+  integrity sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==
+
+"@esbuild/darwin-x64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.24.0.tgz#33087aab31a1eb64c89daf3d2cf8ce1775656107"
+  integrity sha512-rgtz6flkVkh58od4PwTRqxbKH9cOjaXCMZgWD905JOzjFKW+7EiUObfd/Kav+A6Gyud6WZk9w+xu6QLytdi2OA==
+
+"@esbuild/freebsd-arm64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.0.tgz#bb76e5ea9e97fa3c753472f19421075d3a33e8a7"
+  integrity sha512-6Mtdq5nHggwfDNLAHkPlyLBpE5L6hwsuXZX8XNmHno9JuL2+bg2BX5tRkwjyfn6sKbxZTq68suOjgWqCicvPXA==
+
+"@esbuild/freebsd-x64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.24.0.tgz#e0e2ce9249fdf6ee29e5dc3d420c7007fa579b93"
+  integrity sha512-D3H+xh3/zphoX8ck4S2RxKR6gHlHDXXzOf6f/9dbFt/NRBDIE33+cVa49Kil4WUjxMGW0ZIYBYtaGCa2+OsQwQ==
+
+"@esbuild/linux-arm64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.24.0.tgz#d1b2aa58085f73ecf45533c07c82d81235388e75"
+  integrity sha512-TDijPXTOeE3eaMkRYpcy3LarIg13dS9wWHRdwYRnzlwlA370rNdZqbcp0WTyyV/k2zSxfko52+C7jU5F9Tfj1g==
+
+"@esbuild/linux-arm@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.24.0.tgz#8e4915df8ea3e12b690a057e77a47b1d5935ef6d"
+  integrity sha512-gJKIi2IjRo5G6Glxb8d3DzYXlxdEj2NlkixPsqePSZMhLudqPhtZ4BUrpIuTjJYXxvF9njql+vRjB2oaC9XpBw==
+
+"@esbuild/linux-ia32@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.24.0.tgz#8200b1110666c39ab316572324b7af63d82013fb"
+  integrity sha512-K40ip1LAcA0byL05TbCQ4yJ4swvnbzHscRmUilrmP9Am7//0UjPreh4lpYzvThT2Quw66MhjG//20mrufm40mA==
+
+"@esbuild/linux-loong64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.24.0.tgz#6ff0c99cf647504df321d0640f0d32e557da745c"
+  integrity sha512-0mswrYP/9ai+CU0BzBfPMZ8RVm3RGAN/lmOMgW4aFUSOQBjA31UP8Mr6DDhWSuMwj7jaWOT0p0WoZ6jeHhrD7g==
+
+"@esbuild/linux-mips64el@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.24.0.tgz#3f720ccd4d59bfeb4c2ce276a46b77ad380fa1f3"
+  integrity sha512-hIKvXm0/3w/5+RDtCJeXqMZGkI2s4oMUGj3/jM0QzhgIASWrGO5/RlzAzm5nNh/awHE0A19h/CvHQe6FaBNrRA==
+
+"@esbuild/linux-ppc64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.24.0.tgz#9d6b188b15c25afd2e213474bf5f31e42e3aa09e"
+  integrity sha512-HcZh5BNq0aC52UoocJxaKORfFODWXZxtBaaZNuN3PUX3MoDsChsZqopzi5UupRhPHSEHotoiptqikjN/B77mYQ==
+
+"@esbuild/linux-riscv64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.24.0.tgz#f989fdc9752dfda286c9cd87c46248e4dfecbc25"
+  integrity sha512-bEh7dMn/h3QxeR2KTy1DUszQjUrIHPZKyO6aN1X4BCnhfYhuQqedHaa5MxSQA/06j3GpiIlFGSsy1c7Gf9padw==
+
+"@esbuild/linux-s390x@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.24.0.tgz#29ebf87e4132ea659c1489fce63cd8509d1c7319"
+  integrity sha512-ZcQ6+qRkw1UcZGPyrCiHHkmBaj9SiCD8Oqd556HldP+QlpUIe2Wgn3ehQGVoPOvZvtHm8HPx+bH20c9pvbkX3g==
+
+"@esbuild/linux-x64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.24.0.tgz#4af48c5c0479569b1f359ffbce22d15f261c0cef"
+  integrity sha512-vbutsFqQ+foy3wSSbmjBXXIJ6PL3scghJoM8zCL142cGaZKAdCZHyf+Bpu/MmX9zT9Q0zFBVKb36Ma5Fzfa8xA==
+
+"@esbuild/netbsd-x64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.24.0.tgz#1ae73d23cc044a0ebd4f198334416fb26c31366c"
+  integrity sha512-hjQ0R/ulkO8fCYFsG0FZoH+pWgTTDreqpqY7UnQntnaKv95uP5iW3+dChxnx7C3trQQU40S+OgWhUVwCjVFLvg==
+
+"@esbuild/openbsd-arm64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.0.tgz#5d904a4f5158c89859fd902c427f96d6a9e632e2"
+  integrity sha512-MD9uzzkPQbYehwcN583yx3Tu5M8EIoTD+tUgKF982WYL9Pf5rKy9ltgD0eUgs8pvKnmizxjXZyLt0z6DC3rRXg==
+
+"@esbuild/openbsd-x64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.24.0.tgz#4c8aa88c49187c601bae2971e71c6dc5e0ad1cdf"
+  integrity sha512-4ir0aY1NGUhIC1hdoCzr1+5b43mw99uNwVzhIq1OY3QcEwPDO3B7WNXBzaKY5Nsf1+N11i1eOfFcq+D/gOS15Q==
+
+"@esbuild/sunos-x64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.24.0.tgz#8ddc35a0ea38575fa44eda30a5ee01ae2fa54dd4"
+  integrity sha512-jVzdzsbM5xrotH+W5f1s+JtUy1UWgjU0Cf4wMvffTB8m6wP5/kx0KiaLHlbJO+dMgtxKV8RQ/JvtlFcdZ1zCPA==
+
+"@esbuild/win32-arm64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.24.0.tgz#6e79c8543f282c4539db684a207ae0e174a9007b"
+  integrity sha512-iKc8GAslzRpBytO2/aN3d2yb2z8XTVfNV0PjGlCxKo5SgWmNXx82I/Q3aG1tFfS+A2igVCY97TJ8tnYwpUWLCA==
+
+"@esbuild/win32-ia32@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.24.0.tgz#057af345da256b7192d18b676a02e95d0fa39103"
+  integrity sha512-vQW36KZolfIudCcTnaTpmLQ24Ha1RjygBo39/aLkM2kmjkWmZGEJ5Gn9l5/7tzXA42QGIoWbICfg6KLLkIw6yw==
+
+"@esbuild/win32-x64@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.24.0.tgz#168ab1c7e1c318b922637fad8f339d48b01e1244"
+  integrity sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -10085,6 +10205,36 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+esbuild@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.24.0.tgz#f2d470596885fcb2e91c21eb3da3b3c89c0b55e7"
+  integrity sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.24.0"
+    "@esbuild/android-arm" "0.24.0"
+    "@esbuild/android-arm64" "0.24.0"
+    "@esbuild/android-x64" "0.24.0"
+    "@esbuild/darwin-arm64" "0.24.0"
+    "@esbuild/darwin-x64" "0.24.0"
+    "@esbuild/freebsd-arm64" "0.24.0"
+    "@esbuild/freebsd-x64" "0.24.0"
+    "@esbuild/linux-arm" "0.24.0"
+    "@esbuild/linux-arm64" "0.24.0"
+    "@esbuild/linux-ia32" "0.24.0"
+    "@esbuild/linux-loong64" "0.24.0"
+    "@esbuild/linux-mips64el" "0.24.0"
+    "@esbuild/linux-ppc64" "0.24.0"
+    "@esbuild/linux-riscv64" "0.24.0"
+    "@esbuild/linux-s390x" "0.24.0"
+    "@esbuild/linux-x64" "0.24.0"
+    "@esbuild/netbsd-x64" "0.24.0"
+    "@esbuild/openbsd-arm64" "0.24.0"
+    "@esbuild/openbsd-x64" "0.24.0"
+    "@esbuild/sunos-x64" "0.24.0"
+    "@esbuild/win32-arm64" "0.24.0"
+    "@esbuild/win32-ia32" "0.24.0"
+    "@esbuild/win32-x64" "0.24.0"
 
 escalade@^3.1.1, escalade@^3.1.2:
   version "3.2.0"


### PR DESCRIPTION
> Related data-schema PR https://github.com/aws-amplify/amplify-api-next/pull/361

## Description of changes

Updates ConversationTransformer to allow `functionMap?: record<string, lambda.IFunction>` to be passed. This is done to properly reference a custom conversation handler defined via `defineConversationHandlerFunction` in a Gen2 backend.

## CDK / CloudFormation Parameters Changed

## Issue #, if available

## Description of how you validated changes
- New test case asserting `functionMap` value is used for Lambda data source.
## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] ~E2E test run linked~
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
