### PR TITLE
fix: include root cause when overrides build fails

### DIFF
--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -361,10 +361,14 @@ export const transformCategoryStack = async (context: $TSContext, resource: Reco
       const backendDir = pathManager.getBackendDirPath();
       const overrideDir = path.join(backendDir, resource.category, resource.resourceName);
       const isBuild = await buildOverrideDir(backendDir, overrideDir).catch((error) => {
-        throw new AmplifyError('InvalidOverrideError', {
-          message: error.message,
-          link: 'https://docs.amplify.aws/cli/graphql/override/',
-        });
+        throw new AmplifyError(
+          'InvalidOverrideError',
+          {
+            message: error.message,
+            link: 'https://docs.amplify.aws/cli/graphql/override/',
+          },
+          error,
+        );
       });
       try {
         await context.amplify.invokePluginMethod(context, 'awscloudformation', undefined, 'compileSchema', [


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

When overrides building fails. The root cause is eaten. Which makes troubleshooting impossible.
This PR includes root cause in Amplify error.
Similarly to this https://github.com/aws-amplify/amplify-cli/blob/b40e8e86f00b84737dd499ab05e2158b2b4c4315/packages/amplify-cli-core/src/overrides-manager/override-skeleton-generator.ts#L125 .

(copied from https://github.com/aws-amplify/amplify-category-api/pull/3004 , targeting correct branch)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
