### PR TITLE
fix: use correct region setting for the pre-provisioned resource

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/utils/sql-pre-provisioned-cluster.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/utils/sql-pre-provisioned-cluster.ts
@@ -9,7 +9,7 @@ export type PreProvisionedClusterInfo = {
 };
 
 export const getPreProvisionedClusterInfo = async (region: string, engine: SqlEngine): Promise<PreProvisionedClusterInfo | undefined> => {
-  const s3Client = new S3Client({ region });
+  const s3Client = new S3Client({ region: 'us-east-1' });
   const stsClient = new STSClient({ region });
 
   try {

--- a/packages/amplify-graphql-api-construct-tests/src/utils/sql-pre-provisioned-cluster.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/utils/sql-pre-provisioned-cluster.ts
@@ -9,7 +9,7 @@ export type PreProvisionedClusterInfo = {
 };
 
 export const getPreProvisionedClusterInfo = async (region: string, engine: SqlEngine): Promise<PreProvisionedClusterInfo | undefined> => {
-  const s3Client = new S3Client({ region: 'us-east-1' });
+  const s3Client = new S3Client({ region: 'us-east-1' }); // all manifest stacks (buckets) are deployed to region us-east-1
   const stsClient = new STSClient({ region });
 
   try {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR let the E2E has correct region setting when trying to get manifest information about the pre-provisioned resource.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

CI checks.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
