### PR TITLE
feat(conversation): update directive input for tool definition for model list queries

### DIFF
--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -1528,7 +1528,7 @@ export function request(ctx) {
   const clientTools = args.toolConfiguration?.tools?.map((tool) => {
     return { ...tool.toolSpec };
   });
-  const dataTools = [{"name":"list customers","description":"Provides data about the customer sending a message","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { name email activeCart { products { name price } customerId id createdAt updatedAt owner } orderHistory { items { products { name price } customerId id createdAt updatedAt owner } nextToken } id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listCustomers"}}];
+  const dataTools = [{"name":"list_customers","description":"Provides data about the customer sending a message","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { name email activeCart { products { name price } customerId id createdAt updatedAt owner } orderHistory { items { products { name price } customerId id createdAt updatedAt owner } nextToken } id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listCustomers"}}];
   const toolsConfiguration = { dataTools, clientTools };
 
   const messageHistoryQuery = {
@@ -2369,7 +2369,7 @@ export function request(ctx) {
   const clientTools = args.toolConfiguration?.tools?.map((tool) => {
     return { ...tool.toolSpec };
   });
-  const dataTools = [{"name":"list all the todos","description":"lists todos","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { content isDone id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listTodos"}}];
+  const dataTools = [{"name":"list_all_the_todos","description":"lists todos","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { content isDone id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listTodos"}}];
   const toolsConfiguration = { dataTools, clientTools };
 
   const messageHistoryQuery = {

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -2369,7 +2369,7 @@ export function request(ctx) {
   const clientTools = args.toolConfiguration?.tools?.map((tool) => {
     return { ...tool.toolSpec };
   });
-  const dataTools = [{"name":"list_all_the_todos","description":"lists todos","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { content isDone id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listTodos"}}];
+  const dataTools = [{"name":"list_all_the_todos","description":"lists todos","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { content isDone id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listMyTodos"}}];
   const toolsConfiguration = { dataTools, clientTools };
 
   const messageHistoryQuery = {

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -1528,7 +1528,7 @@ export function request(ctx) {
   const clientTools = args.toolConfiguration?.tools?.map((tool) => {
     return { ...tool.toolSpec };
   });
-  const dataTools = [{"name":"listCustomers","description":"Provides data about the customer sending a message","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { name email activeCart { products { name price } customerId id createdAt updatedAt owner } orderHistory { items { products { name price } customerId id createdAt updatedAt owner } nextToken } id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listCustomers"}}];
+  const dataTools = [{"name":"list customers","description":"Provides data about the customer sending a message","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { name email activeCart { products { name price } customerId id createdAt updatedAt owner } orderHistory { items { products { name price } customerId id createdAt updatedAt owner } nextToken } id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listCustomers"}}];
   const toolsConfiguration = { dataTools, clientTools };
 
   const messageHistoryQuery = {
@@ -2369,7 +2369,7 @@ export function request(ctx) {
   const clientTools = args.toolConfiguration?.tools?.map((tool) => {
     return { ...tool.toolSpec };
   });
-  const dataTools = [{"name":"listTodos","description":"lists todos","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { content isDone id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listTodos"}}];
+  const dataTools = [{"name":"list all the todos","description":"lists todos","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { content isDone id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listTodos"}}];
   const toolsConfiguration = { dataTools, clientTools };
 
   const messageHistoryQuery = {
@@ -3210,7 +3210,7 @@ export function request(ctx) {
   const clientTools = args.toolConfiguration?.tools?.map((tool) => {
     return { ...tool.toolSpec };
   });
-  const dataTools = [{"name":"getTemperature","description":"does a thing","inputSchema":{"json":{"type":"object","properties":{"city":{"type":"string","description":"A UTF-8 character sequence."}},"required":["city"]}},"graphqlRequestInputDescriptor":{"selectionSet":"value unit","propertyTypes":{"city":"String!"},"queryName":"getTemperature"}},{"name":"plus","description":"does a different thing","inputSchema":{"json":{"type":"object","properties":{"a":{"type":"number","description":"A signed 32-bit integer value."},"b":{"type":"number","description":"A signed 32-bit integer value."}},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"","propertyTypes":{"a":"Int","b":"Int"},"queryName":"plus"}}];
+  const dataTools = [{"name":"thermometer","description":"does a thing","inputSchema":{"json":{"type":"object","properties":{"city":{"type":"string","description":"A UTF-8 character sequence."}},"required":["city"]}},"graphqlRequestInputDescriptor":{"selectionSet":"value unit","propertyTypes":{"city":"String!"},"queryName":"getTemperature"}},{"name":"calculator","description":"does a different thing","inputSchema":{"json":{"type":"object","properties":{"a":{"type":"number","description":"A signed 32-bit integer value."},"b":{"type":"number","description":"A signed 32-bit integer value."}},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"","propertyTypes":{"a":"Int","b":"Int"},"queryName":"plus"}}];
   const toolsConfiguration = { dataTools, clientTools };
 
   const messageHistoryQuery = {

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
@@ -115,12 +115,23 @@ describe('ConversationTransformer', () => {
     describe('invalid tool definition', () => {
       it('should throw an error if model operation and custom tool fields are mixed', () => {
         const inputSchema = getSchema('conversation-route-invalid-tool-definition-mixed-fields.graphql');
-        expect(() => transform(inputSchema)).toThrow('Invalid tool definitions: calculator');
+        expect(() => transform(inputSchema)).toThrow(
+          'Tool definitions must contain a modelName and modelOperation, or queryName. Invalid tools: calculator',
+        );
       });
 
       it('should throw an error if required fields are missing', () => {
         const inputSchema = getSchema('conversation-route-invalid-tool-definition-missing-fields.graphql');
-        expect(() => transform(inputSchema)).toThrow('Invalid tool definitions: calculator');
+        expect(() => transform(inputSchema)).toThrow(
+          'Tool definitions must contain a modelName and modelOperation, or queryName. Invalid tools: calculator',
+        );
+      });
+
+      it('should throw an error if tool name is invalid', () => {
+        const inputSchema = getSchema('conversation-route-invalid-tool-name.graphql');
+        expect(() => transform(inputSchema)).toThrow(
+          'Tool name must be between 1 and 64 characters, start with a letter, and contain only letters, numbers, and underscores. Found: this is an invalid tool name',
+        );
       });
     });
 

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
@@ -80,6 +80,16 @@ describe('ConversationTransformer', () => {
         out.rootStack.Resources?.[conversationLambdaStackName].Properties?.Parameters?.[conversationLambdaDataSourceFunctionArnRef];
       expect(lambdaDataSourceFunctionArn).toEqual(expectedCustomHandlerArn);
     });
+
+    test('mixing query and model tools', () => {
+      const routeName = 'toolChat';
+      const inputSchema = getSchema('conversation-route-mixed-tools.graphql', { ROUTE_NAME: routeName });
+      const out = transform(inputSchema);
+      expect(out).toBeDefined();
+
+      const invokeLambdaFn = out.resolvers[`Mutation.${routeName}.invoke-lambda.js`];
+      expect(invokeLambdaFn).toBeDefined();
+    });
   });
 
   describe('invalid schemas', () => {

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
@@ -112,6 +112,18 @@ describe('ConversationTransformer', () => {
       });
     });
 
+    describe('invalid tool definition', () => {
+      it('should throw an error if model operation and custom tool fields are mixed', () => {
+        const inputSchema = getSchema('conversation-route-invalid-tool-definition-mixed-fields.graphql');
+        expect(() => transform(inputSchema)).toThrow('Invalid tool definitions: calculator');
+      });
+
+      it('should throw an error if required fields are missing', () => {
+        const inputSchema = getSchema('conversation-route-invalid-tool-definition-missing-fields.graphql');
+        expect(() => transform(inputSchema)).toThrow('Invalid tool definitions: calculator');
+      });
+    });
+
     describe('invalid custom handler configuration', () => {
       it('should throw if both functionName and handler are provided', () => {
         const inputSchema = getSchema('conversation-route-invalid-custom-handler-function-name-and-handler-provided.graphql');

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-query-tool.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-query-tool.graphql
@@ -18,7 +18,10 @@ type Mutation {
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
-    tools: [{ name: "getTemperature", description: "does a thing" }, { name: "plus", description: "does a different thing" }],
+    tools: [
+      { name: "thermometer", description: "does a thing", queryName: "getTemperature" },
+      { name: "calculator", description: "does a different thing", queryName: "plus" }
+    ],
     auth: { strategy: owner, provider: userPools },
   )
 }

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-tool-definition-missing-fields.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-tool-definition-missing-fields.graphql
@@ -1,8 +1,3 @@
-type Todo @model @auth(rules: [{ allow: owner }]) {
-  content: String
-  isDone: Boolean
-}
-
 type Mutation {
   ROUTE_NAME(
     conversationId: ID!,
@@ -15,11 +10,9 @@ type Mutation {
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
     tools: [
       {
-        name: "list all the todos",
-        description: "lists todos",
-        modelName: "Todo",
-        modelOperation: list,
-      },
+        name: "calculator",
+        description: "does a different thing",
+      }
     ],
     auth: { strategy: owner, provider: userPools },
   )

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-tool-definition-mixed-fields.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-tool-definition-mixed-fields.graphql
@@ -1,6 +1,5 @@
-type Todo @model @auth(rules: [{ allow: owner }]) {
-  content: String
-  isDone: Boolean
+type Query {
+  plus(a: Int, b: Int): Int
 }
 
 type Mutation {
@@ -15,11 +14,11 @@ type Mutation {
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
     tools: [
       {
-        name: "list all the todos",
-        description: "lists todos",
-        modelName: "Todo",
-        modelOperation: list,
-      },
+        name: "calculator",
+        description: "does a different thing",
+        queryName: "plus",
+        modelName: "Calculator"
+      }
     ],
     auth: { strategy: owner, provider: userPools },
   )

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-tool-definition-mixed-fields.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-tool-definition-mixed-fields.graphql
@@ -17,7 +17,8 @@ type Mutation {
         name: "calculator",
         description: "does a different thing",
         queryName: "plus",
-        modelName: "Calculator"
+        modelName: "Calculator",
+        modelOperation: list,
       }
     ],
     auth: { strategy: owner, provider: userPools },

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-tool-name.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-tool-name.graphql
@@ -1,8 +1,3 @@
-type Todo @model @auth(rules: [{ allow: owner }]) {
-  content: String
-  isDone: Boolean
-}
-
 type Mutation {
   ROUTE_NAME(
     conversationId: ID!,
@@ -15,11 +10,10 @@ type Mutation {
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
     tools: [
       {
-        name: "list_all_the_todos",
-        description: "lists todos",
-        modelName: "Todo",
-        modelOperation: list,
-      },
+        name: "this is an invalid tool name",
+        description: "does a thing",
+        queryName: "myQuery",
+      }
     ],
     auth: { strategy: owner, provider: userPools },
   )

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-mixed-tools.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-mixed-tools.graphql
@@ -1,0 +1,35 @@
+type Query {
+  plus(a: Int, b: Int): Int
+}
+
+type Todo @model @auth(rules: [{ allow: owner }]) {
+  content: String
+  isDone: Boolean
+}
+
+type Mutation {
+  ROUTE_NAME(
+    conversationId: ID!,
+    content: [ContentBlockInput],
+    aiContext: AWSJSON,
+    toolConfiguration: ToolConfigurationInput
+  ): ConversationMessage
+  @conversation(
+    aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
+    systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
+    tools: [
+      {
+        name: "calculator",
+        description: "does a different thing",
+        queryName: "plus",
+      },
+      {
+        name: "list_all_the_todos",
+        description: "lists todos",
+        modelName: "Todo",
+        modelOperation: list,
+      },
+    ],
+    auth: { strategy: owner, provider: userPools },
+  )
+}

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool-with-relationships.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool-with-relationships.graphql
@@ -32,7 +32,14 @@ type Mutation {
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
-    tools: [{ name: "listCustomers", description: "Provides data about the customer sending a message" }],
+    tools: [
+      {
+        name: "list customers",
+        description: "Provides data about the customer sending a message",
+        modelName: "Customer",
+        modelOperation: list,
+      },
+    ],
     auth: { strategy: owner, provider: userPools },
   )
 }

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool-with-relationships.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool-with-relationships.graphql
@@ -34,7 +34,7 @@ type Mutation {
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
     tools: [
       {
-        name: "list customers",
+        name: "list_customers",
         description: "Provides data about the customer sending a message",
         modelName: "Customer",
         modelOperation: list,

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool.graphql
@@ -1,4 +1,4 @@
-type Todo @model @auth(rules: [{ allow: owner }]) {
+type Todo @model(queries: { list: "listMyTodos" }) @auth(rules: [{ allow: owner }]) {
   content: String
   isDone: Boolean
 }

--- a/packages/amplify-graphql-conversation-transformer/src/conversation-directive-configuration.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/conversation-directive-configuration.ts
@@ -59,6 +59,30 @@ export type ConversationInferenceConfiguration = {
 export type ToolDefinition = {
   name: string;
   description: string;
+  queryName?: string;
+  modelName?: string;
+  modelOperation?: ConversationToolModelOperation;
+};
+
+/**
+ * Conversation Directive Tool Model Operation
+ * Currently limited to `list` operations.
+ */
+export enum ConversationToolModelOperation {
+  list = 'list',
+}
+
+export type ModelOperationTool = {
+  name: string;
+  description: string;
+  modelName: string;
+  modelOperation: ConversationToolModelOperation;
+};
+
+export type CustomQueryTool = {
+  name: string;
+  description: string;
+  queryName: string;
 };
 
 /**

--- a/packages/amplify-graphql-conversation-transformer/src/tools/process-tools.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/tools/process-tools.ts
@@ -57,9 +57,7 @@ export const processTools = (toolDefinitions: ToolDefinition[], ctx: Transformer
   // Process each tool definition
   const tools: Tool[] = toolDefinitions.map((toolDefinition) => {
     const { name: toolName, description } = toolDefinition;
-    const queryName = isModelOperationToolPredicate(toolDefinition)
-      ? modelListQueryName(toolDefinition, ctx)
-      : toolDefinition.queryName;
+    const queryName = isModelOperationToolPredicate(toolDefinition) ? modelListQueryName(toolDefinition, ctx) : toolDefinition.queryName;
     const queryField = queryType.fields?.find((field) => field.name.value === queryName);
 
     if (!queryField) {

--- a/packages/amplify-graphql-conversation-transformer/src/tools/process-tools.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/tools/process-tools.ts
@@ -1,8 +1,9 @@
 import { InvalidDirectiveError, JSONSchema } from '@aws-amplify/graphql-transformer-core';
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { FieldDefinitionNode, InputValueDefinitionNode, ObjectTypeDefinitionNode, TypeNode } from 'graphql';
-import { getBaseType, isNonNullType, isScalar } from 'graphql-transformer-common';
-import { ToolDefinition } from '../conversation-directive-configuration';
+import { getBaseType, isNonNullType, isScalar, toUpper } from 'graphql-transformer-common';
+import pluralize from 'pluralize';
+import { CustomQueryTool, ModelOperationTool, ToolDefinition } from '../conversation-directive-configuration';
 import { generateJSONSchemaFromTypeNode } from './graphql-json-schema-type';
 
 export type Tool = {
@@ -13,6 +14,12 @@ export type Tool = {
   };
   graphqlRequestInputDescriptor?: GraphQLRequestInputDescriptor;
 };
+
+export const isModelOperationToolPredicate = (tool: ToolDefinition): tool is ModelOperationTool =>
+  tool.modelName !== undefined && tool.modelOperation !== undefined && tool.queryName === undefined;
+
+export const isCustomQueryToolPredicate = (tool: ToolDefinition): tool is CustomQueryTool =>
+  tool.queryName !== undefined && tool.modelName === undefined && tool.modelOperation === undefined;
 
 type GraphQLRequestInputDescriptor = {
   selectionSet: string;
@@ -43,13 +50,16 @@ export const processTools = (toolDefinitions: ToolDefinition[], ctx: Transformer
   // Process each tool definition
   const tools: Tool[] = toolDefinitions.map((toolDefinition) => {
     const { name: toolName, description } = toolDefinition;
-    const queryField = queryType.fields?.find((field) => field.name.value === toolName);
+    const queryName = isModelOperationToolPredicate(toolDefinition)
+      ? `list${pluralize(toUpper(toolDefinition.modelName))}`
+      : toolDefinition.queryName;
+    const queryField = queryType.fields?.find((field) => field.name.value === queryName);
 
     if (!queryField) {
       throw new InvalidDirectiveError(`Tool "${toolName}" defined in @conversation directive has no matching Query field definition`);
     }
 
-    return createTool(toolName, description, queryField, ctx);
+    return createTool({ toolName, description, queryField, ctx });
   });
 
   return tools;
@@ -135,7 +145,13 @@ const getObjectTypeFromName = (name: string, ctx: TransformerContextProvider): O
  * @param {TransformerContextProvider} ctx - The transformer context provider.
  * @returns {Tool} A Tool object.
  */
-const createTool = (toolName: string, description: string, queryField: FieldDefinitionNode, ctx: TransformerContextProvider): Tool => {
+const createTool = (input: {
+  toolName: string;
+  description: string;
+  queryField: FieldDefinitionNode;
+  ctx: TransformerContextProvider;
+}): Tool => {
+  const { toolName, description, queryField, ctx } = input;
   const { type: returnType, arguments: fieldArguments } = queryField;
 
   // Generate tool properties and required fields
@@ -151,7 +167,7 @@ const createTool = (toolName: string, description: string, queryField: FieldDefi
   const graphqlRequestInputDescriptor: GraphQLRequestInputDescriptor = {
     selectionSet,
     propertyTypes,
-    queryName: toolName,
+    queryName: queryField.name.value,
   };
 
   return {

--- a/packages/amplify-graphql-conversation-transformer/src/tools/process-tools.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/tools/process-tools.ts
@@ -1,4 +1,4 @@
-import { InvalidDirectiveError, JSONSchema } from '@aws-amplify/graphql-transformer-core';
+import { getFieldNameFor, InvalidDirectiveError, JSONSchema } from '@aws-amplify/graphql-transformer-core';
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import {
   FieldDefinitionNode,
@@ -267,5 +267,5 @@ const modelListQueryName = (modelTool: ModelOperationTool, ctx: TransformerConte
   const listValue = listField?.value as StringValueNode | undefined;
   const listQueryArgument = listValue?.value;
 
-  return listQueryArgument ?? `list${pluralize(toUpper(modelName))}`;
+  return listQueryArgument ?? getFieldNameFor('list', modelName);
 };

--- a/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-field-handler.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-field-handler.ts
@@ -13,8 +13,8 @@ import { ConversationModel, createConversationModel } from '../graphql-types/con
 import {
   createAssistantMutationField,
   createAssistantResponseMutationInput,
-  createAssistantStreamingMutationField,
   createAssistantResponseStreamingMutationInput,
+  createAssistantStreamingMutationField,
   createMessageModel,
   createMessageSubscription,
   MessageModel,
@@ -27,6 +27,7 @@ import {
   getConversationTypeName,
   getMessageSubscriptionFieldName,
 } from '../graphql-types/name-values';
+import { isCustomQueryToolPredicate, isModelOperationToolPredicate } from '../tools/process-tools';
 
 /**
  * @class ConversationFieldHandler
@@ -172,6 +173,18 @@ export class ConversationFieldHandler {
     this.validateReturnType(config);
     this.validateInferenceConfig(config);
     this.validateHandler(config);
+    this.validateToolDefinitions(config);
+  }
+
+  private validateToolDefinitions(config: ConversationDirectiveConfiguration): void {
+    const { tools } = config;
+    if (!tools) return;
+
+    const invalidTools = tools.filter((tool) => !isModelOperationToolPredicate(tool) && !isCustomQueryToolPredicate(tool));
+
+    if (invalidTools.length > 0) {
+      throw new InvalidDirectiveError(`Invalid tool definitions: ${invalidTools.map((tool) => tool.name).join(', ')}`);
+    }
   }
 
   /**

--- a/packages/amplify-graphql-directives/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/amplify-graphql-directives/src/__tests__/__snapshots__/index.test.ts.snap
@@ -256,9 +256,30 @@ Object {
     eventVersion: String!
   }
 
+  # The configuration for a tool.
+  # This is a fake union (GraphQL doesn't support unions in inputs). It is best thought of as:
+  # type ToolMap =
+  #  ({ queryName: string; } | { modelName: string; modelOperation: ConversationToolModelOperation; })
+  #  & { name: string; description: string; }
+  # The conversation transformer validates the input to ensure it conforms to the expected shape.
   input ToolMap {
-    name: String
-    description: String
+    # The name of the tool. This is included in the tool definition provided to the AI model.
+    name: String!
+    # The description of the tool. This is included in the tool definition provided to the AI model.
+    description: String!
+
+    # The name of the GraphQL query that is invoked when the tool is used.
+    queryName: String
+
+    # The name of the Amplify model used by the tool.
+    modelName: String
+    # The model generated operation for the provided Amplify model that is invoked when the tool is used.
+    modelOperation: ConversationToolModelOperation
+  }
+
+  # The model generated operation for the provided Amplify model.
+  enum ConversationToolModelOperation {
+    list
   }
 
   input ConversationInferenceConfiguration {

--- a/packages/amplify-graphql-directives/src/directives/conversation.ts
+++ b/packages/amplify-graphql-directives/src/directives/conversation.ts
@@ -30,9 +30,30 @@ const definition = /* GraphQL */ `
     eventVersion: String!
   }
 
+  # The configuration for a tool.
+  # This is a fake union (GraphQL doesn't support unions in inputs). It is best thought of as:
+  # type ToolMap =
+  #  ({ queryName: string; } | { modelName: string; modelOperation: ConversationToolModelOperation; })
+  #  & { name: string; description: string; }
+  # The conversation transformer validates the input to ensure it conforms to the expected shape.
   input ToolMap {
-    name: String
-    description: String
+    # The name of the tool. This is included in the tool definition provided to the AI model.
+    name: String!
+    # The description of the tool. This is included in the tool definition provided to the AI model.
+    description: String!
+
+    # The name of the GraphQL query that is invoked when the tool is used.
+    queryName: String
+
+    # The name of the Amplify model used by the tool.
+    modelName: String
+    # The model generated operation for the provided Amplify model that is invoked when the tool is used.
+    modelOperation: ConversationToolModelOperation
+  }
+
+  # The model generated operation for the provided Amplify model.
+  enum ConversationToolModelOperation {
+    list
   }
 
   input ConversationInferenceConfiguration {


### PR DESCRIPTION
## Related PR
- https://github.com/aws-amplify/amplify-api-next/pull/390

## Problem

1. Customers wanting to use generated model queries as tools for conversation routes must know the name of the generated model query in advance.

```graphql
type Todo @model @auth(rules: [{ allow: owner }]) {
  content: String
  isDone: Boolean
}

type Mutation {
  chat(
    conversationId: ID!,
    content: [ContentBlockInput],
    aiContext: AWSJSON,
    toolConfiguration: ToolConfigurationInput
  ): ConversationMessage
  @conversation(
    aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
    systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
    tools: [
      {
        name: "listTodos",  # <--- must match query name
        description: "lists todos",
      },
    ],
    auth: { strategy: owner, provider: userPools },
  )
}
```

2. The name of a tool must be the name of the GraphQL query. This is an arbitrary requirement we currently enforce through the directive API that isn't necessary.

## Description of changes

Updates the `ToolMap` input in the `@conversation` directive definition
```diff
  input ToolMap {
-    name: String
-    description: String
+    name: String!
+    description: String!
+    queryName: String
+    modelName: String
+    modelOperation: ConversationToolModelOperation
  }

+  enum ConversationToolModelOperation {
+    list
+  }
```

As referenced in the [inline documentation](https://github.com/aws-amplify/amplify-category-api/pull/3013/files?diff=split&w=0#diff-f57f2ca47a2e1f04b43fff35aa6b420bd0f43cf11cc3c42c392a01a2ab7c17ceR33-R38), this is essentially a fake union type.

### New DX
```graphql
# model generated list query
@conversation(
  aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
  systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
  tools: [
    {
      name: "list_customers",
      description: "Provides data about the customer sending a message",
      modelName: "Customer",
      modelOperation: list,
    },
  ],
  auth: { strategy: owner, provider: userPools },
)

# custom query
@conversation(
  aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
  systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
  tools: [
    { name: "thermometer", description: "does a thing", queryName: "getTemperature" },
    { name: "calculator", description: "does a different thing", queryName: "plus" }
  ],
  auth: { strategy: owner, provider: userPools },
)

```


### Why only support `list` queries?
- We only support queries (non-mutating) tools currently. This is an intentional constraint to prevent unexpected destructive actions through the non-deterministic nature of LLMs.
- We only support `list` queries because `get` queries require the LLM to have the primary key of the relevant model. It's possible to make this work today by including the primary key in the `aiContext` of a message, however this approach hasn't proven dependable or an acceptable DX. We're planning on exploring alternative ways to support `get` queries; until then, we're constraining model generated query tools to `list`.

### Why not just have `data-schema` generate the `queryName` rather than changing the directive API?
This was the initial route I planned, but it's the wrong one as it would force `data-schema` to take a dependency on the implementation details of the model transformer.

### What about custom named model generated list queries?
[Supported](https://github.com/aws-amplify/amplify-category-api/pull/3013/commits/0e7160dfaa95dd9169e3309533391a17350a7467) 😄 

### CDK / CloudFormation Parameters Changed
N/A

## Issue #, if available
N/A

## Description of how you validated changes

## Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] ~E2E test run linked~
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
