### PR TITLE
fix(conversation): inline template for init slot and correct datasource in assistant response mutation

### DIFF
--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -1,80 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 1`] = `
-{
-  "Fn::Join": [
-    "",
-    [
-      "export const request = (ctx) => {
-  ctx.stash.typeName = "Mutation";
-  ctx.stash.fieldName = "pirateChat";
-  ctx.stash.conditions = [];
-  ctx.stash.metadata = {};
-  ctx.stash.metadata.dataSourceType = "AWS_LAMBDA";
-  ctx.stash.metadata.apiId = "",
-      {
-        "Fn::GetAtt": [
-          "GraphQLAPI",
-          "ApiId",
-        ],
-      },
-      "";
-  ctx.stash.connectionAttributes = {};
-  ctx.stash.lambdaFunctionArn = "",
-      {
-        "Fn::GetAtt": [
-          "PirateChatConversationDirectiveLambdaStack",
-          "Outputs.transformerrootstackPirateChatConversationDirectiveLambdaStackPirateChatDefaultConversationHandlerconversationHandlerFunction2B526F1AArn",
-        ],
-      },
-      "";
-  ctx.stash.adminRoles = [];
-  return {};
-}
-
-export const response = (ctx) => {
-  return ctx.prev.result;
-};",
-    ],
-  ],
-}
-`;
-
-exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 2`] = `
-{
-  "Fn::Join": [
-    "",
-    [
-      "export function request(ctx) {
-  ctx.stash.graphqlApiEndpoint = '",
-      {
-        "Fn::GetAtt": [
-          "GraphQLAPI",
-          "GraphQLUrl",
-        ],
-      },
-      "';
-  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
-  ctx.stash.defaultValues.id = util.autoId();
-  const createdAt = util.time.nowISO8601();
-  ctx.stash.defaultValues.createdAt = createdAt;
-  ctx.stash.defaultValues.updatedAt = createdAt;
-  return {
-    version: '2018-05-09',
-    payload: {},
-  };
-}
-
-export function response(ctx) {
-  return {};
-}
-",
-    ],
-  ],
-}
-`;
-
-exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 3`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: AssistantResponseMutation auth slot function code 1`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
   const isAuthorized = false;
@@ -116,10 +42,90 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 4`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: AssistantResponseMutation init slot function code 1`] = `
+"export function request(ctx) {
+  ctx.stash.graphqlApiEndpoint = '[[GRAPHQL_API_ENDPOINT]]';
+  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
+  ctx.stash.defaultValues.id = util.autoId();
+  const createdAt = util.time.nowISO8601();
+  ctx.stash.defaultValues.createdAt = createdAt;
+  ctx.stash.defaultValues.updatedAt = createdAt;
+  return {
+    version: '2018-05-09',
+    payload: {},
+  };
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: AssistantResponseMutation resolver code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export const request = (ctx) => {
+  ctx.stash.typeName = "Mutation";
+  ctx.stash.fieldName = "createAssistantResponsePirateChat";
+  ctx.stash.conditions = [];
+  ctx.stash.metadata = {};
+  ctx.stash.metadata.dataSourceType = "AMAZON_DYNAMODB";
+  ctx.stash.metadata.apiId = "",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "ApiId",
+        ],
+      },
+      "";
+  ctx.stash.connectionAttributes = {};
+  ctx.stash.tableName = "",
+      {
+        "Fn::Select": [
+          1,
+          {
+            "Fn::Split": [
+              "/",
+              {
+                "Fn::Select": [
+                  5,
+                  {
+                    "Fn::Split": [
+                      ":",
+                      {
+                        "Fn::GetAtt": [
+                          "ConversationMessagePirateChat",
+                          "Outputs.transformerrootstackConversationMessagePirateChatConversationMessagePirateChatTableFC80206BTableArn",
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      "";
+  ctx.stash.adminRoles = [];
+  return {};
+}
+
+export const response = (ctx) => {
+  return ctx.prev.result;
+};",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: AssistantResponseMutation verify session owner slot function code 1`] = `
 "export function request(ctx) {
   const { authFilter } = ctx.stash;
-  const { conversationId } = ctx.args;
+  const { conversationId } = ctx.args.input;
 
   const query = {
     expression: 'id = :id',
@@ -151,35 +157,163 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 5`] = `
-"import { util } from '@aws-appsync/utils';
-import * as ddb from '@aws-appsync/utils/dynamodb';
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: AssistantResponseSubscription data slot function code 1`] = `
+"import { util, extensions } from '@aws-appsync/utils';
 
 export function request(ctx) {
-  const args = ctx.stash.transformedArgs ?? ctx.args;
-  const defaultValues = ctx.stash.defaultValues ?? {};
-  const message = {
-    __typename: 'ConversationMessagePirateChat',
-    role: 'user',
-    ...args,
-    ...defaultValues,
-  };
-  const id = ctx.stash.defaultValues.id;
+  ctx.stash.hasAuth = true;
+  const isAuthorized = false;
 
-  return ddb.put({ key: { id }, item: message });
+  if (util.authType() === 'User Pool Authorization') {
+    if (!isAuthorized) {
+      const authFilter = [];
+      let ownerClaim0 = ctx.identity['claims']['sub'];
+      ctx.args.owner = ownerClaim0;
+      const currentClaim1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (ownerClaim0 && currentClaim1) {
+        ownerClaim0 = ownerClaim0 + '::' + currentClaim1;
+        authFilter.push({ owner: { eq: ownerClaim0 } });
+      }
+      const role0_0 = ctx.identity['claims']['sub'];
+      if (role0_0) {
+        authFilter.push({ owner: { eq: role0_0 } });
+      }
+      // we can just reuse currentClaim1 here, but doing this (for now) to mirror the existing
+      // vtl auth resolver.
+      const role0_1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (role0_1) {
+        authFilter.push({ owner: { eq: role0_1 } });
+      }
+      if (authFilter.length !== 0) {
+        ctx.stash.authFilter = { or: authFilter };
+      }
+    }
+  }
+  if (!isAuthorized && ctx.stash.authFilter.length === 0) {
+    util.unauthorized();
+  }
+  ctx.args.filter = { ...ctx.args.filter, and: [{ conversationId: { eq: ctx.args.conversationId } }] };
+  return { version: '2018-05-29', payload: {} };
 }
 
 export function response(ctx) {
-  if (ctx.error) {
-    util.error(ctx.error.message, ctx.error.type);
-  } else {
-    return ctx.result;
-  }
+  const subscriptionFilter = util.transform.toSubscriptionFilter(ctx.args.filter);
+  extensions.setSubscriptionFilter(subscriptionFilter);
+  return null;
 }
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 6`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: AssistantResponseSubscription resolver code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export const request = (ctx) => {
+  ctx.stash.typeName = "Subscription";
+  ctx.stash.fieldName = "onCreateAssistantResponsePirateChat";
+  ctx.stash.conditions = [];
+  ctx.stash.metadata = {};
+  ctx.stash.metadata.dataSourceType = "NONE";
+  ctx.stash.metadata.apiId = "",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "ApiId",
+        ],
+      },
+      "";
+  ctx.stash.connectionAttributes = {};
+  
+  ctx.stash.adminRoles = [];
+  return {};
+}
+
+export const response = (ctx) => {
+  return ctx.prev.result;
+};",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: SendMessageMutation auth slot function code 1`] = `
+"export function request(ctx) {
+  ctx.stash.hasAuth = true;
+  const isAuthorized = false;
+
+  if (util.authType() === 'User Pool Authorization') {
+    if (!isAuthorized) {
+      const authFilter = [];
+      let ownerClaim0 = ctx.identity['claims']['sub'];
+      ctx.args.owner = ownerClaim0;
+      const currentClaim1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (ownerClaim0 && currentClaim1) {
+        ownerClaim0 = ownerClaim0 + '::' + currentClaim1;
+        authFilter.push({ owner: { eq: ownerClaim0 } });
+      }
+      const role0_0 = ctx.identity['claims']['sub'];
+      if (role0_0) {
+        authFilter.push({ owner: { eq: role0_0 } });
+      }
+      // we can just reuse currentClaim1 here, but doing this (for now) to mirror the existing
+      // vtl auth resolver.
+      const role0_1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (role0_1) {
+        authFilter.push({ owner: { eq: role0_1 } });
+      }
+      if (authFilter.length !== 0) {
+        ctx.stash.authFilter = { or: authFilter };
+      }
+    }
+  }
+  if (!isAuthorized && ctx.stash.authFilter.length === 0) {
+    util.unauthorized();
+  }
+  return { version: '2018-05-29', payload: {} };
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: SendMessageMutation init slot function code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export function request(ctx) {
+  ctx.stash.graphqlApiEndpoint = '",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "GraphQLUrl",
+        ],
+      },
+      "';
+  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
+  ctx.stash.defaultValues.id = util.autoId();
+  const createdAt = util.time.nowISO8601();
+  ctx.stash.defaultValues.createdAt = createdAt;
+  ctx.stash.defaultValues.updatedAt = createdAt;
+  return {
+    version: '2018-05-09',
+    payload: {},
+  };
+}
+
+export function response(ctx) {
+  return {};
+}
+",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: SendMessageMutation invoke lambda slot function code 1`] = `
 "import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
@@ -254,7 +388,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 1`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: SendMessageMutation resolver code 1`] = `
 {
   "Fn::Join": [
     "",
@@ -294,41 +428,70 @@ export const response = (ctx) => {
 }
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 2`] = `
-{
-  "Fn::Join": [
-    "",
-    [
-      "export function request(ctx) {
-  ctx.stash.graphqlApiEndpoint = '",
-      {
-        "Fn::GetAtt": [
-          "GraphQLAPI",
-          "GraphQLUrl",
-        ],
-      },
-      "';
-  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
-  ctx.stash.defaultValues.id = util.autoId();
-  const createdAt = util.time.nowISO8601();
-  ctx.stash.defaultValues.createdAt = createdAt;
-  ctx.stash.defaultValues.updatedAt = createdAt;
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: SendMessageMutation verify session owner slot function code 1`] = `
+"export function request(ctx) {
+  const { authFilter } = ctx.stash;
+  const { conversationId } = ctx.args;
+
+  const query = {
+    expression: 'id = :id',
+    expressionValues: util.dynamodb.toMapValues({
+      ':id': conversationId,
+    }),
+  };
+
+  const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
+
   return {
-    version: '2018-05-09',
-    payload: {},
+    operation: 'Query',
+    query,
+    filter,
   };
 }
 
 export function response(ctx) {
-  return {};
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+
+  if (ctx.result.items.length !== 0) {
+    return ctx.result.items[0];
+  }
+
+  util.error('Conversation not found', 'ResourceNotFound');
 }
-",
-    ],
-  ],
-}
+"
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 3`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: SendMessageMutation write message to table slot function code 1`] = `
+"import { util } from '@aws-appsync/utils';
+import * as ddb from '@aws-appsync/utils/dynamodb';
+
+export function request(ctx) {
+  const args = ctx.stash.transformedArgs ?? ctx.args;
+  const defaultValues = ctx.stash.defaultValues ?? {};
+  const message = {
+    __typename: 'ConversationMessagePirateChat',
+    role: 'user',
+    ...args,
+    ...defaultValues,
+  };
+  const id = ctx.stash.defaultValues.id;
+
+  return ddb.put({ key: { id }, item: message });
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  } else {
+    return ctx.result;
+  }
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: AssistantResponseMutation auth slot function code 1`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
   const isAuthorized = false;
@@ -370,10 +533,90 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 4`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: AssistantResponseMutation init slot function code 1`] = `
+"export function request(ctx) {
+  ctx.stash.graphqlApiEndpoint = '[[GRAPHQL_API_ENDPOINT]]';
+  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
+  ctx.stash.defaultValues.id = util.autoId();
+  const createdAt = util.time.nowISO8601();
+  ctx.stash.defaultValues.createdAt = createdAt;
+  ctx.stash.defaultValues.updatedAt = createdAt;
+  return {
+    version: '2018-05-09',
+    payload: {},
+  };
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: AssistantResponseMutation resolver code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export const request = (ctx) => {
+  ctx.stash.typeName = "Mutation";
+  ctx.stash.fieldName = "createAssistantResponsePirateChat";
+  ctx.stash.conditions = [];
+  ctx.stash.metadata = {};
+  ctx.stash.metadata.dataSourceType = "AMAZON_DYNAMODB";
+  ctx.stash.metadata.apiId = "",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "ApiId",
+        ],
+      },
+      "";
+  ctx.stash.connectionAttributes = {};
+  ctx.stash.tableName = "",
+      {
+        "Fn::Select": [
+          1,
+          {
+            "Fn::Split": [
+              "/",
+              {
+                "Fn::Select": [
+                  5,
+                  {
+                    "Fn::Split": [
+                      ":",
+                      {
+                        "Fn::GetAtt": [
+                          "ConversationMessagePirateChat",
+                          "Outputs.transformerrootstackConversationMessagePirateChatConversationMessagePirateChatTableFC80206BTableArn",
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      "";
+  ctx.stash.adminRoles = [];
+  return {};
+}
+
+export const response = (ctx) => {
+  return ctx.prev.result;
+};",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: AssistantResponseMutation verify session owner slot function code 1`] = `
 "export function request(ctx) {
   const { authFilter } = ctx.stash;
-  const { conversationId } = ctx.args;
+  const { conversationId } = ctx.args.input;
 
   const query = {
     expression: 'id = :id',
@@ -405,120 +648,64 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 5`] = `
-"import { util } from '@aws-appsync/utils';
-import * as ddb from '@aws-appsync/utils/dynamodb';
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: AssistantResponseSubscription data slot function code 1`] = `
+"import { util, extensions } from '@aws-appsync/utils';
 
 export function request(ctx) {
-  const args = ctx.stash.transformedArgs ?? ctx.args;
-  const defaultValues = ctx.stash.defaultValues ?? {};
-  const message = {
-    __typename: 'ConversationMessagePirateChat',
-    role: 'user',
-    ...args,
-    ...defaultValues,
-  };
-  const id = ctx.stash.defaultValues.id;
+  ctx.stash.hasAuth = true;
+  const isAuthorized = false;
 
-  return ddb.put({ key: { id }, item: message });
+  if (util.authType() === 'User Pool Authorization') {
+    if (!isAuthorized) {
+      const authFilter = [];
+      let ownerClaim0 = ctx.identity['claims']['sub'];
+      ctx.args.owner = ownerClaim0;
+      const currentClaim1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (ownerClaim0 && currentClaim1) {
+        ownerClaim0 = ownerClaim0 + '::' + currentClaim1;
+        authFilter.push({ owner: { eq: ownerClaim0 } });
+      }
+      const role0_0 = ctx.identity['claims']['sub'];
+      if (role0_0) {
+        authFilter.push({ owner: { eq: role0_0 } });
+      }
+      // we can just reuse currentClaim1 here, but doing this (for now) to mirror the existing
+      // vtl auth resolver.
+      const role0_1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (role0_1) {
+        authFilter.push({ owner: { eq: role0_1 } });
+      }
+      if (authFilter.length !== 0) {
+        ctx.stash.authFilter = { or: authFilter };
+      }
+    }
+  }
+  if (!isAuthorized && ctx.stash.authFilter.length === 0) {
+    util.unauthorized();
+  }
+  ctx.args.filter = { ...ctx.args.filter, and: [{ conversationId: { eq: ctx.args.conversationId } }] };
+  return { version: '2018-05-29', payload: {} };
 }
 
 export function response(ctx) {
-  if (ctx.error) {
-    util.error(ctx.error.message, ctx.error.type);
-  } else {
-    return ctx.result;
-  }
+  const subscriptionFilter = util.transform.toSubscriptionFilter(ctx.args.filter);
+  extensions.setSubscriptionFilter(subscriptionFilter);
+  return null;
 }
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 6`] = `
-"import { util } from '@aws-appsync/utils';
-
-export function request(ctx) {
-  const { args, request } = ctx;
-  const { graphqlApiEndpoint } = ctx.stash;
-
-  const selectionSet = 'id conversationId content { image { format source { bytes }} text toolUse { toolUseId name input } toolResult { status toolUseId content { json text image { format source { bytes }} document { format name source { bytes }} }}} role owner createdAt updatedAt';
-
-  const responseMutation = {
-    name: 'createAssistantResponsePirateChat',
-    inputTypeName: 'CreateConversationMessagePirateChatAssistantInput',
-    selectionSet,
-  };
-  const currentMessageId = ctx.stash.defaultValues.id;
-
-  const modelConfiguration = {
-    modelId: "anthropic.claude-3-haiku-20240307-v1:0",
-    systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
-    inferenceConfiguration: undefined,
-  };
-
-  const clientTools = args.toolConfiguration?.tools?.map((tool) => {
-    return { ...tool.toolSpec };
-  });
-  const dataTools = [{"name":"listTodos","description":"lists todos","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { content isDone id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listTodos"}}];
-  const toolsConfiguration = { dataTools, clientTools };
-
-  const messageHistoryQuery = {
-    getQueryName: 'getConversationMessagePirateChat',
-    getQueryInputTypeName: 'ID',
-    listQueryName: 'listConversationMessagePirateChats',
-    listQueryInputTypeName: 'ModelConversationMessagePirateChatFilterInput',
-    listQueryLimit: undefined,
-  };
-
-  const authHeader = request.headers['authorization'];
-  const payload = {
-    conversationId: args.conversationId,
-    currentMessageId,
-    responseMutation,
-    graphqlApiEndpoint,
-    modelConfiguration,
-    request: { headers: { authorization: authHeader } },
-    messageHistoryQuery,
-    toolsConfiguration,
-  };
-
-  return {
-    operation: 'Invoke',
-    payload,
-    invocationType: 'Event',
-  };
-}
-
-export function response(ctx) {
-  if (ctx.error) {
-    util.appendError(ctx.error.message, ctx.error.type);
-  }
-  const response = {
-    __typename: 'ConversationMessagePirateChat',
-    id: ctx.stash.defaultValues.id,
-    conversationId: ctx.args.conversationId,
-    role: 'user',
-    content: ctx.args.content,
-    aiContext: ctx.args.aiContext,
-    toolConfiguration: ctx.args.toolConfiguration,
-    createdAt: ctx.stash.defaultValues.createdAt,
-    updatedAt: ctx.stash.defaultValues.updatedAt,
-  };
-  return response;
-}
-"
-`;
-
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 1`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: AssistantResponseSubscription resolver code 1`] = `
 {
   "Fn::Join": [
     "",
     [
       "export const request = (ctx) => {
-  ctx.stash.typeName = "Mutation";
-  ctx.stash.fieldName = "pirateChat";
+  ctx.stash.typeName = "Subscription";
+  ctx.stash.fieldName = "onCreateAssistantResponsePirateChat";
   ctx.stash.conditions = [];
   ctx.stash.metadata = {};
-  ctx.stash.metadata.dataSourceType = "AWS_LAMBDA";
+  ctx.stash.metadata.dataSourceType = "NONE";
   ctx.stash.metadata.apiId = "",
       {
         "Fn::GetAtt": [
@@ -528,14 +715,7 @@ exports[`ConversationTransformer valid schemas should transform conversation rou
       },
       "";
   ctx.stash.connectionAttributes = {};
-  ctx.stash.lambdaFunctionArn = "",
-      {
-        "Fn::GetAtt": [
-          "PirateChatConversationDirectiveLambdaStack",
-          "Outputs.transformerrootstackPirateChatConversationDirectiveLambdaStackPirateChatDefaultConversationHandlerconversationHandlerFunction2B526F1AArn",
-        ],
-      },
-      "";
+  
   ctx.stash.adminRoles = [];
   return {};
 }
@@ -548,41 +728,7 @@ export const response = (ctx) => {
 }
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 2`] = `
-{
-  "Fn::Join": [
-    "",
-    [
-      "export function request(ctx) {
-  ctx.stash.graphqlApiEndpoint = '",
-      {
-        "Fn::GetAtt": [
-          "GraphQLAPI",
-          "GraphQLUrl",
-        ],
-      },
-      "';
-  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
-  ctx.stash.defaultValues.id = util.autoId();
-  const createdAt = util.time.nowISO8601();
-  ctx.stash.defaultValues.createdAt = createdAt;
-  ctx.stash.defaultValues.updatedAt = createdAt;
-  return {
-    version: '2018-05-09',
-    payload: {},
-  };
-}
-
-export function response(ctx) {
-  return {};
-}
-",
-    ],
-  ],
-}
-`;
-
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 3`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: SendMessageMutation auth slot function code 1`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
   const isAuthorized = false;
@@ -624,70 +770,41 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 4`] = `
-"export function request(ctx) {
-  const { authFilter } = ctx.stash;
-  const { conversationId } = ctx.args;
-
-  const query = {
-    expression: 'id = :id',
-    expressionValues: util.dynamodb.toMapValues({
-      ':id': conversationId,
-    }),
-  };
-
-  const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
-
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: SendMessageMutation init slot function code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export function request(ctx) {
+  ctx.stash.graphqlApiEndpoint = '",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "GraphQLUrl",
+        ],
+      },
+      "';
+  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
+  ctx.stash.defaultValues.id = util.autoId();
+  const createdAt = util.time.nowISO8601();
+  ctx.stash.defaultValues.createdAt = createdAt;
+  ctx.stash.defaultValues.updatedAt = createdAt;
   return {
-    operation: 'Query',
-    query,
-    filter,
+    version: '2018-05-09',
+    payload: {},
   };
 }
 
 export function response(ctx) {
-  if (ctx.error) {
-    util.error(ctx.error.message, ctx.error.type);
-  }
-
-  if (ctx.result.items.length !== 0) {
-    return ctx.result.items[0];
-  }
-
-  util.error('Conversation not found', 'ResourceNotFound');
+  return {};
 }
-"
+",
+    ],
+  ],
+}
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 5`] = `
-"import { util } from '@aws-appsync/utils';
-import * as ddb from '@aws-appsync/utils/dynamodb';
-
-export function request(ctx) {
-  const args = ctx.stash.transformedArgs ?? ctx.args;
-  const defaultValues = ctx.stash.defaultValues ?? {};
-  const message = {
-    __typename: 'ConversationMessagePirateChat',
-    role: 'user',
-    ...args,
-    ...defaultValues,
-  };
-  const id = ctx.stash.defaultValues.id;
-
-  return ddb.put({ key: { id }, item: message });
-}
-
-export function response(ctx) {
-  if (ctx.error) {
-    util.error(ctx.error.message, ctx.error.type);
-  } else {
-    return ctx.result;
-  }
-}
-"
-`;
-
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 6`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: SendMessageMutation invoke lambda slot function code 1`] = `
 "import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
@@ -762,7 +879,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with query tools 1`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: SendMessageMutation resolver code 1`] = `
 {
   "Fn::Join": [
     "",
@@ -802,41 +919,70 @@ export const response = (ctx) => {
 }
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with query tools 2`] = `
-{
-  "Fn::Join": [
-    "",
-    [
-      "export function request(ctx) {
-  ctx.stash.graphqlApiEndpoint = '",
-      {
-        "Fn::GetAtt": [
-          "GraphQLAPI",
-          "GraphQLUrl",
-        ],
-      },
-      "';
-  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
-  ctx.stash.defaultValues.id = util.autoId();
-  const createdAt = util.time.nowISO8601();
-  ctx.stash.defaultValues.createdAt = createdAt;
-  ctx.stash.defaultValues.updatedAt = createdAt;
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: SendMessageMutation verify session owner slot function code 1`] = `
+"export function request(ctx) {
+  const { authFilter } = ctx.stash;
+  const { conversationId } = ctx.args;
+
+  const query = {
+    expression: 'id = :id',
+    expressionValues: util.dynamodb.toMapValues({
+      ':id': conversationId,
+    }),
+  };
+
+  const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
+
   return {
-    version: '2018-05-09',
-    payload: {},
+    operation: 'Query',
+    query,
+    filter,
   };
 }
 
 export function response(ctx) {
-  return {};
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+
+  if (ctx.result.items.length !== 0) {
+    return ctx.result.items[0];
+  }
+
+  util.error('Conversation not found', 'ResourceNotFound');
 }
-",
-    ],
-  ],
-}
+"
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with query tools 3`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: SendMessageMutation write message to table slot function code 1`] = `
+"import { util } from '@aws-appsync/utils';
+import * as ddb from '@aws-appsync/utils/dynamodb';
+
+export function request(ctx) {
+  const args = ctx.stash.transformedArgs ?? ctx.args;
+  const defaultValues = ctx.stash.defaultValues ?? {};
+  const message = {
+    __typename: 'ConversationMessagePirateChat',
+    role: 'user',
+    ...args,
+    ...defaultValues,
+  };
+  const id = ctx.stash.defaultValues.id;
+
+  return ddb.put({ key: { id }, item: message });
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  } else {
+    return ctx.result;
+  }
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: AssistantResponseMutation auth slot function code 1`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
   const isAuthorized = false;
@@ -878,7 +1024,393 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with query tools 4`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: AssistantResponseMutation init slot function code 1`] = `
+"export function request(ctx) {
+  ctx.stash.graphqlApiEndpoint = '[[GRAPHQL_API_ENDPOINT]]';
+  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
+  ctx.stash.defaultValues.id = util.autoId();
+  const createdAt = util.time.nowISO8601();
+  ctx.stash.defaultValues.createdAt = createdAt;
+  ctx.stash.defaultValues.updatedAt = createdAt;
+  return {
+    version: '2018-05-09',
+    payload: {},
+  };
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: AssistantResponseMutation resolver code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export const request = (ctx) => {
+  ctx.stash.typeName = "Mutation";
+  ctx.stash.fieldName = "createAssistantResponsePirateChat";
+  ctx.stash.conditions = [];
+  ctx.stash.metadata = {};
+  ctx.stash.metadata.dataSourceType = "AMAZON_DYNAMODB";
+  ctx.stash.metadata.apiId = "",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "ApiId",
+        ],
+      },
+      "";
+  ctx.stash.connectionAttributes = {};
+  ctx.stash.tableName = "",
+      {
+        "Fn::Select": [
+          1,
+          {
+            "Fn::Split": [
+              "/",
+              {
+                "Fn::Select": [
+                  5,
+                  {
+                    "Fn::Split": [
+                      ":",
+                      {
+                        "Fn::GetAtt": [
+                          "ConversationMessagePirateChat",
+                          "Outputs.transformerrootstackConversationMessagePirateChatConversationMessagePirateChatTableFC80206BTableArn",
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      "";
+  ctx.stash.adminRoles = [];
+  return {};
+}
+
+export const response = (ctx) => {
+  return ctx.prev.result;
+};",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: AssistantResponseMutation verify session owner slot function code 1`] = `
+"export function request(ctx) {
+  const { authFilter } = ctx.stash;
+  const { conversationId } = ctx.args.input;
+
+  const query = {
+    expression: 'id = :id',
+    expressionValues: util.dynamodb.toMapValues({
+      ':id': conversationId,
+    }),
+  };
+
+  const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
+
+  return {
+    operation: 'Query',
+    query,
+    filter,
+  };
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+
+  if (ctx.result.items.length !== 0) {
+    return ctx.result.items[0];
+  }
+
+  util.error('Conversation not found', 'ResourceNotFound');
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: AssistantResponseSubscription data slot function code 1`] = `
+"import { util, extensions } from '@aws-appsync/utils';
+
+export function request(ctx) {
+  ctx.stash.hasAuth = true;
+  const isAuthorized = false;
+
+  if (util.authType() === 'User Pool Authorization') {
+    if (!isAuthorized) {
+      const authFilter = [];
+      let ownerClaim0 = ctx.identity['claims']['sub'];
+      ctx.args.owner = ownerClaim0;
+      const currentClaim1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (ownerClaim0 && currentClaim1) {
+        ownerClaim0 = ownerClaim0 + '::' + currentClaim1;
+        authFilter.push({ owner: { eq: ownerClaim0 } });
+      }
+      const role0_0 = ctx.identity['claims']['sub'];
+      if (role0_0) {
+        authFilter.push({ owner: { eq: role0_0 } });
+      }
+      // we can just reuse currentClaim1 here, but doing this (for now) to mirror the existing
+      // vtl auth resolver.
+      const role0_1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (role0_1) {
+        authFilter.push({ owner: { eq: role0_1 } });
+      }
+      if (authFilter.length !== 0) {
+        ctx.stash.authFilter = { or: authFilter };
+      }
+    }
+  }
+  if (!isAuthorized && ctx.stash.authFilter.length === 0) {
+    util.unauthorized();
+  }
+  ctx.args.filter = { ...ctx.args.filter, and: [{ conversationId: { eq: ctx.args.conversationId } }] };
+  return { version: '2018-05-29', payload: {} };
+}
+
+export function response(ctx) {
+  const subscriptionFilter = util.transform.toSubscriptionFilter(ctx.args.filter);
+  extensions.setSubscriptionFilter(subscriptionFilter);
+  return null;
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: AssistantResponseSubscription resolver code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export const request = (ctx) => {
+  ctx.stash.typeName = "Subscription";
+  ctx.stash.fieldName = "onCreateAssistantResponsePirateChat";
+  ctx.stash.conditions = [];
+  ctx.stash.metadata = {};
+  ctx.stash.metadata.dataSourceType = "NONE";
+  ctx.stash.metadata.apiId = "",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "ApiId",
+        ],
+      },
+      "";
+  ctx.stash.connectionAttributes = {};
+  
+  ctx.stash.adminRoles = [];
+  return {};
+}
+
+export const response = (ctx) => {
+  return ctx.prev.result;
+};",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: SendMessageMutation auth slot function code 1`] = `
+"export function request(ctx) {
+  ctx.stash.hasAuth = true;
+  const isAuthorized = false;
+
+  if (util.authType() === 'User Pool Authorization') {
+    if (!isAuthorized) {
+      const authFilter = [];
+      let ownerClaim0 = ctx.identity['claims']['sub'];
+      ctx.args.owner = ownerClaim0;
+      const currentClaim1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (ownerClaim0 && currentClaim1) {
+        ownerClaim0 = ownerClaim0 + '::' + currentClaim1;
+        authFilter.push({ owner: { eq: ownerClaim0 } });
+      }
+      const role0_0 = ctx.identity['claims']['sub'];
+      if (role0_0) {
+        authFilter.push({ owner: { eq: role0_0 } });
+      }
+      // we can just reuse currentClaim1 here, but doing this (for now) to mirror the existing
+      // vtl auth resolver.
+      const role0_1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (role0_1) {
+        authFilter.push({ owner: { eq: role0_1 } });
+      }
+      if (authFilter.length !== 0) {
+        ctx.stash.authFilter = { or: authFilter };
+      }
+    }
+  }
+  if (!isAuthorized && ctx.stash.authFilter.length === 0) {
+    util.unauthorized();
+  }
+  return { version: '2018-05-29', payload: {} };
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: SendMessageMutation init slot function code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export function request(ctx) {
+  ctx.stash.graphqlApiEndpoint = '",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "GraphQLUrl",
+        ],
+      },
+      "';
+  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
+  ctx.stash.defaultValues.id = util.autoId();
+  const createdAt = util.time.nowISO8601();
+  ctx.stash.defaultValues.createdAt = createdAt;
+  ctx.stash.defaultValues.updatedAt = createdAt;
+  return {
+    version: '2018-05-09',
+    payload: {},
+  };
+}
+
+export function response(ctx) {
+  return {};
+}
+",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: SendMessageMutation invoke lambda slot function code 1`] = `
+"import { util } from '@aws-appsync/utils';
+
+export function request(ctx) {
+  const { args, request } = ctx;
+  const { graphqlApiEndpoint } = ctx.stash;
+
+  const selectionSet = 'id conversationId content { image { format source { bytes }} text toolUse { toolUseId name input } toolResult { status toolUseId content { json text image { format source { bytes }} document { format name source { bytes }} }}} role owner createdAt updatedAt';
+
+  const responseMutation = {
+    name: 'createAssistantResponsePirateChat',
+    inputTypeName: 'CreateConversationMessagePirateChatAssistantInput',
+    selectionSet,
+  };
+  const currentMessageId = ctx.stash.defaultValues.id;
+
+  const modelConfiguration = {
+    modelId: "anthropic.claude-3-haiku-20240307-v1:0",
+    systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
+    inferenceConfiguration: undefined,
+  };
+
+  const clientTools = args.toolConfiguration?.tools?.map((tool) => {
+    return { ...tool.toolSpec };
+  });
+  const dataTools = [{"name":"listTodos","description":"lists todos","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { content isDone id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listTodos"}}];
+  const toolsConfiguration = { dataTools, clientTools };
+
+  const messageHistoryQuery = {
+    getQueryName: 'getConversationMessagePirateChat',
+    getQueryInputTypeName: 'ID',
+    listQueryName: 'listConversationMessagePirateChats',
+    listQueryInputTypeName: 'ModelConversationMessagePirateChatFilterInput',
+    listQueryLimit: undefined,
+  };
+
+  const authHeader = request.headers['authorization'];
+  const payload = {
+    conversationId: args.conversationId,
+    currentMessageId,
+    responseMutation,
+    graphqlApiEndpoint,
+    modelConfiguration,
+    request: { headers: { authorization: authHeader } },
+    messageHistoryQuery,
+    toolsConfiguration,
+  };
+
+  return {
+    operation: 'Invoke',
+    payload,
+    invocationType: 'Event',
+  };
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.appendError(ctx.error.message, ctx.error.type);
+  }
+  const response = {
+    __typename: 'ConversationMessagePirateChat',
+    id: ctx.stash.defaultValues.id,
+    conversationId: ctx.args.conversationId,
+    role: 'user',
+    content: ctx.args.content,
+    aiContext: ctx.args.aiContext,
+    toolConfiguration: ctx.args.toolConfiguration,
+    createdAt: ctx.stash.defaultValues.createdAt,
+    updatedAt: ctx.stash.defaultValues.updatedAt,
+  };
+  return response;
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: SendMessageMutation resolver code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export const request = (ctx) => {
+  ctx.stash.typeName = "Mutation";
+  ctx.stash.fieldName = "pirateChat";
+  ctx.stash.conditions = [];
+  ctx.stash.metadata = {};
+  ctx.stash.metadata.dataSourceType = "AWS_LAMBDA";
+  ctx.stash.metadata.apiId = "",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "ApiId",
+        ],
+      },
+      "";
+  ctx.stash.connectionAttributes = {};
+  ctx.stash.lambdaFunctionArn = "",
+      {
+        "Fn::GetAtt": [
+          "PirateChatConversationDirectiveLambdaStack",
+          "Outputs.transformerrootstackPirateChatConversationDirectiveLambdaStackPirateChatDefaultConversationHandlerconversationHandlerFunction2B526F1AArn",
+        ],
+      },
+      "";
+  ctx.stash.adminRoles = [];
+  return {};
+}
+
+export const response = (ctx) => {
+  return ctx.prev.result;
+};",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: SendMessageMutation verify session owner slot function code 1`] = `
 "export function request(ctx) {
   const { authFilter } = ctx.stash;
   const { conversationId } = ctx.args;
@@ -913,7 +1445,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with query tools 5`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: SendMessageMutation write message to table slot function code 1`] = `
 "import { util } from '@aws-appsync/utils';
 import * as ddb from '@aws-appsync/utils/dynamodb';
 
@@ -941,7 +1473,320 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with query tools 6`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: AssistantResponseMutation auth slot function code 1`] = `
+"export function request(ctx) {
+  ctx.stash.hasAuth = true;
+  const isAuthorized = false;
+
+  if (util.authType() === 'User Pool Authorization') {
+    if (!isAuthorized) {
+      const authFilter = [];
+      let ownerClaim0 = ctx.identity['claims']['sub'];
+      ctx.args.owner = ownerClaim0;
+      const currentClaim1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (ownerClaim0 && currentClaim1) {
+        ownerClaim0 = ownerClaim0 + '::' + currentClaim1;
+        authFilter.push({ owner: { eq: ownerClaim0 } });
+      }
+      const role0_0 = ctx.identity['claims']['sub'];
+      if (role0_0) {
+        authFilter.push({ owner: { eq: role0_0 } });
+      }
+      // we can just reuse currentClaim1 here, but doing this (for now) to mirror the existing
+      // vtl auth resolver.
+      const role0_1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (role0_1) {
+        authFilter.push({ owner: { eq: role0_1 } });
+      }
+      if (authFilter.length !== 0) {
+        ctx.stash.authFilter = { or: authFilter };
+      }
+    }
+  }
+  if (!isAuthorized && ctx.stash.authFilter.length === 0) {
+    util.unauthorized();
+  }
+  return { version: '2018-05-29', payload: {} };
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: AssistantResponseMutation init slot function code 1`] = `
+"export function request(ctx) {
+  ctx.stash.graphqlApiEndpoint = '[[GRAPHQL_API_ENDPOINT]]';
+  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
+  ctx.stash.defaultValues.id = util.autoId();
+  const createdAt = util.time.nowISO8601();
+  ctx.stash.defaultValues.createdAt = createdAt;
+  ctx.stash.defaultValues.updatedAt = createdAt;
+  return {
+    version: '2018-05-09',
+    payload: {},
+  };
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: AssistantResponseMutation resolver code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export const request = (ctx) => {
+  ctx.stash.typeName = "Mutation";
+  ctx.stash.fieldName = "createAssistantResponsePirateChat";
+  ctx.stash.conditions = [];
+  ctx.stash.metadata = {};
+  ctx.stash.metadata.dataSourceType = "AMAZON_DYNAMODB";
+  ctx.stash.metadata.apiId = "",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "ApiId",
+        ],
+      },
+      "";
+  ctx.stash.connectionAttributes = {};
+  ctx.stash.tableName = "",
+      {
+        "Fn::Select": [
+          1,
+          {
+            "Fn::Split": [
+              "/",
+              {
+                "Fn::Select": [
+                  5,
+                  {
+                    "Fn::Split": [
+                      ":",
+                      {
+                        "Fn::GetAtt": [
+                          "ConversationMessagePirateChat",
+                          "Outputs.transformerrootstackConversationMessagePirateChatConversationMessagePirateChatTableFC80206BTableArn",
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      "";
+  ctx.stash.adminRoles = [];
+  return {};
+}
+
+export const response = (ctx) => {
+  return ctx.prev.result;
+};",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: AssistantResponseMutation verify session owner slot function code 1`] = `
+"export function request(ctx) {
+  const { authFilter } = ctx.stash;
+  const { conversationId } = ctx.args.input;
+
+  const query = {
+    expression: 'id = :id',
+    expressionValues: util.dynamodb.toMapValues({
+      ':id': conversationId,
+    }),
+  };
+
+  const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
+
+  return {
+    operation: 'Query',
+    query,
+    filter,
+  };
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+
+  if (ctx.result.items.length !== 0) {
+    return ctx.result.items[0];
+  }
+
+  util.error('Conversation not found', 'ResourceNotFound');
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: AssistantResponseSubscription data slot function code 1`] = `
+"import { util, extensions } from '@aws-appsync/utils';
+
+export function request(ctx) {
+  ctx.stash.hasAuth = true;
+  const isAuthorized = false;
+
+  if (util.authType() === 'User Pool Authorization') {
+    if (!isAuthorized) {
+      const authFilter = [];
+      let ownerClaim0 = ctx.identity['claims']['sub'];
+      ctx.args.owner = ownerClaim0;
+      const currentClaim1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (ownerClaim0 && currentClaim1) {
+        ownerClaim0 = ownerClaim0 + '::' + currentClaim1;
+        authFilter.push({ owner: { eq: ownerClaim0 } });
+      }
+      const role0_0 = ctx.identity['claims']['sub'];
+      if (role0_0) {
+        authFilter.push({ owner: { eq: role0_0 } });
+      }
+      // we can just reuse currentClaim1 here, but doing this (for now) to mirror the existing
+      // vtl auth resolver.
+      const role0_1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (role0_1) {
+        authFilter.push({ owner: { eq: role0_1 } });
+      }
+      if (authFilter.length !== 0) {
+        ctx.stash.authFilter = { or: authFilter };
+      }
+    }
+  }
+  if (!isAuthorized && ctx.stash.authFilter.length === 0) {
+    util.unauthorized();
+  }
+  ctx.args.filter = { ...ctx.args.filter, and: [{ conversationId: { eq: ctx.args.conversationId } }] };
+  return { version: '2018-05-29', payload: {} };
+}
+
+export function response(ctx) {
+  const subscriptionFilter = util.transform.toSubscriptionFilter(ctx.args.filter);
+  extensions.setSubscriptionFilter(subscriptionFilter);
+  return null;
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: AssistantResponseSubscription resolver code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export const request = (ctx) => {
+  ctx.stash.typeName = "Subscription";
+  ctx.stash.fieldName = "onCreateAssistantResponsePirateChat";
+  ctx.stash.conditions = [];
+  ctx.stash.metadata = {};
+  ctx.stash.metadata.dataSourceType = "NONE";
+  ctx.stash.metadata.apiId = "",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "ApiId",
+        ],
+      },
+      "";
+  ctx.stash.connectionAttributes = {};
+  
+  ctx.stash.adminRoles = [];
+  return {};
+}
+
+export const response = (ctx) => {
+  return ctx.prev.result;
+};",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: SendMessageMutation auth slot function code 1`] = `
+"export function request(ctx) {
+  ctx.stash.hasAuth = true;
+  const isAuthorized = false;
+
+  if (util.authType() === 'User Pool Authorization') {
+    if (!isAuthorized) {
+      const authFilter = [];
+      let ownerClaim0 = ctx.identity['claims']['sub'];
+      ctx.args.owner = ownerClaim0;
+      const currentClaim1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (ownerClaim0 && currentClaim1) {
+        ownerClaim0 = ownerClaim0 + '::' + currentClaim1;
+        authFilter.push({ owner: { eq: ownerClaim0 } });
+      }
+      const role0_0 = ctx.identity['claims']['sub'];
+      if (role0_0) {
+        authFilter.push({ owner: { eq: role0_0 } });
+      }
+      // we can just reuse currentClaim1 here, but doing this (for now) to mirror the existing
+      // vtl auth resolver.
+      const role0_1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (role0_1) {
+        authFilter.push({ owner: { eq: role0_1 } });
+      }
+      if (authFilter.length !== 0) {
+        ctx.stash.authFilter = { or: authFilter };
+      }
+    }
+  }
+  if (!isAuthorized && ctx.stash.authFilter.length === 0) {
+    util.unauthorized();
+  }
+  return { version: '2018-05-29', payload: {} };
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: SendMessageMutation init slot function code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export function request(ctx) {
+  ctx.stash.graphqlApiEndpoint = '",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "GraphQLUrl",
+        ],
+      },
+      "';
+  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
+  ctx.stash.defaultValues.id = util.autoId();
+  const createdAt = util.time.nowISO8601();
+  ctx.stash.defaultValues.createdAt = createdAt;
+  ctx.stash.defaultValues.updatedAt = createdAt;
+  return {
+    version: '2018-05-09',
+    payload: {},
+  };
+}
+
+export function response(ctx) {
+  return {};
+}
+",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: SendMessageMutation invoke lambda slot function code 1`] = `
 "import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
@@ -1012,6 +1857,109 @@ export function response(ctx) {
     updatedAt: ctx.stash.defaultValues.updatedAt,
   };
   return response;
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: SendMessageMutation resolver code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export const request = (ctx) => {
+  ctx.stash.typeName = "Mutation";
+  ctx.stash.fieldName = "pirateChat";
+  ctx.stash.conditions = [];
+  ctx.stash.metadata = {};
+  ctx.stash.metadata.dataSourceType = "AWS_LAMBDA";
+  ctx.stash.metadata.apiId = "",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "ApiId",
+        ],
+      },
+      "";
+  ctx.stash.connectionAttributes = {};
+  ctx.stash.lambdaFunctionArn = "",
+      {
+        "Fn::GetAtt": [
+          "PirateChatConversationDirectiveLambdaStack",
+          "Outputs.transformerrootstackPirateChatConversationDirectiveLambdaStackPirateChatDefaultConversationHandlerconversationHandlerFunction2B526F1AArn",
+        ],
+      },
+      "";
+  ctx.stash.adminRoles = [];
+  return {};
+}
+
+export const response = (ctx) => {
+  return ctx.prev.result;
+};",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: SendMessageMutation verify session owner slot function code 1`] = `
+"export function request(ctx) {
+  const { authFilter } = ctx.stash;
+  const { conversationId } = ctx.args;
+
+  const query = {
+    expression: 'id = :id',
+    expressionValues: util.dynamodb.toMapValues({
+      ':id': conversationId,
+    }),
+  };
+
+  const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
+
+  return {
+    operation: 'Query',
+    query,
+    filter,
+  };
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+
+  if (ctx.result.items.length !== 0) {
+    return ctx.result.items[0];
+  }
+
+  util.error('Conversation not found', 'ResourceNotFound');
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: SendMessageMutation write message to table slot function code 1`] = `
+"import { util } from '@aws-appsync/utils';
+import * as ddb from '@aws-appsync/utils/dynamodb';
+
+export function request(ctx) {
+  const args = ctx.stash.transformedArgs ?? ctx.args;
+  const defaultValues = ctx.stash.defaultValues ?? {};
+  const message = {
+    __typename: 'ConversationMessagePirateChat',
+    role: 'user',
+    ...args,
+    ...defaultValues,
+  };
+  const id = ctx.stash.defaultValues.id;
+
+  return ddb.put({ key: { id }, item: message });
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  } else {
+    return ctx.result;
+  }
 }
 "
 `;

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -41,6 +41,40 @@ export const response = (ctx) => {
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 2`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export function request(ctx) {
+  ctx.stash.graphqlApiEndpoint = '",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "GraphQLUrl",
+        ],
+      },
+      "';
+  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
+  ctx.stash.defaultValues.id = util.autoId();
+  const createdAt = util.time.nowISO8601();
+  ctx.stash.defaultValues.createdAt = createdAt;
+  ctx.stash.defaultValues.updatedAt = createdAt;
+  return {
+    version: '2018-05-09',
+    payload: {},
+  };
+}
+
+export function response(ctx) {
+  return {};
+}
+",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 3`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
   const isAuthorized = false;
@@ -82,7 +116,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 3`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 4`] = `
 "export function request(ctx) {
   const { authFilter } = ctx.stash;
   const { conversationId } = ctx.args;
@@ -117,7 +151,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 4`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 5`] = `
 "import { util } from '@aws-appsync/utils';
 import * as ddb from '@aws-appsync/utils/dynamodb';
 
@@ -145,7 +179,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 5`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration 6`] = `
 "import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
@@ -261,6 +295,40 @@ export const response = (ctx) => {
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 2`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export function request(ctx) {
+  ctx.stash.graphqlApiEndpoint = '",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "GraphQLUrl",
+        ],
+      },
+      "';
+  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
+  ctx.stash.defaultValues.id = util.autoId();
+  const createdAt = util.time.nowISO8601();
+  ctx.stash.defaultValues.createdAt = createdAt;
+  ctx.stash.defaultValues.updatedAt = createdAt;
+  return {
+    version: '2018-05-09',
+    payload: {},
+  };
+}
+
+export function response(ctx) {
+  return {};
+}
+",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 3`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
   const isAuthorized = false;
@@ -302,7 +370,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 3`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 4`] = `
 "export function request(ctx) {
   const { authFilter } = ctx.stash;
   const { conversationId } = ctx.args;
@@ -337,7 +405,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 4`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 5`] = `
 "import { util } from '@aws-appsync/utils';
 import * as ddb from '@aws-appsync/utils/dynamodb';
 
@@ -365,7 +433,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 5`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool 6`] = `
 "import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
@@ -481,6 +549,40 @@ export const response = (ctx) => {
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 2`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export function request(ctx) {
+  ctx.stash.graphqlApiEndpoint = '",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "GraphQLUrl",
+        ],
+      },
+      "';
+  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
+  ctx.stash.defaultValues.id = util.autoId();
+  const createdAt = util.time.nowISO8601();
+  ctx.stash.defaultValues.createdAt = createdAt;
+  ctx.stash.defaultValues.updatedAt = createdAt;
+  return {
+    version: '2018-05-09',
+    payload: {},
+  };
+}
+
+export function response(ctx) {
+  return {};
+}
+",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 3`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
   const isAuthorized = false;
@@ -522,7 +624,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 3`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 4`] = `
 "export function request(ctx) {
   const { authFilter } = ctx.stash;
   const { conversationId } = ctx.args;
@@ -557,7 +659,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 4`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 5`] = `
 "import { util } from '@aws-appsync/utils';
 import * as ddb from '@aws-appsync/utils/dynamodb';
 
@@ -585,7 +687,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 5`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships 6`] = `
 "import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {
@@ -701,6 +803,40 @@ export const response = (ctx) => {
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with query tools 2`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export function request(ctx) {
+  ctx.stash.graphqlApiEndpoint = '",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "GraphQLUrl",
+        ],
+      },
+      "';
+  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
+  ctx.stash.defaultValues.id = util.autoId();
+  const createdAt = util.time.nowISO8601();
+  ctx.stash.defaultValues.createdAt = createdAt;
+  ctx.stash.defaultValues.updatedAt = createdAt;
+  return {
+    version: '2018-05-09',
+    payload: {},
+  };
+}
+
+export function response(ctx) {
+  return {};
+}
+",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools 3`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
   const isAuthorized = false;
@@ -742,7 +878,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with query tools 3`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools 4`] = `
 "export function request(ctx) {
   const { authFilter } = ctx.stash;
   const { conversationId } = ctx.args;
@@ -777,7 +913,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with query tools 4`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools 5`] = `
 "import { util } from '@aws-appsync/utils';
 import * as ddb from '@aws-appsync/utils/dynamodb';
 
@@ -805,7 +941,7 @@ export function response(ctx) {
 "
 `;
 
-exports[`ConversationTransformer valid schemas should transform conversation route with query tools 5`] = `
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools 6`] = `
 "import { util } from '@aws-appsync/utils';
 
 export function request(ctx) {

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
@@ -131,8 +131,6 @@ describe('ConversationTransformer', () => {
   });
 });
 
-
-
 const assertAssistantResponseSubscriptionResources = (routeName: string, resources: DeploymentResources) => {
   const resolverName = `SubscriptiononCreateAssistantResponse${toUpper(routeName)}Resolver`;
 
@@ -144,7 +142,7 @@ const assertAssistantResponseSubscriptionResources = (routeName: string, resourc
   const dataFn = resources.resolvers[`Subscription.onCreateAssistantResponse${toUpper(routeName)}.assistant-message.js`];
   expect(dataFn).toBeDefined();
   expect(dataFn).toMatchSnapshot('AssistantResponseSubscription data slot function code');
-}
+};
 
 const assertAssistantResponseMutationResources = (routeName: string, resources: DeploymentResources) => {
   const resolverName = `MutationcreateAssistantResponse${toUpper(routeName)}Resolver`;
@@ -167,16 +165,18 @@ const assertAssistantResponseMutationResources = (routeName: string, resources: 
   expect(verifySessionOwnerFn).toMatchSnapshot('AssistantResponseMutation verify session owner slot function code');
 
   // ----- Data Source Assertions -----
-  const verifySessionOwnerFnDataSourceName = getFunctionConfigurationForPipelineSlot(
-    resources, resolverName, 2
-  ).Properties.DataSourceName['Fn::GetAtt'][0];
+  const verifySessionOwnerFnDataSourceName = getFunctionConfigurationForPipelineSlot(resources, resolverName, 2).Properties.DataSourceName[
+    'Fn::GetAtt'
+  ][0];
   expect(verifySessionOwnerFnDataSourceName).toBeDefined();
   expect(verifySessionOwnerFnDataSourceName).toEqual(conversationTableDataSourceName(routeName));
 
-  const dataFnDataSourceName = getFunctionConfigurationForPipelineSlot(resources, resolverName, 3).Properties.DataSourceName['Fn::GetAtt'][0];
+  const dataFnDataSourceName = getFunctionConfigurationForPipelineSlot(resources, resolverName, 3).Properties.DataSourceName[
+    'Fn::GetAtt'
+  ][0];
   expect(dataFnDataSourceName).toBeDefined();
   expect(dataFnDataSourceName).toEqual(messageTableDataSourceName(routeName));
-}
+};
 
 const assertSendMessageMutationResources = (routeName: string, resources: DeploymentResources) => {
   const resolverName = `Mutation${routeName}Resolver`;
@@ -209,22 +209,22 @@ const assertSendMessageMutationResources = (routeName: string, resources: Deploy
   expect(invokeLambdaFn).toMatchSnapshot('SendMessageMutation invoke lambda slot function code');
 
   // ----- Data Source Assertions -----
-  const verifySessionOwnerFnDataSourceName = getFunctionConfigurationForPipelineSlot(
-    resources, resolverName, 2
-  ).Properties.DataSourceName['Fn::GetAtt'][0];
+  const verifySessionOwnerFnDataSourceName = getFunctionConfigurationForPipelineSlot(resources, resolverName, 2).Properties.DataSourceName[
+    'Fn::GetAtt'
+  ][0];
   expect(verifySessionOwnerFnDataSourceName).toBeDefined();
   expect(verifySessionOwnerFnDataSourceName).toEqual(conversationTableDataSourceName(routeName));
 
-  const writeMessageToTableFnDataSourceName = getFunctionConfigurationForPipelineSlot(
-    resources, resolverName, 3
-  ).Properties.DataSourceName['Fn::GetAtt'][0];
+  const writeMessageToTableFnDataSourceName = getFunctionConfigurationForPipelineSlot(resources, resolverName, 3).Properties.DataSourceName[
+    'Fn::GetAtt'
+  ][0];
   expect(writeMessageToTableFnDataSourceName).toBeDefined();
   expect(writeMessageToTableFnDataSourceName).toEqual(messageTableDataSourceName(routeName));
 
   // The lambda function is deployed in a separate stack, so we need to resolve the stack name.
-  const invokeLambdaFnDataSource = getFunctionConfigurationForPipelineSlot(
-    resources, resolverName, 4
-  ).Properties.DataSourceName['Fn::GetAtt'];
+  const invokeLambdaFnDataSource = getFunctionConfigurationForPipelineSlot(resources, resolverName, 4).Properties.DataSourceName[
+    'Fn::GetAtt'
+  ];
   expect(invokeLambdaFnDataSource).toBeDefined();
   const stackName = invokeLambdaFnDataSource[0];
   expect(stackName).toEqual(lambdaFunctionStackName(routeName));
@@ -233,7 +233,7 @@ const assertSendMessageMutationResources = (routeName: string, resources: Deploy
   const outputsKey = invokeLambdaFnDataSource[1].split('Outputs.')[1];
   const lambdaDataSourceName = resources.stacks?.[stackName].Outputs?.[outputsKey].Value['Fn::GetAtt'][0];
   expect(lambdaDataSourceName).toEqual(lambdaFunctionDataSourceName(routeName));
-}
+};
 
 const conversationTableDataSourceName = (routeName: string) => `Conversation${toUpper(routeName)}`;
 const messageTableDataSourceName = (routeName: string) => `ConversationMessage${toUpper(routeName)}`;

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/assistant-response-pipeline-definition.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/assistant-response-pipeline-definition.ts
@@ -61,7 +61,7 @@ function data(): ResolverFunctionDefinition {
     slotName: 'data',
     fileName: 'assistant-mutation-resolver-fn.template.js',
     generateTemplate: templateGenerator('assistant-response'),
-    dataSource: (config) => config.dataSources.lambdaFunctionDataSource,
+    dataSource: (config) => config.dataSources.messageTableDataSource,
     substitutions: (config) => ({
       CONVERSATION_MESSAGE_TYPE_NAME: config.message.model.name.value,
     }),

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/assistant-response-subscription-pipeline-definition.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/assistant-response-subscription-pipeline-definition.ts
@@ -1,5 +1,10 @@
 import { ConversationDirectiveConfiguration } from '../conversation-directive-configuration';
-import { createResolverFunctionDefinition, PipelineDefinition, ResolverFunctionDefinition } from './resolver-function-definition';
+import {
+  createResolverFunctionDefinition,
+  createS3AssetMappingTemplateGenerator,
+  PipelineDefinition,
+  ResolverFunctionDefinition,
+} from './resolver-function-definition';
 
 /**
  * The pipeline definition for the assistant response subscription resolver.
@@ -18,10 +23,13 @@ function data(): ResolverFunctionDefinition {
   return createResolverFunctionDefinition({
     slotName: 'data',
     fileName: 'assistant-messages-subscription-resolver-fn.template.js',
-    templateName: (config) => `Subscription.${fieldName(config)}.assistant-message.js`,
+    generateTemplate: createS3AssetMappingTemplateGenerator('Subscription', 'assistant-message', fieldName),
   });
 }
 
+/**
+ * Field name for the assistant response subscription.
+ */
 function fieldName(config: ConversationDirectiveConfiguration): string {
   return config.assistantResponseSubscriptionField.name.value;
 }

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/list-messages-init-resolver.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/list-messages-init-resolver.ts
@@ -1,5 +1,9 @@
 import { LIST_MESSAGES_INDEX_NAME } from '../graphql-types/name-values';
-import { createResolverFunctionDefinition, ResolverFunctionDefinition } from './resolver-function-definition';
+import {
+  createResolverFunctionDefinition,
+  createS3AssetMappingTemplateGenerator,
+  ResolverFunctionDefinition,
+} from './resolver-function-definition';
 
 /**
  * The definition of the init slot for the list messages resolver.
@@ -8,7 +12,7 @@ import { createResolverFunctionDefinition, ResolverFunctionDefinition } from './
 export const listMessagesInitFunctionDefinition: ResolverFunctionDefinition = createResolverFunctionDefinition({
   slotName: 'init',
   fileName: 'list-messages-init-resolver-fn.template.js',
-  templateName: (config) => `Query.${config.field.name.value}.list-messages-init.js`,
+  generateTemplate: createS3AssetMappingTemplateGenerator('Query', 'list-messages-init', (config) => config.field.name.value),
   substitutions: () => ({
     INDEX_NAME: LIST_MESSAGES_INDEX_NAME,
   }),

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/resolver-function-definition.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/resolver-function-definition.ts
@@ -1,5 +1,6 @@
-import { DataSourceProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { DataSourceProvider, MappingTemplateProvider, TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { ConversationDirectiveConfiguration } from '../conversation-directive-configuration';
+import { MappingTemplate } from '@aws-amplify/graphql-transformer-core';
 
 /**
  * Creates a resolver function definition based on the provided definition, with NONE data source and empty substitutions if not provided.
@@ -22,9 +23,9 @@ export const createResolverFunctionDefinition = (
 export type ResolverFunctionDefinition = {
   slotName: string;
   fileName: string;
-  templateName: (config: ConversationDirectiveConfiguration) => string;
+  generateTemplate: (config: ConversationDirectiveConfiguration, code: string) => MappingTemplateProvider;
   dataSource: (config: ConversationDirectiveConfiguration) => DataSourceProvider | undefined;
-  substitutions: (config: ConversationDirectiveConfiguration) => Record<string, string>;
+  substitutions: (config: ConversationDirectiveConfiguration, ctx: TransformerContextProvider) => Record<string, string>;
 };
 
 /**
@@ -36,6 +37,14 @@ export type PipelineDefinition = {
   responseSlots: ResolverFunctionDefinition[];
   field: (config: ConversationDirectiveConfiguration) => { typeName: string; fieldName: string };
 };
+
+/**
+ * Creates an S3 asset mapping template generator for the resolver function.
+ */
+export const createS3AssetMappingTemplateGenerator =
+  (parentName: string, slotName: string, fieldName: (config: ConversationDirectiveConfiguration) => string) =>
+  (config: ConversationDirectiveConfiguration, code: string) =>
+    MappingTemplate.s3MappingFunctionCodeFromString(code, `${parentName}.${fieldName(config)}.${slotName}.js`);
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/send-message-pipeline-definition.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/send-message-pipeline-definition.ts
@@ -6,7 +6,12 @@ import {
   getConversationMessageListQueryInputTypeName,
   getConversationMessageListQueryName,
 } from '../graphql-types/name-values';
-import { createResolverFunctionDefinition, createS3AssetMappingTemplateGenerator, PipelineDefinition, ResolverFunctionDefinition } from './resolver-function-definition';
+import {
+  createResolverFunctionDefinition,
+  createS3AssetMappingTemplateGenerator,
+  PipelineDefinition,
+  ResolverFunctionDefinition,
+} from './resolver-function-definition';
 
 /**
  * The pipeline definition for the send message mutation resolver.

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/send-message-pipeline-definition.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/send-message-pipeline-definition.ts
@@ -1,3 +1,4 @@
+import { MappingTemplate } from '@aws-amplify/graphql-transformer-core';
 import { ConversationDirectiveConfiguration } from '../conversation-directive-configuration';
 import {
   CONVERSATION_MESSAGE_GET_QUERY_INPUT_TYPE_NAME,
@@ -5,7 +6,7 @@ import {
   getConversationMessageListQueryInputTypeName,
   getConversationMessageListQueryName,
 } from '../graphql-types/name-values';
-import { createResolverFunctionDefinition, PipelineDefinition, ResolverFunctionDefinition } from './resolver-function-definition';
+import { createResolverFunctionDefinition, createS3AssetMappingTemplateGenerator, PipelineDefinition, ResolverFunctionDefinition } from './resolver-function-definition';
 
 /**
  * The pipeline definition for the send message mutation resolver.
@@ -19,12 +20,17 @@ export const sendMessagePipelineDefinition: PipelineDefinition = {
 
 /**
  * The init slot for the send message mutation resolver.
+ * Note: The init slot references the GraphQL API endpoint, which neccesitates the usage of an inline template
+ * because CDK cannot substitite the  Fn:GetAtt:GraphQLUrl in S3 Asset based resolver functions.
  */
 function init(): ResolverFunctionDefinition {
   return createResolverFunctionDefinition({
     slotName: 'init',
     fileName: 'init-resolver-fn.template.js',
-    templateName: generateTemplateName('init'),
+    generateTemplate: (_, code) => MappingTemplate.inlineTemplateFromString(code),
+    substitutions: (_, ctx) => ({
+      GRAPHQL_API_ENDPOINT: ctx.api.graphqlUrl,
+    }),
   });
 }
 
@@ -35,7 +41,7 @@ function auth(): ResolverFunctionDefinition {
   return createResolverFunctionDefinition({
     slotName: 'auth',
     fileName: 'auth-resolver-fn.template.js',
-    templateName: generateTemplateName('auth'),
+    generateTemplate: templateGenerator('auth'),
   });
 }
 
@@ -46,7 +52,7 @@ function verifySessionOwner(): ResolverFunctionDefinition {
   return createResolverFunctionDefinition({
     slotName: 'verifySessionOwner',
     fileName: 'verify-session-owner-resolver-fn.template.js',
-    templateName: generateTemplateName('verify-session-owner'),
+    generateTemplate: templateGenerator('verify-session-owner'),
     dataSource: (config) => config.dataSources.conversationTableDataSource,
     substitutions: () => ({
       CONVERSATION_ID_PARENT: 'ctx.args',
@@ -61,7 +67,7 @@ function writeMessageToTable(): ResolverFunctionDefinition {
   return createResolverFunctionDefinition({
     slotName: 'writeMessageToTable',
     fileName: 'write-message-to-table-resolver-fn.template.js',
-    templateName: generateTemplateName('write-message-to-table'),
+    generateTemplate: templateGenerator('write-message-to-table'),
     dataSource: (config) => config.dataSources.messageTableDataSource,
     substitutions: (config) => ({
       CONVERSATION_MESSAGE_TYPE_NAME: config.message.model.name.value,
@@ -76,7 +82,7 @@ function invokeLambda(): ResolverFunctionDefinition {
   return createResolverFunctionDefinition({
     slotName: 'data',
     fileName: 'invoke-lambda-resolver-fn.template.js',
-    templateName: generateTemplateName('invoke-lambda'),
+    generateTemplate: templateGenerator('invoke-lambda'),
     dataSource: (config) => config.dataSources.lambdaFunctionDataSource,
     substitutions: invokeLambdaResolverSubstitutions,
   });
@@ -104,10 +110,17 @@ function invokeLambdaResolverSubstitutions(config: ConversationDirectiveConfigur
 }
 
 /**
- * The function to generate the template name for the resolver function.
+ * Field name for the send message mutation.
  */
-function generateTemplateName(slotName: string) {
-  return (config: ConversationDirectiveConfiguration) => `Mutation.${config.field.name.value}.${slotName}.js`;
+function fieldName(config: ConversationDirectiveConfiguration): string {
+  return config.field.name.value;
+}
+
+/**
+ * Creates a template generator specific to the send message pipeline for a given slot name.
+ */
+function templateGenerator(slotName: string) {
+  return createS3AssetMappingTemplateGenerator('Mutation', slotName, fieldName);
 }
 
 const selectionSet = `id conversationId content { image { format source { bytes }} text toolUse { toolUseId name input } toolResult { status toolUseId content { json text image { format source { bytes }} document { format name source { bytes }} }}} role owner createdAt updatedAt`;

--- a/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
@@ -94,15 +94,16 @@ export class ConversationResolverGenerator {
     const fieldName = directive.field.name.value;
 
     // Generate and add resolvers for send message, assistant response, and subscription
-    const conversationPipelineResolver = generateResolverPipeline(sendMessagePipelineDefinition, directive);
+    const conversationPipelineResolver = generateResolverPipeline(sendMessagePipelineDefinition, directive, ctx);
     ctx.resolvers.addResolver(parentName, fieldName, conversationPipelineResolver);
 
-    const assistantResponsePipelineResolver = generateResolverPipeline(assistantResponsePipelineDefinition, directive);
+    const assistantResponsePipelineResolver = generateResolverPipeline(assistantResponsePipelineDefinition, directive, ctx);
     ctx.resolvers.addResolver(parentName, directive.assistantResponseMutation.field.name.value, assistantResponsePipelineResolver);
 
     const assistantResponseSubscriptionPipelineResolver = generateResolverPipeline(
       assistantResponseSubscriptionPipelineDefinition,
       directive,
+      ctx,
     );
     ctx.resolvers.addResolver(
       'Subscription',
@@ -215,7 +216,7 @@ export class ConversationResolverGenerator {
     const messageName = directive.message.model.name.value;
     const pluralized = pluralize(messageName);
     const listMessagesResolver = ctx.resolvers.getResolver('Query', `list${pluralized}`) as TransformerResolver;
-    const initResolverFn = generateResolverFunction(listMessagesInitFunctionDefinition, directive);
+    const initResolverFn = generateResolverFunction(listMessagesInitFunctionDefinition, directive, ctx);
     listMessagesResolver.addJsFunctionToSlot('init', initResolverFn);
   }
 


### PR DESCRIPTION
## Description of changes
Fixes two issues introduced in https://github.com/aws-amplify/amplify-category-api/pull/2957
1. uses inline template for `init` slot in send message mutation to work around `Fn:GetAtt:GraphQLUrl` not resolving in S3 Asset based templates.
2. fixes incorrect data source for assistant response mutation resolver.

This also adds test assertions for expected data sources and snapshots for the remaining resolver functions generated within the conversation transformer.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

## Description of how you validated changes
- manually tested

Note: I'm working on adding support for subscriptions in the E2E test package to mitigate the risk of these silly regressions in the future.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] ~E2E test run linked~
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
