### PR TITLE
feat(conversation): support response streaming

### DIFF
--- a/dependency_licenses.txt
+++ b/dependency_licenses.txt
@@ -19075,6 +19075,32 @@ SOFTWARE.
 
 -----
 
+The following software may be included in this product: json-schema-to-ts, ts-algebra. A copy of the source code may be downloaded from git+https://github.com/ThomasAribart/json-schema-to-ts.git (json-schema-to-ts), git+https://github.com/ThomasAribart/ts-algebra.git (ts-algebra). This software contains the following license and notice below:
+
+MIT License
+
+Copyright (c) 2020 Thomas Aribart
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----
+
 The following software may be included in this product: json5. A copy of the source code may be downloaded from git+https://github.com/json5/json5.git. This software contains the following license and notice below:
 
 MIT License

--- a/packages/amplify-data-construct/.jsii
+++ b/packages/amplify-data-construct/.jsii
@@ -6,7 +6,7 @@
     ]
   },
   "bundled": {
-    "@aws-amplify/ai-constructs": "^0.2.0",
+    "@aws-amplify/ai-constructs": "^0.7.0",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.5",
@@ -4027,5 +4027,5 @@
   },
   "types": {},
   "version": "1.12.0",
-  "fingerprint": "/DOa/fCCk7aFh+C6wvl13XcNtVQrXnGIloMfAxMxmpo="
+  "fingerprint": "ExmoK7dmBE1jGZPaSgQH3I8RRZSPeq4ueEfFr34vbHg="
 }

--- a/packages/amplify-data-construct/package.json
+++ b/packages/amplify-data-construct/package.json
@@ -157,7 +157,7 @@
     "semver"
   ],
   "dependencies": {
-    "@aws-amplify/ai-constructs": "^0.2.0",
+    "@aws-amplify/ai-constructs": "^0.7.0",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-api-construct": "1.16.0",

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/API.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/API.ts
@@ -3,7 +3,6 @@
 //  This file was automatically generated and should not be edited.
 
 export type ConversationMessagePirateChat = {
-  __typename: 'ConversationMessagePirateChat';
   aiContext?: string | null;
   associatedUserMessageId?: string | null;
   content?: Array<ContentBlock | null> | null;
@@ -18,7 +17,6 @@ export type ConversationMessagePirateChat = {
 };
 
 export type ConversationMessage = {
-  __typename: 'ConversationMessage';
   aiContext?: string | null;
   content?: Array<ContentBlock | null> | null;
   conversationId: string;
@@ -31,7 +29,6 @@ export type ConversationMessage = {
 };
 
 export type ContentBlock = {
-  __typename: 'ContentBlock';
   document?: DocumentBlock | null;
   image?: ImageBlock | null;
   text?: string | null;
@@ -40,37 +37,31 @@ export type ContentBlock = {
 };
 
 export type DocumentBlock = {
-  __typename: 'DocumentBlock';
   format: string;
   name: string;
   source: DocumentBlockSource;
 };
 
 export type DocumentBlockSource = {
-  __typename: 'DocumentBlockSource';
   bytes?: string | null;
 };
 
 export type ImageBlock = {
-  __typename: 'ImageBlock';
   format: string;
   source: ImageBlockSource;
 };
 
 export type ImageBlockSource = {
-  __typename: 'ImageBlockSource';
   bytes?: string | null;
 };
 
 export type ToolResultBlock = {
-  __typename: 'ToolResultBlock';
   content: Array<ToolResultContentBlock>;
   status?: string | null;
   toolUseId: string;
 };
 
 export type ToolResultContentBlock = {
-  __typename: 'ToolResultContentBlock';
   document?: DocumentBlock | null;
   image?: ImageBlock | null;
   json?: string | null;
@@ -78,14 +69,12 @@ export type ToolResultContentBlock = {
 };
 
 export type ToolUseBlock = {
-  __typename: 'ToolUseBlock';
   input: string;
   name: string;
   toolUseId: string;
 };
 
 export type ConversationPirateChat = {
-  __typename: 'ConversationPirateChat';
   createdAt: string;
   id: string;
   messages?: ModelConversationMessagePirateChatConnection | null;
@@ -96,7 +85,6 @@ export type ConversationPirateChat = {
 };
 
 export type ModelConversationMessagePirateChatConnection = {
-  __typename: 'ModelConversationMessagePirateChatConnection';
   items: Array<ConversationMessagePirateChat | null>;
   nextToken?: string | null;
 };
@@ -107,24 +95,20 @@ export enum ConversationParticipantRole {
 }
 
 export type ToolConfiguration = {
-  __typename: 'ToolConfiguration';
   tools?: Array<Tool | null> | null;
 };
 
 export type Tool = {
-  __typename: 'Tool';
   toolSpec?: ToolSpecification | null;
 };
 
 export type ToolSpecification = {
-  __typename: 'ToolSpecification';
   description?: string | null;
   inputSchema: ToolInputSchema;
   name: string;
 };
 
 export type ToolInputSchema = {
-  __typename: 'ToolInputSchema';
   json?: string | null;
 };
 
@@ -215,7 +199,6 @@ export type ModelConversationPirateChatFilterInput = {
 };
 
 export type ModelConversationPirateChatConnection = {
-  __typename: 'ModelConversationPirateChatConnection';
   items: Array<ConversationPirateChat | null>;
   nextToken?: string | null;
 };
@@ -270,6 +253,31 @@ export type ToolUseBlockInput = {
   input: string;
   name: string;
   toolUseId: string;
+};
+
+export type CreateConversationMessagePirateChatAssistantStreamingInput = {
+  accumulatedTurnContent?: Array<ContentBlockInput | null> | null;
+  associatedUserMessageId: string;
+  contentBlockDeltaIndex?: number | null;
+  contentBlockDoneAtIndex?: number | null;
+  contentBlockIndex: number;
+  contentBlockText?: string | null;
+  contentBlockToolUse?: string | null;
+  conversationId: string;
+  stopReason?: string | null;
+};
+
+export type ConversationMessageStreamPart = {
+  associatedUserMessageId: string;
+  contentBlockDeltaIndex?: number | null;
+  contentBlockDoneAtIndex?: number | null;
+  contentBlockIndex: number;
+  contentBlockText?: string | null;
+  contentBlockToolUse?: ToolUseBlock | null;
+  conversationId: string;
+  id: string;
+  owner?: string | null;
+  stopReason?: string | null;
 };
 
 export type ModelConversationMessagePirateChatConditionInput = {
@@ -393,15 +401,12 @@ export type GetConversationMessagePirateChatQueryVariables = {
 
 export type GetConversationMessagePirateChatQuery = {
   getConversationMessagePirateChat?: {
-    __typename: 'ConversationMessagePirateChat';
     aiContext?: string | null;
     associatedUserMessageId?: string | null;
     content?: Array<{
-      __typename: 'ContentBlock';
       text?: string | null;
     } | null> | null;
     conversation?: {
-      __typename: 'ConversationPirateChat';
       createdAt: string;
       id: string;
       metadata?: string | null;
@@ -414,9 +419,7 @@ export type GetConversationMessagePirateChatQuery = {
     id: string;
     owner?: string | null;
     role?: ConversationParticipantRole | null;
-    toolConfiguration?: {
-      __typename: 'ToolConfiguration';
-    } | null;
+    toolConfiguration?: {} | null;
     updatedAt: string;
   } | null;
 };
@@ -427,11 +430,9 @@ export type GetConversationPirateChatQueryVariables = {
 
 export type GetConversationPirateChatQuery = {
   getConversationPirateChat?: {
-    __typename: 'ConversationPirateChat';
     createdAt: string;
     id: string;
     messages?: {
-      __typename: 'ModelConversationMessagePirateChatConnection';
       nextToken?: string | null;
     } | null;
     metadata?: string | null;
@@ -449,10 +450,15 @@ export type ListConversationMessagePirateChatsQueryVariables = {
 
 export type ListConversationMessagePirateChatsQuery = {
   listConversationMessagePirateChats?: {
-    __typename: 'ModelConversationMessagePirateChatConnection';
     items: Array<{
-      __typename: 'ConversationMessagePirateChat';
       aiContext?: string | null;
+      content?: Array<{
+        text?: string | null;
+        document?: DocumentBlock | null;
+        image?: ImageBlock | null;
+        toolResult?: ToolResultBlock | null;
+        toolUse?: ToolUseBlock | null;
+      } | null> | null;
       associatedUserMessageId?: string | null;
       conversationId: string;
       createdAt: string;
@@ -473,9 +479,7 @@ export type ListConversationPirateChatsQueryVariables = {
 
 export type ListConversationPirateChatsQuery = {
   listConversationPirateChats?: {
-    __typename: 'ModelConversationPirateChatConnection';
     items: Array<{
-      __typename: 'ConversationPirateChat';
       createdAt: string;
       id: string;
       metadata?: string | null;
@@ -493,15 +497,12 @@ export type CreateAssistantResponsePirateChatMutationVariables = {
 
 export type CreateAssistantResponsePirateChatMutation = {
   createAssistantResponsePirateChat?: {
-    __typename: 'ConversationMessagePirateChat';
     aiContext?: string | null;
     associatedUserMessageId?: string | null;
     content?: Array<{
-      __typename: 'ContentBlock';
       text?: string | null;
     } | null> | null;
     conversation?: {
-      __typename: 'ConversationPirateChat';
       createdAt: string;
       id: string;
       metadata?: string | null;
@@ -514,10 +515,31 @@ export type CreateAssistantResponsePirateChatMutation = {
     id: string;
     owner?: string | null;
     role?: ConversationParticipantRole | null;
-    toolConfiguration?: {
-      __typename: 'ToolConfiguration';
-    } | null;
+    toolConfiguration?: {} | null;
     updatedAt: string;
+  } | null;
+};
+
+export type CreateAssistantResponseStreamPirateChatMutationVariables = {
+  input: CreateConversationMessagePirateChatAssistantStreamingInput;
+};
+
+export type CreateAssistantResponseStreamPirateChatMutation = {
+  createAssistantResponseStreamPirateChat?: {
+    associatedUserMessageId: string;
+    contentBlockDeltaIndex?: number | null;
+    contentBlockDoneAtIndex?: number | null;
+    contentBlockIndex: number;
+    contentBlockText?: string | null;
+    contentBlockToolUse?: {
+      input: string;
+      name: string;
+      toolUseId: string;
+    } | null;
+    conversationId: string;
+    id: string;
+    owner?: string | null;
+    stopReason?: string | null;
   } | null;
 };
 
@@ -528,15 +550,12 @@ export type CreateConversationMessagePirateChatMutationVariables = {
 
 export type CreateConversationMessagePirateChatMutation = {
   createConversationMessagePirateChat?: {
-    __typename: 'ConversationMessagePirateChat';
     aiContext?: string | null;
     associatedUserMessageId?: string | null;
     content?: Array<{
-      __typename: 'ContentBlock';
       text?: string | null;
     } | null> | null;
     conversation?: {
-      __typename: 'ConversationPirateChat';
       createdAt: string;
       id: string;
       metadata?: string | null;
@@ -549,9 +568,7 @@ export type CreateConversationMessagePirateChatMutation = {
     id: string;
     owner?: string | null;
     role?: ConversationParticipantRole | null;
-    toolConfiguration?: {
-      __typename: 'ToolConfiguration';
-    } | null;
+    toolConfiguration?: {} | null;
     updatedAt: string;
   } | null;
 };
@@ -563,11 +580,9 @@ export type CreateConversationPirateChatMutationVariables = {
 
 export type CreateConversationPirateChatMutation = {
   createConversationPirateChat?: {
-    __typename: 'ConversationPirateChat';
     createdAt: string;
     id: string;
     messages?: {
-      __typename: 'ModelConversationMessagePirateChatConnection';
       nextToken?: string | null;
     } | null;
     metadata?: string | null;
@@ -584,15 +599,12 @@ export type DeleteConversationMessagePirateChatMutationVariables = {
 
 export type DeleteConversationMessagePirateChatMutation = {
   deleteConversationMessagePirateChat?: {
-    __typename: 'ConversationMessagePirateChat';
     aiContext?: string | null;
     associatedUserMessageId?: string | null;
     content?: Array<{
-      __typename: 'ContentBlock';
       text?: string | null;
     } | null> | null;
     conversation?: {
-      __typename: 'ConversationPirateChat';
       createdAt: string;
       id: string;
       metadata?: string | null;
@@ -605,9 +617,7 @@ export type DeleteConversationMessagePirateChatMutation = {
     id: string;
     owner?: string | null;
     role?: ConversationParticipantRole | null;
-    toolConfiguration?: {
-      __typename: 'ToolConfiguration';
-    } | null;
+    toolConfiguration?: {} | null;
     updatedAt: string;
   } | null;
 };
@@ -619,11 +629,9 @@ export type DeleteConversationPirateChatMutationVariables = {
 
 export type DeleteConversationPirateChatMutation = {
   deleteConversationPirateChat?: {
-    __typename: 'ConversationPirateChat';
     createdAt: string;
     id: string;
     messages?: {
-      __typename: 'ModelConversationMessagePirateChatConnection';
       nextToken?: string | null;
     } | null;
     metadata?: string | null;
@@ -642,24 +650,20 @@ export type PirateChatMutationVariables = {
 
 export type PirateChatMutation = {
   pirateChat: {
-    __typename: 'ConversationMessagePirateChat';
     aiContext?: string | null;
     content?: Array<{
-      __typename: 'ContentBlock';
       text?: string | null;
+      toolResult?: ToolResultBlockInput | null;
     } | null> | null;
     conversationId: string;
     createdAt?: string | null;
     id: string;
     owner?: string | null;
     role?: ConversationParticipantRole | null;
-    toolConfiguration?: {
-      __typename: 'ToolConfiguration';
-    } | null;
+    toolConfiguration?: {} | null;
     updatedAt?: string | null;
     associatedUserMessageId?: string | null;
     conversation?: {
-      __typename: 'ConversationPirateChat';
       createdAt: string;
       id: string;
       metadata?: string | null;
@@ -677,11 +681,9 @@ export type UpdateConversationPirateChatMutationVariables = {
 
 export type UpdateConversationPirateChatMutation = {
   updateConversationPirateChat?: {
-    __typename: 'ConversationPirateChat';
     createdAt: string;
     id: string;
     messages?: {
-      __typename: 'ModelConversationMessagePirateChatConnection';
       nextToken?: string | null;
     } | null;
     metadata?: string | null;
@@ -697,31 +699,20 @@ export type OnCreateAssistantResponsePirateChatSubscriptionVariables = {
 
 export type OnCreateAssistantResponsePirateChatSubscription = {
   onCreateAssistantResponsePirateChat?: {
-    __typename: 'ConversationMessagePirateChat';
-    aiContext?: string | null;
-    associatedUserMessageId?: string | null;
-    content?: Array<{
-      __typename: 'ContentBlock';
-      text?: string | null;
-    } | null> | null;
-    conversation?: {
-      __typename: 'ConversationPirateChat';
-      createdAt: string;
-      id: string;
-      metadata?: string | null;
-      name?: string | null;
-      owner?: string | null;
-      updatedAt: string;
+    associatedUserMessageId: string;
+    contentBlockDeltaIndex?: number | null;
+    contentBlockDoneAtIndex?: number | null;
+    contentBlockIndex: number;
+    contentBlockText?: string | null;
+    contentBlockToolUse?: {
+      input: string;
+      name: string;
+      toolUseId: string;
     } | null;
     conversationId: string;
-    createdAt: string;
     id: string;
     owner?: string | null;
-    role?: ConversationParticipantRole | null;
-    toolConfiguration?: {
-      __typename: 'ToolConfiguration';
-    } | null;
-    updatedAt: string;
+    stopReason?: string | null;
   } | null;
 };
 
@@ -732,15 +723,12 @@ export type OnCreateConversationMessagePirateChatSubscriptionVariables = {
 
 export type OnCreateConversationMessagePirateChatSubscription = {
   onCreateConversationMessagePirateChat?: {
-    __typename: 'ConversationMessagePirateChat';
     aiContext?: string | null;
     associatedUserMessageId?: string | null;
     content?: Array<{
-      __typename: 'ContentBlock';
       text?: string | null;
     } | null> | null;
     conversation?: {
-      __typename: 'ConversationPirateChat';
       createdAt: string;
       id: string;
       metadata?: string | null;
@@ -753,9 +741,7 @@ export type OnCreateConversationMessagePirateChatSubscription = {
     id: string;
     owner?: string | null;
     role?: ConversationParticipantRole | null;
-    toolConfiguration?: {
-      __typename: 'ToolConfiguration';
-    } | null;
+    toolConfiguration?: {} | null;
     updatedAt: string;
   } | null;
 };

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/mutations.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/mutations.ts
@@ -16,7 +16,45 @@ export const createAssistantResponsePirateChat = /* GraphQL */ `mutation CreateA
     associatedUserMessageId
     content {
       text
-      __typename
+      toolResult {
+        status
+        content {
+          document {
+            format
+            name
+            source {
+              bytes
+            }
+          }
+          image {
+            format
+            source {
+              bytes
+            }
+          }
+          json
+          text
+        }
+        toolUseId
+      }
+      toolUse {
+        input
+        name
+        toolUseId
+      }
+      image {
+        format
+        source {
+          bytes
+        }
+      }
+      document {
+        format
+        name
+        source {
+          bytes
+        }
+      }
     }
     conversation {
       createdAt
@@ -25,7 +63,6 @@ export const createAssistantResponsePirateChat = /* GraphQL */ `mutation CreateA
       name
       owner
       updatedAt
-      __typename
     }
     conversationId
     createdAt
@@ -33,13 +70,45 @@ export const createAssistantResponsePirateChat = /* GraphQL */ `mutation CreateA
     owner
     role
     toolConfiguration {
-      __typename
+      tools {
+        toolSpec {
+          description
+          inputSchema {
+            json
+          }
+          name
+        }
+      }
     }
     updatedAt
-    __typename
   }
 }
 ` as GeneratedMutation<APITypes.CreateAssistantResponsePirateChatMutationVariables, APITypes.CreateAssistantResponsePirateChatMutation>;
+export const createAssistantResponseStreamPirateChat = /* GraphQL */ `mutation CreateAssistantResponseStreamPirateChat(
+  $input: CreateConversationMessagePirateChatAssistantStreamingInput!
+) {
+  createAssistantResponseStreamPirateChat(input: $input) {
+    associatedUserMessageId
+    contentBlockDeltaIndex
+    contentBlockDoneAtIndex
+    contentBlockIndex
+    contentBlockText
+    contentBlockToolUse {
+      input
+      name
+      toolUseId
+    }
+    conversationId
+    id
+    owner
+    stopReason
+  }
+}
+` as GeneratedMutation<
+  APITypes.CreateAssistantResponseStreamPirateChatMutationVariables,
+  APITypes.CreateAssistantResponseStreamPirateChatMutation
+>;
+
 export const createConversationMessagePirateChat = /* GraphQL */ `mutation CreateConversationMessagePirateChat(
   $condition: ModelConversationMessagePirateChatConditionInput
   $input: CreateConversationMessagePirateChatInput!
@@ -49,7 +118,45 @@ export const createConversationMessagePirateChat = /* GraphQL */ `mutation Creat
     associatedUserMessageId
     content {
       text
-      __typename
+      toolResult {
+        status
+        content {
+          document {
+            format
+            name
+            source {
+              bytes
+            }
+          }
+          image {
+            format
+            source {
+              bytes
+            }
+          }
+          json
+          text
+        }
+        toolUseId
+      }
+      toolUse {
+        input
+        name
+        toolUseId
+      }
+      image {
+        format
+        source {
+          bytes
+        }
+      }
+      document {
+        format
+        name
+        source {
+          bytes
+        }
+      }
     }
     conversation {
       createdAt
@@ -58,7 +165,6 @@ export const createConversationMessagePirateChat = /* GraphQL */ `mutation Creat
       name
       owner
       updatedAt
-      __typename
     }
     conversationId
     createdAt
@@ -66,13 +172,21 @@ export const createConversationMessagePirateChat = /* GraphQL */ `mutation Creat
     owner
     role
     toolConfiguration {
-      __typename
+      tools {
+        toolSpec {
+          description
+          inputSchema {
+            json
+          }
+          name
+        }
+      }
     }
     updatedAt
-    __typename
   }
 }
 ` as GeneratedMutation<APITypes.CreateConversationMessagePirateChatMutationVariables, APITypes.CreateConversationMessagePirateChatMutation>;
+
 export const createConversationPirateChat = /* GraphQL */ `mutation CreateConversationPirateChat(
   $condition: ModelConversationPirateChatConditionInput
   $input: CreateConversationPirateChatInput!
@@ -82,13 +196,11 @@ export const createConversationPirateChat = /* GraphQL */ `mutation CreateConver
     id
     messages {
       nextToken
-      __typename
     }
     metadata
     name
     owner
     updatedAt
-    __typename
   }
 }
 ` as GeneratedMutation<APITypes.CreateConversationPirateChatMutationVariables, APITypes.CreateConversationPirateChatMutation>;
@@ -101,7 +213,45 @@ export const deleteConversationMessagePirateChat = /* GraphQL */ `mutation Delet
     associatedUserMessageId
     content {
       text
-      __typename
+      toolResult {
+        status
+        content {
+          document {
+            format
+            name
+            source {
+              bytes
+            }
+          }
+          image {
+            format
+            source {
+              bytes
+            }
+          }
+          json
+          text
+        }
+        toolUseId
+      }
+      toolUse {
+        input
+        name
+        toolUseId
+      }
+      image {
+        format
+        source {
+          bytes
+        }
+      }
+      document {
+        format
+        name
+        source {
+          bytes
+        }
+      }
     }
     conversation {
       createdAt
@@ -110,7 +260,6 @@ export const deleteConversationMessagePirateChat = /* GraphQL */ `mutation Delet
       name
       owner
       updatedAt
-      __typename
     }
     conversationId
     createdAt
@@ -118,10 +267,17 @@ export const deleteConversationMessagePirateChat = /* GraphQL */ `mutation Delet
     owner
     role
     toolConfiguration {
-      __typename
+      tools {
+        toolSpec {
+          description
+          inputSchema {
+            json
+          }
+          name
+        }
+      }
     }
     updatedAt
-    __typename
   }
 }
 ` as GeneratedMutation<APITypes.DeleteConversationMessagePirateChatMutationVariables, APITypes.DeleteConversationMessagePirateChatMutation>;
@@ -134,13 +290,13 @@ export const deleteConversationPirateChat = /* GraphQL */ `mutation DeleteConver
     id
     messages {
       nextToken
-      __typename
+
     }
     metadata
     name
     owner
     updatedAt
-    __typename
+
   }
 }
 ` as GeneratedMutation<APITypes.DeleteConversationPirateChatMutationVariables, APITypes.DeleteConversationPirateChatMutation>;
@@ -159,7 +315,45 @@ export const pirateChat = /* GraphQL */ `mutation PirateChat(
     aiContext
     content {
       text
-      __typename
+      toolResult {
+        status
+        content {
+          document {
+            format
+            name
+            source {
+              bytes
+            }
+          }
+          image {
+            format
+            source {
+              bytes
+            }
+          }
+          json
+          text
+        }
+        toolUseId
+      }
+      toolUse {
+        input
+        name
+        toolUseId
+      }
+      image {
+        format
+        source {
+          bytes
+        }
+      }
+      document {
+        format
+        name
+        source {
+          bytes
+        }
+      }
     }
     conversationId
     createdAt
@@ -167,7 +361,15 @@ export const pirateChat = /* GraphQL */ `mutation PirateChat(
     owner
     role
     toolConfiguration {
-      __typename
+      tools {
+        toolSpec {
+          description
+          inputSchema {
+            json
+          }
+          name
+        }
+      }
     }
     updatedAt
 
@@ -180,7 +382,7 @@ export const pirateChat = /* GraphQL */ `mutation PirateChat(
         name
         owner
         updatedAt
-        __typename
+
       }
     }
   }
@@ -195,13 +397,13 @@ export const updateConversationPirateChat = /* GraphQL */ `mutation UpdateConver
     id
     messages {
       nextToken
-      __typename
+
     }
     metadata
     name
     owner
     updatedAt
-    __typename
+
   }
 }
 ` as GeneratedMutation<APITypes.UpdateConversationPirateChatMutationVariables, APITypes.UpdateConversationPirateChatMutation>;

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/queries.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/queries.ts
@@ -14,7 +14,45 @@ export const getConversationMessagePirateChat = /* GraphQL */ `query GetConversa
     associatedUserMessageId
     content {
       text
-      __typename
+      toolResult {
+        status
+        content {
+          document {
+            format
+            name
+            source {
+              bytes
+            }
+          }
+          image {
+            format
+            source {
+              bytes
+            }
+          }
+          json
+          text
+        }
+        toolUseId
+      }
+      toolUse {
+        input
+        name
+        toolUseId
+      }
+      image {
+        format
+        source {
+          bytes
+        }
+      }
+      document {
+        format
+        name
+        source {
+          bytes
+        }
+      }
     }
     conversation {
       createdAt
@@ -23,7 +61,6 @@ export const getConversationMessagePirateChat = /* GraphQL */ `query GetConversa
       name
       owner
       updatedAt
-      __typename
     }
     conversationId
     createdAt
@@ -31,10 +68,18 @@ export const getConversationMessagePirateChat = /* GraphQL */ `query GetConversa
     owner
     role
     toolConfiguration {
-      __typename
+      tools {
+        toolSpec {
+          description
+          inputSchema {
+            json
+          }
+          name
+        }
+      }
     }
     updatedAt
-    __typename
+
   }
 }
 ` as GeneratedQuery<APITypes.GetConversationMessagePirateChatQueryVariables, APITypes.GetConversationMessagePirateChatQuery>;
@@ -44,13 +89,13 @@ export const getConversationPirateChat = /* GraphQL */ `query GetConversationPir
     id
     messages {
       nextToken
-      __typename
+
     }
     metadata
     name
     owner
     updatedAt
-    __typename
+
   }
 }
 ` as GeneratedQuery<APITypes.GetConversationPirateChatQueryVariables, APITypes.GetConversationPirateChatQuery>;
@@ -66,6 +111,48 @@ export const listConversationMessagePirateChats = /* GraphQL */ `query ListConve
   ) {
     items {
       aiContext
+      content {
+        text
+        toolResult {
+          status
+          content {
+            document {
+              format
+              name
+              source {
+                bytes
+              }
+            }
+            image {
+              format
+              source {
+                bytes
+              }
+            }
+            json
+            text
+          }
+          toolUseId
+        }
+        toolUse {
+          input
+          name
+          toolUseId
+        }
+        image {
+          format
+          source {
+            bytes
+          }
+        }
+        document {
+          format
+          name
+          source {
+            bytes
+          }
+        }
+      }
       associatedUserMessageId
       conversationId
       createdAt
@@ -73,10 +160,8 @@ export const listConversationMessagePirateChats = /* GraphQL */ `query ListConve
       owner
       role
       updatedAt
-      __typename
     }
     nextToken
-    __typename
   }
 }
 ` as GeneratedQuery<APITypes.ListConversationMessagePirateChatsQueryVariables, APITypes.ListConversationMessagePirateChatsQuery>;
@@ -97,10 +182,8 @@ export const listConversationPirateChats = /* GraphQL */ `query ListConversation
       name
       owner
       updatedAt
-      __typename
     }
     nextToken
-    __typename
   }
 }
 ` as GeneratedQuery<APITypes.ListConversationPirateChatsQueryVariables, APITypes.ListConversationPirateChatsQuery>;

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/schema-conversation.graphql
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/schema-conversation.graphql
@@ -176,3 +176,16 @@ type ToolSpecification {
 type ToolInputSchema {
   json: AWSJSON
 }
+
+type ConversationMessageStreamPart {
+  id: ID!
+  owner: String
+  conversationId: ID!
+  associatedUserMessageId: ID!
+  contentBlockIndex: Int!
+  contentBlockText: String
+  contentBlockDeltaIndex: Int
+  contentBlockToolUse: ToolUseBlock
+  contentBlockDoneAtIndex: Int
+  stopReason: String
+}

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/subscriptions.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/subscriptions.ts
@@ -10,31 +10,20 @@ type GeneratedSubscription<InputType, OutputType> = string & {
 
 export const onCreateAssistantResponsePirateChat = /* GraphQL */ `subscription OnCreateAssistantResponsePirateChat($conversationId: ID) {
   onCreateAssistantResponsePirateChat(conversationId: $conversationId) {
-    aiContext
     associatedUserMessageId
-    content {
-      text
-      __typename
-    }
-    conversation {
-      createdAt
-      id
-      metadata
+    contentBlockDeltaIndex
+    contentBlockDoneAtIndex
+    contentBlockIndex
+    contentBlockText
+    contentBlockToolUse {
+      input
       name
-      owner
-      updatedAt
-      __typename
+      toolUseId
     }
     conversationId
-    createdAt
     id
     owner
-    role
-    toolConfiguration {
-      __typename
-    }
-    updatedAt
-    __typename
+    stopReason
   }
 }
 ` as GeneratedSubscription<
@@ -50,7 +39,45 @@ export const onCreateConversationMessagePirateChat = /* GraphQL */ `subscription
     associatedUserMessageId
     content {
       text
-      __typename
+      toolResult {
+        status
+        content {
+          document {
+            format
+            name
+            source {
+              bytes
+            }
+          }
+          image {
+            format
+            source {
+              bytes
+            }
+          }
+          json
+          text
+        }
+        toolUseId
+      }
+      toolUse {
+        input
+        name
+        toolUseId
+      }
+      image {
+        format
+        source {
+          bytes
+        }
+      }
+      document {
+        format
+        name
+        source {
+          bytes
+        }
+      }
     }
     conversation {
       createdAt
@@ -59,7 +86,6 @@ export const onCreateConversationMessagePirateChat = /* GraphQL */ `subscription
       name
       owner
       updatedAt
-      __typename
     }
     conversationId
     createdAt
@@ -67,10 +93,17 @@ export const onCreateConversationMessagePirateChat = /* GraphQL */ `subscription
     owner
     role
     toolConfiguration {
-      __typename
+      tools {
+        toolSpec {
+          description
+          inputSchema {
+            json
+          }
+          name
+        }
+      }
     }
     updatedAt
-    __typename
   }
 }
 ` as GeneratedSubscription<

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/test-implementations.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/test-implementations.ts
@@ -1,9 +1,11 @@
 import { AppSyncGraphqlResponse, doAppSyncGraphqlOperation, doAppSyncGraphqlQuery } from '../../utils';
 import {
+  ContentBlockInput,
   CreateConversationPirateChatMutation,
   GetConversationPirateChatQuery,
   ListConversationMessagePirateChatsQuery,
   PirateChatMutation,
+  ToolConfigurationInput,
   UpdateConversationPirateChatMutation,
 } from './API';
 import { createConversationPirateChat, pirateChat, updateConversationPirateChat } from './graphql/mutations';
@@ -50,19 +52,22 @@ export const doUpdateConversationPirateChat = async (
   });
 };
 
-export const doSendMessagePirateChat = async (
-  apiEndpoint: string,
-  accessToken: string,
-  conversationId: string,
-  content: { text: string }[],
-): Promise<AppSyncGraphqlResponse<PirateChatMutation>> => {
+export const doSendMessagePirateChat = async (input: {
+  apiEndpoint: string;
+  accessToken: string;
+  conversationId: string;
+  content: ContentBlockInput[];
+  toolConfiguration?: ToolConfigurationInput;
+}): Promise<AppSyncGraphqlResponse<PirateChatMutation>> => {
+  const { apiEndpoint, accessToken, conversationId, content, toolConfiguration } = input;
   return doAppSyncGraphqlOperation({
     apiEndpoint,
-    auth: { accessToken: accessToken },
+    auth: { accessToken },
     query: pirateChat,
     variables: {
       conversationId,
       content,
+      toolConfiguration,
     },
   });
 };

--- a/packages/amplify-graphql-api-construct-tests/src/utils/appsync-graphql/subscription.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/utils/appsync-graphql/subscription.ts
@@ -261,17 +261,21 @@ export const mergeNamedAsyncIterators = async function* <T>(
     }
   };
 
-  for (const [name, stream] of iterators) {
+  const startNewIteration = (name: string, stream: AsyncIterableIterator<T>) => {
     const promise = processIterator(name, stream);
     pending.add(promise);
 
-    // When this promise resolves, remove it from pending and add result if valid
     promise.then((result) => {
       pending.delete(promise);
       if (result) {
         results.push(result);
+        startNewIteration(name, stream);
       }
     });
+  };
+
+  for (const [name, stream] of iterators) {
+    startNewIteration(name, stream);
   }
 
   // Keep yielding while we have pending promises or results to return

--- a/packages/amplify-graphql-api-construct-tests/src/utils/duration-constants.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/utils/duration-constants.ts
@@ -1,4 +1,5 @@
 export const ONE_MINUTE = 60 * 1000;
+export const DURATION_5_MINUTES = 5 * ONE_MINUTE;
 export const DURATION_10_MINUTES = 10 * ONE_MINUTE;
 export const DURATION_20_MINUTES = 20 * ONE_MINUTE;
 export const DURATION_30_MINUTES = 30 * ONE_MINUTE;

--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -6,7 +6,7 @@
     ]
   },
   "bundled": {
-    "@aws-amplify/ai-constructs": "^0.2.0",
+    "@aws-amplify/ai-constructs": "^0.7.0",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.5",
@@ -8959,5 +8959,5 @@
     }
   },
   "version": "1.16.0",
-  "fingerprint": "VEla8i8zK56MoLZb+VDFgHYtmx05U+2+wn0/AblYxgY="
+  "fingerprint": "LSSGtQqH7AGe4UEccyFSgqGwzRCn9xhGZrlbBs3w6uA="
 }

--- a/packages/amplify-graphql-api-construct/package.json
+++ b/packages/amplify-graphql-api-construct/package.json
@@ -158,7 +158,7 @@
     "semver"
   ],
   "dependencies": {
-    "@aws-amplify/ai-constructs": "^0.2.0",
+    "@aws-amplify/ai-constructs": "^0.7.0",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.5",

--- a/packages/amplify-graphql-conversation-transformer/package.json
+++ b/packages/amplify-graphql-conversation-transformer/package.json
@@ -24,7 +24,7 @@
     "extract-api": "ts-node ../../scripts/extract-api.ts"
   },
   "dependencies": {
-    "@aws-amplify/ai-constructs": "^0.2.0",
+    "@aws-amplify/ai-constructs": "^0.7.0",
     "@aws-amplify/graphql-directives": "2.4.0",
     "@aws-amplify/graphql-index-transformer": "3.0.7",
     "@aws-amplify/graphql-model-transformer": "3.0.7",

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -157,6 +157,263 @@ export function response(ctx) {
 "
 `;
 
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: AssistantResponseStreamMutation auth slot function code 1`] = `
+"export function request(ctx) {
+  ctx.stash.hasAuth = true;
+  const isAuthorized = false;
+
+  if (util.authType() === 'User Pool Authorization') {
+    if (!isAuthorized) {
+      const authFilter = [];
+      let ownerClaim0 = ctx.identity['claims']['sub'];
+      ctx.args.owner = ownerClaim0;
+      const currentClaim1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (ownerClaim0 && currentClaim1) {
+        ownerClaim0 = ownerClaim0 + '::' + currentClaim1;
+        authFilter.push({ owner: { eq: ownerClaim0 } });
+      }
+      const role0_0 = ctx.identity['claims']['sub'];
+      if (role0_0) {
+        authFilter.push({ owner: { eq: role0_0 } });
+      }
+      // we can just reuse currentClaim1 here, but doing this (for now) to mirror the existing
+      // vtl auth resolver.
+      const role0_1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (role0_1) {
+        authFilter.push({ owner: { eq: role0_1 } });
+      }
+      if (authFilter.length !== 0) {
+        ctx.stash.authFilter = { or: authFilter };
+      }
+    }
+  }
+  if (!isAuthorized && ctx.stash.authFilter.length === 0) {
+    util.unauthorized();
+  }
+  return { version: '2018-05-29', payload: {} };
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: AssistantResponseStreamMutation data slot function code 1`] = `
+"import { util } from '@aws-appsync/utils';
+import * as ddb from '@aws-appsync/utils/dynamodb';
+
+/**
+ * Sends a request to the attached data source
+ * @param {import('@aws-appsync/utils').Context} ctx the context
+ * @returns {*} the request
+ */
+export function request(ctx) {
+  const {
+    conversationId,
+    associatedUserMessageId,
+    accumulatedTurnContent
+  } = ctx.args.input;
+
+  const { owner } = ctx.args;
+  const { createdAt, updatedAt } = ctx.stash.defaultValues;
+
+  const assistantResponseId = \`\${associatedUserMessageId}#response\`;
+  const expression = 'SET #typename = :typename, #conversationId = :conversationId, #associatedUserMessageId = :associatedUserMessageId, #role = :role, #content = :content, #owner = :owner, #createdAt = if_not_exists(#createdAt, :createdAt), #updatedAt = :updatedAt';
+
+  const expressionValues = util.dynamodb.toMapValues({
+    ':typename': 'ConversationMessagePirateChat',
+    ':conversationId': conversationId,
+    ':associatedUserMessageId': associatedUserMessageId,
+    ':role': 'assistant',
+    ':content': accumulatedTurnContent,
+    ':owner': owner,
+    ':createdAt': createdAt,
+    ':updatedAt': updatedAt,
+  });
+
+  // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  const expressionNames = {
+    '#typename': '__typename',
+    '#conversationId': 'conversationId',
+    '#associatedUserMessageId': 'associatedUserMessageId',
+    '#role': 'role',
+    '#content': 'content',
+    '#owner': 'owner',
+    '#createdAt': 'createdAt',
+    '#updatedAt': 'updatedAt',
+  };
+
+  return {
+    operation: 'UpdateItem',
+    key: util.dynamodb.toMapValues({ id: assistantResponseId }),
+    update: {
+      expression,
+      expressionValues,
+      expressionNames,
+    },
+  };
+}
+
+/**
+ * Returns the resolver result
+ * @param {import('@aws-appsync/utils').Context} ctx the context
+ * @returns {*} the result
+ */
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+  const streamId = \`\${ctx.args.input.associatedUserMessageId}#stream\`;
+  const { owner } = ctx.args;
+  const event = ctx.args.input;
+
+  const streamEvent = {
+    ...event,
+    __typename: 'ConversationMessageStreamPart',
+    id: streamId,
+    owner,
+  };
+
+  // TODO: The lambda event should provide the toolUse directly.
+  if (event.contentBlockToolUse && event.contentBlockToolUse.toolUse) {
+    streamEvent.contentBlockToolUse = event.contentBlockToolUse.toolUse;
+  }
+
+  return streamEvent;
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: AssistantResponseStreamMutation init slot function code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export function request(ctx) {
+  ctx.stash.graphqlApiEndpoint = '",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "GraphQLUrl",
+        ],
+      },
+      "';
+  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
+  ctx.stash.defaultValues.id = util.autoId();
+  const createdAt = util.time.nowISO8601();
+  ctx.stash.defaultValues.createdAt = createdAt;
+  ctx.stash.defaultValues.updatedAt = createdAt;
+  return {
+    version: '2018-05-09',
+    payload: {},
+  };
+}
+
+export function response(ctx) {
+  return {};
+}
+",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: AssistantResponseStreamMutation resolver code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export const request = (ctx) => {
+  ctx.stash.typeName = "Mutation";
+  ctx.stash.fieldName = "createAssistantResponseStreamPirateChat";
+  ctx.stash.conditions = [];
+  ctx.stash.metadata = {};
+  ctx.stash.metadata.dataSourceType = "AMAZON_DYNAMODB";
+  ctx.stash.metadata.apiId = "",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "ApiId",
+        ],
+      },
+      "";
+  ctx.stash.connectionAttributes = {};
+  ctx.stash.tableName = "",
+      {
+        "Fn::Select": [
+          1,
+          {
+            "Fn::Split": [
+              "/",
+              {
+                "Fn::Select": [
+                  5,
+                  {
+                    "Fn::Split": [
+                      ":",
+                      {
+                        "Fn::GetAtt": [
+                          "ConversationMessagePirateChat",
+                          "Outputs.transformerrootstackConversationMessagePirateChatConversationMessagePirateChatTableFC80206BTableArn",
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      "";
+  ctx.stash.adminRoles = [];
+  return {};
+}
+
+export const response = (ctx) => {
+  return ctx.prev.result;
+};",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: AssistantResponseStreamMutation verify session owner slot function code 1`] = `
+"export function request(ctx) {
+  const { authFilter } = ctx.stash;
+  const { conversationId } = ctx.args.input;
+
+  const query = {
+    expression: 'id = :id',
+    expressionValues: util.dynamodb.toMapValues({
+      ':id': conversationId,
+    }),
+  };
+
+  const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
+
+  return {
+    operation: 'Query',
+    query,
+    filter,
+  };
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+
+  if (ctx.result.items.length !== 0) {
+    return ctx.result.items[0];
+  }
+
+  util.error('Conversation not found', 'ResourceNotFound');
+}
+"
+`;
+
 exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: AssistantResponseSubscription data slot function code 1`] = `
 "import { util, extensions } from '@aws-appsync/utils';
 
@@ -320,13 +577,14 @@ export function request(ctx) {
   const { args, request } = ctx;
   const { graphqlApiEndpoint } = ctx.stash;
 
-  const selectionSet = 'id conversationId content { image { format source { bytes }} text toolUse { toolUseId name input } toolResult { status toolUseId content { json text image { format source { bytes }} document { format name source { bytes }} }}} role owner createdAt updatedAt';
+  const selectionSet = 'associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner';
 
-  const responseMutation = {
-    name: 'createAssistantResponsePirateChat',
-    inputTypeName: 'CreateConversationMessagePirateChatAssistantInput',
+  const streamingResponseMutation = {
+    name: 'createAssistantResponseStreamPirateChat',
+    inputTypeName: 'CreateConversationMessagePirateChatAssistantStreamingInput',
     selectionSet,
   };
+
   const currentMessageId = ctx.stash.defaultValues.id;
 
   const modelConfiguration = {
@@ -353,12 +611,13 @@ export function request(ctx) {
   const payload = {
     conversationId: args.conversationId,
     currentMessageId,
-    responseMutation,
+    responseMutation: streamingResponseMutation,
     graphqlApiEndpoint,
     modelConfiguration,
     request: { headers: { authorization: authHeader } },
     messageHistoryQuery,
     toolsConfiguration,
+    streamResponse: true,
   };
 
   return {
@@ -648,6 +907,263 @@ export function response(ctx) {
 "
 `;
 
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: AssistantResponseStreamMutation auth slot function code 1`] = `
+"export function request(ctx) {
+  ctx.stash.hasAuth = true;
+  const isAuthorized = false;
+
+  if (util.authType() === 'User Pool Authorization') {
+    if (!isAuthorized) {
+      const authFilter = [];
+      let ownerClaim0 = ctx.identity['claims']['sub'];
+      ctx.args.owner = ownerClaim0;
+      const currentClaim1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (ownerClaim0 && currentClaim1) {
+        ownerClaim0 = ownerClaim0 + '::' + currentClaim1;
+        authFilter.push({ owner: { eq: ownerClaim0 } });
+      }
+      const role0_0 = ctx.identity['claims']['sub'];
+      if (role0_0) {
+        authFilter.push({ owner: { eq: role0_0 } });
+      }
+      // we can just reuse currentClaim1 here, but doing this (for now) to mirror the existing
+      // vtl auth resolver.
+      const role0_1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (role0_1) {
+        authFilter.push({ owner: { eq: role0_1 } });
+      }
+      if (authFilter.length !== 0) {
+        ctx.stash.authFilter = { or: authFilter };
+      }
+    }
+  }
+  if (!isAuthorized && ctx.stash.authFilter.length === 0) {
+    util.unauthorized();
+  }
+  return { version: '2018-05-29', payload: {} };
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: AssistantResponseStreamMutation data slot function code 1`] = `
+"import { util } from '@aws-appsync/utils';
+import * as ddb from '@aws-appsync/utils/dynamodb';
+
+/**
+ * Sends a request to the attached data source
+ * @param {import('@aws-appsync/utils').Context} ctx the context
+ * @returns {*} the request
+ */
+export function request(ctx) {
+  const {
+    conversationId,
+    associatedUserMessageId,
+    accumulatedTurnContent
+  } = ctx.args.input;
+
+  const { owner } = ctx.args;
+  const { createdAt, updatedAt } = ctx.stash.defaultValues;
+
+  const assistantResponseId = \`\${associatedUserMessageId}#response\`;
+  const expression = 'SET #typename = :typename, #conversationId = :conversationId, #associatedUserMessageId = :associatedUserMessageId, #role = :role, #content = :content, #owner = :owner, #createdAt = if_not_exists(#createdAt, :createdAt), #updatedAt = :updatedAt';
+
+  const expressionValues = util.dynamodb.toMapValues({
+    ':typename': 'ConversationMessagePirateChat',
+    ':conversationId': conversationId,
+    ':associatedUserMessageId': associatedUserMessageId,
+    ':role': 'assistant',
+    ':content': accumulatedTurnContent,
+    ':owner': owner,
+    ':createdAt': createdAt,
+    ':updatedAt': updatedAt,
+  });
+
+  // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  const expressionNames = {
+    '#typename': '__typename',
+    '#conversationId': 'conversationId',
+    '#associatedUserMessageId': 'associatedUserMessageId',
+    '#role': 'role',
+    '#content': 'content',
+    '#owner': 'owner',
+    '#createdAt': 'createdAt',
+    '#updatedAt': 'updatedAt',
+  };
+
+  return {
+    operation: 'UpdateItem',
+    key: util.dynamodb.toMapValues({ id: assistantResponseId }),
+    update: {
+      expression,
+      expressionValues,
+      expressionNames,
+    },
+  };
+}
+
+/**
+ * Returns the resolver result
+ * @param {import('@aws-appsync/utils').Context} ctx the context
+ * @returns {*} the result
+ */
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+  const streamId = \`\${ctx.args.input.associatedUserMessageId}#stream\`;
+  const { owner } = ctx.args;
+  const event = ctx.args.input;
+
+  const streamEvent = {
+    ...event,
+    __typename: 'ConversationMessageStreamPart',
+    id: streamId,
+    owner,
+  };
+
+  // TODO: The lambda event should provide the toolUse directly.
+  if (event.contentBlockToolUse && event.contentBlockToolUse.toolUse) {
+    streamEvent.contentBlockToolUse = event.contentBlockToolUse.toolUse;
+  }
+
+  return streamEvent;
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: AssistantResponseStreamMutation init slot function code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export function request(ctx) {
+  ctx.stash.graphqlApiEndpoint = '",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "GraphQLUrl",
+        ],
+      },
+      "';
+  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
+  ctx.stash.defaultValues.id = util.autoId();
+  const createdAt = util.time.nowISO8601();
+  ctx.stash.defaultValues.createdAt = createdAt;
+  ctx.stash.defaultValues.updatedAt = createdAt;
+  return {
+    version: '2018-05-09',
+    payload: {},
+  };
+}
+
+export function response(ctx) {
+  return {};
+}
+",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: AssistantResponseStreamMutation resolver code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export const request = (ctx) => {
+  ctx.stash.typeName = "Mutation";
+  ctx.stash.fieldName = "createAssistantResponseStreamPirateChat";
+  ctx.stash.conditions = [];
+  ctx.stash.metadata = {};
+  ctx.stash.metadata.dataSourceType = "AMAZON_DYNAMODB";
+  ctx.stash.metadata.apiId = "",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "ApiId",
+        ],
+      },
+      "";
+  ctx.stash.connectionAttributes = {};
+  ctx.stash.tableName = "",
+      {
+        "Fn::Select": [
+          1,
+          {
+            "Fn::Split": [
+              "/",
+              {
+                "Fn::Select": [
+                  5,
+                  {
+                    "Fn::Split": [
+                      ":",
+                      {
+                        "Fn::GetAtt": [
+                          "ConversationMessagePirateChat",
+                          "Outputs.transformerrootstackConversationMessagePirateChatConversationMessagePirateChatTableFC80206BTableArn",
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      "";
+  ctx.stash.adminRoles = [];
+  return {};
+}
+
+export const response = (ctx) => {
+  return ctx.prev.result;
+};",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: AssistantResponseStreamMutation verify session owner slot function code 1`] = `
+"export function request(ctx) {
+  const { authFilter } = ctx.stash;
+  const { conversationId } = ctx.args.input;
+
+  const query = {
+    expression: 'id = :id',
+    expressionValues: util.dynamodb.toMapValues({
+      ':id': conversationId,
+    }),
+  };
+
+  const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
+
+  return {
+    operation: 'Query',
+    query,
+    filter,
+  };
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+
+  if (ctx.result.items.length !== 0) {
+    return ctx.result.items[0];
+  }
+
+  util.error('Conversation not found', 'ResourceNotFound');
+}
+"
+`;
+
 exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: AssistantResponseSubscription data slot function code 1`] = `
 "import { util, extensions } from '@aws-appsync/utils';
 
@@ -811,13 +1327,14 @@ export function request(ctx) {
   const { args, request } = ctx;
   const { graphqlApiEndpoint } = ctx.stash;
 
-  const selectionSet = 'id conversationId content { image { format source { bytes }} text toolUse { toolUseId name input } toolResult { status toolUseId content { json text image { format source { bytes }} document { format name source { bytes }} }}} role owner createdAt updatedAt';
+  const selectionSet = 'associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner';
 
-  const responseMutation = {
-    name: 'createAssistantResponsePirateChat',
-    inputTypeName: 'CreateConversationMessagePirateChatAssistantInput',
+  const streamingResponseMutation = {
+    name: 'createAssistantResponseStreamPirateChat',
+    inputTypeName: 'CreateConversationMessagePirateChatAssistantStreamingInput',
     selectionSet,
   };
+
   const currentMessageId = ctx.stash.defaultValues.id;
 
   const modelConfiguration = {
@@ -844,12 +1361,13 @@ export function request(ctx) {
   const payload = {
     conversationId: args.conversationId,
     currentMessageId,
-    responseMutation,
+    responseMutation: streamingResponseMutation,
     graphqlApiEndpoint,
     modelConfiguration,
     request: { headers: { authorization: authHeader } },
     messageHistoryQuery,
     toolsConfiguration,
+    streamResponse: true,
   };
 
   return {
@@ -1139,6 +1657,263 @@ export function response(ctx) {
 "
 `;
 
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: AssistantResponseStreamMutation auth slot function code 1`] = `
+"export function request(ctx) {
+  ctx.stash.hasAuth = true;
+  const isAuthorized = false;
+
+  if (util.authType() === 'User Pool Authorization') {
+    if (!isAuthorized) {
+      const authFilter = [];
+      let ownerClaim0 = ctx.identity['claims']['sub'];
+      ctx.args.owner = ownerClaim0;
+      const currentClaim1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (ownerClaim0 && currentClaim1) {
+        ownerClaim0 = ownerClaim0 + '::' + currentClaim1;
+        authFilter.push({ owner: { eq: ownerClaim0 } });
+      }
+      const role0_0 = ctx.identity['claims']['sub'];
+      if (role0_0) {
+        authFilter.push({ owner: { eq: role0_0 } });
+      }
+      // we can just reuse currentClaim1 here, but doing this (for now) to mirror the existing
+      // vtl auth resolver.
+      const role0_1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (role0_1) {
+        authFilter.push({ owner: { eq: role0_1 } });
+      }
+      if (authFilter.length !== 0) {
+        ctx.stash.authFilter = { or: authFilter };
+      }
+    }
+  }
+  if (!isAuthorized && ctx.stash.authFilter.length === 0) {
+    util.unauthorized();
+  }
+  return { version: '2018-05-29', payload: {} };
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: AssistantResponseStreamMutation data slot function code 1`] = `
+"import { util } from '@aws-appsync/utils';
+import * as ddb from '@aws-appsync/utils/dynamodb';
+
+/**
+ * Sends a request to the attached data source
+ * @param {import('@aws-appsync/utils').Context} ctx the context
+ * @returns {*} the request
+ */
+export function request(ctx) {
+  const {
+    conversationId,
+    associatedUserMessageId,
+    accumulatedTurnContent
+  } = ctx.args.input;
+
+  const { owner } = ctx.args;
+  const { createdAt, updatedAt } = ctx.stash.defaultValues;
+
+  const assistantResponseId = \`\${associatedUserMessageId}#response\`;
+  const expression = 'SET #typename = :typename, #conversationId = :conversationId, #associatedUserMessageId = :associatedUserMessageId, #role = :role, #content = :content, #owner = :owner, #createdAt = if_not_exists(#createdAt, :createdAt), #updatedAt = :updatedAt';
+
+  const expressionValues = util.dynamodb.toMapValues({
+    ':typename': 'ConversationMessagePirateChat',
+    ':conversationId': conversationId,
+    ':associatedUserMessageId': associatedUserMessageId,
+    ':role': 'assistant',
+    ':content': accumulatedTurnContent,
+    ':owner': owner,
+    ':createdAt': createdAt,
+    ':updatedAt': updatedAt,
+  });
+
+  // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  const expressionNames = {
+    '#typename': '__typename',
+    '#conversationId': 'conversationId',
+    '#associatedUserMessageId': 'associatedUserMessageId',
+    '#role': 'role',
+    '#content': 'content',
+    '#owner': 'owner',
+    '#createdAt': 'createdAt',
+    '#updatedAt': 'updatedAt',
+  };
+
+  return {
+    operation: 'UpdateItem',
+    key: util.dynamodb.toMapValues({ id: assistantResponseId }),
+    update: {
+      expression,
+      expressionValues,
+      expressionNames,
+    },
+  };
+}
+
+/**
+ * Returns the resolver result
+ * @param {import('@aws-appsync/utils').Context} ctx the context
+ * @returns {*} the result
+ */
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+  const streamId = \`\${ctx.args.input.associatedUserMessageId}#stream\`;
+  const { owner } = ctx.args;
+  const event = ctx.args.input;
+
+  const streamEvent = {
+    ...event,
+    __typename: 'ConversationMessageStreamPart',
+    id: streamId,
+    owner,
+  };
+
+  // TODO: The lambda event should provide the toolUse directly.
+  if (event.contentBlockToolUse && event.contentBlockToolUse.toolUse) {
+    streamEvent.contentBlockToolUse = event.contentBlockToolUse.toolUse;
+  }
+
+  return streamEvent;
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: AssistantResponseStreamMutation init slot function code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export function request(ctx) {
+  ctx.stash.graphqlApiEndpoint = '",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "GraphQLUrl",
+        ],
+      },
+      "';
+  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
+  ctx.stash.defaultValues.id = util.autoId();
+  const createdAt = util.time.nowISO8601();
+  ctx.stash.defaultValues.createdAt = createdAt;
+  ctx.stash.defaultValues.updatedAt = createdAt;
+  return {
+    version: '2018-05-09',
+    payload: {},
+  };
+}
+
+export function response(ctx) {
+  return {};
+}
+",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: AssistantResponseStreamMutation resolver code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export const request = (ctx) => {
+  ctx.stash.typeName = "Mutation";
+  ctx.stash.fieldName = "createAssistantResponseStreamPirateChat";
+  ctx.stash.conditions = [];
+  ctx.stash.metadata = {};
+  ctx.stash.metadata.dataSourceType = "AMAZON_DYNAMODB";
+  ctx.stash.metadata.apiId = "",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "ApiId",
+        ],
+      },
+      "";
+  ctx.stash.connectionAttributes = {};
+  ctx.stash.tableName = "",
+      {
+        "Fn::Select": [
+          1,
+          {
+            "Fn::Split": [
+              "/",
+              {
+                "Fn::Select": [
+                  5,
+                  {
+                    "Fn::Split": [
+                      ":",
+                      {
+                        "Fn::GetAtt": [
+                          "ConversationMessagePirateChat",
+                          "Outputs.transformerrootstackConversationMessagePirateChatConversationMessagePirateChatTableFC80206BTableArn",
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      "";
+  ctx.stash.adminRoles = [];
+  return {};
+}
+
+export const response = (ctx) => {
+  return ctx.prev.result;
+};",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: AssistantResponseStreamMutation verify session owner slot function code 1`] = `
+"export function request(ctx) {
+  const { authFilter } = ctx.stash;
+  const { conversationId } = ctx.args.input;
+
+  const query = {
+    expression: 'id = :id',
+    expressionValues: util.dynamodb.toMapValues({
+      ':id': conversationId,
+    }),
+  };
+
+  const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
+
+  return {
+    operation: 'Query',
+    query,
+    filter,
+  };
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+
+  if (ctx.result.items.length !== 0) {
+    return ctx.result.items[0];
+  }
+
+  util.error('Conversation not found', 'ResourceNotFound');
+}
+"
+`;
+
 exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: AssistantResponseSubscription data slot function code 1`] = `
 "import { util, extensions } from '@aws-appsync/utils';
 
@@ -1302,13 +2077,14 @@ export function request(ctx) {
   const { args, request } = ctx;
   const { graphqlApiEndpoint } = ctx.stash;
 
-  const selectionSet = 'id conversationId content { image { format source { bytes }} text toolUse { toolUseId name input } toolResult { status toolUseId content { json text image { format source { bytes }} document { format name source { bytes }} }}} role owner createdAt updatedAt';
+  const selectionSet = 'associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner';
 
-  const responseMutation = {
-    name: 'createAssistantResponsePirateChat',
-    inputTypeName: 'CreateConversationMessagePirateChatAssistantInput',
+  const streamingResponseMutation = {
+    name: 'createAssistantResponseStreamPirateChat',
+    inputTypeName: 'CreateConversationMessagePirateChatAssistantStreamingInput',
     selectionSet,
   };
+
   const currentMessageId = ctx.stash.defaultValues.id;
 
   const modelConfiguration = {
@@ -1335,12 +2111,13 @@ export function request(ctx) {
   const payload = {
     conversationId: args.conversationId,
     currentMessageId,
-    responseMutation,
+    responseMutation: streamingResponseMutation,
     graphqlApiEndpoint,
     modelConfiguration,
     request: { headers: { authorization: authHeader } },
     messageHistoryQuery,
     toolsConfiguration,
+    streamResponse: true,
   };
 
   return {
@@ -1630,6 +2407,263 @@ export function response(ctx) {
 "
 `;
 
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: AssistantResponseStreamMutation auth slot function code 1`] = `
+"export function request(ctx) {
+  ctx.stash.hasAuth = true;
+  const isAuthorized = false;
+
+  if (util.authType() === 'User Pool Authorization') {
+    if (!isAuthorized) {
+      const authFilter = [];
+      let ownerClaim0 = ctx.identity['claims']['sub'];
+      ctx.args.owner = ownerClaim0;
+      const currentClaim1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (ownerClaim0 && currentClaim1) {
+        ownerClaim0 = ownerClaim0 + '::' + currentClaim1;
+        authFilter.push({ owner: { eq: ownerClaim0 } });
+      }
+      const role0_0 = ctx.identity['claims']['sub'];
+      if (role0_0) {
+        authFilter.push({ owner: { eq: role0_0 } });
+      }
+      // we can just reuse currentClaim1 here, but doing this (for now) to mirror the existing
+      // vtl auth resolver.
+      const role0_1 = ctx.identity['claims']['username'] ?? ctx.identity['claims']['cognito:username'];
+      if (role0_1) {
+        authFilter.push({ owner: { eq: role0_1 } });
+      }
+      if (authFilter.length !== 0) {
+        ctx.stash.authFilter = { or: authFilter };
+      }
+    }
+  }
+  if (!isAuthorized && ctx.stash.authFilter.length === 0) {
+    util.unauthorized();
+  }
+  return { version: '2018-05-29', payload: {} };
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: AssistantResponseStreamMutation data slot function code 1`] = `
+"import { util } from '@aws-appsync/utils';
+import * as ddb from '@aws-appsync/utils/dynamodb';
+
+/**
+ * Sends a request to the attached data source
+ * @param {import('@aws-appsync/utils').Context} ctx the context
+ * @returns {*} the request
+ */
+export function request(ctx) {
+  const {
+    conversationId,
+    associatedUserMessageId,
+    accumulatedTurnContent
+  } = ctx.args.input;
+
+  const { owner } = ctx.args;
+  const { createdAt, updatedAt } = ctx.stash.defaultValues;
+
+  const assistantResponseId = \`\${associatedUserMessageId}#response\`;
+  const expression = 'SET #typename = :typename, #conversationId = :conversationId, #associatedUserMessageId = :associatedUserMessageId, #role = :role, #content = :content, #owner = :owner, #createdAt = if_not_exists(#createdAt, :createdAt), #updatedAt = :updatedAt';
+
+  const expressionValues = util.dynamodb.toMapValues({
+    ':typename': 'ConversationMessagePirateChat',
+    ':conversationId': conversationId,
+    ':associatedUserMessageId': associatedUserMessageId,
+    ':role': 'assistant',
+    ':content': accumulatedTurnContent,
+    ':owner': owner,
+    ':createdAt': createdAt,
+    ':updatedAt': updatedAt,
+  });
+
+  // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  const expressionNames = {
+    '#typename': '__typename',
+    '#conversationId': 'conversationId',
+    '#associatedUserMessageId': 'associatedUserMessageId',
+    '#role': 'role',
+    '#content': 'content',
+    '#owner': 'owner',
+    '#createdAt': 'createdAt',
+    '#updatedAt': 'updatedAt',
+  };
+
+  return {
+    operation: 'UpdateItem',
+    key: util.dynamodb.toMapValues({ id: assistantResponseId }),
+    update: {
+      expression,
+      expressionValues,
+      expressionNames,
+    },
+  };
+}
+
+/**
+ * Returns the resolver result
+ * @param {import('@aws-appsync/utils').Context} ctx the context
+ * @returns {*} the result
+ */
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+  const streamId = \`\${ctx.args.input.associatedUserMessageId}#stream\`;
+  const { owner } = ctx.args;
+  const event = ctx.args.input;
+
+  const streamEvent = {
+    ...event,
+    __typename: 'ConversationMessageStreamPart',
+    id: streamId,
+    owner,
+  };
+
+  // TODO: The lambda event should provide the toolUse directly.
+  if (event.contentBlockToolUse && event.contentBlockToolUse.toolUse) {
+    streamEvent.contentBlockToolUse = event.contentBlockToolUse.toolUse;
+  }
+
+  return streamEvent;
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: AssistantResponseStreamMutation init slot function code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export function request(ctx) {
+  ctx.stash.graphqlApiEndpoint = '",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "GraphQLUrl",
+        ],
+      },
+      "';
+  ctx.stash.defaultValues = ctx.stash.defaultValues ?? {};
+  ctx.stash.defaultValues.id = util.autoId();
+  const createdAt = util.time.nowISO8601();
+  ctx.stash.defaultValues.createdAt = createdAt;
+  ctx.stash.defaultValues.updatedAt = createdAt;
+  return {
+    version: '2018-05-09',
+    payload: {},
+  };
+}
+
+export function response(ctx) {
+  return {};
+}
+",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: AssistantResponseStreamMutation resolver code 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "export const request = (ctx) => {
+  ctx.stash.typeName = "Mutation";
+  ctx.stash.fieldName = "createAssistantResponseStreamPirateChat";
+  ctx.stash.conditions = [];
+  ctx.stash.metadata = {};
+  ctx.stash.metadata.dataSourceType = "AMAZON_DYNAMODB";
+  ctx.stash.metadata.apiId = "",
+      {
+        "Fn::GetAtt": [
+          "GraphQLAPI",
+          "ApiId",
+        ],
+      },
+      "";
+  ctx.stash.connectionAttributes = {};
+  ctx.stash.tableName = "",
+      {
+        "Fn::Select": [
+          1,
+          {
+            "Fn::Split": [
+              "/",
+              {
+                "Fn::Select": [
+                  5,
+                  {
+                    "Fn::Split": [
+                      ":",
+                      {
+                        "Fn::GetAtt": [
+                          "ConversationMessagePirateChat",
+                          "Outputs.transformerrootstackConversationMessagePirateChatConversationMessagePirateChatTableFC80206BTableArn",
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      "";
+  ctx.stash.adminRoles = [];
+  return {};
+}
+
+export const response = (ctx) => {
+  return ctx.prev.result;
+};",
+    ],
+  ],
+}
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: AssistantResponseStreamMutation verify session owner slot function code 1`] = `
+"export function request(ctx) {
+  const { authFilter } = ctx.stash;
+  const { conversationId } = ctx.args.input;
+
+  const query = {
+    expression: 'id = :id',
+    expressionValues: util.dynamodb.toMapValues({
+      ':id': conversationId,
+    }),
+  };
+
+  const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
+
+  return {
+    operation: 'Query',
+    query,
+    filter,
+  };
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+
+  if (ctx.result.items.length !== 0) {
+    return ctx.result.items[0];
+  }
+
+  util.error('Conversation not found', 'ResourceNotFound');
+}
+"
+`;
+
 exports[`ConversationTransformer valid schemas should transform conversation route with query tools: AssistantResponseSubscription data slot function code 1`] = `
 "import { util, extensions } from '@aws-appsync/utils';
 
@@ -1793,13 +2827,14 @@ export function request(ctx) {
   const { args, request } = ctx;
   const { graphqlApiEndpoint } = ctx.stash;
 
-  const selectionSet = 'id conversationId content { image { format source { bytes }} text toolUse { toolUseId name input } toolResult { status toolUseId content { json text image { format source { bytes }} document { format name source { bytes }} }}} role owner createdAt updatedAt';
+  const selectionSet = 'associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner';
 
-  const responseMutation = {
-    name: 'createAssistantResponsePirateChat',
-    inputTypeName: 'CreateConversationMessagePirateChatAssistantInput',
+  const streamingResponseMutation = {
+    name: 'createAssistantResponseStreamPirateChat',
+    inputTypeName: 'CreateConversationMessagePirateChatAssistantStreamingInput',
     selectionSet,
   };
+
   const currentMessageId = ctx.stash.defaultValues.id;
 
   const modelConfiguration = {
@@ -1826,12 +2861,13 @@ export function request(ctx) {
   const payload = {
     conversationId: args.conversationId,
     currentMessageId,
-    responseMutation,
+    responseMutation: streamingResponseMutation,
     graphqlApiEndpoint,
     modelConfiguration,
     request: { headers: { authorization: authHeader } },
     messageHistoryQuery,
     toolsConfiguration,
+    streamResponse: true,
   };
 
   return {

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-schema-types.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-schema-types.graphql
@@ -154,3 +154,16 @@ type ToolSpecification {
 type ToolInputSchema {
   json: AWSJSON
 }
+
+type ConversationMessageStreamPart {
+  id: ID!
+  owner: String
+  conversationId: ID!
+  associatedUserMessageId: ID!
+  contentBlockIndex: Int!
+  contentBlockText: String
+  contentBlockDeltaIndex: Int
+  contentBlockToolUse: ToolUseBlock
+  contentBlockDoneAtIndex: Int
+  stopReason: String
+}

--- a/packages/amplify-graphql-conversation-transformer/src/conversation-directive-configuration.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/conversation-directive-configuration.ts
@@ -31,6 +31,7 @@ export type ConversationDirectiveConfiguration = {
   conversation: ConversationModel;
   message: MessageModel;
   assistantResponseMutation: { field: FieldDefinitionNode; input: InputObjectTypeDefinitionNode };
+  assistantResponseStreamingMutation: { field: FieldDefinitionNode; input: InputObjectTypeDefinitionNode };
   assistantResponseSubscriptionField: FieldDefinitionNode;
   dataSources: ConversationDirectiveDataSources;
 };

--- a/packages/amplify-graphql-conversation-transformer/src/graphql-types/message-model.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/graphql-types/message-model.ts
@@ -91,16 +91,12 @@ export const createMessageModel = (
   };
 };
 
-export const createMessageSubscription = (
-  subscriptionName: string,
-  conversationMessageTypeName: string,
-  onMutationName: string,
-): FieldDefinitionNode => {
+export const createMessageSubscription = (subscriptionName: string, onMutationName: string): FieldDefinitionNode => {
   const awsSubscribeDirective = makeDirective('aws_subscribe', [makeArgument('mutations', makeValueNode([onMutationName]))]);
   const cognitoAuthDirective = makeDirective('aws_cognito_user_pools', []);
 
   const args: InputValueDefinitionNode[] = [makeInputValueDefinition('conversationId', makeNamedType('ID'))];
-  const subscriptionField = makeField(subscriptionName, args, makeNamedType(conversationMessageTypeName), [
+  const subscriptionField = makeField(subscriptionName, args, makeNamedType(STREAM_RESPONSE_TYPE_NAME), [
     awsSubscribeDirective,
     cognitoAuthDirective,
   ]);
@@ -128,6 +124,37 @@ export const createAssistantResponseMutationInput = (messageName: string): Input
   };
 };
 
+export const createAssistantResponseStreamingMutationInput = (messageModelName: string): InputObjectTypeDefinitionNode => {
+  const inputName = `Create${messageModelName}AssistantStreamingInput`;
+  return {
+    kind: 'InputObjectTypeDefinition',
+    name: { kind: 'Name', value: inputName },
+    fields: [
+      makeInputValueDefinition('conversationId', makeNonNullType(makeNamedType('ID'))),
+      makeInputValueDefinition('associatedUserMessageId', makeNonNullType(makeNamedType('ID'))),
+      makeInputValueDefinition('contentBlockIndex', makeNonNullType(makeNamedType('Int'))),
+
+      makeInputValueDefinition('contentBlockText', makeNamedType('String')),
+      makeInputValueDefinition('contentBlockDeltaIndex', makeNamedType('Int')),
+
+      makeInputValueDefinition('contentBlockToolUse', makeNamedType('AWSJSON')),
+      makeInputValueDefinition('contentBlockDoneAtIndex', makeNamedType('Int')),
+
+      makeInputValueDefinition('stopReason', makeNamedType('String')),
+
+      makeInputValueDefinition('accumulatedTurnContent', makeListType(makeNamedType('ContentBlockInput'))),
+    ],
+  };
+};
+
+export const createAssistantStreamingMutationField = (fieldName: string, inputTypeName: string): FieldDefinitionNode => {
+  const args = [makeInputValueDefinition('input', makeNonNullType(makeNamedType(inputTypeName)))];
+  const cognitoAuthDirective = makeDirective('aws_cognito_user_pools', []);
+  const createAssistantResponseMutation = makeField(fieldName, args, makeNamedType(STREAM_RESPONSE_TYPE_NAME), [cognitoAuthDirective]);
+  return createAssistantResponseMutation;
+};
+
+/**
 /**
  * Creates a model directive for the message model.
  * @returns {DirectiveNode} The model directive node.
@@ -255,4 +282,30 @@ const constructConversationMessageModel = (
   };
 
   return object;
+};
+
+const STREAM_RESPONSE_TYPE_NAME = 'ConversationMessageStreamPart';
+
+export const constructStreamResponseType = (): ObjectTypeDefinitionNode => {
+  return {
+    kind: 'ObjectTypeDefinition',
+    name: { kind: 'Name', value: STREAM_RESPONSE_TYPE_NAME },
+    fields: [
+      makeField('id', [], makeNonNullType(makeNamedType('ID'))),
+      makeField('owner', [], makeNamedType('String')),
+      makeField('conversationId', [], makeNonNullType(makeNamedType('ID'))),
+      makeField('associatedUserMessageId', [], makeNonNullType(makeNamedType('ID'))),
+
+      makeField('contentBlockIndex', [], makeNonNullType(makeNamedType('Int'))),
+
+      makeField('contentBlockText', [], makeNamedType('String')),
+      makeField('contentBlockDeltaIndex', [], makeNamedType('Int')),
+
+      makeField('contentBlockToolUse', [], makeNamedType('AWSJSON')),
+
+      makeField('contentBlockDoneAtIndex', [], makeNamedType('Int')),
+
+      makeField('stopReason', [], makeNamedType('String')),
+    ],
+  };
 };

--- a/packages/amplify-graphql-conversation-transformer/src/graphql-types/name-values.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/graphql-types/name-values.ts
@@ -18,6 +18,9 @@ export const getMessageSubscriptionFieldName = (config: ConversationDirectiveCon
 export const getAssistantMutationFieldName = (config: ConversationDirectiveConfiguration) =>
   `createAssistantResponse${upperCaseConversationFieldName(config)}`;
 
+export const getAssistantStreamingMutationFieldName = (config: ConversationDirectiveConfiguration) =>
+  `createAssistantResponseStream${upperCaseConversationFieldName(config)}`;
+
 export const getFunctionStackName = (config: ConversationDirectiveConfiguration) =>
   `${upperCaseConversationFieldName(config)}ConversationDirectiveLambdaStack`;
 

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/assistant-response-stream-pipeline-definition.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/assistant-response-stream-pipeline-definition.ts
@@ -1,0 +1,88 @@
+import { MappingTemplate } from '@aws-amplify/graphql-transformer-core';
+import { ConversationDirectiveConfiguration } from '../conversation-directive-configuration';
+import {
+  createResolverFunctionDefinition,
+  createS3AssetMappingTemplateGenerator,
+  PipelineDefinition,
+  ResolverFunctionDefinition,
+} from './resolver-function-definition';
+import { toUpper } from 'graphql-transformer-common';
+
+/**
+ * The pipeline definition for the assistant response stream mutation resolver.
+ */
+export const assistantResponseStreamPipelineDefinition: PipelineDefinition = {
+  requestSlots: [init(), auth(), verifySessionOwner()],
+  dataSlot: data(),
+  responseSlots: [],
+  field: (config) => ({ typeName: 'Mutation', fieldName: fieldName(config) }),
+};
+
+/**
+ * The init slot for the assistant response mutation resolver.
+ */
+function init(): ResolverFunctionDefinition {
+  return createResolverFunctionDefinition({
+    slotName: 'init',
+    fileName: 'init-resolver-fn.template.js',
+    generateTemplate: (_, code) => MappingTemplate.inlineTemplateFromString(code),
+    substitutions: (_, ctx) => ({
+      GRAPHQL_API_ENDPOINT: ctx.api.graphqlUrl,
+    }),
+  });
+}
+
+/**
+ * The auth slot for the assistant response mutation resolver.
+ */
+function auth(): ResolverFunctionDefinition {
+  return createResolverFunctionDefinition({
+    slotName: 'auth',
+    fileName: 'auth-resolver-fn.template.js',
+    generateTemplate: templateGenerator('auth'),
+  });
+}
+
+/**
+ * The verify session owner slot for the assistant response mutation resolver.
+ */
+function verifySessionOwner(): ResolverFunctionDefinition {
+  return createResolverFunctionDefinition({
+    slotName: 'verifySessionOwner',
+    fileName: 'verify-session-owner-resolver-fn.template.js',
+    generateTemplate: templateGenerator('verify-session-owner'),
+    dataSource: (config) => config.dataSources.conversationTableDataSource,
+    substitutions: () => ({
+      CONVERSATION_ID_PARENT: 'ctx.args.input',
+    }),
+  });
+}
+
+/**
+ * The data slot for the assistant response mutation resolver.
+ */
+function data(): ResolverFunctionDefinition {
+  return createResolverFunctionDefinition({
+    slotName: 'data',
+    fileName: 'assistant-streaming-mutation-resolver-fn.template.js',
+    generateTemplate: templateGenerator('persist-message'),
+    dataSource: (config) => config.dataSources.messageTableDataSource,
+    substitutions: (config) => ({
+      CONVERSATION_MESSAGE_TYPE_NAME: `ConversationMessage${toUpper(config.field.name.value)}`,
+    }),
+  });
+}
+
+/**
+ * Field name for the assistant response mutation.
+ */
+function fieldName(config: ConversationDirectiveConfiguration): string {
+  return config.assistantResponseStreamingMutation.field.name.value;
+}
+
+/**
+ * Creates a template generator specific to the assistant response pipeline for a given slot name.
+ */
+function templateGenerator(slotName: string) {
+  return createS3AssetMappingTemplateGenerator('Mutation', slotName, fieldName);
+}

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/index.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/index.ts
@@ -1,4 +1,5 @@
 import { assistantResponsePipelineDefinition } from './assistant-response-pipeline-definition';
+import { assistantResponseStreamPipelineDefinition } from './assistant-response-stream-pipeline-definition';
 import { assistantResponseSubscriptionPipelineDefinition } from './assistant-response-subscription-pipeline-definition';
 import { generateResolverFunction, generateResolverPipeline } from './generate-resolver';
 import { listMessagesInitFunctionDefinition } from './list-messages-init-resolver';
@@ -6,6 +7,7 @@ import { sendMessagePipelineDefinition } from './send-message-pipeline-definitio
 
 export {
   assistantResponsePipelineDefinition,
+  assistantResponseStreamPipelineDefinition,
   assistantResponseSubscriptionPipelineDefinition,
   generateResolverFunction,
   generateResolverPipeline,

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/send-message-pipeline-definition.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/send-message-pipeline-definition.ts
@@ -101,7 +101,7 @@ function invokeLambdaResolverSubstitutions(config: ConversationDirectiveConfigur
     MODEL_ID: JSON.stringify(config.aiModel),
     SYSTEM_PROMPT: JSON.stringify(config.systemPrompt),
     DATA_TOOLS: JSON.stringify(config.toolSpec),
-    SELECTION_SET: selectionSet,
+    SELECTION_SET: streamingSelectionSet,
     INFERENCE_CONFIGURATION: JSON.stringify(config.inferenceConfiguration),
     RESPONSE_MUTATION_NAME: config.assistantResponseMutation.field.name.value,
     RESPONSE_MUTATION_INPUT_TYPE_NAME: config.assistantResponseMutation.input.name.value,
@@ -111,6 +111,8 @@ function invokeLambdaResolverSubstitutions(config: ConversationDirectiveConfigur
     LIST_QUERY_NAME: getConversationMessageListQueryName(config),
     LIST_QUERY_INPUT_TYPE_NAME: getConversationMessageListQueryInputTypeName(config),
     LIST_QUERY_LIMIT: 'undefined',
+    STREAMING_RESPONSE_MUTATION_NAME: config.assistantResponseStreamingMutation.field.name.value,
+    STREAMING_RESPONSE_MUTATION_INPUT_TYPE_NAME: config.assistantResponseStreamingMutation.input.name.value,
   };
 }
 
@@ -129,3 +131,4 @@ function templateGenerator(slotName: string) {
 }
 
 const selectionSet = `id conversationId content { image { format source { bytes }} text toolUse { toolUseId name input } toolResult { status toolUseId content { json text image { format source { bytes }} document { format name source { bytes }} }}} role owner createdAt updatedAt`;
+const streamingSelectionSet = `associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner`;

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/assistant-streaming-mutation-resolver-fn.template.js
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/assistant-streaming-mutation-resolver-fn.template.js
@@ -1,0 +1,82 @@
+import { util } from '@aws-appsync/utils';
+import * as ddb from '@aws-appsync/utils/dynamodb';
+
+/**
+ * Sends a request to the attached data source
+ * @param {import('@aws-appsync/utils').Context} ctx the context
+ * @returns {*} the request
+ */
+export function request(ctx) {
+  const {
+    conversationId,
+    associatedUserMessageId,
+    accumulatedTurnContent
+  } = ctx.args.input;
+
+  const { owner } = ctx.args;
+  const { createdAt, updatedAt } = ctx.stash.defaultValues;
+
+  const assistantResponseId = `${associatedUserMessageId}#response`;
+  const expression = 'SET #typename = :typename, #conversationId = :conversationId, #associatedUserMessageId = :associatedUserMessageId, #role = :role, #content = :content, #owner = :owner, #createdAt = if_not_exists(#createdAt, :createdAt), #updatedAt = :updatedAt';
+
+  const expressionValues = util.dynamodb.toMapValues({
+    ':typename': '[[CONVERSATION_MESSAGE_TYPE_NAME]]',
+    ':conversationId': conversationId,
+    ':associatedUserMessageId': associatedUserMessageId,
+    ':role': 'assistant',
+    ':content': accumulatedTurnContent,
+    ':owner': owner,
+    ':createdAt': createdAt,
+    ':updatedAt': updatedAt,
+  });
+
+  // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
+  const expressionNames = {
+    '#typename': '__typename',
+    '#conversationId': 'conversationId',
+    '#associatedUserMessageId': 'associatedUserMessageId',
+    '#role': 'role',
+    '#content': 'content',
+    '#owner': 'owner',
+    '#createdAt': 'createdAt',
+    '#updatedAt': 'updatedAt',
+  };
+
+  return {
+    operation: 'UpdateItem',
+    key: util.dynamodb.toMapValues({ id: assistantResponseId }),
+    update: {
+      expression,
+      expressionValues,
+      expressionNames,
+    },
+  };
+}
+
+/**
+ * Returns the resolver result
+ * @param {import('@aws-appsync/utils').Context} ctx the context
+ * @returns {*} the result
+ */
+export function response(ctx) {
+  if (ctx.error) {
+    util.error(ctx.error.message, ctx.error.type);
+  }
+  const streamId = `${ctx.args.input.associatedUserMessageId}#stream`;
+  const { owner } = ctx.args;
+  const event = ctx.args.input;
+
+  const streamEvent = {
+    ...event,
+    __typename: 'ConversationMessageStreamPart',
+    id: streamId,
+    owner,
+  };
+
+  // TODO: The lambda event should provide the toolUse directly.
+  if (event.contentBlockToolUse && event.contentBlockToolUse.toolUse) {
+    streamEvent.contentBlockToolUse = event.contentBlockToolUse.toolUse;
+  }
+
+  return streamEvent;
+}

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/invoke-lambda-resolver-fn.template.js
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/invoke-lambda-resolver-fn.template.js
@@ -6,11 +6,12 @@ export function request(ctx) {
 
   const selectionSet = '[[SELECTION_SET]]';
 
-  const responseMutation = {
-    name: '[[RESPONSE_MUTATION_NAME]]',
-    inputTypeName: '[[RESPONSE_MUTATION_INPUT_TYPE_NAME]]',
+  const streamingResponseMutation = {
+    name: '[[STREAMING_RESPONSE_MUTATION_NAME]]',
+    inputTypeName: '[[STREAMING_RESPONSE_MUTATION_INPUT_TYPE_NAME]]',
     selectionSet,
   };
+
   const currentMessageId = ctx.stash.defaultValues.id;
 
   const modelConfiguration = {
@@ -37,12 +38,13 @@ export function request(ctx) {
   const payload = {
     conversationId: args.conversationId,
     currentMessageId,
-    responseMutation,
+    responseMutation: streamingResponseMutation,
     graphqlApiEndpoint,
     modelConfiguration,
     request: { headers: { authorization: authHeader } },
     messageHistoryQuery,
     toolsConfiguration,
+    streamResponse: true,
   };
 
   return {

--- a/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-field-handler.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-field-handler.ts
@@ -13,6 +13,8 @@ import { ConversationModel, createConversationModel } from '../graphql-types/con
 import {
   createAssistantMutationField,
   createAssistantResponseMutationInput,
+  createAssistantStreamingMutationField,
+  createAssistantResponseStreamingMutationInput,
   createMessageModel,
   createMessageSubscription,
   MessageModel,
@@ -20,6 +22,7 @@ import {
 import {
   CONVERSATION_MESSAGES_REFERENCE_FIELD_NAME,
   getAssistantMutationFieldName,
+  getAssistantStreamingMutationFieldName,
   getConversationMessageTypeName,
   getConversationTypeName,
   getMessageSubscriptionFieldName,
@@ -127,17 +130,15 @@ export class ConversationFieldHandler {
 
   private createSupportingFields(config: ConversationDirectiveConfiguration): {
     assistantResponseMutation: { field: FieldDefinitionNode; input: InputObjectTypeDefinitionNode };
+    assistantResponseStreamingMutation: { field: FieldDefinitionNode; input: InputObjectTypeDefinitionNode };
     assistantResponseSubscriptionField: FieldDefinitionNode;
   } {
     const conversationMessageTypeName = getConversationMessageTypeName(config);
     const messageSubscriptionFieldName = getMessageSubscriptionFieldName(config);
     const assistantMutationFieldName = getAssistantMutationFieldName(config);
+    const assistantStreamingMutationFieldName = getAssistantStreamingMutationFieldName(config);
 
-    const assistantResponseSubscriptionField = createMessageSubscription(
-      messageSubscriptionFieldName,
-      conversationMessageTypeName,
-      assistantMutationFieldName,
-    );
+    const assistantResponseSubscriptionField = createMessageSubscription(messageSubscriptionFieldName, assistantStreamingMutationFieldName);
 
     const assistantResponseMutationInput = createAssistantResponseMutationInput(conversationMessageTypeName);
     const assistantResponseMutationField = createAssistantMutationField(
@@ -146,8 +147,18 @@ export class ConversationFieldHandler {
       assistantResponseMutationInput.name.value,
     );
 
+    const assistantResponseStreamingMutationInput = createAssistantResponseStreamingMutationInput(conversationMessageTypeName);
+    const assistantResponseStreamingMutationField = createAssistantStreamingMutationField(
+      assistantStreamingMutationFieldName,
+      assistantResponseStreamingMutationInput.name.value,
+    );
+
     return {
       assistantResponseMutation: { field: assistantResponseMutationField, input: assistantResponseMutationInput },
+      assistantResponseStreamingMutation: {
+        field: assistantResponseStreamingMutationField,
+        input: assistantResponseStreamingMutationInput,
+      },
       assistantResponseSubscriptionField,
     };
   }

--- a/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-prepare-handler.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-prepare-handler.ts
@@ -1,8 +1,9 @@
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { BelongsToTransformer, HasManyTransformer } from '@aws-amplify/graphql-relational-transformer';
 import { DDB_AMPLIFY_MANAGED_DATASOURCE_STRATEGY, InvalidTransformerError } from '@aws-amplify/graphql-transformer-core';
-import { TransformerAuthProvider, TransformerPrepareStepContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { ConversationDirectiveConfiguration } from '../conversation-directive-configuration';
+import { constructStreamResponseType } from '../graphql-types/message-model';
+import { TransformerAuthProvider, TransformerPrepareStepContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 
 /**
  * @class ConversationPrepareHandler
@@ -65,7 +66,8 @@ export class ConversationPrepareHandler {
    */
   private prepareResourcesForDirective(directive: ConversationDirectiveConfiguration, ctx: TransformerPrepareStepContextProvider): void {
     // TODO: Add @aws_cognito_user_pools directive to send messages mutation
-    const { conversation, message, assistantResponseMutation, assistantResponseSubscriptionField } = directive;
+    const { conversation, message, assistantResponseMutation, assistantResponseStreamingMutation, assistantResponseSubscriptionField } =
+      directive;
 
     // Extract model names for later use
     const conversationName = conversation.model.name.value;
@@ -73,7 +75,8 @@ export class ConversationPrepareHandler {
 
     // Add necessary inputs, fields, and objects to the output schema
     ctx.output.addInput(assistantResponseMutation.input);
-    ctx.output.addMutationFields([assistantResponseMutation.field]);
+    ctx.output.addInput(assistantResponseStreamingMutation.input);
+    ctx.output.addMutationFields([assistantResponseMutation.field, assistantResponseStreamingMutation.field]);
     ctx.output.addSubscriptionFields([assistantResponseSubscriptionField]);
     ctx.output.addObject(conversation.model);
     ctx.output.addObject(message.model);

--- a/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
@@ -15,6 +15,7 @@ import {
 } from '../graphql-types/name-values';
 import {
   assistantResponsePipelineDefinition,
+  assistantResponseStreamPipelineDefinition,
   assistantResponseSubscriptionPipelineDefinition,
   generateResolverFunction,
   generateResolverPipeline,
@@ -99,6 +100,13 @@ export class ConversationResolverGenerator {
 
     const assistantResponsePipelineResolver = generateResolverPipeline(assistantResponsePipelineDefinition, directive, ctx);
     ctx.resolvers.addResolver(parentName, directive.assistantResponseMutation.field.name.value, assistantResponsePipelineResolver);
+
+    const assistantResponseStreamingPipelineResolver = generateResolverPipeline(assistantResponseStreamPipelineDefinition, directive, ctx);
+    ctx.resolvers.addResolver(
+      parentName,
+      directive.assistantResponseStreamingMutation.field.name.value,
+      assistantResponseStreamingPipelineResolver,
+    );
 
     const assistantResponseSubscriptionPipelineResolver = generateResolverPipeline(
       assistantResponseSubscriptionPipelineDefinition,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,14 +10,17 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aws-amplify/ai-constructs@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/ai-constructs/-/ai-constructs-0.2.0.tgz#91db9586d8e656a4ad7f2b0b539a2221a38124b2"
-  integrity sha512-aqmUrUvbWpebJcNCvoFywHLTQXNIlli8VE2i9+sSMlQXAG2zRiqcpDdRha+0NQnPNj09K2/DMLTe79ldwDaGkQ==
+"@aws-amplify/ai-constructs@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/ai-constructs/-/ai-constructs-0.7.0.tgz#477750d62e2c564b0d156ab53d8845cbb38290ab"
+  integrity sha512-HfKvoafva68HulV223wBC6V6bA/ibM1UEAEjy+m//l+zhdTlfYauA4EUpHfyXg83eWxBhmT5rtAheqNmIlzNxQ==
   dependencies:
+    "@aws-amplify/backend-output-schemas" "^1.4.0"
+    "@aws-amplify/platform-core" "^1.1.0"
     "@aws-amplify/plugin-types" "^1.0.1"
     "@aws-sdk/client-bedrock-runtime" "^3.622.0"
     "@smithy/types" "^3.3.0"
+    json-schema-to-ts "^3.1.1"
 
 "@aws-amplify/amplify-app@^5.0.35":
   version "5.0.36"
@@ -288,6 +291,11 @@
   resolved "https://registry.npmjs.org/@aws-amplify/backend-output-schemas/-/backend-output-schemas-1.2.0.tgz#3894e558c3866b90003e4020014e61f4589a97a1"
   integrity sha512-UMQfPlfzyvYsV9A/MyoFm8T87MxsLZBzABSkmD5Y/sh8XTIJlqRHibzKStoN7xuK5S1Iz1okRVoxhFxSy0alrg==
 
+"@aws-amplify/backend-output-schemas@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/backend-output-schemas/-/backend-output-schemas-1.4.0.tgz#8abed00fe0ff67c2f3282c8e517db2df28c8fa0a"
+  integrity sha512-/p2t/wWV1CTObJnewmLKlx48AYGhhRKp2Ne51DNZ1gV4CAwZx9Jmtyjv65h3zQ6Gk6WTTcjeNORncgEa1Gq5CA==
+
 "@aws-amplify/backend-output-storage@^1.0.0", "@aws-amplify/backend-output-storage@^1.1.1":
   version "1.1.1"
   resolved "https://registry.npmjs.org/@aws-amplify/backend-output-storage/-/backend-output-storage-1.1.1.tgz#17db84d9e01e04f1fbfb7f1d9477c6e328b6ec50"
@@ -372,7 +380,7 @@
     fflate "0.7.3"
     pako "2.0.4"
 
-"@aws-amplify/platform-core@^1.0.0", "@aws-amplify/platform-core@^1.0.6":
+"@aws-amplify/platform-core@^1.0.0", "@aws-amplify/platform-core@^1.0.6", "@aws-amplify/platform-core@^1.1.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@aws-amplify/platform-core/-/platform-core-1.1.0.tgz#85002b14e37caeb8f90916554e57f7809582e94a"
   integrity sha512-9iOM+dpht1f52WUHPyaXyeF8Z27TNgqBS86JmIhcsqWltUsCqoQDKPVjaTj8No05oMzm+icWc96dPG/EZIE3jw==
@@ -4682,6 +4690,13 @@
     "@babel/helper-create-class-features-plugin" "^7.10.5"
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-typescript" "^7.10.4"
+
+"@babel/runtime@^7.18.3":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
+  integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
 
 "@babel/runtime@^7.9.6":
   version "7.25.6"
@@ -12941,6 +12956,14 @@ json-parse-helpfulerror@^1.0.3:
   dependencies:
     jju "^1.1.0"
 
+json-schema-to-ts@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz#81f3acaf5a34736492f6f5f51870ef9ece1ca853"
+  integrity sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    ts-algebra "^2.0.0"
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -16723,6 +16746,11 @@ triple-beam@^1.3.0:
   version "1.4.1"
   resolved "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz#6fde70271dc6e5d73ca0c3b24e2d92afb7441984"
   integrity sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==
+
+ts-algebra@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ts-algebra/-/ts-algebra-2.0.0.tgz#4e3e0953878f26518fce7f6bb115064a65388b7a"
+  integrity sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==
 
 ts-dedent@^2.0.0:
   version "2.2.0"


### PR DESCRIPTION
## Description of changes
- Adds support for streaming assistant responses.
- Updates E2E test cases for streaming.
- Adds E2E test case for streaming with client tools.
- Adds snapshot test cases for streaming resolvers.

### Design
The key change here is that the lambda function sends chunks / events to the assistant response mutation rather than a full message.

**Example**
Bedrock streaming response “hello world” is broken up into two chunks “hello” and “ world”. 
```js
// first event
{ 
  // mutation response 
   conversationId: '123',
  associatedUserMessageId: 'abc',
  contentBlockIndex: 0,
  contentBlockDeltaIndex: 0,
  contentBlockText: 'hello',
  
  // persisted in messages table
  accumulatedTurnContent: [{ text: 'hello' }]
}

// second event
{
  // mutation response  
  conversationId: '123',
  associatedUserMessageId: 'abc',
  contentBlockIndex: 0,
  contentBlockDeltaIndex: 1,
  contentBlockText: ' world',
  
  // persisted in messages table
  accumulatedTurnContent: [{ text: 'hello world' }]
}
```

#### Types

**GraphQL Input**
The input type for the assistant response stream mutation invoked by the Lambda function.

```graphql
input CreateConversationMessageRouteAssistantStreamingInput {
  # always included
  conversationId: ID!
  associatedUserMessageId: ID!
  contentBlockIndex: Int!
  accumulatedTurnContent: [ContentBlock]
  
  # text chunk 
  contentBlockDeltaIndex: Int
  contentBlockText: String
 
  # end of block. applicable to text blocks.
  contentBlockDoneAtIndex: Int
   
  # well-formed tool use (client tool)
  contentBlockToolUse: AWSJSON 
  
  # turn complete
  stopReason: String  
}
```

**ConversationMessageStreamPart Type**
The response type of the assistant response stream mutation and paired subscription

```graphql
type ConversationMessageStreamPart {
  id: ID!
  owner: String
  conversationId: ID!
  associatedUserMessageId: ID!
  contentBlockIndex: Int!
  contentBlockText: String
  contentBlockDeltaIndex: Int
  contentBlockToolUse: ToolUseBlock
  contentBlockDoneAtIndex: Int
  stopReason: String
}
```

### Data Flow
![image](https://github.com/user-attachments/assets/c835c3a1-4b2d-44bd-be0a-9146c754bc0f)


### Related PRs
- https://github.com/aws-amplify/amplify-codegen/pull/899
- https://github.com/aws-amplify/amplify-api-next/pull/379

## CDK / CloudFormation Parameters Changed
N/A

## Issue #, if available
N/A

## Description of how you validated changes
- [E2E Test Run](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:122dce71-3871-4001-a531-f77a9e735998?region=us-east-1)

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
