### PR TITLE
fix: Include root cause when overrides build fails.

### DIFF
--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -361,10 +361,14 @@ export const transformCategoryStack = async (context: $TSContext, resource: Reco
       const backendDir = pathManager.getBackendDirPath();
       const overrideDir = path.join(backendDir, resource.category, resource.resourceName);
       const isBuild = await buildOverrideDir(backendDir, overrideDir).catch((error) => {
-        throw new AmplifyError('InvalidOverrideError', {
-          message: error.message,
-          link: 'https://docs.amplify.aws/cli/graphql/override/',
-        });
+        throw new AmplifyError(
+          'InvalidOverrideError',
+          {
+            message: error.message,
+            link: 'https://docs.amplify.aws/cli/graphql/override/',
+          },
+          error,
+        );
       });
       try {
         await context.amplify.invokePluginMethod(context, 'awscloudformation', undefined, 'compileSchema', [

--- a/yarn.lock
+++ b/yarn.lock
@@ -10267,7 +10267,7 @@ async@^3.2.0, async@^3.2.4:
 
 async@^3.2.3:
   version "3.2.6"
-  resolved "https://registry.npmjs.org/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
   integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
 
 asynciterator.prototype@^1.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -10260,10 +10260,15 @@ async@^2.6.4:
   dependencies:
     lodash "^4.17.14"
 
-async@^3.2.0, async@^3.2.3, async@^3.2.4:
+async@^3.2.0, async@^3.2.4:
   version "3.2.5"
   resolved "https://registry.npmjs.org/async/-/async-3.2.5.tgz#ebd52a8fdaf7a2289a24df399f8d8485c8a46b66"
   integrity sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==
+
+async@^3.2.3:
+  version "3.2.6"
+  resolved "https://registry.npmjs.org/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
+  integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
 
 asynciterator.prototype@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

When overrides building fails. The root cause is eaten. Which makes troubleshooting impossible.
This PR includes root cause in Amplify error.
Similarly to this https://github.com/aws-amplify/amplify-cli/blob/b40e8e86f00b84737dd499ab05e2158b2b4c4315/packages/amplify-cli-core/src/overrides-manager/override-skeleton-generator.ts#L125 .



#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
