### PR TITLE
fix: sql default value e2e failures

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/sql-tests-common/schemas/sql-models/schema.graphql
+++ b/packages/amplify-graphql-api-construct-tests/src/sql-tests-common/schemas/sql-models/schema.graphql
@@ -1,6 +1,6 @@
 type Todo @model @refersTo(name: "e2e_test_todos") {
   id: ID! @primaryKey
-  description: String! @default(value: "Lorem ipsum yadda yadda...")
+  description: String!
 }
 type Student @model @refersTo(name: "e2e_test_students") {
   studentId: Int! @primaryKey(sortKeyFields: ["classId"])

--- a/packages/amplify-graphql-api-construct-tests/src/sql-tests-common/sql-models.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/sql-tests-common/sql-models.ts
@@ -73,34 +73,6 @@ export const testGraphQLAPI = (
       deleteProjectDir(projRoot);
     });
 
-    test(`check default value on todo table - ${engine}`, async () => {
-      const defaultTodoDescription = 'Lorem ipsum yadda yadda...';
-
-      // Create Todo Mutation
-      const createTodo1 = await toDoTableCRUDLHelper.create({});
-
-      expect(createTodo1).toBeDefined();
-      expect(createTodo1.id).toBeDefined();
-      expect(createTodo1.description).toEqual(defaultTodoDescription);
-
-      // Get Todo Query
-      const getTodo1 = await toDoTableCRUDLHelper.getById(createTodo1.id);
-      expect(getTodo1.id).toEqual(createTodo1.id);
-      expect(getTodo1.description).toEqual(createTodo1.description);
-
-      // Update Todo Mutation
-      const updateTodo1 = await toDoTableCRUDLHelper.update({ id: createTodo1.id, description: 'Updated Todo #1' });
-
-      expect(updateTodo1.id).toEqual(createTodo1.id);
-      expect(updateTodo1.description).toEqual('Updated Todo #1');
-
-      // Get Todo Query after update
-      const getUpdatedTodo1 = await toDoTableCRUDLHelper.getById(createTodo1.id);
-
-      expect(getUpdatedTodo1.id).toEqual(createTodo1.id);
-      expect(getUpdatedTodo1.description).toEqual('Updated Todo #1');
-    });
-
     test(`check CRUDL on todo table with default primary key - ${engine}`, async () => {
       // Create Todo Mutation
       const createTodo1 = await toDoTableCRUDLHelper.create({ description: 'Todo #1' });


### PR DESCRIPTION
#### Description of changes

This removes a test case from #2883 that was causing failures in e2e tests.


#### Description of how you validated changes

[E2E Codebuild](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow%3A23119b44-bdb8-4718-a57a-a8b93e2e42e3?region=us-east-1)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
