### PR TITLE
fix: override the node version to have the cleanup workflow work

### DIFF
--- a/codebuild_specs/cleanup_workflow.yml
+++ b/codebuild_specs/cleanup_workflow.yml
@@ -8,7 +8,7 @@ env:
 phases:
   build:
     commands:
-      - source ./shared-scripts.sh && _setupNodeVersion
+      - source ./shared-scripts.sh && _setupNodeVersion "${AMPLIFY_NODE_VERSION}"
       - yarn production-build
       - cd packages/amplify-e2e-tests && yarn clean-e2e-resources
 artifacts:

--- a/codebuild_specs/cleanup_workflow.yml
+++ b/codebuild_specs/cleanup_workflow.yml
@@ -8,6 +8,7 @@ env:
 phases:
   build:
     commands:
+      - source ./shared-scripts.sh && _setupNodeVersion
       - yarn production-build
       - cd packages/amplify-e2e-tests && yarn clean-e2e-resources
 artifacts:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Setup the node version to the defined version to let the cleanup workflow work build and work as expected, and have resources cleanup back to normal operation.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

CI cleanup workflow.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
