### PR TITLE
chore: cleanup imports and update deprecated jest functions

### DIFF
--- a/packages/amplify-graphql-schema-generator/src/__tests__/generate-schema.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/generate-schema.test.ts
@@ -91,7 +91,7 @@ describe('enum imports', () => {
     model.setPrimaryKey(['id']);
     dbschema.addModel(model);
 
-    expect(() => generateGraphQLSchema(dbschema)).toThrowError(
+    expect(() => generateGraphQLSchema(dbschema)).toThrow(
       'Enum "UserStatus" (values: ACTIVE-0,INACTIVE-1) contains one or more invalid values. Enum values must match the regex [_A-Za-z][_0-9A-Za-z]*.',
     );
   });

--- a/packages/amplify-graphql-schema-generator/src/__tests__/generate-ts-data-schema.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/generate-ts-data-schema.test.ts
@@ -343,7 +343,7 @@ describe('Type name conversions', () => {
       },
     };
 
-    expect(() => generateTypescriptDataSchema(dbschema, config)).toThrowError(
+    expect(() => generateTypescriptDataSchema(dbschema, config)).toThrow(
       'No valid tables found. Make sure at least one table has a primary key.',
     );
   });

--- a/packages/amplify-graphql-schema-generator/src/__tests__/input.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/input.test.ts
@@ -28,7 +28,7 @@ describe('Amplify Input read/write from schema', () => {
       engine: String = \"mysql\"
       globalAuthRule: AuthRule = { allow: public } # This "input" configures a global authorization rule to enable public access to all models in this schema. Learn more about authorization rules here:${authDocLink}
     }`;
-    const constructedInputString = await constructDefaultGlobalAmplifyInput(ImportedRDSType.MYSQL, true, authDocLink);
+    const constructedInputString = constructDefaultGlobalAmplifyInput(ImportedRDSType.MYSQL, true, authDocLink);
     expect(constructedInputString?.replace(/\s/g, '')).toEqual(expectedGraphQLInputString.replace(/\s/g, ''));
   });
 
@@ -45,7 +45,7 @@ describe('Amplify Input read/write from schema', () => {
       globalAuthRule: AuthRule = { allow: public } # This "input" configures a global authorization rule to enable public access to all models in this schema. Learn more about authorization rules here:https://docs.amplify.aws/cli/graphql/authorization-rules 
     }`;
 
-    const readInputNode = await readRDSGlobalAmplifyInput(parse(mockInputSchema));
+    const readInputNode = readRDSGlobalAmplifyInput(parse(mockInputSchema));
     expect(readInputNode).toMatchSnapshot();
   });
 
@@ -68,7 +68,7 @@ describe('Amplify Input read/write from schema', () => {
       database: 'mockdatabase',
     };
 
-    const constructedInputDefinition = await constructRDSGlobalAmplifyInput(userInputs, parse(mockInputSchema));
+    const constructedInputDefinition = constructRDSGlobalAmplifyInput(userInputs, parse(mockInputSchema));
     expect(constructedInputDefinition).toMatchSnapshot();
   });
 });

--- a/packages/amplify-graphql-schema-generator/src/__tests__/mysql-datasource-adapter.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/mysql-datasource-adapter.test.ts
@@ -1,4 +1,4 @@
-import { DataSourceAdapter, MySQLDataSourceAdapter } from '../datasource-adapter';
+import { DataSourceAdapter } from '../datasource-adapter';
 import { getMySQLSchemaQuery } from '../datasource-adapter/mysql-datasource-adapter';
 import { Engine, Field, FieldType, Index, Model, Schema } from '../schema-representation';
 import { generateGraphQLSchema, isComputeExpression } from '../schema-generator';
@@ -51,11 +51,11 @@ describe('testMySQLDataSourceAdapter', () => {
     adapter.getFields = jest.fn(() => []);
     adapter.getPrimaryKey = jest.fn();
     adapter.getIndexes = jest.fn(() => []);
-    await adapter.getModels();
-    expect(adapter.getTablesList).toBeCalledTimes(1);
-    expect(adapter.getFields).toBeCalledTimes(1);
-    expect(adapter.getIndexes).toBeCalledTimes(1);
-    expect(adapter.getPrimaryKey).toBeCalledTimes(1);
+    adapter.getModels();
+    expect(adapter.getTablesList).toHaveBeenCalledTimes(1);
+    expect(adapter.getFields).toHaveBeenCalledTimes(1);
+    expect(adapter.getIndexes).toHaveBeenCalledTimes(1);
+    expect(adapter.getPrimaryKey).toHaveBeenCalledTimes(1);
   });
 
   it('test generate graphql schema from internal reprensentation', () => {
@@ -210,7 +210,7 @@ describe('testMySQLDataSourceAdapter', () => {
         exclude: [String] = ["Tasks"]
       }
     `;
-    expect(() => generateGraphQLSchema(dbschema, amplifyInputType)).toThrowError(
+    expect(() => generateGraphQLSchema(dbschema, amplifyInputType)).toThrow(
       'Cannot specify both include and exclude options. Please check your GraphQL schema.',
     );
   });
@@ -251,7 +251,7 @@ describe('testMySQLDataSourceAdapter', () => {
         include: String = "Tasks"
       }
     `;
-    expect(() => generateGraphQLSchema(dbschema, amplifyInputTypeInclude)).toThrowError(
+    expect(() => generateGraphQLSchema(dbschema, amplifyInputTypeInclude)).toThrow(
       'Invalid value for include option. Please check your GraphQL schema.',
     );
 
@@ -262,7 +262,7 @@ describe('testMySQLDataSourceAdapter', () => {
         exclude: String = "Tasks"
       }
     `;
-    expect(() => generateGraphQLSchema(dbschema, amplifyInputTypeExclude)).toThrowError(
+    expect(() => generateGraphQLSchema(dbschema, amplifyInputTypeExclude)).toThrow(
       'Invalid value for include option. Please check your GraphQL schema.',
     );
   });

--- a/packages/amplify-graphql-schema-generator/src/__tests__/mysql-string-datasource-adapter.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/mysql-string-datasource-adapter.test.ts
@@ -1,8 +1,6 @@
 import { StringDataSourceAdapter, MySQLStringDataSourceAdapter } from '../datasource-adapter';
-import { Engine, Field, FieldType, Index, Model, Schema } from '../schema-representation';
-import { generateGraphQLSchema, isComputeExpression } from '../schema-generator';
+import { Field, FieldType, Index } from '../schema-representation';
 import { schemas } from './__utils__/schemas';
-import { gql } from 'graphql-transformer-core';
 
 class TestStringDataSourceAdapter extends StringDataSourceAdapter {
   public getTablesList(): string[] {
@@ -51,10 +49,10 @@ describe('testStringDataSourceAdapter', () => {
     adapter.getPrimaryKey = jest.fn();
     adapter.getIndexes = jest.fn(() => []);
     adapter.getModels();
-    expect(adapter.getTablesList).toBeCalledTimes(1);
-    expect(adapter.getFields).toBeCalledTimes(1);
-    expect(adapter.getIndexes).toBeCalledTimes(1);
-    expect(adapter.getPrimaryKey).toBeCalledTimes(1);
+    expect(adapter.getTablesList).toHaveBeenCalledTimes(1);
+    expect(adapter.getFields).toHaveBeenCalledTimes(1);
+    expect(adapter.getIndexes).toHaveBeenCalledTimes(1);
+    expect(adapter.getPrimaryKey).toHaveBeenCalledTimes(1);
   });
 
   it('test mysql datatype mapping', () => {

--- a/packages/amplify-graphql-schema-generator/src/__tests__/pg-datasource-adapter.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/pg-datasource-adapter.test.ts
@@ -1,4 +1,4 @@
-import { DataSourceAdapter, PostgresDataSourceAdapter } from '../datasource-adapter';
+import { DataSourceAdapter } from '../datasource-adapter';
 import { getPostgresSchemaQuery } from '../datasource-adapter/pg-datasource-adapter';
 import { Engine, Field, FieldType, Index, Model, Schema } from '../schema-representation';
 import { generateGraphQLSchema, isComputeExpression } from '../schema-generator';
@@ -51,11 +51,11 @@ describe('testPostgresDataSourceAdapter', () => {
     adapter.getFields = jest.fn(() => []);
     adapter.getPrimaryKey = jest.fn();
     adapter.getIndexes = jest.fn(() => []);
-    await adapter.getModels();
-    expect(adapter.getTablesList).toBeCalledTimes(1);
-    expect(adapter.getFields).toBeCalledTimes(1);
-    expect(adapter.getIndexes).toBeCalledTimes(1);
-    expect(adapter.getPrimaryKey).toBeCalledTimes(1);
+    adapter.getModels();
+    expect(adapter.getTablesList).toHaveBeenCalledTimes(1);
+    expect(adapter.getFields).toHaveBeenCalledTimes(1);
+    expect(adapter.getIndexes).toHaveBeenCalledTimes(1);
+    expect(adapter.getPrimaryKey).toHaveBeenCalledTimes(1);
   });
 
   it('test generate graphql schema from internal reprensentation', () => {
@@ -210,7 +210,7 @@ describe('testPostgresDataSourceAdapter', () => {
         exclude: [String] = ["Tasks"]
       }
     `;
-    expect(() => generateGraphQLSchema(dbschema, amplifyInputType)).toThrowError(
+    expect(() => generateGraphQLSchema(dbschema, amplifyInputType)).toThrow(
       'Cannot specify both include and exclude options. Please check your GraphQL schema.',
     );
   });
@@ -251,7 +251,7 @@ describe('testPostgresDataSourceAdapter', () => {
         include: String = "Tasks"
       }
     `;
-    expect(() => generateGraphQLSchema(dbschema, amplifyInputTypeInclude)).toThrowError(
+    expect(() => generateGraphQLSchema(dbschema, amplifyInputTypeInclude)).toThrow(
       'Invalid value for include option. Please check your GraphQL schema.',
     );
 
@@ -262,7 +262,7 @@ describe('testPostgresDataSourceAdapter', () => {
         exclude: String = "Tasks"
       }
     `;
-    expect(() => generateGraphQLSchema(dbschema, amplifyInputTypeExclude)).toThrowError(
+    expect(() => generateGraphQLSchema(dbschema, amplifyInputTypeExclude)).toThrow(
       'Invalid value for include option. Please check your GraphQL schema.',
     );
   });

--- a/packages/amplify-graphql-schema-generator/src/__tests__/pg-string-datasource-adapter.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/pg-string-datasource-adapter.test.ts
@@ -1,8 +1,6 @@
 import { StringDataSourceAdapter, PostgresStringDataSourceAdapter } from '../datasource-adapter';
 import { Field, FieldType, Index } from '../schema-representation';
-import { generateGraphQLSchema, isComputeExpression } from '../schema-generator';
 import { schemas } from './__utils__/schemas';
-import { gql } from 'graphql-transformer-core';
 
 class TestStringDataSourceAdapter extends StringDataSourceAdapter {
   public getTablesList(): string[] {
@@ -47,10 +45,10 @@ describe('testPostgresStringDataSourceAdapter', () => {
     adapter.getPrimaryKey = jest.fn();
     adapter.getIndexes = jest.fn(() => []);
     adapter.getModels();
-    expect(adapter.getTablesList).toBeCalledTimes(1);
-    expect(adapter.getFields).toBeCalledTimes(1);
-    expect(adapter.getIndexes).toBeCalledTimes(1);
-    expect(adapter.getPrimaryKey).toBeCalledTimes(1);
+    expect(adapter.getTablesList).toHaveBeenCalledTimes(1);
+    expect(adapter.getFields).toHaveBeenCalledTimes(1);
+    expect(adapter.getIndexes).toHaveBeenCalledTimes(1);
+    expect(adapter.getPrimaryKey).toHaveBeenCalledTimes(1);
   });
 
   it('test postgres datatype mapping', () => {


### PR DESCRIPTION
#### Description of changes
Small cleanup changes from while I was working on #2952.

This pull request focuses on cleaning/updating test cases in the `amplify-graphql-schema-generator` package. The most important changes include replacing `toThrowError` with `toThrow` for exception assertions, removing unnecessary `await` keywords, and cleaning up imports in several test files.

##### CDK / CloudFormation Parameters Changed
**N/a**

#### Issue #, if available
**N/a**

#### Description of how you validated changes
Root level `yarn test`

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] [E2E test run linked](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:62f86115-6750-4789-b4f2-c128ef69250e?region=us-east-1)
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
