### PR TITLE
fix(generation): remove trailing comma in inferenceConfig resolver code

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/generations/graphql/schema-generation.graphql
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/generations/graphql/schema-generation.graphql
@@ -4,7 +4,12 @@ type Recipe {
 }
 
 type Query {
-  summarize(input: String): String @generation(aiModel: "anthropic.claude-3-haiku-20240307-v1:0", systemPrompt: "summarize the input.")
+  summarize(input: String): String
+    @generation(
+      aiModel: "anthropic.claude-3-haiku-20240307-v1:0"
+      systemPrompt: "summarize the input."
+      inferenceConfiguration: { temperature: 0.5 }
+    )
 
   generateRecipe(description: String): Recipe
     @generation(aiModel: "anthropic.claude-3-haiku-20240307-v1:0", systemPrompt: "You are a 3 star michelin chef that generates recipes.")

--- a/packages/amplify-graphql-generation-transformer/src/__tests__/__snapshots__/amplify-graphql-generation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-generation-transformer/src/__tests__/__snapshots__/amplify-graphql-generation-transformer.test.ts.snap
@@ -519,7 +519,7 @@ export function request(ctx) {
   const toolConfig = {"tools":[{"toolSpec":{"name":"responseType","description":"Generate a response type for the given field.","inputSchema":{"json":{"type":"object","properties":{"value":{"type":"string","description":"A UTF-8 character sequence."}},"required":["value"]}}}}],"toolChoice":{"tool":{"name":"responseType"}}};
   const prompt = "Generate a string based on the description.";
   const args = JSON.stringify(ctx.args);
-  const inferenceConfig = { inferenceConfig: {"maxTokens":100,"temperature":0.7,"topP":0.9} },;
+  const inferenceConfig = { inferenceConfig: {"maxTokens":100,"temperature":0.7,"topP":0.9} };
 
   return {
     resourcePath: '/model/anthropic.claude-3-haiku-20240307-v1:0/converse',

--- a/packages/amplify-graphql-generation-transformer/src/resolvers/invoke-bedrock.ts
+++ b/packages/amplify-graphql-generation-transformer/src/resolvers/invoke-bedrock.ts
@@ -55,7 +55,7 @@ const generateResolver = (fileName: string, values: Record<string, string>): str
  */
 const getInferenceConfigResolverDefinition = (inferenceConfiguration?: InferenceConfiguration): string => {
   return inferenceConfiguration && Object.keys(inferenceConfiguration).length > 0
-    ? `{ inferenceConfig: ${JSON.stringify(inferenceConfiguration)} },`
+    ? `{ inferenceConfig: ${JSON.stringify(inferenceConfiguration)} }`
     : 'undefined';
 };
 


### PR DESCRIPTION
#### Description of changes
If an `inferenceConfiguration` is specified in a `@generation` directive, it creates invalid JS code due to a trailing comma, resulting in a failed deployment.

- Removes trailing comma.
- Adds `inferenceConfiguration` to an E2E test case to catch related regressions in the future.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Ran the generation E2E tests locally.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] ~E2E test run linked~ (ran locally)
- [ ] ~Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)~
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
