### PR TITLE
feat(conversation): require auth input for conversation directive

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/schema-conversation.graphql
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/schema-conversation.graphql
@@ -8,6 +8,7 @@ type Mutation {
     @conversation(
       aiModel: "anthropic.claude-3-haiku-20240307-v1:0"
       systemPrompt: "You are a helpful chatbot that responds in the voice and tone of a pirate. Respond in 20 words or less."
+      auth: { strategy: owner, provider: userPools }
     )
     @aws_cognito_user_pools
 }

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-handler-deprecated.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-handler-deprecated.graphql
@@ -7,6 +7,7 @@ type Mutation {
   ): ConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
+    auth: { strategy: owner, provider: userPools },
     functionName: "FnROUTE_NAME",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
   )

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-handler.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-handler.graphql
@@ -7,6 +7,7 @@ type Mutation {
   ): ConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
+    auth: { strategy: owner, provider: userPools },
     handler: {
       functionName: "FnROUTE_NAME",
       eventVersion: "1.0"

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-query-tool.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-query-tool.graphql
@@ -18,6 +18,7 @@ type Mutation {
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
-    tools: [{ name: "getTemperature", description: "does a thing" }, { name: "plus", description: "does a different thing" }]
+    tools: [{ name: "getTemperature", description: "does a thing" }, { name: "plus", description: "does a different thing" }],
+    auth: { strategy: owner, provider: userPools },
   )
 }

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-inference-configuration-template.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-inference-configuration-template.graphql
@@ -8,6 +8,7 @@ type Mutation {
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
+    auth: { strategy: owner, provider: userPools },
     INFERENENCE_CONFIGURATION
   )
 }

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-custom-handler-event-version.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-custom-handler-event-version.graphql
@@ -7,6 +7,7 @@ type Mutation {
   ): ConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
+    auth: { strategy: owner, provider: userPools },
     handler: {
       functionName: "testFunctionName",
       eventVersion: "EVENT_VERSION"

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-custom-handler-function-name-and-handler-provided.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-custom-handler-function-name-and-handler-provided.graphql
@@ -7,6 +7,7 @@ type Mutation {
   ): ConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
+    auth: { strategy: owner, provider: userPools },
     functionName: "testFunctionName",
     handler: {
       functionName: "testFunctionName",

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-missing-ai-model.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-missing-ai-model.graphql
@@ -6,6 +6,7 @@ type Mutation {
     toolConfiguration: ToolConfigurationInput
   ): ConversationMessage
   @conversation(
-    systemPrompt: "You are a helpful chatbot."
+    systemPrompt: "You are a helpful chatbot.",
+    auth: { strategy: owner, provider: userPools },
   )
 }

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-missing-system-prompt.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-missing-system-prompt.graphql
@@ -5,5 +5,8 @@ type Mutation {
     aiContext: AWSJSON,
     toolConfiguration: ToolConfigurationInput
   ): ConversationMessage
-  @conversation(aiModel: "anthropic.claude-3-haiku-20240307-v1:0")
+  @conversation(
+    aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
+    auth: { strategy: owner, provider: userPools },
+  )
 }

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-return-type.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-return-type.graphql
@@ -7,6 +7,7 @@ type Mutation {
   ): String
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
-    systemPrompt: "You are a helpful chatbot."
+    systemPrompt: "You are a helpful chatbot.",
+    auth: { strategy: owner, provider: userPools },
   )
 }

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool-with-relationships.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool-with-relationships.graphql
@@ -32,6 +32,7 @@ type Mutation {
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
-    tools: [{ name: "listCustomers", description: "Provides data about the customer sending a message" }]
+    tools: [{ name: "listCustomers", description: "Provides data about the customer sending a message" }],
+    auth: { strategy: owner, provider: userPools },
   )
 }

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool.graphql
@@ -13,6 +13,7 @@ type Mutation {
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
-    tools: [{ name: "listTodos", description: "lists todos" }]
+    tools: [{ name: "listTodos", description: "lists todos" }],
+    auth: { strategy: owner, provider: userPools },
   )
 }

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-with-inference-configuration.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-with-inference-configuration.graphql
@@ -12,6 +12,7 @@ type Mutation {
         temperature: 0.5,
         topP: 0.9,
         maxTokens: 100,
-    }
+    },
+    auth: { strategy: owner, provider: userPools },
   )
 }

--- a/packages/amplify-graphql-directives/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/amplify-graphql-directives/src/__tests__/__snapshots__/index.test.ts.snap
@@ -231,12 +231,26 @@ Object {
   directive @conversation(
     aiModel: String!
     systemPrompt: String!
+    auth: ConversationAuth!
     functionName: String
     handler: ConversationHandlerFunctionConfiguration
     tools: [ToolMap]
     inferenceConfiguration: ConversationInferenceConfiguration
   ) on FIELD_DEFINITION
-  
+
+  input ConversationAuth {
+    strategy: ConversationAuthStrategy!
+    provider: ConversationAuthProvider!
+  }
+
+  enum ConversationAuthStrategy {
+    owner
+  }
+
+  enum ConversationAuthProvider {
+    userPools
+  }
+
   input ConversationHandlerFunctionConfiguration {
     functionName: String!
     eventVersion: String!

--- a/packages/amplify-graphql-directives/src/directives/conversation.ts
+++ b/packages/amplify-graphql-directives/src/directives/conversation.ts
@@ -5,12 +5,26 @@ const definition = /* GraphQL */ `
   directive @${name}(
     aiModel: String!
     systemPrompt: String!
+    auth: ConversationAuth!
     functionName: String
     handler: ConversationHandlerFunctionConfiguration
     tools: [ToolMap]
     inferenceConfiguration: ConversationInferenceConfiguration
   ) on FIELD_DEFINITION
-  
+
+  input ConversationAuth {
+    strategy: ConversationAuthStrategy!
+    provider: ConversationAuthProvider!
+  }
+
+  enum ConversationAuthStrategy {
+    owner
+  }
+
+  enum ConversationAuthProvider {
+    userPools
+  }
+
   input ConversationHandlerFunctionConfiguration {
     functionName: String!
     eventVersion: String!


### PR DESCRIPTION
## Related PR
- https://github.com/aws-amplify/amplify-api-next/pull/384

## Problem
The `@conversation` directive implicitly uses owner auth (cognito user pool) for associated models and operations because it's the only supported option. 

In the future, we may want to extend conversation routes to additional authorization strategies. When that time comes, we'll be forced to make a decision between:
1. implicit owner auth by default, opt into new authorization strategies
**--- or ---**
2. breaking change (forcing explicit authorization definition)

## Description of changes

We're not going to support additional authorization strategies by GA, but we are making the decision to go with _2. breaking change (forcing explicit authorization definition)_ already. We're doing this now while we can so that we don't have to make a difficult decision later.

- Adds `auth: ConversationAuth!` argument to `@conversation` directive.

The only supported strategy and provider for now are `owner` and `userPools`:
```gql
input ConversationAuth {
  strategy: ConversationAuthStrategy!
  provider: ConversationAuthProvider!
}
enum ConversationAuthStrategy {
  owner
}
enum ConversationAuthProvider {
  userPools
}
```

#### Why not just use `@auth`?
We could, but that would involve adding a check in the auth transformer that skipped any of it's work if the field also contained a `@conversation` directive. I'm not ok with doing that.

##### CDK / CloudFormation Parameters Changed

#### Issue #, if available

#### Description of how you validated changes
- [E2E test run](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:1ef0ecd7-5bf0-4c90-9d6e-9d4e9357685c?region=us-east-1#)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
