### PR TITLE
feat(conversation): enable update mutations on conversation model

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/API.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/API.ts
@@ -5,6 +5,7 @@
 export type ConversationMessagePirateChat = {
   __typename: 'ConversationMessagePirateChat';
   aiContext?: string | null;
+  associatedUserMessageId?: string | null;
   content?: Array<ContentBlock | null> | null;
   conversation?: ConversationPirateChat | null;
   conversationId: string;
@@ -130,6 +131,7 @@ export type ToolInputSchema = {
 export type ModelConversationMessagePirateChatFilterInput = {
   aiContext?: ModelStringInput | null;
   and?: Array<ModelConversationMessagePirateChatFilterInput | null> | null;
+  associatedUserMessageId?: ModelIDInput | null;
   conversationId?: ModelIDInput | null;
   createdAt?: ModelStringInput | null;
   id?: ModelIDInput | null;
@@ -273,6 +275,7 @@ export type ToolUseBlockInput = {
 export type ModelConversationMessagePirateChatConditionInput = {
   aiContext?: ModelStringInput | null;
   and?: Array<ModelConversationMessagePirateChatConditionInput | null> | null;
+  associatedUserMessageId?: ModelIDInput | null;
   conversationId?: ModelIDInput | null;
   createdAt?: ModelStringInput | null;
   not?: ModelConversationMessagePirateChatConditionInput | null;
@@ -284,6 +287,7 @@ export type ModelConversationMessagePirateChatConditionInput = {
 
 export type CreateConversationMessagePirateChatInput = {
   aiContext?: string | null;
+  associatedUserMessageId?: string | null;
   content?: Array<ContentBlockInput | null> | null;
   conversationId: string;
   id?: string | null;
@@ -334,9 +338,16 @@ export type DeleteConversationPirateChatInput = {
   id: string;
 };
 
+export type UpdateConversationPirateChatInput = {
+  id: string;
+  metadata?: string | null;
+  name?: string | null;
+};
+
 export type ModelSubscriptionConversationMessagePirateChatFilterInput = {
   aiContext?: ModelSubscriptionStringInput | null;
   and?: Array<ModelSubscriptionConversationMessagePirateChatFilterInput | null> | null;
+  associatedUserMessageId?: ModelSubscriptionIDInput | null;
   conversationId?: ModelSubscriptionIDInput | null;
   createdAt?: ModelSubscriptionStringInput | null;
   id?: ModelSubscriptionIDInput | null;
@@ -384,6 +395,7 @@ export type GetConversationMessagePirateChatQuery = {
   getConversationMessagePirateChat?: {
     __typename: 'ConversationMessagePirateChat';
     aiContext?: string | null;
+    associatedUserMessageId?: string | null;
     content?: Array<{
       __typename: 'ContentBlock';
       text?: string | null;
@@ -441,6 +453,7 @@ export type ListConversationMessagePirateChatsQuery = {
     items: Array<{
       __typename: 'ConversationMessagePirateChat';
       aiContext?: string | null;
+      associatedUserMessageId?: string | null;
       conversationId: string;
       createdAt: string;
       id: string;
@@ -482,6 +495,7 @@ export type CreateAssistantResponsePirateChatMutation = {
   createAssistantResponsePirateChat?: {
     __typename: 'ConversationMessagePirateChat';
     aiContext?: string | null;
+    associatedUserMessageId?: string | null;
     content?: Array<{
       __typename: 'ContentBlock';
       text?: string | null;
@@ -516,6 +530,7 @@ export type CreateConversationMessagePirateChatMutation = {
   createConversationMessagePirateChat?: {
     __typename: 'ConversationMessagePirateChat';
     aiContext?: string | null;
+    associatedUserMessageId?: string | null;
     content?: Array<{
       __typename: 'ContentBlock';
       text?: string | null;
@@ -571,6 +586,7 @@ export type DeleteConversationMessagePirateChatMutation = {
   deleteConversationMessagePirateChat?: {
     __typename: 'ConversationMessagePirateChat';
     aiContext?: string | null;
+    associatedUserMessageId?: string | null;
     content?: Array<{
       __typename: 'ContentBlock';
       text?: string | null;
@@ -641,6 +657,7 @@ export type PirateChatMutation = {
       __typename: 'ToolConfiguration';
     } | null;
     updatedAt?: string | null;
+    associatedUserMessageId?: string | null;
     conversation?: {
       __typename: 'ConversationPirateChat';
       createdAt: string;
@@ -653,6 +670,27 @@ export type PirateChatMutation = {
   } | null;
 };
 
+export type UpdateConversationPirateChatMutationVariables = {
+  condition?: ModelConversationPirateChatConditionInput | null;
+  input: UpdateConversationPirateChatInput;
+};
+
+export type UpdateConversationPirateChatMutation = {
+  updateConversationPirateChat?: {
+    __typename: 'ConversationPirateChat';
+    createdAt: string;
+    id: string;
+    messages?: {
+      __typename: 'ModelConversationMessagePirateChatConnection';
+      nextToken?: string | null;
+    } | null;
+    metadata?: string | null;
+    name?: string | null;
+    owner?: string | null;
+    updatedAt: string;
+  } | null;
+};
+
 export type OnCreateAssistantResponsePirateChatSubscriptionVariables = {
   conversationId?: string | null;
 };
@@ -661,6 +699,7 @@ export type OnCreateAssistantResponsePirateChatSubscription = {
   onCreateAssistantResponsePirateChat?: {
     __typename: 'ConversationMessagePirateChat';
     aiContext?: string | null;
+    associatedUserMessageId?: string | null;
     content?: Array<{
       __typename: 'ContentBlock';
       text?: string | null;
@@ -695,6 +734,7 @@ export type OnCreateConversationMessagePirateChatSubscription = {
   onCreateConversationMessagePirateChat?: {
     __typename: 'ConversationMessagePirateChat';
     aiContext?: string | null;
+    associatedUserMessageId?: string | null;
     content?: Array<{
       __typename: 'ContentBlock';
       text?: string | null;

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/conversation.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/conversation.test.ts
@@ -6,7 +6,12 @@ import { createNewProjectDir, deleteProjectDir } from 'amplify-category-api-e2e-
 import { cdkDeploy, cdkDestroy, initCDKProject } from '../../commands';
 import { DDB_AMPLIFY_MANAGED_DATASOURCE_STRATEGY } from '@aws-amplify/graphql-transformer-core';
 import { createCognitoUser, signInCognitoUser, TestDefinition, writeStackConfig, writeTestDefinitions } from '../../utils';
-import { doCreateConversationPirateChat, doListConversationMessagesPirateChat, doSendMessagePirateChat, doUpdateConversationPirateChat } from './test-implementations';
+import {
+  doCreateConversationPirateChat,
+  doListConversationMessagesPirateChat,
+  doSendMessagePirateChat,
+  doUpdateConversationPirateChat,
+} from './test-implementations';
 
 jest.setTimeout(DURATION_20_MINUTES);
 

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/conversation.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/conversation.test.ts
@@ -6,7 +6,7 @@ import { createNewProjectDir, deleteProjectDir } from 'amplify-category-api-e2e-
 import { cdkDeploy, cdkDestroy, initCDKProject } from '../../commands';
 import { DDB_AMPLIFY_MANAGED_DATASOURCE_STRATEGY } from '@aws-amplify/graphql-transformer-core';
 import { createCognitoUser, signInCognitoUser, TestDefinition, writeStackConfig, writeTestDefinitions } from '../../utils';
-import { doCreateConversationPirateChat, doListConversationMessagesPirateChat, doSendMessagePirateChat } from './test-implementations';
+import { doCreateConversationPirateChat, doListConversationMessagesPirateChat, doSendMessagePirateChat, doUpdateConversationPirateChat } from './test-implementations';
 
 jest.setTimeout(DURATION_20_MINUTES);
 
@@ -102,6 +102,20 @@ describe('conversation', () => {
 
       expect(messages.body.data.listConversationMessagePirateChats.items).toHaveLength(1);
       expect(messages.body.data.listConversationMessagePirateChats.items[0].conversationId).toBe(id);
+    });
+
+    test('update conversation', async () => {
+      const conversationResult = await doCreateConversationPirateChat(apiEndpoint, accessToken);
+
+      const { id } = conversationResult.body.data.createConversationPirateChat;
+      expect(id).toBeDefined();
+
+      const updateConversationResult = await doUpdateConversationPirateChat(apiEndpoint, accessToken, id, 'updated conversation name');
+
+      const updatedConversation = updateConversationResult.body.data.updateConversationPirateChat;
+      const { name, id: updatedId } = updatedConversation;
+      expect(name).toEqual('updated conversation name');
+      expect(updatedId).toEqual(id);
     });
 
     describe('conversation owner auth negative tests', () => {

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/mutations.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/mutations.ts
@@ -13,6 +13,7 @@ export const createAssistantResponsePirateChat = /* GraphQL */ `mutation CreateA
 ) {
   createAssistantResponsePirateChat(input: $input) {
     aiContext
+    associatedUserMessageId
     content {
       text
       __typename
@@ -45,6 +46,7 @@ export const createConversationMessagePirateChat = /* GraphQL */ `mutation Creat
 ) {
   createConversationMessagePirateChat(condition: $condition, input: $input) {
     aiContext
+    associatedUserMessageId
     content {
       text
       __typename
@@ -96,6 +98,7 @@ export const deleteConversationMessagePirateChat = /* GraphQL */ `mutation Delet
 ) {
   deleteConversationMessagePirateChat(condition: $condition, input: $input) {
     aiContext
+    associatedUserMessageId
     content {
       text
       __typename
@@ -169,6 +172,7 @@ export const pirateChat = /* GraphQL */ `mutation PirateChat(
     updatedAt
 
     ... on ConversationMessagePirateChat {
+      associatedUserMessageId
       conversation {
         createdAt
         id
@@ -182,3 +186,22 @@ export const pirateChat = /* GraphQL */ `mutation PirateChat(
   }
 }
 ` as GeneratedMutation<APITypes.PirateChatMutationVariables, APITypes.PirateChatMutation>;
+export const updateConversationPirateChat = /* GraphQL */ `mutation UpdateConversationPirateChat(
+  $condition: ModelConversationPirateChatConditionInput
+  $input: UpdateConversationPirateChatInput!
+) {
+  updateConversationPirateChat(condition: $condition, input: $input) {
+    createdAt
+    id
+    messages {
+      nextToken
+      __typename
+    }
+    metadata
+    name
+    owner
+    updatedAt
+    __typename
+  }
+}
+` as GeneratedMutation<APITypes.UpdateConversationPirateChatMutationVariables, APITypes.UpdateConversationPirateChatMutation>;

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/queries.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/queries.ts
@@ -11,6 +11,7 @@ type GeneratedQuery<InputType, OutputType> = string & {
 export const getConversationMessagePirateChat = /* GraphQL */ `query GetConversationMessagePirateChat($id: ID!) {
   getConversationMessagePirateChat(id: $id) {
     aiContext
+    associatedUserMessageId
     content {
       text
       __typename
@@ -65,6 +66,7 @@ export const listConversationMessagePirateChats = /* GraphQL */ `query ListConve
   ) {
     items {
       aiContext
+      associatedUserMessageId
       conversationId
       createdAt
       id

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/subscriptions.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/subscriptions.ts
@@ -11,10 +11,7 @@ type GeneratedSubscription<InputType, OutputType> = string & {
 export const onCreateAssistantResponsePirateChat = /* GraphQL */ `subscription OnCreateAssistantResponsePirateChat($conversationId: ID) {
   onCreateAssistantResponsePirateChat(conversationId: $conversationId) {
     aiContext
-    assistantContent {
-      text
-      __typename
-    }
+    associatedUserMessageId
     content {
       text
       __typename
@@ -50,10 +47,7 @@ export const onCreateConversationMessagePirateChat = /* GraphQL */ `subscription
 ) {
   onCreateConversationMessagePirateChat(filter: $filter, owner: $owner) {
     aiContext
-    assistantContent {
-      text
-      __typename
-    }
+    associatedUserMessageId
     content {
       text
       __typename

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/test-implementations.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/test-implementations.ts
@@ -1,11 +1,12 @@
-import { AppSyncGraphqlResponse, doAppSyncGraphqlMutation, doAppSyncGraphqlOperation, doAppSyncGraphqlQuery } from '../../utils';
+import { AppSyncGraphqlResponse, doAppSyncGraphqlOperation, doAppSyncGraphqlQuery } from '../../utils';
 import {
   CreateConversationPirateChatMutation,
   GetConversationPirateChatQuery,
   ListConversationMessagePirateChatsQuery,
   PirateChatMutation,
+  UpdateConversationPirateChatMutation,
 } from './API';
-import { createConversationPirateChat, pirateChat } from './graphql/mutations';
+import { createConversationPirateChat, pirateChat, updateConversationPirateChat } from './graphql/mutations';
 import { getConversationPirateChat, listConversationMessagePirateChats } from './graphql/queries';
 
 export const doCreateConversationPirateChat = async (
@@ -32,6 +33,20 @@ export const doGetConversationPirateChat = async (
     variables: {
       id: conversationId,
     },
+  });
+};
+
+export const doUpdateConversationPirateChat = async (
+  apiEndpoint: string,
+  accessToken: string,
+  conversationId: string,
+  name: string,
+): Promise<AppSyncGraphqlResponse<UpdateConversationPirateChatMutation>> => {
+  return doAppSyncGraphqlOperation({
+    apiEndpoint,
+    auth: { accessToken: accessToken },
+    query: updateConversationPirateChat,
+    variables: { input: { id: conversationId, name } },
   });
 };
 

--- a/packages/amplify-graphql-conversation-transformer/src/graphql-types/session-model.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/graphql-types/session-model.ts
@@ -124,7 +124,6 @@ const createSessionModelDirective = (): DirectiveNode => {
   };
   return makeDirective('model', [
     makeArgument('subscriptions', subscriptionsOffValue),
-    makeArgument('mutations', makeValueNode({ update: null })),
   ]);
 };
 

--- a/packages/amplify-graphql-conversation-transformer/src/graphql-types/session-model.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/graphql-types/session-model.ts
@@ -122,9 +122,7 @@ const createSessionModelDirective = (): DirectiveNode => {
       },
     ],
   };
-  return makeDirective('model', [
-    makeArgument('subscriptions', subscriptionsOffValue),
-  ]);
+  return makeDirective('model', [makeArgument('subscriptions', subscriptionsOffValue)]);
 };
 
 /**


### PR DESCRIPTION
## Description of changes
- Enables model generated update mutation on `Conversation<RouteName>` model type for conversation routes.
- Adds E2E test for update conversation mutation.

### Related PRs
- codegen: https://github.com/aws-amplify/amplify-codegen/pull/895
- data-schema: https://github.com/aws-amplify/amplify-api-next/pull/365

Release ordering:
1./2. `amplify-category-api` and `amplify-codegen`. Note: Ideally `amplify-category-api` first, but it's not entirely necessary.
3. `amplify-api-next`. This must go last to ensure the update API in the data client hits an existing GraphQL mutation field.

## CDK / CloudFormation Parameters Changed
N/A

## Issue #, if available
N/A

## Description of how you validated changes
- CI PR Workflow
- Added E2E test -- [E2E run](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/build/amplify-category-api-e2e-workflow%3A1b69a8eb-18c3-4b0c-b12c-ec2bdf6bbc24?region=us-east-1)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
