### PR TITLE
feat(conversation): sorting and performant list queries

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/conversation.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/conversation.test.ts
@@ -206,7 +206,6 @@ describe('conversation', () => {
         const messages = listMessagesResult.body.data.listConversationMessagePirateChats.items;
         expect(messages.length).toBeGreaterThanOrEqual(4);
         const createdAts = messages.map((message) => message.createdAt);
-        console.log(createdAts);
         expect(createdAts).toEqual([...createdAts].sort((a, b) => new Date(a).getTime() - new Date(b).getTime()));
       },
       ONE_MINUTE,

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/test-implementations.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/test-implementations.ts
@@ -4,12 +4,13 @@ import {
   CreateConversationPirateChatMutation,
   GetConversationPirateChatQuery,
   ListConversationMessagePirateChatsQuery,
+  ListConversationPirateChatsQuery,
   PirateChatMutation,
   ToolConfigurationInput,
   UpdateConversationPirateChatMutation,
 } from './API';
 import { createConversationPirateChat, pirateChat, updateConversationPirateChat } from './graphql/mutations';
-import { getConversationPirateChat, listConversationMessagePirateChats } from './graphql/queries';
+import { getConversationPirateChat, listConversationMessagePirateChats, listConversationPirateChats } from './graphql/queries';
 
 export const doCreateConversationPirateChat = async (
   apiEndpoint: string,
@@ -35,6 +36,17 @@ export const doGetConversationPirateChat = async (
     variables: {
       id: conversationId,
     },
+  });
+};
+
+export const doListConversationsPirateChat = async (
+  apiEndpoint: string,
+  accessToken: string,
+): Promise<AppSyncGraphqlResponse<ListConversationPirateChatsQuery>> => {
+  return doAppSyncGraphqlQuery({
+    apiEndpoint,
+    auth: { accessToken: accessToken },
+    query: listConversationPirateChats,
   });
 };
 

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -494,6 +494,86 @@ export const response = (ctx) => {
 }
 `;
 
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: ListConversationsInit resolver function code 1`] = `
+"import { util } from '@aws-appsync/utils';
+
+export function request(ctx) {
+  ctx.stash.metadata.index = 'gsi-Conversation.typename.updatedAt';
+  ctx.stash.modelQueryExpression = {
+      expression: '#typename = :typename',
+      expressionNames: {
+        '#typename': '__typename',
+      },
+      expressionValues: util.dynamodb.toMapValues({
+        ':typename': 'ConversationPirateChat',
+      }),
+    };
+  ctx.args.sortDirection = 'DESC';
+  return {};
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: ListMessagesInit resolver function code 1`] = `
+"import { util } from '@aws-appsync/utils';
+
+export function request(ctx) {
+  ctx.stash.metadata.index = 'gsi-ConversationMessage.conversationId.createdAt';
+  const conversationId = ctx.args?.filter?.conversationId?.eq;
+  if (conversationId) {
+    // If a conversationId was provided, we're going to execute a query
+    // rather than a scan. The index (gsi) we're performing this query on has
+    // a partitionKey of conversationId.
+    // We need to remove conversationId from the filter to prevent a
+    // DynamoDB exception:
+    // \`Filter Expression can only contain non-primary key attributes\`
+    delete ctx.args.filter.conversationId;
+    // If conversationId was the only filter, remove the filter object
+    // to prevent errors when the \`{}\` filter is combined with
+    // the \`authFilter\` further downstream.
+    if (Object.keys(ctx.args.filter).length === 0) {
+        delete ctx.args.filter;
+    }
+    ctx.stash.modelQueryExpression = {
+      expression: '#conversationId = :conversationId',
+      expressionNames: {
+        '#conversationId': 'conversationId',
+      },
+      expressionValues: util.dynamodb.toMapValues({
+        ':conversationId': conversationId,
+      }),
+    };
+  }
+  ctx.args.sortDirection = 'DESC';
+  return {};
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: ListMessagesPostDataLoad resolver function code 1`] = `
+"export function request(ctx) {
+  return {};
+}
+
+export function response(ctx) {
+  // Conversation messages are retrieved from DynamoDB in descending order by createdAt.
+  // We reverse them here because the most recent messages should be last in the list for clients:
+  // We can't use ascending order because we can miss the most recent messages due to limits / pagination.
+  const { items, ...rest } = ctx.prev.result;
+  const reversed = items.reverse();
+  return { items: reversed, ...rest };
+}
+"
+`;
+
 exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: SendMessageMutation auth slot function code 1`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
@@ -688,36 +768,36 @@ export const response = (ctx) => {
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: SendMessageMutation verify session owner slot function code 1`] = `
-"export function request(ctx) {
+"import { util } from '@aws-appsync/utils';
+
+export function request(ctx) {
   const { authFilter } = ctx.stash;
   const { conversationId } = ctx.args;
-
-  const query = {
-    expression: 'id = :id',
-    expressionValues: util.dynamodb.toMapValues({
-      ':id': conversationId,
-    }),
-  };
 
   const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
 
   return {
-    operation: 'Query',
-    query,
-    filter,
+    operation: 'UpdateItem',
+    key: util.dynamodb.toMapValues({ id: conversationId }),
+    update: {
+      expression: 'SET #updatedAt = :updatedAt',
+      expressionValues: util.dynamodb.toMapValues({
+        ':updatedAt': ctx.stash.defaultValues.createdAt,
+      }),
+      expressionNames: {
+        '#updatedAt': 'updatedAt',
+      },
+    },
+    condition: filter
   };
 }
 
 export function response(ctx) {
   if (ctx.error) {
-    util.error(ctx.error.message, ctx.error.type);
+    util.error('Conversation not found', 'ResourceNotFound');
   }
 
-  if (ctx.result.items.length !== 0) {
-    return ctx.result.items[0];
-  }
-
-  util.error('Conversation not found', 'ResourceNotFound');
+  return ctx.result;
 }
 "
 `;
@@ -1244,6 +1324,86 @@ export const response = (ctx) => {
 }
 `;
 
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: ListConversationsInit resolver function code 1`] = `
+"import { util } from '@aws-appsync/utils';
+
+export function request(ctx) {
+  ctx.stash.metadata.index = 'gsi-Conversation.typename.updatedAt';
+  ctx.stash.modelQueryExpression = {
+      expression: '#typename = :typename',
+      expressionNames: {
+        '#typename': '__typename',
+      },
+      expressionValues: util.dynamodb.toMapValues({
+        ':typename': 'ConversationPirateChat',
+      }),
+    };
+  ctx.args.sortDirection = 'DESC';
+  return {};
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: ListMessagesInit resolver function code 1`] = `
+"import { util } from '@aws-appsync/utils';
+
+export function request(ctx) {
+  ctx.stash.metadata.index = 'gsi-ConversationMessage.conversationId.createdAt';
+  const conversationId = ctx.args?.filter?.conversationId?.eq;
+  if (conversationId) {
+    // If a conversationId was provided, we're going to execute a query
+    // rather than a scan. The index (gsi) we're performing this query on has
+    // a partitionKey of conversationId.
+    // We need to remove conversationId from the filter to prevent a
+    // DynamoDB exception:
+    // \`Filter Expression can only contain non-primary key attributes\`
+    delete ctx.args.filter.conversationId;
+    // If conversationId was the only filter, remove the filter object
+    // to prevent errors when the \`{}\` filter is combined with
+    // the \`authFilter\` further downstream.
+    if (Object.keys(ctx.args.filter).length === 0) {
+        delete ctx.args.filter;
+    }
+    ctx.stash.modelQueryExpression = {
+      expression: '#conversationId = :conversationId',
+      expressionNames: {
+        '#conversationId': 'conversationId',
+      },
+      expressionValues: util.dynamodb.toMapValues({
+        ':conversationId': conversationId,
+      }),
+    };
+  }
+  ctx.args.sortDirection = 'DESC';
+  return {};
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: ListMessagesPostDataLoad resolver function code 1`] = `
+"export function request(ctx) {
+  return {};
+}
+
+export function response(ctx) {
+  // Conversation messages are retrieved from DynamoDB in descending order by createdAt.
+  // We reverse them here because the most recent messages should be last in the list for clients:
+  // We can't use ascending order because we can miss the most recent messages due to limits / pagination.
+  const { items, ...rest } = ctx.prev.result;
+  const reversed = items.reverse();
+  return { items: reversed, ...rest };
+}
+"
+`;
+
 exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: SendMessageMutation auth slot function code 1`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
@@ -1438,36 +1598,36 @@ export const response = (ctx) => {
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: SendMessageMutation verify session owner slot function code 1`] = `
-"export function request(ctx) {
+"import { util } from '@aws-appsync/utils';
+
+export function request(ctx) {
   const { authFilter } = ctx.stash;
   const { conversationId } = ctx.args;
-
-  const query = {
-    expression: 'id = :id',
-    expressionValues: util.dynamodb.toMapValues({
-      ':id': conversationId,
-    }),
-  };
 
   const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
 
   return {
-    operation: 'Query',
-    query,
-    filter,
+    operation: 'UpdateItem',
+    key: util.dynamodb.toMapValues({ id: conversationId }),
+    update: {
+      expression: 'SET #updatedAt = :updatedAt',
+      expressionValues: util.dynamodb.toMapValues({
+        ':updatedAt': ctx.stash.defaultValues.createdAt,
+      }),
+      expressionNames: {
+        '#updatedAt': 'updatedAt',
+      },
+    },
+    condition: filter
   };
 }
 
 export function response(ctx) {
   if (ctx.error) {
-    util.error(ctx.error.message, ctx.error.type);
+    util.error('Conversation not found', 'ResourceNotFound');
   }
 
-  if (ctx.result.items.length !== 0) {
-    return ctx.result.items[0];
-  }
-
-  util.error('Conversation not found', 'ResourceNotFound');
+  return ctx.result;
 }
 "
 `;
@@ -1994,6 +2154,86 @@ export const response = (ctx) => {
 }
 `;
 
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: ListConversationsInit resolver function code 1`] = `
+"import { util } from '@aws-appsync/utils';
+
+export function request(ctx) {
+  ctx.stash.metadata.index = 'gsi-Conversation.typename.updatedAt';
+  ctx.stash.modelQueryExpression = {
+      expression: '#typename = :typename',
+      expressionNames: {
+        '#typename': '__typename',
+      },
+      expressionValues: util.dynamodb.toMapValues({
+        ':typename': 'ConversationPirateChat',
+      }),
+    };
+  ctx.args.sortDirection = 'DESC';
+  return {};
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: ListMessagesInit resolver function code 1`] = `
+"import { util } from '@aws-appsync/utils';
+
+export function request(ctx) {
+  ctx.stash.metadata.index = 'gsi-ConversationMessage.conversationId.createdAt';
+  const conversationId = ctx.args?.filter?.conversationId?.eq;
+  if (conversationId) {
+    // If a conversationId was provided, we're going to execute a query
+    // rather than a scan. The index (gsi) we're performing this query on has
+    // a partitionKey of conversationId.
+    // We need to remove conversationId from the filter to prevent a
+    // DynamoDB exception:
+    // \`Filter Expression can only contain non-primary key attributes\`
+    delete ctx.args.filter.conversationId;
+    // If conversationId was the only filter, remove the filter object
+    // to prevent errors when the \`{}\` filter is combined with
+    // the \`authFilter\` further downstream.
+    if (Object.keys(ctx.args.filter).length === 0) {
+        delete ctx.args.filter;
+    }
+    ctx.stash.modelQueryExpression = {
+      expression: '#conversationId = :conversationId',
+      expressionNames: {
+        '#conversationId': 'conversationId',
+      },
+      expressionValues: util.dynamodb.toMapValues({
+        ':conversationId': conversationId,
+      }),
+    };
+  }
+  ctx.args.sortDirection = 'DESC';
+  return {};
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: ListMessagesPostDataLoad resolver function code 1`] = `
+"export function request(ctx) {
+  return {};
+}
+
+export function response(ctx) {
+  // Conversation messages are retrieved from DynamoDB in descending order by createdAt.
+  // We reverse them here because the most recent messages should be last in the list for clients:
+  // We can't use ascending order because we can miss the most recent messages due to limits / pagination.
+  const { items, ...rest } = ctx.prev.result;
+  const reversed = items.reverse();
+  return { items: reversed, ...rest };
+}
+"
+`;
+
 exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: SendMessageMutation auth slot function code 1`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
@@ -2188,36 +2428,36 @@ export const response = (ctx) => {
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: SendMessageMutation verify session owner slot function code 1`] = `
-"export function request(ctx) {
+"import { util } from '@aws-appsync/utils';
+
+export function request(ctx) {
   const { authFilter } = ctx.stash;
   const { conversationId } = ctx.args;
-
-  const query = {
-    expression: 'id = :id',
-    expressionValues: util.dynamodb.toMapValues({
-      ':id': conversationId,
-    }),
-  };
 
   const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
 
   return {
-    operation: 'Query',
-    query,
-    filter,
+    operation: 'UpdateItem',
+    key: util.dynamodb.toMapValues({ id: conversationId }),
+    update: {
+      expression: 'SET #updatedAt = :updatedAt',
+      expressionValues: util.dynamodb.toMapValues({
+        ':updatedAt': ctx.stash.defaultValues.createdAt,
+      }),
+      expressionNames: {
+        '#updatedAt': 'updatedAt',
+      },
+    },
+    condition: filter
   };
 }
 
 export function response(ctx) {
   if (ctx.error) {
-    util.error(ctx.error.message, ctx.error.type);
+    util.error('Conversation not found', 'ResourceNotFound');
   }
 
-  if (ctx.result.items.length !== 0) {
-    return ctx.result.items[0];
-  }
-
-  util.error('Conversation not found', 'ResourceNotFound');
+  return ctx.result;
 }
 "
 `;
@@ -2744,6 +2984,86 @@ export const response = (ctx) => {
 }
 `;
 
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: ListConversationsInit resolver function code 1`] = `
+"import { util } from '@aws-appsync/utils';
+
+export function request(ctx) {
+  ctx.stash.metadata.index = 'gsi-Conversation.typename.updatedAt';
+  ctx.stash.modelQueryExpression = {
+      expression: '#typename = :typename',
+      expressionNames: {
+        '#typename': '__typename',
+      },
+      expressionValues: util.dynamodb.toMapValues({
+        ':typename': 'ConversationPirateChat',
+      }),
+    };
+  ctx.args.sortDirection = 'DESC';
+  return {};
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: ListMessagesInit resolver function code 1`] = `
+"import { util } from '@aws-appsync/utils';
+
+export function request(ctx) {
+  ctx.stash.metadata.index = 'gsi-ConversationMessage.conversationId.createdAt';
+  const conversationId = ctx.args?.filter?.conversationId?.eq;
+  if (conversationId) {
+    // If a conversationId was provided, we're going to execute a query
+    // rather than a scan. The index (gsi) we're performing this query on has
+    // a partitionKey of conversationId.
+    // We need to remove conversationId from the filter to prevent a
+    // DynamoDB exception:
+    // \`Filter Expression can only contain non-primary key attributes\`
+    delete ctx.args.filter.conversationId;
+    // If conversationId was the only filter, remove the filter object
+    // to prevent errors when the \`{}\` filter is combined with
+    // the \`authFilter\` further downstream.
+    if (Object.keys(ctx.args.filter).length === 0) {
+        delete ctx.args.filter;
+    }
+    ctx.stash.modelQueryExpression = {
+      expression: '#conversationId = :conversationId',
+      expressionNames: {
+        '#conversationId': 'conversationId',
+      },
+      expressionValues: util.dynamodb.toMapValues({
+        ':conversationId': conversationId,
+      }),
+    };
+  }
+  ctx.args.sortDirection = 'DESC';
+  return {};
+}
+
+export function response(ctx) {
+  return {};
+}
+"
+`;
+
+exports[`ConversationTransformer valid schemas should transform conversation route with query tools: ListMessagesPostDataLoad resolver function code 1`] = `
+"export function request(ctx) {
+  return {};
+}
+
+export function response(ctx) {
+  // Conversation messages are retrieved from DynamoDB in descending order by createdAt.
+  // We reverse them here because the most recent messages should be last in the list for clients:
+  // We can't use ascending order because we can miss the most recent messages due to limits / pagination.
+  const { items, ...rest } = ctx.prev.result;
+  const reversed = items.reverse();
+  return { items: reversed, ...rest };
+}
+"
+`;
+
 exports[`ConversationTransformer valid schemas should transform conversation route with query tools: SendMessageMutation auth slot function code 1`] = `
 "export function request(ctx) {
   ctx.stash.hasAuth = true;
@@ -2938,36 +3258,36 @@ export const response = (ctx) => {
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with query tools: SendMessageMutation verify session owner slot function code 1`] = `
-"export function request(ctx) {
+"import { util } from '@aws-appsync/utils';
+
+export function request(ctx) {
   const { authFilter } = ctx.stash;
   const { conversationId } = ctx.args;
-
-  const query = {
-    expression: 'id = :id',
-    expressionValues: util.dynamodb.toMapValues({
-      ':id': conversationId,
-    }),
-  };
 
   const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
 
   return {
-    operation: 'Query',
-    query,
-    filter,
+    operation: 'UpdateItem',
+    key: util.dynamodb.toMapValues({ id: conversationId }),
+    update: {
+      expression: 'SET #updatedAt = :updatedAt',
+      expressionValues: util.dynamodb.toMapValues({
+        ':updatedAt': ctx.stash.defaultValues.createdAt,
+      }),
+      expressionNames: {
+        '#updatedAt': 'updatedAt',
+      },
+    },
+    condition: filter
   };
 }
 
 export function response(ctx) {
   if (ctx.error) {
-    util.error(ctx.error.message, ctx.error.type);
+    util.error('Conversation not found', 'ResourceNotFound');
   }
 
-  if (ctx.result.items.length !== 0) {
-    return ctx.result.items[0];
-  }
-
-  util.error('Conversation not found', 'ResourceNotFound');
+  return ctx.result;
 }
 "
 `;

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
@@ -44,13 +44,9 @@ describe('ConversationTransformer', () => {
       assertAssistantResponseMutationResources(routeName, out);
       assertAssistantResponseSubscriptionResources(routeName, out);
       assertAssistantResponseStreamMutationResources(routeName, out);
+      assertSlotsForModelGeneratedOperations(routeName, out);
       const schema = parse(out.schema);
       validateModelSchema(schema);
-
-      expect(
-        out.stacks.ConversationMessagePirateChat.Resources![`ListConversationMessage${toUpper(routeName)}Resolver`].Properties
-          .PipelineConfig.Functions,
-      ).toHaveLength(4);
     });
 
     it.each([
@@ -131,6 +127,20 @@ describe('ConversationTransformer', () => {
     });
   });
 });
+
+const assertSlotsForModelGeneratedOperations = (routeName: string, resources: DeploymentResources) => {
+  const listMessagesInitFn = resources.resolvers[`Query.${routeName}.list-messages-init.js`];
+  expect(listMessagesInitFn).toBeDefined();
+  expect(listMessagesInitFn).toMatchSnapshot('ListMessagesInit resolver function code');
+
+  const listMessagesPostDataLoadFn = resources.resolvers[`Query.${routeName}.list-messages-post-processing.js`];
+  expect(listMessagesPostDataLoadFn).toBeDefined();
+  expect(listMessagesPostDataLoadFn).toMatchSnapshot('ListMessagesPostDataLoad resolver function code');
+
+  const listConversationsInitFn = resources.resolvers[`Query.${routeName}.list-conversations-init.js`];
+  expect(listConversationsInitFn).toBeDefined();
+  expect(listConversationsInitFn).toMatchSnapshot('ListConversationsInit resolver function code');
+};
 
 const assertAssistantResponseSubscriptionResources = (routeName: string, resources: DeploymentResources) => {
   const resolverName = `SubscriptiononCreateAssistantResponse${toUpper(routeName)}Resolver`;

--- a/packages/amplify-graphql-conversation-transformer/src/graphql-types/name-values.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/graphql-types/name-values.ts
@@ -4,6 +4,7 @@ import { ConversationDirectiveConfiguration } from '../conversation-directive-co
 
 export const CONVERSATION_MESSAGES_REFERENCE_FIELD_NAME = 'conversationId';
 export const LIST_MESSAGES_INDEX_NAME = 'gsi-ConversationMessage.conversationId.createdAt';
+export const LIST_CONVERSATIONS_INDEX_NAME = 'gsi-Conversation.typename.updatedAt';
 export const CONVERSATION_MESSAGE_GET_QUERY_INPUT_TYPE_NAME = 'ID';
 
 export const getConversationTypeName = (config: ConversationDirectiveConfiguration) =>

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/index.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/index.ts
@@ -2,7 +2,9 @@ import { assistantResponsePipelineDefinition } from './assistant-response-pipeli
 import { assistantResponseStreamPipelineDefinition } from './assistant-response-stream-pipeline-definition';
 import { assistantResponseSubscriptionPipelineDefinition } from './assistant-response-subscription-pipeline-definition';
 import { generateResolverFunction, generateResolverPipeline } from './generate-resolver';
-import { listMessagesInitFunctionDefinition } from './list-messages-init-resolver';
+import { listConversationsInitFunctionDefinition } from './list-conversations-init-resolver-definition';
+import { listMessagesInitFunctionDefinition } from './list-messages-init-resolver-definition';
+import { listMessagesPostProcessingFunctionDefinition } from './list-messages-post-processing-resolver-definition';
 import { sendMessagePipelineDefinition } from './send-message-pipeline-definition';
 
 export {
@@ -11,6 +13,8 @@ export {
   assistantResponseSubscriptionPipelineDefinition,
   generateResolverFunction,
   generateResolverPipeline,
+  listConversationsInitFunctionDefinition,
   listMessagesInitFunctionDefinition,
+  listMessagesPostProcessingFunctionDefinition,
   sendMessagePipelineDefinition,
 };

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/list-conversations-init-resolver-definition.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/list-conversations-init-resolver-definition.ts
@@ -1,0 +1,29 @@
+import { LIST_CONVERSATIONS_INDEX_NAME } from '../graphql-types/name-values';
+import {
+  createResolverFunctionDefinition,
+  createS3AssetMappingTemplateGenerator,
+  ResolverFunctionDefinition,
+} from './resolver-function-definition';
+
+/**
+ * The definition of the init slot for the list conversations resolver.
+ * This is used to set the index within the model generated list query.
+ */
+export const listConversationsInitFunctionDefinition: ResolverFunctionDefinition = createResolverFunctionDefinition({
+  slotName: 'init',
+  fileName: 'list-conversations-init-set-index-resolver-fn.template.js',
+  generateTemplate: createS3AssetMappingTemplateGenerator('Query', 'list-conversations-init', (config) => config.field.name.value),
+  substitutions: (config) => ({
+    INDEX_NAME: LIST_CONVERSATIONS_INDEX_NAME,
+    MODEL_QUERY_EXPRESSION: `{
+      expression: '#typename = :typename',
+      expressionNames: {
+        '#typename': '__typename',
+      },
+      expressionValues: util.dynamodb.toMapValues({
+        ':typename': '${config.conversation.model.name.value}',
+      }),
+    }`,
+    SORT_DIRECTION: 'DESC',
+  }),
+});

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/list-messages-init-resolver-definition.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/list-messages-init-resolver-definition.ts
@@ -11,7 +11,7 @@ import {
  */
 export const listMessagesInitFunctionDefinition: ResolverFunctionDefinition = createResolverFunctionDefinition({
   slotName: 'init',
-  fileName: 'list-messages-init-resolver-fn.template.js',
+  fileName: 'list-messages-init-set-index-resolver-fn.template.js',
   generateTemplate: createS3AssetMappingTemplateGenerator('Query', 'list-messages-init', (config) => config.field.name.value),
   substitutions: () => ({
     INDEX_NAME: LIST_MESSAGES_INDEX_NAME,

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/list-messages-post-processing-resolver-definition.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/list-messages-post-processing-resolver-definition.ts
@@ -1,0 +1,15 @@
+import {
+  createResolverFunctionDefinition,
+  createS3AssetMappingTemplateGenerator,
+  ResolverFunctionDefinition,
+} from './resolver-function-definition';
+
+/**
+ * The definition of the init slot for the list messages resolver.
+ * This is used to set the index within the model generated list query.
+ */
+export const listMessagesPostProcessingFunctionDefinition: ResolverFunctionDefinition = createResolverFunctionDefinition({
+  slotName: 'postDataLoad',
+  fileName: 'list-messages-post-processing-resolver-fn.template.js',
+  generateTemplate: createS3AssetMappingTemplateGenerator('Query', 'list-messages-post-processing', (config) => config.field.name.value),
+});

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/send-message-pipeline-definition.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/send-message-pipeline-definition.ts
@@ -56,7 +56,7 @@ function auth(): ResolverFunctionDefinition {
 function verifySessionOwner(): ResolverFunctionDefinition {
   return createResolverFunctionDefinition({
     slotName: 'verifySessionOwner',
-    fileName: 'verify-session-owner-resolver-fn.template.js',
+    fileName: 'set-updated-at-conversation-table-fn.template.js',
     generateTemplate: templateGenerator('verify-session-owner'),
     dataSource: (config) => config.dataSources.conversationTableDataSource,
     substitutions: () => ({

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/list-conversations-init-set-index-resolver-fn.template.js
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/list-conversations-init-set-index-resolver-fn.template.js
@@ -1,0 +1,12 @@
+import { util } from '@aws-appsync/utils';
+
+export function request(ctx) {
+  ctx.stash.metadata.index = '[[INDEX_NAME]]';
+  ctx.stash.modelQueryExpression = [[MODEL_QUERY_EXPRESSION]];
+  ctx.args.sortDirection = '[[SORT_DIRECTION]]';
+  return {};
+}
+
+export function response(ctx) {
+  return {};
+}

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/list-messages-init-resolver-fn.template.js
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/list-messages-init-resolver-fn.template.js
@@ -1,8 +1,0 @@
-export function request(ctx) {
-  ctx.stash.metadata.index = '[[INDEX_NAME]]';
-  return {};
-}
-
-export function response(ctx) {
-  return {};
-}

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/list-messages-init-set-index-resolver-fn.template.js
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/list-messages-init-set-index-resolver-fn.template.js
@@ -1,0 +1,36 @@
+import { util } from '@aws-appsync/utils';
+
+export function request(ctx) {
+  ctx.stash.metadata.index = '[[INDEX_NAME]]';
+  const conversationId = ctx.args?.filter?.conversationId?.eq;
+  if (conversationId) {
+    // If a conversationId was provided, we're going to execute a query
+    // rather than a scan. The index (gsi) we're performing this query on has
+    // a partitionKey of conversationId.
+    // We need to remove conversationId from the filter to prevent a
+    // DynamoDB exception:
+    // `Filter Expression can only contain non-primary key attributes`
+    delete ctx.args.filter.conversationId;
+    // If conversationId was the only filter, remove the filter object
+    // to prevent errors when the `{}` filter is combined with
+    // the `authFilter` further downstream.
+    if (Object.keys(ctx.args.filter).length === 0) {
+        delete ctx.args.filter;
+    }
+    ctx.stash.modelQueryExpression = {
+      expression: '#conversationId = :conversationId',
+      expressionNames: {
+        '#conversationId': 'conversationId',
+      },
+      expressionValues: util.dynamodb.toMapValues({
+        ':conversationId': conversationId,
+      }),
+    };
+  }
+  ctx.args.sortDirection = 'DESC';
+  return {};
+}
+
+export function response(ctx) {
+  return {};
+}

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/list-messages-post-processing-resolver-fn.template.js
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/list-messages-post-processing-resolver-fn.template.js
@@ -1,0 +1,12 @@
+export function request(ctx) {
+  return {};
+}
+
+export function response(ctx) {
+  // Conversation messages are retrieved from DynamoDB in descending order by createdAt.
+  // We reverse them here because the most recent messages should be last in the list for clients:
+  // We can't use ascending order because we can miss the most recent messages due to limits / pagination.
+  const { items, ...rest } = ctx.prev.result;
+  const reversed = items.reverse();
+  return { items: reversed, ...rest };
+}

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/set-updated-at-conversation-table-fn.template.js
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/set-updated-at-conversation-table-fn.template.js
@@ -1,0 +1,31 @@
+import { util } from '@aws-appsync/utils';
+
+export function request(ctx) {
+  const { authFilter } = ctx.stash;
+  const { conversationId } = [[CONVERSATION_ID_PARENT]];
+
+  const filter = JSON.parse(util.transform.toDynamoDBFilterExpression(authFilter));
+
+  return {
+    operation: 'UpdateItem',
+    key: util.dynamodb.toMapValues({ id: conversationId }),
+    update: {
+      expression: 'SET #updatedAt = :updatedAt',
+      expressionValues: util.dynamodb.toMapValues({
+        ':updatedAt': ctx.stash.defaultValues.createdAt,
+      }),
+      expressionNames: {
+        '#updatedAt': 'updatedAt',
+      },
+    },
+    condition: filter
+  };
+}
+
+export function response(ctx) {
+  if (ctx.error) {
+    util.error('Conversation not found', 'ResourceNotFound');
+  }
+
+  return ctx.result;
+}

--- a/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
@@ -267,30 +267,30 @@ export class ConversationResolverGenerator {
     );
   }
 
-    /**
+  /**
    * Sets up the conversation table index
    * @param ctx - The transformer context provider
    * @param directive - The conversation directive configuration
    */
-    private setUpConversationTableIndex(ctx: TransformerContextProvider, directive: ConversationDirectiveConfiguration): void {
-      const conversationName = directive.conversation.model.name.value;
-      const conversation = directive.conversation.model;
+  private setUpConversationTableIndex(ctx: TransformerContextProvider, directive: ConversationDirectiveConfiguration): void {
+    const conversationName = directive.conversation.model.name.value;
+    const conversation = directive.conversation.model;
 
-      const conversationTable = getTable(ctx, conversation);
-      const gsiPartitionKeyName = '__typename';
-      const gsiPartitionKeyType = 'S';
-      const gsiSortKeyName = 'updatedAt';
-      const gsiSortKeyType = 'S';
+    const conversationTable = getTable(ctx, conversation);
+    const gsiPartitionKeyName = '__typename';
+    const gsiPartitionKeyType = 'S';
+    const gsiSortKeyName = 'updatedAt';
+    const gsiSortKeyType = 'S';
 
-      this.addGlobalSecondaryIndex(
-        conversationTable,
-        ctx,
-        conversationName,
-        LIST_CONVERSATIONS_INDEX_NAME,
-        { name: gsiPartitionKeyName, type: gsiPartitionKeyType },
-        { name: gsiSortKeyName, type: gsiSortKeyType },
-      );
-    }
+    this.addGlobalSecondaryIndex(
+      conversationTable,
+      ctx,
+      conversationName,
+      LIST_CONVERSATIONS_INDEX_NAME,
+      { name: gsiPartitionKeyName, type: gsiPartitionKeyType },
+      { name: gsiSortKeyName, type: gsiSortKeyType },
+    );
+  }
 
   /**
    * Adds a Global Secondary Index (GSI) to a DynamoDB table and overrides it at the CloudFormation level.


### PR DESCRIPTION
## Problem Statement

### 1. List Messages Ordering
The current `listConversationMessages` query uses a GSI to return messages ordered by `createdAt`. That GSI is:
- Name: `gsi-ConversationMessage.conversationId.createdAt`
- PK: `conversationId`
- SK: `createdAt`

The model generated list query does a DynamoDB Scan operation.

These messages are retrieved in ascending order because that is the only option for DynamoDB Scan operations. This is seemingly what we want -- most recent message as the final element. This ordering matches what a user interface would expect and is required by Bedrock's Converse API. It is, however, problematic for long running conversations with messages exceeding the provided `limit` argument. In these cases, the most recent messages are omitted. What we actually want is to retrieve the messages from the DynamoDB table in descending order, then reverse the elements of the array before returning. This ensures that we're including the most recent messages. Using descending order ([`ScanIndexForward`](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-ScanIndexForward)` = false`) forces us to use a DynamoDB query operation, which is a good thing -- yay performant reads!

### 2. List Conversations Ordering
The model generated list conversations query currently doesn't use a GSI with sort key for ordering. For clients listing conversations, we'd like the results to be ordered in descending order by the most recently active conversations. This would match expected ordering in user interfaces of customer applications and in Amplify console where customers should be able to view conversation records.

## Description of changes

### 1. List Messages Ordering
- Updates `init` slot of model generated `listConversationMessages` query. ([reference](https://github.com/aws-amplify/amplify-category-api/pull/2997/files#diff-3365a7aa9bf7e001d5b54d4918ad0f9a4123957b40f65b93fc199abb91e58688))
  - if a `conversationId: { eq: '<id>' }` expression is included in the arguments, define a query expression to use query rather than scan.
  - sets the `sortDirection` to `'DESC'`.
- Adds `postDataLoad` slot to model generated `listConversationMessages` query to reverse items. ([reference](https://github.com/aws-amplify/amplify-category-api/pull/2997/files#diff-0c7fbf2212fd5de3e7f3358052ca3ea5745c865e6be17c99eae7af5572318384))

### 2. List Conversations Ordering
- Adds GSI to Conversation table for listing conversations in descending order by `updatedAt`. ([reference](https://github.com/aws-amplify/amplify-category-api/pull/2997/files#diff-acac0d969168e1ad99e7b9ac168ca4ab8f0599009b632a23e9608bb59b30c2adR275-R293))
- Adds `init` slot on model generated `listConversations` query: ([reference1](https://github.com/aws-amplify/amplify-category-api/pull/2997/files#diff-9dd6ff278c457b3e4405bc6dda546dee1945b6683d4c2f11c0122eaae538e7cd), [reference2](https://github.com/aws-amplify/amplify-category-api/pull/2997/files#diff-6c1e5869293bf5b8400612a826985166edbb7c018ada36befc01e1d0a5123b52))
  - defines `index` for querying by GSI.
  - defines query expression to use query rather than scan.
  - sets the `sortDirection` to `'DESC'`.
- Updates send message resolver to the `updatedAt` field on the conversation table. ([reference](https://github.com/aws-amplify/amplify-category-api/pull/2997/files#diff-6faba3512ff8d1bc579cd2e38243e7f9ff27fdd32a3f2bc2746732c72375d798))

## CDK / CloudFormation Parameters Changed
N/A

## Issue #, if available
N/A

## Description of how you validated changes
- [E2E test run](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:8049148f-4c03-4441-b48e-579ec9a108c7?region=us-east-1)

## Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
