### PR TITLE
feat: constrain custom conversation handler event version

### DIFF
--- a/codebuild_specs/scripts/lint_pr.sh
+++ b/codebuild_specs/scripts/lint_pr.sh
@@ -9,6 +9,8 @@ if [ -z "$PR_NUM" ]; then
   exit
 fi
 
+export NODE_OPTIONS=--max-old-space-size=4096
+
 # get PR file list, filter out removed files, filter only JS/TS files, then pass to the linter
 # The linter will print the errors but the build will still pass.
 # This is intentional because we have thousands of lint errors that will require a separate effort to resolve

--- a/packages/amplify-graphql-conversation-transformer/API.md
+++ b/packages/amplify-graphql-conversation-transformer/API.md
@@ -27,6 +27,8 @@ export class ConversationTransformer extends TransformerPluginBase {
     generateResolvers: (ctx: TransformerContextProvider) => void;
     // (undocumented)
     prepare: (ctx: TransformerPrepareStepContextProvider) => void;
+    // (undocumented)
+    validate: () => void;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/amplify-graphql-conversation-transformer/package.json
+++ b/packages/amplify-graphql-conversation-transformer/package.json
@@ -34,7 +34,8 @@
     "graphql": "^15.5.0",
     "graphql-mapping-template": "5.0.1",
     "graphql-transformer-common": "5.0.1",
-    "immer": "^9.0.12"
+    "immer": "^9.0.12",
+    "semver": "^7.6.3"
   },
   "devDependencies": {
     "@aws-amplify/graphql-transformer-test-utils": "1.0.4",

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should transform conversation route with inference configuration 1`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 1`] = `
 {
   "Fn::Join": [
     "",
@@ -40,7 +40,7 @@ export const response = (ctx) => {
 }
 `;
 
-exports[`should transform conversation route with inference configuration 2`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 2`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
   const isAuthorized = false;
@@ -82,7 +82,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`should transform conversation route with inference configuration 3`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 3`] = `
 "export function request(ctx) {
   const { authFilter } = ctx.stash;
   const { conversationId } = ctx.args;
@@ -117,7 +117,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`should transform conversation route with inference configuration 4`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 4`] = `
 "import { util } from '@aws-appsync/utils';
 import * as ddb from '@aws-appsync/utils/dynamodb';
 
@@ -145,7 +145,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`should transform conversation route with inference configuration 5`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 5`] = `
 "import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
@@ -221,7 +221,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`should transform conversation route with model query tool 1`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 1`] = `
 {
   "Fn::Join": [
     "",
@@ -261,7 +261,7 @@ export const response = (ctx) => {
 }
 `;
 
-exports[`should transform conversation route with model query tool 2`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 2`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
   const isAuthorized = false;
@@ -303,7 +303,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`should transform conversation route with model query tool 3`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 3`] = `
 "export function request(ctx) {
   const { authFilter } = ctx.stash;
   const { conversationId } = ctx.args;
@@ -338,7 +338,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`should transform conversation route with model query tool 4`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 4`] = `
 "import { util } from '@aws-appsync/utils';
 import * as ddb from '@aws-appsync/utils/dynamodb';
 
@@ -366,7 +366,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`should transform conversation route with model query tool 5`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 5`] = `
 "import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
@@ -444,7 +444,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`should transform conversation route with model query tool including relationships 1`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 1`] = `
 {
   "Fn::Join": [
     "",
@@ -484,7 +484,7 @@ export const response = (ctx) => {
 }
 `;
 
-exports[`should transform conversation route with model query tool including relationships 2`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 2`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
   const isAuthorized = false;
@@ -526,7 +526,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`should transform conversation route with model query tool including relationships 3`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 3`] = `
 "export function request(ctx) {
   const { authFilter } = ctx.stash;
   const { conversationId } = ctx.args;
@@ -561,7 +561,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`should transform conversation route with model query tool including relationships 4`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 4`] = `
 "import { util } from '@aws-appsync/utils';
 import * as ddb from '@aws-appsync/utils/dynamodb';
 
@@ -589,7 +589,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`should transform conversation route with model query tool including relationships 5`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 5`] = `
 "import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
@@ -667,7 +667,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`should transform conversation route with query tools 1`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools 1`] = `
 {
   "Fn::Join": [
     "",
@@ -707,7 +707,7 @@ export const response = (ctx) => {
 }
 `;
 
-exports[`should transform conversation route with query tools 2`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools 2`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
   const isAuthorized = false;
@@ -749,7 +749,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`should transform conversation route with query tools 3`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools 3`] = `
 "export function request(ctx) {
   const { authFilter } = ctx.stash;
   const { conversationId } = ctx.args;
@@ -784,7 +784,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`should transform conversation route with query tools 4`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools 4`] = `
 "import { util } from '@aws-appsync/utils';
 import * as ddb from '@aws-appsync/utils/dynamodb';
 
@@ -812,7 +812,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`should transform conversation route with query tools 5`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools 5`] = `
 "import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 1`] = `
+exports[`should transform conversation route with inference configuration 1`] = `
 {
   "Fn::Join": [
     "",
@@ -40,7 +40,7 @@ export const response = (ctx) => {
 }
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 2`] = `
+exports[`should transform conversation route with inference configuration 2`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
   const isAuthorized = false;
@@ -82,7 +82,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 3`] = `
+exports[`should transform conversation route with inference configuration 3`] = `
 "export function request(ctx) {
   const { authFilter } = ctx.stash;
   const { conversationId } = ctx.args;
@@ -117,7 +117,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 4`] = `
+exports[`should transform conversation route with inference configuration 4`] = `
 "import { util } from '@aws-appsync/utils';
 import * as ddb from '@aws-appsync/utils/dynamodb';
 
@@ -145,7 +145,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 5`] = `
+exports[`should transform conversation route with inference configuration 5`] = `
 "import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
@@ -221,7 +221,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 1`] = `
+exports[`should transform conversation route with model query tool 1`] = `
 {
   "Fn::Join": [
     "",
@@ -261,7 +261,7 @@ export const response = (ctx) => {
 }
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 2`] = `
+exports[`should transform conversation route with model query tool 2`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
   const isAuthorized = false;
@@ -303,7 +303,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 3`] = `
+exports[`should transform conversation route with model query tool 3`] = `
 "export function request(ctx) {
   const { authFilter } = ctx.stash;
   const { conversationId } = ctx.args;
@@ -338,7 +338,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 4`] = `
+exports[`should transform conversation route with model query tool 4`] = `
 "import { util } from '@aws-appsync/utils';
 import * as ddb from '@aws-appsync/utils/dynamodb';
 
@@ -366,7 +366,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 5`] = `
+exports[`should transform conversation route with model query tool 5`] = `
 "import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
@@ -444,7 +444,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 1`] = `
+exports[`should transform conversation route with model query tool including relationships 1`] = `
 {
   "Fn::Join": [
     "",
@@ -484,7 +484,7 @@ export const response = (ctx) => {
 }
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 2`] = `
+exports[`should transform conversation route with model query tool including relationships 2`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
   const isAuthorized = false;
@@ -526,7 +526,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 3`] = `
+exports[`should transform conversation route with model query tool including relationships 3`] = `
 "export function request(ctx) {
   const { authFilter } = ctx.stash;
   const { conversationId } = ctx.args;
@@ -561,7 +561,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 4`] = `
+exports[`should transform conversation route with model query tool including relationships 4`] = `
 "import { util } from '@aws-appsync/utils';
 import * as ddb from '@aws-appsync/utils/dynamodb';
 
@@ -589,7 +589,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 5`] = `
+exports[`should transform conversation route with model query tool including relationships 5`] = `
 "import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
@@ -667,7 +667,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with query tools 1`] = `
+exports[`should transform conversation route with query tools 1`] = `
 {
   "Fn::Join": [
     "",
@@ -707,7 +707,7 @@ export const response = (ctx) => {
 }
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with query tools 2`] = `
+exports[`should transform conversation route with query tools 2`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
   const isAuthorized = false;
@@ -749,7 +749,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with query tools 3`] = `
+exports[`should transform conversation route with query tools 3`] = `
 "export function request(ctx) {
   const { authFilter } = ctx.stash;
   const { conversationId } = ctx.args;
@@ -784,7 +784,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with query tools 4`] = `
+exports[`should transform conversation route with query tools 4`] = `
 "import { util } from '@aws-appsync/utils';
 import * as ddb from '@aws-appsync/utils/dynamodb';
 
@@ -812,7 +812,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with query tools 5`] = `
+exports[`should transform conversation route with query tools 5`] = `
 "import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
@@ -12,7 +12,6 @@ import * as path from 'path';
 import { Code, Function, IFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { GenerationTransformer } from '@aws-amplify/graphql-generation-transformer';
 import { toUpper } from 'graphql-transformer-common';
-import { describe } from 'jest-circus';
 
 const conversationSchemaTypes = fs.readFileSync(path.join(__dirname, 'schemas/conversation-schema-types.graphql'), 'utf8');
 

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-handler-deprecated.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-handler-deprecated.graphql
@@ -7,10 +7,7 @@ type Mutation {
   ): ConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
-    handler: {
-      functionName: "FnROUTE_NAME",
-      eventVersion: "1.0"
-    },
+    functionName: "FnROUTE_NAME",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
   )
 }

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-custom-handler-event-version.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-custom-handler-event-version.graphql
@@ -8,8 +8,8 @@ type Mutation {
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     handler: {
-      functionName: "FnROUTE_NAME",
-      eventVersion: "1.0"
+      functionName: "testFunctionName",
+      eventVersion: "EVENT_VERSION"
     },
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
   )

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-custom-handler-function-name-and-handler-provided.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-custom-handler-function-name-and-handler-provided.graphql
@@ -7,8 +7,9 @@ type Mutation {
   ): ConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
+    functionName: "testFunctionName",
     handler: {
-      functionName: "FnROUTE_NAME",
+      functionName: "testFunctionName",
       eventVersion: "1.0"
     },
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",

--- a/packages/amplify-graphql-conversation-transformer/src/grapqhl-conversation-transformer.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/grapqhl-conversation-transformer.ts
@@ -24,7 +24,13 @@ export type ConversationDirectiveConfiguration = {
   parent: ObjectTypeDefinitionNode;
   directive: DirectiveNode;
   aiModel: string;
+  /**
+   * Custom handler function name.
+   *
+   * @deprecated Replaced by 'handler'
+   */
   functionName: string | undefined;
+  handler: ConversationHandlerFunctionConfiguration | undefined;
   field: FieldDefinitionNode;
   responseMutationInputTypeName: string;
   responseMutationName: string;
@@ -34,6 +40,14 @@ export type ConversationDirectiveConfiguration = {
   conversationModel: ConversationModel;
   messageModel: MessageModel;
   inferenceConfiguration: ConversationInferenceConfiguration;
+};
+
+/**
+ * Conversation Handler Function Configuration
+ */
+export type ConversationHandlerFunctionConfiguration = {
+  functionName: string;
+  eventVersion: string;
 };
 
 /**

--- a/packages/amplify-graphql-conversation-transformer/src/grapqhl-conversation-transformer.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/grapqhl-conversation-transformer.ts
@@ -16,6 +16,7 @@ import { ConversationPrepareHandler } from './transformer-steps/conversation-pre
 import { ConversationResolverGenerator } from './transformer-steps/conversation-resolver-generator';
 import { ConversationFieldHandler } from './transformer-steps/conversation-field-handler';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as semver from 'semver';
 
 /**
  * Configuration for the Conversation Directive
@@ -113,11 +114,23 @@ export class ConversationTransformer extends TransformerPluginBase {
   prepare = (ctx: TransformerPrepareStepContextProvider): void => {
     this.prepareHandler.prepare(ctx, this.directives);
   };
-}
 
-const validate = (config: ConversationDirectiveConfiguration, ctx: TransformerContextProvider): void => {
-  const { field } = config;
-  if (field.type.kind !== 'NamedType' || field.type.name.value !== 'ConversationMessage') {
-    throw new InvalidDirectiveError('@conversation return type must be ConversationMessage');
-  }
-};
+  validate = (): void => {
+    for (const directive of this.directives) {
+      if (directive.field.type.kind !== 'NamedType' || directive.field.type.name.value !== 'ConversationMessage') {
+        throw new InvalidDirectiveError('@conversation return type must be ConversationMessage');
+      }
+      if (directive.handler && directive.functionName) {
+        throw new InvalidDirectiveError("'functionName' and 'handler' are mutually exclusive");
+      }
+      if (directive.handler) {
+        const eventVersion = semver.coerce(directive.handler.eventVersion);
+        if (eventVersion?.major !== 1) {
+          throw new Error(
+            `Unsupported custom conversation handler. Expected eventVersion to match 1.x, received ${directive.handler.eventVersion}`,
+          );
+        }
+      }
+    }
+  };
+}

--- a/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
@@ -20,7 +20,6 @@ import { conversationMessageSubscriptionMappingTamplate } from '../resolvers/ass
 import { overrideIndexAtCfnLevel } from '@aws-amplify/graphql-index-transformer';
 import pluralize from 'pluralize';
 import { listMessageInitMappingTemplate } from '../resolvers/list-messages-init-resolver';
-import * as semver from 'semver';
 
 type KeyAttributeDefinition = {
   name: string;
@@ -110,16 +109,7 @@ export class ConversationResolverGenerator {
     functionStack: cdk.Stack,
     capitalizedFieldName: string,
   ): { functionDataSourceId: string; referencedFunction: IFunction } {
-    if (directive.handler && directive.functionName) {
-      throw new Error("'functionName' and 'handler' are mutually exclusive");
-    }
     if (directive.handler) {
-      const eventVersion = semver.coerce(directive.handler.eventVersion);
-      if (eventVersion?.major !== 1) {
-        throw new Error(
-          `Unsupported custom conversation handler. Expected eventVersion to match 1.x, received ${directive.handler.eventVersion}`,
-        );
-      }
       return this.setupExistingFunctionDataSource(directive.handler.functionName);
     } else if (directive.functionName) {
       return this.setupExistingFunctionDataSource(directive.functionName);

--- a/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
@@ -20,6 +20,7 @@ import { conversationMessageSubscriptionMappingTamplate } from '../resolvers/ass
 import { overrideIndexAtCfnLevel } from '@aws-amplify/graphql-index-transformer';
 import pluralize from 'pluralize';
 import { listMessageInitMappingTemplate } from '../resolvers/list-messages-init-resolver';
+import * as semver from 'semver';
 
 type KeyAttributeDefinition = {
   name: string;
@@ -109,7 +110,16 @@ export class ConversationResolverGenerator {
     functionStack: cdk.Stack,
     capitalizedFieldName: string,
   ): { functionDataSourceId: string; referencedFunction: IFunction } {
-    if (directive.functionName) {
+    if (directive.handler && directive.functionName) {
+      throw new Error("'functionName' and 'handler' are mutually exclusive");
+    }
+    if (directive.handler) {
+      const eventVersion = semver.coerce(directive.handler.eventVersion);
+      if (eventVersion?.major !== 1) {
+        throw new Error(`Unsupported custom conversation handler. Expected eventVersion to match 1.x, received ${directive.handler.eventVersion}`);
+      }
+      return this.setupExistingFunctionDataSource(directive.handler.functionName);
+    } else if (directive.functionName) {
       return this.setupExistingFunctionDataSource(directive.functionName);
     } else {
       return this.setupDefaultConversationHandler(functionStack, capitalizedFieldName, directive.aiModel);

--- a/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
@@ -116,7 +116,9 @@ export class ConversationResolverGenerator {
     if (directive.handler) {
       const eventVersion = semver.coerce(directive.handler.eventVersion);
       if (eventVersion?.major !== 1) {
-        throw new Error(`Unsupported custom conversation handler. Expected eventVersion to match 1.x, received ${directive.handler.eventVersion}`);
+        throw new Error(
+          `Unsupported custom conversation handler. Expected eventVersion to match 1.x, received ${directive.handler.eventVersion}`,
+        );
       }
       return this.setupExistingFunctionDataSource(directive.handler.functionName);
     } else if (directive.functionName) {

--- a/packages/amplify-graphql-directives/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/amplify-graphql-directives/src/__tests__/__snapshots__/index.test.ts.snap
@@ -232,9 +232,15 @@ Object {
     aiModel: String!
     systemPrompt: String!
     functionName: String
+    handler: ConversationHandlerFunctionConfiguration
     tools: [ToolMap]
     inferenceConfiguration: ConversationInferenceConfiguration
   ) on FIELD_DEFINITION
+  
+  input ConversationHandlerFunctionConfiguration {
+    functionName: String!
+    eventVersion: String!
+  }
 
   input ToolMap {
     name: String

--- a/packages/amplify-graphql-directives/src/directives/conversation.ts
+++ b/packages/amplify-graphql-directives/src/directives/conversation.ts
@@ -6,9 +6,15 @@ const definition = /* GraphQL */ `
     aiModel: String!
     systemPrompt: String!
     functionName: String
+    handler: ConversationHandlerFunctionConfiguration
     tools: [ToolMap]
     inferenceConfiguration: ConversationInferenceConfiguration
   ) on FIELD_DEFINITION
+  
+  input ConversationHandlerFunctionConfiguration {
+    functionName: String!
+    eventVersion: String!
+  }
 
   input ToolMap {
     name: String

--- a/yarn.lock
+++ b/yarn.lock
@@ -9456,10 +9456,10 @@ cookie-signature@1.0.6:
   resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
 
-cookie@0.6.0, cookie@0.7.0, cookie@^0.4.0:
-  version "0.7.0"
-  resolved "https://registry.npmjs.org/cookie/-/cookie-0.7.0.tgz#2148f68a77245d5c2c0005d264bc3e08cfa0655d"
-  integrity sha512-qCf+V4dtlNhSRXGAZatc1TasyFO6GjohcOul807YOb5ik3+kQSnb4d7iajeCL8QHaJ4uZEjCgiCJerKXwdRVlQ==
+cookie@0.6.0, cookie@^0.4.0, cookie@^0.7.0:
+  version "0.7.2"
+  resolved "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 copyfiles@^2.2.0:
   version "2.4.1"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Change how `@conversation` directive accepts custom conversation handler.

From:
```
@conversation(
  aiModel: "anthropic.claude-3-haiku-20240307-v1:0", 
  systemPrompt: "Hello, world!",
  functionName: "FnCustomHandlerChatBot",
  eventVersion: '1.0'
)
```

To:
```
@conversation(
  aiModel: "anthropic.claude-3-haiku-20240307-v1:0", 
  systemPrompt: "Hello, world!",
  handler: {
    functionName: "FnCustomHandlerChatBot",
    eventVersion: '1.0'
  }
)
```

While still accepting older version. Older version will be removed upon GA.

#### Motivation

This is a companion PR to https://github.com/aws-amplify/amplify-backend/pull/2089 .
And a pre-requisite for https://github.com/aws-amplify/amplify-api-next/pull/369 .

These PRs setup a versioning for the event protocol between conversation route resolvers and lambda handler.

The protocol versioning works as follows:
1. We plumb event version through custom conversation handler -> schema -> transformer at runtime.
2. We're using subset of semver, i.e. `<major>.<minor>`. Patch is meaningless for protocol versioning.
3. We assert that protocol version must match on `<major>` digit. (mismatches within minor version should result in disabled functionality, not runtime errors).

This prepares us for future handling of `2.x` and higher versions of event. Where we can:
1. Either create a payload compatible to provided custom handler.
2. Or fail with validation and ask customer to provide matching version of custom handler.

(This decision will be made later, when break actually happens, in this PR we establish necessary primitives to handle it in the future, and assert correctness of current state where we only have single major version).


##### CDK / CloudFormation Parameters Changed

NONE.

#### Description of how you validated changes

Added unit tests.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
