### PR TITLE
fix(conversation): allow changes to systemPrompt, inferenceConfig, aiModel to be hotswapped

### DIFF
--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -43,24 +43,118 @@ export const response = (ctx) => {
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 2`] = `
-{
-  "Fn::Join": [
-    "",
-    [
-      "import { util } from '@aws-appsync/utils';
+"export function request(ctx) {
+  ctx.stash.hasAuth = true;
+  const isAuthorized = false;
+
+  if (util.authType() === 'User Pool Authorization') {
+    if (!isAuthorized) {
+      const authFilter = [];
+      let ownerClaim0 = ctx.identity['claims']['sub'];
+      ctx.args.owner = ownerClaim0;
+      const currentClaim1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (ownerClaim0 && currentClaim1) {
+        ownerClaim0 = ownerClaim0 + '::' + currentClaim1;
+        authFilter.push({ owner: { eq: ownerClaim0 } });
+      }
+      const role0_0 = ctx.identity['claims']['sub'];
+      if (role0_0) {
+        authFilter.push({ owner: { eq: role0_0 } });
+      }
+      // we can just reuse currentClaim1 here, but doing this (for now) to mirror the existing
+      // vtl auth resolver.
+      const role0_1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (role0_1) {
+        authFilter.push({ owner: { eq: role0_1 } });
+      }
+      if (authFilter.length !== 0) {
+        ctx.stash.authFilter = { or: authFilter };
+      }
+    }
+  }
+  if (!isAuthorized && ctx.stash.authFilter.length === 0) {
+    util.unauthorized();
+  }
+  return { version: '2018-05-29', payload: {} };
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 3`] = `
+"export function request(ctx) {
+  const { authFilter } = ctx.stash;
+
+  const query = {
+    expression: 'id = :id',
+    expressionValues: util.dynamodb.toMapValues({
+      ':id': ctx.args.conversationId,
+    }),
+  };
+
+  const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
+
+  return {
+    operation: 'Query',
+    query,
+    filter,
+  };
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+
+  if (ctx.result.items.length !== 0) {
+    return ctx.result.items[0];
+  }
+
+  util.error('Conversation not found', 'ResourceNotFound');
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 4`] = `
+"import { util } from '@aws-appsync/utils';
+import * as ddb from '@aws-appsync/utils/dynamodb';
+
+export function request(ctx) {
+  const args = ctx.stash.transformedArgs ?? ctx.args;
+  const defaultValues = ctx.stash.defaultValues ?? {};
+  const message = {
+    __typename: 'ConversationMessagepirateChat',
+    role: 'user',
+    ...args,
+    ...defaultValues,
+  };
+  const id = ctx.stash.defaultValues.id;
+
+  return ddb.put({ key: { id }, item: message });
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  } else {
+    return ctx.result;
+  }
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 5`] = `
+"import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
   const { args, request, prev } = ctx;
+  const { graphqlApiEndpoint } = ctx.stash;
+
   
   const selectionSet = 'id conversationId content { image { format source { bytes }} text toolUse { toolUseId name input } toolResult { status toolUseId content { json text image { format source { bytes }} document { format name source { bytes }} }}} role owner createdAt updatedAt';
-  const graphqlApiEndpoint = '",
-      {
-        "Fn::GetAtt": [
-          "GraphQLAPI",
-          "GraphQLUrl",
-        ],
-      },
-      "';
 
   const messages = prev.result.items;
   const responseMutation = {
@@ -116,10 +210,7 @@ export function response(ctx) {
   };
   return response;
 }
-",
-    ],
-  ],
-}
+"
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 1`] = `
@@ -165,24 +256,118 @@ export const response = (ctx) => {
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 2`] = `
-{
-  "Fn::Join": [
-    "",
-    [
-      "import { util } from '@aws-appsync/utils';
+"export function request(ctx) {
+  ctx.stash.hasAuth = true;
+  const isAuthorized = false;
+
+  if (util.authType() === 'User Pool Authorization') {
+    if (!isAuthorized) {
+      const authFilter = [];
+      let ownerClaim0 = ctx.identity['claims']['sub'];
+      ctx.args.owner = ownerClaim0;
+      const currentClaim1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (ownerClaim0 && currentClaim1) {
+        ownerClaim0 = ownerClaim0 + '::' + currentClaim1;
+        authFilter.push({ owner: { eq: ownerClaim0 } });
+      }
+      const role0_0 = ctx.identity['claims']['sub'];
+      if (role0_0) {
+        authFilter.push({ owner: { eq: role0_0 } });
+      }
+      // we can just reuse currentClaim1 here, but doing this (for now) to mirror the existing
+      // vtl auth resolver.
+      const role0_1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (role0_1) {
+        authFilter.push({ owner: { eq: role0_1 } });
+      }
+      if (authFilter.length !== 0) {
+        ctx.stash.authFilter = { or: authFilter };
+      }
+    }
+  }
+  if (!isAuthorized && ctx.stash.authFilter.length === 0) {
+    util.unauthorized();
+  }
+  return { version: '2018-05-29', payload: {} };
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 3`] = `
+"export function request(ctx) {
+  const { authFilter } = ctx.stash;
+
+  const query = {
+    expression: 'id = :id',
+    expressionValues: util.dynamodb.toMapValues({
+      ':id': ctx.args.conversationId,
+    }),
+  };
+
+  const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
+
+  return {
+    operation: 'Query',
+    query,
+    filter,
+  };
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+
+  if (ctx.result.items.length !== 0) {
+    return ctx.result.items[0];
+  }
+
+  util.error('Conversation not found', 'ResourceNotFound');
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 4`] = `
+"import { util } from '@aws-appsync/utils';
+import * as ddb from '@aws-appsync/utils/dynamodb';
+
+export function request(ctx) {
+  const args = ctx.stash.transformedArgs ?? ctx.args;
+  const defaultValues = ctx.stash.defaultValues ?? {};
+  const message = {
+    __typename: 'ConversationMessagepirateChat',
+    role: 'user',
+    ...args,
+    ...defaultValues,
+  };
+  const id = ctx.stash.defaultValues.id;
+
+  return ddb.put({ key: { id }, item: message });
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  } else {
+    return ctx.result;
+  }
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 5`] = `
+"import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
   const { args, request, prev } = ctx;
+  const { graphqlApiEndpoint } = ctx.stash;
+
   const toolDefinitions = {"tools":[{"name":"listTodos","description":"lists todos","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { content isDone id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listTodos"}}]};
   const selectionSet = 'id conversationId content { image { format source { bytes }} text toolUse { toolUseId name input } toolResult { status toolUseId content { json text image { format source { bytes }} document { format name source { bytes }} }}} role owner createdAt updatedAt';
-  const graphqlApiEndpoint = '",
-      {
-        "Fn::GetAtt": [
-          "GraphQLAPI",
-          "GraphQLUrl",
-        ],
-      },
-      "';
 
   const messages = prev.result.items;
   const responseMutation = {
@@ -240,10 +425,7 @@ export function response(ctx) {
   };
   return response;
 }
-",
-    ],
-  ],
-}
+"
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 1`] = `
@@ -289,24 +471,118 @@ export const response = (ctx) => {
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 2`] = `
-{
-  "Fn::Join": [
-    "",
-    [
-      "import { util } from '@aws-appsync/utils';
+"export function request(ctx) {
+  ctx.stash.hasAuth = true;
+  const isAuthorized = false;
+
+  if (util.authType() === 'User Pool Authorization') {
+    if (!isAuthorized) {
+      const authFilter = [];
+      let ownerClaim0 = ctx.identity['claims']['sub'];
+      ctx.args.owner = ownerClaim0;
+      const currentClaim1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (ownerClaim0 && currentClaim1) {
+        ownerClaim0 = ownerClaim0 + '::' + currentClaim1;
+        authFilter.push({ owner: { eq: ownerClaim0 } });
+      }
+      const role0_0 = ctx.identity['claims']['sub'];
+      if (role0_0) {
+        authFilter.push({ owner: { eq: role0_0 } });
+      }
+      // we can just reuse currentClaim1 here, but doing this (for now) to mirror the existing
+      // vtl auth resolver.
+      const role0_1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (role0_1) {
+        authFilter.push({ owner: { eq: role0_1 } });
+      }
+      if (authFilter.length !== 0) {
+        ctx.stash.authFilter = { or: authFilter };
+      }
+    }
+  }
+  if (!isAuthorized && ctx.stash.authFilter.length === 0) {
+    util.unauthorized();
+  }
+  return { version: '2018-05-29', payload: {} };
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 3`] = `
+"export function request(ctx) {
+  const { authFilter } = ctx.stash;
+
+  const query = {
+    expression: 'id = :id',
+    expressionValues: util.dynamodb.toMapValues({
+      ':id': ctx.args.conversationId,
+    }),
+  };
+
+  const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
+
+  return {
+    operation: 'Query',
+    query,
+    filter,
+  };
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+
+  if (ctx.result.items.length !== 0) {
+    return ctx.result.items[0];
+  }
+
+  util.error('Conversation not found', 'ResourceNotFound');
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 4`] = `
+"import { util } from '@aws-appsync/utils';
+import * as ddb from '@aws-appsync/utils/dynamodb';
+
+export function request(ctx) {
+  const args = ctx.stash.transformedArgs ?? ctx.args;
+  const defaultValues = ctx.stash.defaultValues ?? {};
+  const message = {
+    __typename: 'ConversationMessagepirateChat',
+    role: 'user',
+    ...args,
+    ...defaultValues,
+  };
+  const id = ctx.stash.defaultValues.id;
+
+  return ddb.put({ key: { id }, item: message });
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  } else {
+    return ctx.result;
+  }
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 5`] = `
+"import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
   const { args, request, prev } = ctx;
+  const { graphqlApiEndpoint } = ctx.stash;
+
   const toolDefinitions = {"tools":[{"name":"listCustomers","description":"Provides data about the customer sending a message","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { name email activeCart { products { name price } customerId id createdAt updatedAt owner } orderHistory { items { products { name price } customerId id createdAt updatedAt owner } nextToken } id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listCustomers"}}]};
   const selectionSet = 'id conversationId content { image { format source { bytes }} text toolUse { toolUseId name input } toolResult { status toolUseId content { json text image { format source { bytes }} document { format name source { bytes }} }}} role owner createdAt updatedAt';
-  const graphqlApiEndpoint = '",
-      {
-        "Fn::GetAtt": [
-          "GraphQLAPI",
-          "GraphQLUrl",
-        ],
-      },
-      "';
 
   const messages = prev.result.items;
   const responseMutation = {
@@ -364,10 +640,7 @@ export function response(ctx) {
   };
   return response;
 }
-",
-    ],
-  ],
-}
+"
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with query tools 1`] = `
@@ -413,24 +686,118 @@ export const response = (ctx) => {
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with query tools 2`] = `
-{
-  "Fn::Join": [
-    "",
-    [
-      "import { util } from '@aws-appsync/utils';
+"export function request(ctx) {
+  ctx.stash.hasAuth = true;
+  const isAuthorized = false;
+
+  if (util.authType() === 'User Pool Authorization') {
+    if (!isAuthorized) {
+      const authFilter = [];
+      let ownerClaim0 = ctx.identity['claims']['sub'];
+      ctx.args.owner = ownerClaim0;
+      const currentClaim1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (ownerClaim0 && currentClaim1) {
+        ownerClaim0 = ownerClaim0 + '::' + currentClaim1;
+        authFilter.push({ owner: { eq: ownerClaim0 } });
+      }
+      const role0_0 = ctx.identity['claims']['sub'];
+      if (role0_0) {
+        authFilter.push({ owner: { eq: role0_0 } });
+      }
+      // we can just reuse currentClaim1 here, but doing this (for now) to mirror the existing
+      // vtl auth resolver.
+      const role0_1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (role0_1) {
+        authFilter.push({ owner: { eq: role0_1 } });
+      }
+      if (authFilter.length !== 0) {
+        ctx.stash.authFilter = { or: authFilter };
+      }
+    }
+  }
+  if (!isAuthorized && ctx.stash.authFilter.length === 0) {
+    util.unauthorized();
+  }
+  return { version: '2018-05-29', payload: {} };
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools 3`] = `
+"export function request(ctx) {
+  const { authFilter } = ctx.stash;
+
+  const query = {
+    expression: 'id = :id',
+    expressionValues: util.dynamodb.toMapValues({
+      ':id': ctx.args.conversationId,
+    }),
+  };
+
+  const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
+
+  return {
+    operation: 'Query',
+    query,
+    filter,
+  };
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+
+  if (ctx.result.items.length !== 0) {
+    return ctx.result.items[0];
+  }
+
+  util.error('Conversation not found', 'ResourceNotFound');
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools 4`] = `
+"import { util } from '@aws-appsync/utils';
+import * as ddb from '@aws-appsync/utils/dynamodb';
+
+export function request(ctx) {
+  const args = ctx.stash.transformedArgs ?? ctx.args;
+  const defaultValues = ctx.stash.defaultValues ?? {};
+  const message = {
+    __typename: 'ConversationMessagepirateChat',
+    role: 'user',
+    ...args,
+    ...defaultValues,
+  };
+  const id = ctx.stash.defaultValues.id;
+
+  return ddb.put({ key: { id }, item: message });
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  } else {
+    return ctx.result;
+  }
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools 5`] = `
+"import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
   const { args, request, prev } = ctx;
+  const { graphqlApiEndpoint } = ctx.stash;
+
   const toolDefinitions = {"tools":[{"name":"getTemperature","description":"does a thing","inputSchema":{"json":{"type":"object","properties":{"city":{"type":"string","description":"A UTF-8 character sequence."}},"required":["city"]}},"graphqlRequestInputDescriptor":{"selectionSet":"value unit","propertyTypes":{"city":"String!"},"queryName":"getTemperature"}},{"name":"plus","description":"does a different thing","inputSchema":{"json":{"type":"object","properties":{"a":{"type":"number","description":"A signed 32-bit integer value."},"b":{"type":"number","description":"A signed 32-bit integer value."}},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"","propertyTypes":{"a":"Int","b":"Int"},"queryName":"plus"}}]};
   const selectionSet = 'id conversationId content { image { format source { bytes }} text toolUse { toolUseId name input } toolResult { status toolUseId content { json text image { format source { bytes }} document { format name source { bytes }} }}} role owner createdAt updatedAt';
-  const graphqlApiEndpoint = '",
-      {
-        "Fn::GetAtt": [
-          "GraphQLAPI",
-          "GraphQLUrl",
-        ],
-      },
-      "';
 
   const messages = prev.result.items;
   const responseMutation = {
@@ -488,8 +855,5 @@ export function response(ctx) {
   };
   return response;
 }
-",
-    ],
-  ],
-}
+"
 `;

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
@@ -83,9 +83,21 @@ const assertResolverSnapshot = (routeName: string, resources: DeploymentResource
   expect(resolverCode).toBeDefined();
   expect(resolverCode).toMatchSnapshot();
 
-  const resolverFnCode = getResolverFnResource(routeName, resources);
-  expect(resolverFnCode).toBeDefined();
-  expect(resolverFnCode).toMatchSnapshot();
+  const authFn = resources?.resolvers[`Mutation.${routeName}.auth.js`]
+  expect(authFn).toBeDefined();
+  expect(authFn).toMatchSnapshot();
+
+  const verifySessionOwnerFn = resources?.resolvers[`Mutation.${routeName}.verify-session-owner.js`]
+  expect(verifySessionOwnerFn).toBeDefined();
+  expect(verifySessionOwnerFn).toMatchSnapshot();
+
+  const writeMessageToTableFn = resources?.resolvers[`Mutation.${routeName}.write-message-to-table.js`]
+  expect(writeMessageToTableFn).toBeDefined();
+  expect(writeMessageToTableFn).toMatchSnapshot();
+
+  const invokeLambdaFn = resources?.resolvers[`Mutation.${routeName}.invoke-lambda.js`]
+  expect(invokeLambdaFn).toBeDefined();
+  expect(invokeLambdaFn).toMatchSnapshot();
 };
 
 const getResolverResource = (mutationName: string, resources?: Record<string, any>): Record<string, any> => {

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
@@ -83,19 +83,19 @@ const assertResolverSnapshot = (routeName: string, resources: DeploymentResource
   expect(resolverCode).toBeDefined();
   expect(resolverCode).toMatchSnapshot();
 
-  const authFn = resources?.resolvers[`Mutation.${routeName}.auth.js`]
+  const authFn = resources?.resolvers[`Mutation.${routeName}.auth.js`];
   expect(authFn).toBeDefined();
   expect(authFn).toMatchSnapshot();
 
-  const verifySessionOwnerFn = resources?.resolvers[`Mutation.${routeName}.verify-session-owner.js`]
+  const verifySessionOwnerFn = resources?.resolvers[`Mutation.${routeName}.verify-session-owner.js`];
   expect(verifySessionOwnerFn).toBeDefined();
   expect(verifySessionOwnerFn).toMatchSnapshot();
 
-  const writeMessageToTableFn = resources?.resolvers[`Mutation.${routeName}.write-message-to-table.js`]
+  const writeMessageToTableFn = resources?.resolvers[`Mutation.${routeName}.write-message-to-table.js`];
   expect(writeMessageToTableFn).toBeDefined();
   expect(writeMessageToTableFn).toMatchSnapshot();
 
-  const invokeLambdaFn = resources?.resolvers[`Mutation.${routeName}.invoke-lambda.js`]
+  const invokeLambdaFn = resources?.resolvers[`Mutation.${routeName}.invoke-lambda.js`];
   expect(invokeLambdaFn).toBeDefined();
   expect(invokeLambdaFn).toMatchSnapshot();
 };

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/init-resolver-fn.template.js
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/init-resolver-fn.template.js
@@ -1,4 +1,5 @@
 export function request(ctx) {
+  ctx.stash.graphqlApiEndpoint = '[[GRAPHQL_API_ENDPOINT]]';
   ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
   ctx.stash.defaultValues.id = util.autoId();
   const createdAt = util.time.nowISO8601();

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/init-resolver.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/init-resolver.ts
@@ -9,9 +9,7 @@ import path from 'path';
  *
  * @returns {MappingTemplateProvider} An object containing request and response MappingTemplateProviders.
  */
-export const initMappingTemplate = (
-  ctx: TransformerContextProvider,
-): MappingTemplateProvider => {
+export const initMappingTemplate = (ctx: TransformerContextProvider): MappingTemplateProvider => {
   const substitutions = {
     GRAPHQL_API_ENDPOINT: ctx.api.graphqlUrl,
   };

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/init-resolver.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/init-resolver.ts
@@ -1,8 +1,7 @@
 import { MappingTemplate } from '@aws-amplify/graphql-transformer-core';
-import { MappingTemplateProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { MappingTemplateProvider, TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import fs from 'fs';
 import path from 'path';
-import { ConversationDirectiveConfiguration } from '../grapqhl-conversation-transformer';
 
 /**
  * Creates and returns the mapping template for the init resolver.
@@ -10,8 +9,18 @@ import { ConversationDirectiveConfiguration } from '../grapqhl-conversation-tran
  *
  * @returns {MappingTemplateProvider} An object containing request and response MappingTemplateProviders.
  */
-export const initMappingTemplate = (config: ConversationDirectiveConfiguration): MappingTemplateProvider => {
-  const resolver = fs.readFileSync(path.join(__dirname, 'init-resolver-fn.template.js'), 'utf8');
-  const templateName = `Mutation.${config.field.name.value}.init.js`;
-  return MappingTemplate.s3MappingFunctionCodeFromString(resolver, templateName);
+export const initMappingTemplate = (
+  ctx: TransformerContextProvider,
+): MappingTemplateProvider => {
+  const substitutions = {
+    GRAPHQL_API_ENDPOINT: ctx.api.graphqlUrl,
+  };
+
+  let resolver = fs.readFileSync(path.join(__dirname, 'init-resolver-fn.template.js'), 'utf8');
+  Object.entries(substitutions).forEach(([key, value]) => {
+    const replaced = resolver.replace(new RegExp(`\\[\\[${key}\\]\\]`, 'g'), value);
+    resolver = replaced;
+  });
+
+  return MappingTemplate.inlineTemplateFromString(resolver);
 };

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/invoke-lambda-resolver-fn.template.js
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/invoke-lambda-resolver-fn.template.js
@@ -2,9 +2,10 @@ import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
   const { args, request, prev } = ctx;
+  const { graphqlApiEndpoint } = ctx.stash;
+
   [[TOOL_DEFINITIONS_LINE]]
   const selectionSet = '[[SELECTION_SET]]';
-  const graphqlApiEndpoint = '[[GRAPHQL_API_ENDPOINT]]';
 
   const messages = prev.result.items;
   const responseMutation = {

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/invoke-lambda-resolver.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/invoke-lambda-resolver.ts
@@ -12,13 +12,9 @@ import dedent from 'ts-dedent';
  * @param {TransformerContextProvider} ctx - The transformer context provider.
  * @returns {MappingTemplateProvider} An object containing request and response mapping functions.
  */
-export const invokeLambdaMappingTemplate = (
-  config: ConversationDirectiveConfiguration,
-  ctx: TransformerContextProvider,
-): MappingTemplateProvider => {
+export const invokeLambdaMappingTemplate = (config: ConversationDirectiveConfiguration): MappingTemplateProvider => {
   const { TOOL_DEFINITIONS_LINE, TOOLS_CONFIGURATION_LINE } = generateToolLines(config);
   const SELECTION_SET = selectionSet;
-  const GRAPHQL_API_ENDPOINT = ctx.api.graphqlUrl;
   const MODEL_CONFIGURATION_LINE = generateModelConfigurationLine(config);
   const RESPONSE_MUTATION_NAME = config.responseMutationName;
   const RESPONSE_MUTATION_INPUT_TYPE_NAME = config.responseMutationInputTypeName;
@@ -28,7 +24,6 @@ export const invokeLambdaMappingTemplate = (
     TOOL_DEFINITIONS_LINE,
     TOOLS_CONFIGURATION_LINE,
     SELECTION_SET,
-    GRAPHQL_API_ENDPOINT,
     MODEL_CONFIGURATION_LINE,
     RESPONSE_MUTATION_NAME,
     RESPONSE_MUTATION_INPUT_TYPE_NAME,
@@ -40,11 +35,12 @@ export const invokeLambdaMappingTemplate = (
     const replaced = resolver.replace(new RegExp(`\\[\\[${key}\\]\\]`, 'g'), value);
     resolver = replaced;
   });
+  const templateName = `Mutation.${config.field.name.value}.invoke-lambda.js`;
 
   // This unfortunately needs to be an inline template because an s3 mapping template doesn't allow the CDK
   // to substitute token values, which is necessary for this resolver function due to its reference of
   // `ctx.api.graphqlUrl`.
-  return MappingTemplate.inlineTemplateFromString(resolver);
+  return MappingTemplate.s3MappingFunctionCodeFromString(resolver, templateName);
 };
 
 const generateToolLines = (config: ConversationDirectiveConfiguration) => {

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/invoke-lambda-resolver.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/invoke-lambda-resolver.ts
@@ -37,9 +37,6 @@ export const invokeLambdaMappingTemplate = (config: ConversationDirectiveConfigu
   });
   const templateName = `Mutation.${config.field.name.value}.invoke-lambda.js`;
 
-  // This unfortunately needs to be an inline template because an s3 mapping template doesn't allow the CDK
-  // to substitute token values, which is necessary for this resolver function due to its reference of
-  // `ctx.api.graphqlUrl`.
   return MappingTemplate.s3MappingFunctionCodeFromString(resolver, templateName);
 };
 

--- a/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
@@ -51,7 +51,7 @@ export class ConversationResolverGenerator {
     this.createAssistantResponseSubscriptionResolver(ctx, directive, capitalizedFieldName);
 
     const functionDataSource = this.addLambdaDataSource(ctx, functionDataSourceId, referencedFunction, capitalizedFieldName);
-    const invokeLambdaFunction = invokeLambdaMappingTemplate(directive, ctx);
+    const invokeLambdaFunction = invokeLambdaMappingTemplate(directive);
 
     this.setupMessageTableIndex(ctx, directive);
 
@@ -203,7 +203,7 @@ export class ConversationResolverGenerator {
     directive: ConversationDirectiveConfiguration,
   ): void {
     // Add init function
-    const initFunction = initMappingTemplate(directive);
+    const initFunction = initMappingTemplate(ctx);
     resolver.addJsFunctionToSlot('init', initFunction);
 
     // Add auth function
@@ -218,7 +218,7 @@ export class ConversationResolverGenerator {
     resolver.addJsFunctionToSlot('verifySessionOwner', verifySessionOwnerFunction, conversationSessionDDBDataSource as any);
 
     // Add writeMessageToTable function
-    const writeMessageToTableFunction = writeMessageToTableMappingTemplate(capitalizedFieldName);
+    const writeMessageToTableFunction = writeMessageToTableMappingTemplate(directive.field.name.value);
     const messageModelName = `ConversationMessage${capitalizedFieldName}`;
     const messageModelDDBDataSourceName = getModelDataSourceNameForTypeName(ctx, messageModelName);
     const messageDDBDataSource = ctx.api.host.getDataSource(messageModelDDBDataSourceName);


### PR DESCRIPTION
## Description of changes
Resources that reference 
```
"Fn::GetAtt": [
  "GraphQLAPI",
  "GraphQLUrl",
],
```
are not hot-swappable. This is a CDK constraint. 

The `invoke-lambda` resolver function currently references `ctx.api.graphqlUrl` in the resolver code. In addition to the GraphQLUrl, the `invoke-lambda` resolver function also contains the `systemPrompt`, `aiModel`, and `inferenceConfiguration` values defined in a conversation route / `@conversation` directive.

This is less than ideal because any changes to `systemPrompt`, `aiModel`, and/or `inferenceConfiguration` cannot hotswap today.

This change moves the `ctx.api.graphqlUrl` / `"Fn:GetAtt": ["GraphQLAPI", "GraphQLUrl"]` reference into the existing `init` resolver function. In turn, changes to `systemPrompt`, `aiModel`, and/or `'inferenceConfiguration` are now hotswapped.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available

#### Description of how you validated changes

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] ~E2E test run linked~
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
