### PR TITLE
test(conversation): add subscription based e2e tests

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/package.json
+++ b/packages/amplify-graphql-api-construct-tests/package.json
@@ -34,6 +34,7 @@
     "amplify-category-api-e2e-core": "5.0.4",
     "aws-amplify": "^4.2.8",
     "aws-appsync": "^4.1.1",
+    "ws": "^8.18.0",
     "fs-extra": "^8.1.0",
     "generate-password": "~1.7.0",
     "node-fetch": "^2.6.7"

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/conversation.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/conversation.test.ts
@@ -1,11 +1,13 @@
 /* eslint-disable import/namespace */
-import * as path from 'path';
-import * as fs from 'fs-extra';
-import { DURATION_20_MINUTES } from '../../utils/duration-constants';
-import { createNewProjectDir, deleteProjectDir } from 'amplify-category-api-e2e-core';
-import { cdkDeploy, cdkDestroy, initCDKProject } from '../../commands';
 import { DDB_AMPLIFY_MANAGED_DATASOURCE_STRATEGY } from '@aws-amplify/graphql-transformer-core';
+import { createNewProjectDir, deleteProjectDir } from 'amplify-category-api-e2e-core';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { cdkDeploy, cdkDestroy, initCDKProject } from '../../commands';
 import { createCognitoUser, signInCognitoUser, TestDefinition, writeStackConfig, writeTestDefinitions } from '../../utils';
+import { AppSyncSubscriptionClient, consumeYields, mergeNamedAsyncIterators } from '../../utils/appsync-graphql/subscription';
+import { DURATION_20_MINUTES, ONE_MINUTE } from '../../utils/duration-constants';
+import { onCreateAssistantResponsePirateChat } from './graphql/subscriptions';
 import {
   doCreateConversationPirateChat,
   doListConversationMessagesPirateChat,
@@ -21,63 +23,44 @@ describe('conversation', () => {
 
   describe('conversation route', () => {
     const projFolderName = `${baseProjFolderName}-model`;
-    let apiEndpoint: string;
     let projRoot: string;
     let accessToken: string;
     let accessToken2: string;
+    let apiEndpoint: string;
+    let realtimeEndpoint: string;
 
     beforeAll(async () => {
       projRoot = await createNewProjectDir(projFolderName);
-      const templatePath = path.resolve(path.join(__dirname, '..', 'backends', 'configurable-stack'));
-      const name = await initCDKProject(projRoot, templatePath, {
-        additionalDependencies: ['esbuild'],
-      });
+      const { apiEndpoint: graphqlEndpoint, userPoolClientId, userPoolId } = await deployCdk(projRoot);
+      apiEndpoint = graphqlEndpoint;
+      realtimeEndpoint = apiEndpoint.replace('appsync-api', 'appsync-realtime-api').replace('https://', 'wss://');
 
-      const conversationSchemaPath = path.resolve(path.join(__dirname, 'graphql', 'schema-conversation.graphql'));
-      const conversationSchema = fs.readFileSync(conversationSchemaPath).toString();
-
-      const testDefinitions: Record<string, TestDefinition> = {
-        conversation: {
-          schema: [conversationSchema].join('\n'),
-          strategy: DDB_AMPLIFY_MANAGED_DATASOURCE_STRATEGY,
-        },
-      };
-
-      writeStackConfig(projRoot, { prefix: 'Conversation' });
-      writeTestDefinitions(testDefinitions, projRoot);
-
-      const outputs = await cdkDeploy(projRoot, '--all');
-      const { awsAppsyncApiEndpoint, UserPoolClientId: userPoolClientId, UserPoolId: userPoolId } = outputs[name];
-
-      apiEndpoint = awsAppsyncApiEndpoint;
-
-      const { username: username1, password: password1 } = await createCognitoUser({
+      const { username: user1Username, password: user1Password } = await createCognitoUser({
         region,
         userPoolId,
       });
 
-      const { accessToken: newAccessToken1 } = await signInCognitoUser({
-        username: username1,
-        password: password1,
+      const { accessToken: user1AccessToken } = await signInCognitoUser({
+        username: user1Username,
+        password: user1Password,
         region,
         userPoolClientId,
       });
 
-      accessToken = newAccessToken1;
-
-      const { username: username2, password: password2 } = await createCognitoUser({
+      const { username: user2Username, password: user2Password } = await createCognitoUser({
         region,
         userPoolId,
       });
 
-      const { accessToken: newAccessToken2 } = await signInCognitoUser({
-        username: username2,
-        password: password2,
+      const { accessToken: user2AccessToken } = await signInCognitoUser({
+        username: user2Username,
+        password: user2Password,
         region,
         userPoolClientId,
       });
 
-      accessToken2 = newAccessToken2;
+      accessToken = user1AccessToken;
+      accessToken2 = user2AccessToken;
     });
 
     afterAll(async () => {
@@ -89,58 +72,85 @@ describe('conversation', () => {
       deleteProjectDir(projRoot);
     });
 
-    test('happy path', async () => {
-      const conversationResult = await doCreateConversationPirateChat(apiEndpoint, accessToken);
+    test(
+      'happy path: user creates conversation, sends message, and receives response through subscription',
+      async () => {
+        // create a conversation
+        const conversationResult = await doCreateConversationPirateChat(apiEndpoint, accessToken);
+        const { id: conversationId } = conversationResult.body.data.createConversationPirateChat;
+        expect(conversationId).toBeDefined();
 
-      const { id } = conversationResult.body.data.createConversationPirateChat;
-      expect(id).toBeDefined();
+        // subscribe to the conversation
+        const client = new AppSyncSubscriptionClient(realtimeEndpoint, apiEndpoint);
+        const connection = await client.connect({ accessToken });
+        const subscription = connection.subscribe({
+          query: onCreateAssistantResponsePirateChat,
+          variables: { conversationId },
+          auth: { accessToken },
+        });
 
-      const sendMessageResult = await doSendMessagePirateChat(apiEndpoint, accessToken, id, [{ text: 'Hello, world!' }]);
+        // send a message to the conversation
+        const sendMessageResult = await doSendMessagePirateChat(apiEndpoint, accessToken, conversationId, [{ text: 'Hello, world!' }]);
+        const message = sendMessageResult.body.data?.pirateChat;
+        expect(message).toBeDefined();
+        expect(message.content).toHaveLength(1);
+        expect(message.content[0].text).toEqual('Hello, world!');
+        expect(message.conversationId).toEqual(conversationId);
 
-      const message = sendMessageResult.body.data.pirateChat;
-      expect(message).toBeDefined();
-      expect(message.content).toHaveLength(1);
-      expect(message.content[0].text).toEqual('Hello, world!');
-      expect(message.conversationId).toEqual(id);
-
-      const messages = await doListConversationMessagesPirateChat(apiEndpoint, accessToken, id);
-
-      expect(messages.body.data.listConversationMessagePirateChats.items).toHaveLength(1);
-      expect(messages.body.data.listConversationMessagePirateChats.items[0].conversationId).toBe(id);
-    });
+        // expect to receive the assistant response in the subscription
+        for await (const event of subscription) {
+          expect(event.onCreateAssistantResponsePirateChat.conversationId).toEqual(conversationId);
+          expect(event.onCreateAssistantResponsePirateChat.content).toHaveLength(1);
+          expect(event.onCreateAssistantResponsePirateChat.content[0].text).toBeDefined();
+          expect(event.onCreateAssistantResponsePirateChat.role).toEqual('assistant');
+          break;
+        }
+      },
+      ONE_MINUTE,
+    );
 
     test('update conversation', async () => {
+      // create a conversation
       const conversationResult = await doCreateConversationPirateChat(apiEndpoint, accessToken);
 
       const { id } = conversationResult.body.data.createConversationPirateChat;
       expect(id).toBeDefined();
 
+      // update the conversation
       const updateConversationResult = await doUpdateConversationPirateChat(apiEndpoint, accessToken, id, 'updated conversation name');
 
       const updatedConversation = updateConversationResult.body.data.updateConversationPirateChat;
       const { name, id: updatedId } = updatedConversation;
+      // expect the name to be updated
       expect(name).toEqual('updated conversation name');
+      // expect the id to be the same
       expect(updatedId).toEqual(id);
     });
 
     describe('conversation owner auth negative tests', () => {
-      test('userB cannot send message to userAs conversation', async () => {
+      test('user2 cannot send message to user1s conversation', async () => {
+        // user1 creates a conversation
         const conversationResult = await doCreateConversationPirateChat(apiEndpoint, accessToken);
         const { id } = conversationResult.body.data.createConversationPirateChat;
 
+        // user2 attempts to send a message to the conversation
         const sendMessageResult = await doSendMessagePirateChat(apiEndpoint, accessToken2, id, [{ text: 'Hello, world!' }]);
 
+        // expect the response data to be null
         expect(sendMessageResult.body.data.pirateChat).toBeNull();
         const sendMessageErrors = sendMessageResult.body.errors;
 
+        // expect there to be a `ResourceNotFound` error
         expect(sendMessageErrors).toHaveLength(1);
         expect(sendMessageErrors[0].errorType).toEqual('ResourceNotFound');
       });
 
-      test('userB cannot read userAs conversation history', async () => {
+      test('user2 cannot read user1s conversation history', async () => {
+        // user1 creates a conversation
         const conversationResult = await doCreateConversationPirateChat(apiEndpoint, accessToken);
         const { id } = conversationResult.body.data.createConversationPirateChat;
 
+        // user1 sends a message to the conversation
         const sendMessageResult = await doSendMessagePirateChat(apiEndpoint, accessToken, id, [{ text: 'Hello, world!' }]);
         const message = sendMessageResult.body.data.pirateChat;
         expect(message).toBeDefined();
@@ -148,15 +158,117 @@ describe('conversation', () => {
         expect(message.content[0].text).toEqual('Hello, world!');
         expect(message.conversationId).toEqual(id);
 
-        // This should return messages because userA is the conversation owner.
+        // user1 should be able to read the conversation history
         const messages = await doListConversationMessagesPirateChat(apiEndpoint, accessToken, id);
         expect(messages.body.data.listConversationMessagePirateChats.items).toHaveLength(1);
         expect(messages.body.data.listConversationMessagePirateChats.items[0].conversationId).toBe(id);
 
-        // This should not return messages because userB is not the conversation owner.
+        // user2 should not be able to read the conversation history
         const messagesB = await doListConversationMessagesPirateChat(apiEndpoint, accessToken2, id);
         expect(messagesB.body.data.listConversationMessagePirateChats.items).toHaveLength(0);
       });
-    });
+
+      test('user does not receive events from another user\'s conversation', async () => {
+        // user1 creates a conversation
+        const user1ConversationResult = await doCreateConversationPirateChat(apiEndpoint, accessToken);
+        const { id: user1ConversationId } = user1ConversationResult.body.data.createConversationPirateChat;
+
+        // user2 creates a conversation
+        const user2ConversationResult = await doCreateConversationPirateChat(apiEndpoint, accessToken2);
+        const { id: user2ConversationId } = user2ConversationResult.body.data.createConversationPirateChat;
+
+        // user1 opens a connection
+        const user1Connection = await new AppSyncSubscriptionClient(realtimeEndpoint, apiEndpoint).connect({ accessToken });
+
+        // user2 opens a connection
+        const user2Connection = await new AppSyncSubscriptionClient(realtimeEndpoint, apiEndpoint).connect({ accessToken: accessToken2 });
+
+        // user1 subscribes to user1's conversation
+        const user1SubscriptionForUser1Conversation = user1Connection.subscribe({
+          query: onCreateAssistantResponsePirateChat,
+          variables: { conversationId: user1ConversationId },
+          auth: { accessToken },
+        });
+
+        // user1 subscribes to user2's conversation
+        const user1SubscriptionForUser2Conversation = user1Connection.subscribe({
+          query: onCreateAssistantResponsePirateChat,
+          variables: { conversationId: user2ConversationId },
+          auth: { accessToken },
+        });
+
+        // user2 subscribes to user2's conversation
+        const user2SubscriptionForUser2Conversation = user2Connection.subscribe({
+          query: onCreateAssistantResponsePirateChat,
+          variables: { conversationId: user2ConversationId },
+          auth: { accessToken: accessToken2 },
+        });
+
+        // user2 subscribes to user1's conversation
+        const user2SubscriptionForUser1Conversation = user2Connection.subscribe({
+          query: onCreateAssistantResponsePirateChat,
+          variables: { conversationId: user1ConversationId },
+          auth: { accessToken: accessToken2 },
+        });
+
+        // merge the subscription streams into a single stream
+        const mergedSubscriptionStream = mergeNamedAsyncIterators(
+          // these should not receive any events
+          ['user1-user2', user1SubscriptionForUser2Conversation],
+          ['user2-user1', user2SubscriptionForUser1Conversation],
+          // these should receive events
+          ['user1-user1', user1SubscriptionForUser1Conversation],
+          ['user2-user2', user2SubscriptionForUser2Conversation],
+        );
+
+        // user1 sends message to user1's conversation
+        await doSendMessagePirateChat(apiEndpoint, accessToken, user1ConversationId, [{ text: 'Hello, world!' }]);
+
+        // user2 sends message to user2's conversation
+        await doSendMessagePirateChat(apiEndpoint, accessToken2, user2ConversationId, [{ text: 'Hello, world!' }]);
+
+        // consume two events from the merged stream
+        const events = await consumeYields(mergedSubscriptionStream, 2);
+
+        events.forEach(([name, value]) => {
+          switch (name) {
+            case 'user1-user2':
+            case 'user2-user1':
+              throw new Error(`subscription event received by wrong user. Name: ${name}. Event: ${JSON.stringify(value, null, 2)}`);
+            case 'user1-user1':
+              expect(value.onCreateAssistantResponsePirateChat.conversationId).toEqual(user1ConversationId);
+              break;
+            case 'user2-user2':
+              expect(value.onCreateAssistantResponsePirateChat.conversationId).toEqual(user2ConversationId);
+              break;
+          }
+        });
+      },
+      ONE_MINUTE,
+    );
   });
 });
+
+const deployCdk = async (projRoot: string): Promise<{ apiEndpoint: string; userPoolClientId: string; userPoolId: string }> => {
+  const templatePath = path.resolve(path.join(__dirname, '..', 'backends', 'configurable-stack'));
+  const name = await initCDKProject(projRoot, templatePath, {
+    additionalDependencies: ['esbuild'],
+  });
+
+  const conversationSchemaPath = path.resolve(path.join(__dirname, 'graphql', 'schema-conversation.graphql'));
+  const conversationSchema = fs.readFileSync(conversationSchemaPath).toString();
+
+  const testDefinitions: Record<string, TestDefinition> = {
+    conversation: {
+      schema: [conversationSchema].join('\n'),
+      strategy: DDB_AMPLIFY_MANAGED_DATASOURCE_STRATEGY,
+    },
+  };
+
+  writeStackConfig(projRoot, { prefix: 'Conversation' });
+  writeTestDefinitions(testDefinitions, projRoot);
+
+  const outputs = await cdkDeploy(projRoot, '--all');
+  const { awsAppsyncApiEndpoint, UserPoolClientId, UserPoolId } = outputs[name];
+  return { apiEndpoint: awsAppsyncApiEndpoint, userPoolClientId: UserPoolClientId, userPoolId: UserPoolId };
+};

--- a/packages/amplify-graphql-api-construct-tests/src/utils/appsync-graphql/subscription.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/utils/appsync-graphql/subscription.ts
@@ -97,13 +97,13 @@ export class AppSyncConnection {
 }
 
 /**
-  * A client for connecting to an AppSync realtime endpoint.
-  *
-  * @example
-  * const client = new AppSyncSubscriptionClient(realtimeEndpoint, graphqlEndpoint);
-  * const connection = await client.connect(auth);
-  * const subscription = connection.subscribe({ query, variables, auth });
-*/
+ * A client for connecting to an AppSync realtime endpoint.
+ *
+ * @example
+ * const client = new AppSyncSubscriptionClient(realtimeEndpoint, graphqlEndpoint);
+ * const connection = await client.connect(auth);
+ * const subscription = connection.subscribe({ query, variables, auth });
+ */
 export class AppSyncSubscriptionClient {
   ws: WebSocket;
 
@@ -266,7 +266,7 @@ export const mergeNamedAsyncIterators = async function* <T>(
     pending.add(promise);
 
     // When this promise resolves, remove it from pending and add result if valid
-    promise.then(result => {
+    promise.then((result) => {
       pending.delete(promise);
       if (result) {
         results.push(result);
@@ -301,7 +301,7 @@ export const mergeNamedAsyncIterators = async function* <T>(
   const values = await consumeYields(subscription, 3);
 */
 export async function consumeYields<T>(iterator: AsyncIterableIterator<T>, numYields: number): Promise<Array<T | undefined>> {
-  const yieldsPromises = Array.from({ length: numYields }, () => iterator.next().then(({ value, done }) => done ? undefined : value));
+  const yieldsPromises = Array.from({ length: numYields }, () => iterator.next().then(({ value, done }) => (done ? undefined : value)));
   const yields = await Promise.all(yieldsPromises);
   return yields;
 }

--- a/packages/amplify-graphql-api-construct-tests/src/utils/appsync-graphql/subscription.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/utils/appsync-graphql/subscription.ts
@@ -1,0 +1,309 @@
+import { randomUUID } from 'crypto';
+import { OperationAuthInputAccessToken, OperationAuthInputApiKey } from './common';
+import WebSocket from 'ws';
+import * as url from 'url';
+
+type GeneratedSubscription<InputType, OutputType> = string & {
+  __generatedSubscriptionInput: InputType;
+  __generatedSubscriptionOutput: OutputType;
+};
+
+export type AppSyncSubscriptionAuth = OperationAuthInputAccessToken | OperationAuthInputApiKey;
+
+export type SubscribeInput<Input, Output> = {
+  query: GeneratedSubscription<Input, Output>;
+  variables?: Input;
+  auth: AppSyncSubscriptionAuth;
+  /**
+   * `id` for the subscription. If not provided, a random UUID will be generated.
+   */
+  id?: string;
+};
+
+/**
+ * Manages subscriptions to AppSync realtime endpoints.
+ *
+ * @example
+ * const client = new AppSyncSubscriptionClient(realtimeEndpoint, graphqlEndpoint);
+ * const connection = await client.connect(auth);
+ * const subscription = connection.subscribe({ query, variables, auth });
+ *
+ * for await (const value of subscription) {
+ *   console.log(value);
+ * }
+ */
+export class AppSyncConnection {
+  // TODO: Add a `close` method for the connection.
+  // TODO: Add a `close` method for individual subscriptions.
+
+  subscriptions: Record<string, { stream: AsyncIterableIterator<any> }>;
+
+  constructor(private client: AppSyncSubscriptionClient) {
+    this.subscriptions = {};
+  }
+
+  subscribe<Input, Output>(input: SubscribeInput<Input, Output>): AsyncIterableIterator<Output> {
+    const { query, variables, auth, id = randomUUID() } = input;
+    const authHeaders = this.client.generateAuthHeaders(auth);
+    const data = JSON.stringify({
+      query,
+      variables,
+    });
+
+    const subscriptionMessage = {
+      id,
+      payload: {
+        data,
+        extensions: {
+          authorization: authHeaders,
+        },
+      },
+      type: MESSAGE_TYPES.GQL_START,
+    };
+
+    this.client.ws.send(JSON.stringify(subscriptionMessage));
+
+    const generator = async function* () {
+      while (true) {
+        yield new Promise<Output>((resolve, reject) => {
+          this.client.ws.on('message', (data: any) => {
+            const message = JSON.parse(data.toString());
+            if (message.type === MESSAGE_TYPES.GQL_START_ACK && message.id === id) {
+              // Subscription started, but no data yet
+            } else if (message.type === MESSAGE_TYPES.GQL_DATA && message.id === id) {
+              resolve(message.payload.data as Output);
+            } else if (message.type === MESSAGE_TYPES.GQL_ERROR && message.id === id) {
+              reject(new Error(message.payload.errors));
+            } else if (message.type === MESSAGE_TYPES.GQL_COMPLETE && message.id === id) {
+              return; // End of subscription
+            }
+          });
+        });
+      }
+    }.bind(this)();
+
+    const stream = {
+      [Symbol.asyncIterator]() {
+        return generator;
+      },
+      next() {
+        return generator.next();
+      },
+    };
+
+    this.subscriptions[id] = { stream };
+    return stream;
+  }
+}
+
+/**
+  * A client for connecting to an AppSync realtime endpoint.
+  *
+  * @example
+  * const client = new AppSyncSubscriptionClient(realtimeEndpoint, graphqlEndpoint);
+  * const connection = await client.connect(auth);
+  * const subscription = connection.subscribe({ query, variables, auth });
+*/
+export class AppSyncSubscriptionClient {
+  ws: WebSocket;
+
+  constructor(private realtimeEndpoint: string, private graphqlEndpoint: string) {}
+
+  connect(auth: AppSyncSubscriptionAuth): Promise<AppSyncConnection> {
+    const connectionHeaders = this.generateAuthHeaders(auth);
+    const connectionUrl = this.generateConnectionUrl(connectionHeaders, '{}');
+
+    this.ws = new WebSocket(connectionUrl, 'graphql-ws');
+    this.ws.on('open', () => this.onOpen(this.ws));
+    this.ws.on('close', this.onClose);
+
+    return new Promise((resolve, reject) => {
+      this.ws.addEventListener('message', ({ data }) => {
+        const message = data.toString();
+        if (JSON.parse(message).type === MESSAGE_TYPES.GQL_CONNECTION_ACK) {
+          resolve(new AppSyncConnection(this));
+        }
+      });
+
+      this.ws.addEventListener('error', ({ error }) => {
+        reject(error);
+      });
+    });
+  }
+
+  private onClose() {
+    // noop currently
+  }
+
+  private onOpen(ws: WebSocket) {
+    // once the socket is open, we send the connection init message
+    ws.send(
+      JSON.stringify({
+        type: MESSAGE_TYPES.GQL_CONNECTION_INIT,
+      }),
+    );
+  }
+
+  generateAuthHeaders(auth: AppSyncSubscriptionAuth) {
+    const { host } = url.parse(this.graphqlEndpoint);
+    if ('accessToken' in auth) {
+      return {
+        Authorization: auth.accessToken,
+        host,
+      };
+    }
+
+    if ('apiKey' in auth) {
+      return {
+        'x-api-key': auth.apiKey,
+        host,
+      };
+    }
+  }
+
+  private generateConnectionUrl(headers: Record<string, string>, payload: string = '{}') {
+    const headerString = JSON.stringify(headers);
+    const encodedHeaders = Buffer.from(headerString).toString('base64');
+    const encodedPayload = Buffer.from(payload).toString('base64');
+    return `${this.realtimeEndpoint}?header=${encodedHeaders}&payload=${encodedPayload}`;
+  }
+}
+
+/*
+  Copy pasted from
+  https://github.com/awslabs/aws-mobile-appsync-sdk-js/blob/ea05577f639ce4c473c51cff25e5b51ac78a0c0d/packages/aws-appsync-subscription-link/src/types/index.ts
+*/
+export enum MESSAGE_TYPES {
+  /**
+   * Client -> Server message.
+   * This message type is the first message after handshake and this will initialize AWS AppSync RealTime communication
+   */
+  GQL_CONNECTION_INIT = 'connection_init',
+  /**
+   * Server -> Client message
+   * This message type is in case there is an issue with AWS AppSync RealTime when establishing connection
+   */
+  GQL_CONNECTION_ERROR = 'connection_error',
+  /**
+   * Server -> Client message.
+   * This message type is for the ack response from AWS AppSync RealTime for GQL_CONNECTION_INIT message
+   */
+  GQL_CONNECTION_ACK = 'connection_ack',
+  /**
+   * Client -> Server message.
+   * This message type is for register subscriptions with AWS AppSync RealTime
+   */
+  GQL_START = 'start',
+  /**
+   * Server -> Client message.
+   * This message type is for the ack response from AWS AppSync RealTime for GQL_START message
+   */
+  GQL_START_ACK = 'start_ack',
+  /**
+   * Server -> Client message.
+   * This message type is for subscription message from AWS AppSync RealTime
+   */
+  GQL_DATA = 'data',
+  /**
+   * Server -> Client message.
+   * This message type helps the client to know is still receiving messages from AWS AppSync RealTime
+   */
+  GQL_CONNECTION_KEEP_ALIVE = 'ka',
+  /**
+   * Client -> Server message.
+   * This message type is for unregister subscriptions with AWS AppSync RealTime
+   */
+  GQL_STOP = 'stop',
+  /**
+   * Server -> Client message.
+   * This message type is for the ack response from AWS AppSync RealTime for GQL_STOP message
+   */
+  GQL_COMPLETE = 'complete',
+  /**
+   * Server -> Client message.
+   * This message type is for sending error messages from AWS AppSync RealTime to the client
+   */
+  GQL_ERROR = 'error', // Server -> Client
+}
+
+// #region async iterator utilities
+
+/**
+  * Merges multiple async iterators into a single async iterator, yielding values from each iterator with their corresponding names
+  * Note: The combined iterator will yield values from each iterator as received, not necessarily in the order of the
+  * elements of the `iterators` array. This is intentional -- it allows for merging streams from multiple subscriptions, including those
+  * that are not expected to receive any events (e.g. resolver based authorization scenarios).
+
+  * In the example below, `subscription2` may yield values before `subscription1`.
+  *
+  * @example
+  * const merged = mergeNamedAsyncIterators([
+  *   ['subscription1', subscription1],
+  *   ['subscription2', subscription2],
+  * ]);
+  * for await (const [name, value] of merged) {
+  *   console.log(name, value);
+  * }
+  */
+export const mergeNamedAsyncIterators = async function* <T>(
+  ...iterators: [name: string, stream: AsyncIterableIterator<T>][]
+): AsyncIterableIterator<[name: string, value: T]> {
+  const pending = new Set<Promise<[string, T] | null>>();
+  const results: [string, T][] = [];
+
+  const processIterator = async (name: string, stream: AsyncIterableIterator<T>) => {
+    try {
+      const { value, done } = await stream.next();
+      if (done) return null;
+      return [name, value] as [string, T];
+    } catch (error) {
+      return null;
+    }
+  };
+
+  for (const [name, stream] of iterators) {
+    const promise = processIterator(name, stream);
+    pending.add(promise);
+
+    // When this promise resolves, remove it from pending and add result if valid
+    promise.then(result => {
+      pending.delete(promise);
+      if (result) {
+        results.push(result);
+      }
+    });
+  }
+
+  // Keep yielding while we have pending promises or results to return
+  while (pending.size > 0 || results.length > 0) {
+    // If we have results, yield the first one
+    if (results.length > 0) {
+      yield results.shift();
+      continue;
+    }
+
+    // Wait for at least one promise to resolve
+    if (pending.size > 0) {
+      await Promise.race(Array.from(pending));
+    }
+  }
+};
+
+/**
+  Consumes a given number of yields from an iterator.
+  Returns an array of the yielded values, with undefined values for any yields that
+  did not produce a value (due to the iterator being exhausted).
+
+  @example
+  // AsyncIterableIterator<{ foo: string }>
+  const subscription = connection.subscribe({ query, variables, auth });
+  // Array<{ foo: string } | undefined>
+  const values = await consumeYields(subscription, 3);
+*/
+export async function consumeYields<T>(iterator: AsyncIterableIterator<T>, numYields: number): Promise<Array<T | undefined>> {
+  const yieldsPromises = Array.from({ length: numYields }, () => iterator.next().then(({ value, done }) => done ? undefined : value));
+  const yields = await Promise.all(yieldsPromises);
+  return yields;
+}
+
+// #endregion async iterator utilities

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -192,7 +192,7 @@ export function request(ctx) {
   if (!isAuthorized && ctx.stash.authFilter.length === 0) {
     util.unauthorized();
   }
-  ctx.args.filter = { ...ctx.args.filter, and: [{ conversationId: { eq: ctx.args.conversationId } }] };
+  ctx.args.filter = { ...ctx.stash.authFilter, and: [{ conversationId: { eq: ctx.args.conversationId } }] };
   return { version: '2018-05-29', payload: {} };
 }
 
@@ -683,7 +683,7 @@ export function request(ctx) {
   if (!isAuthorized && ctx.stash.authFilter.length === 0) {
     util.unauthorized();
   }
-  ctx.args.filter = { ...ctx.args.filter, and: [{ conversationId: { eq: ctx.args.conversationId } }] };
+  ctx.args.filter = { ...ctx.stash.authFilter, and: [{ conversationId: { eq: ctx.args.conversationId } }] };
   return { version: '2018-05-29', payload: {} };
 }
 
@@ -1174,7 +1174,7 @@ export function request(ctx) {
   if (!isAuthorized && ctx.stash.authFilter.length === 0) {
     util.unauthorized();
   }
-  ctx.args.filter = { ...ctx.args.filter, and: [{ conversationId: { eq: ctx.args.conversationId } }] };
+  ctx.args.filter = { ...ctx.stash.authFilter, and: [{ conversationId: { eq: ctx.args.conversationId } }] };
   return { version: '2018-05-29', payload: {} };
 }
 
@@ -1665,7 +1665,7 @@ export function request(ctx) {
   if (!isAuthorized && ctx.stash.authFilter.length === 0) {
     util.unauthorized();
   }
-  ctx.args.filter = { ...ctx.args.filter, and: [{ conversationId: { eq: ctx.args.conversationId } }] };
+  ctx.args.filter = { ...ctx.stash.authFilter, and: [{ conversationId: { eq: ctx.args.conversationId } }] };
   return { version: '2018-05-29', payload: {} };
 }
 

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/assistant-messages-subscription-resolver-fn.template.js
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/assistant-messages-subscription-resolver-fn.template.js
@@ -32,7 +32,7 @@ export function request(ctx) {
   if (!isAuthorized && ctx.stash.authFilter.length === 0) {
     util.unauthorized();
   }
-  ctx.args.filter = { ...ctx.args.filter, and: [{ conversationId: { eq: ctx.args.conversationId } }] };
+  ctx.args.filter = { ...ctx.stash.authFilter, and: [{ conversationId: { eq: ctx.args.conversationId } }] };
   return { version: '2018-05-29', payload: {} };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17544,7 +17544,7 @@ ws@^7.5.7:
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
-ws@^8.5.0:
+ws@^8.18.0, ws@^8.5.0:
   version "8.18.0"
   resolved "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
   integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==


### PR DESCRIPTION
#### Description of changes
- Adds basic support for subscriptions in `amplify-graphql-api-construct-tests` ([reference](https://github.com/aws-amplify/amplify-category-api/pull/2983/files#diff-c9ad0a23d671ba2265df0aa91d87cb7722267d349fa3964326b29355e078de6e))
- Updates existing happy path E2E test to assert on assistant response through subscription. ([reference](https://github.com/aws-amplify/amplify-category-api/pull/2983/files#diff-455f8729f27403b483bf84b6e8bdcc5afe0ea696ba56209ffcbc7141507cebb3R75-R110))
- Adds negative owner auth test asserting that user's cannot receive events from another user's conversation. ([reference](https://github.com/aws-amplify/amplify-category-api/pull/2983/files#diff-455f8729f27403b483bf84b6e8bdcc5afe0ea696ba56209ffcbc7141507cebb3R171-R248))
- Includes correct auth filter in subscription resolver function. ([reference](https://github.com/aws-amplify/amplify-category-api/pull/2983/files#diff-b650758ff236506b789198f4e12e0cd630ba081b96aa43458d57d6bb00daf38cR35))


> [!NOTE]
> For subscription support, I explored using the Ampilfy v6 client, the AppSync Mobile AppSync SDK JS, and the apollo client directly. Each of those options were problematic for varying reasons (likely operator error). Because these are only used in E2E tests, I opted to write the connection and subscription logic myself. We can always revisit this at a later time.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
- [E2E tests](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:e25a4320-0c54-4b67-8052-392bd274b51a?region=us-east-1)

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
