### PR TITLE
fix(conversation): plumb outputStorageStrategy through transformer to handler

### DIFF
--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -4029,7 +4029,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 868
+        "line": 872
       },
       "name": "AddFunctionProps",
       "properties": [
@@ -4042,7 +4042,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 872
+            "line": 876
           },
           "name": "dataSource",
           "type": {
@@ -4058,7 +4058,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 877
+            "line": 881
           },
           "name": "name",
           "type": {
@@ -4075,7 +4075,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 912
+            "line": 916
           },
           "name": "code",
           "optional": true,
@@ -4093,7 +4093,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 884
+            "line": 888
           },
           "name": "description",
           "optional": true,
@@ -4111,7 +4111,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 891
+            "line": 895
           },
           "name": "requestMappingTemplate",
           "optional": true,
@@ -4129,7 +4129,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 898
+            "line": 902
           },
           "name": "responseMappingTemplate",
           "optional": true,
@@ -4147,7 +4147,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 905
+            "line": 909
           },
           "name": "runtime",
           "optional": true,
@@ -4490,7 +4490,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 314
+            "line": 315
           },
           "name": "addDynamoDbDataSource",
           "parameters": [
@@ -4539,7 +4539,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 326
+            "line": 327
           },
           "name": "addElasticsearchDataSource",
           "parameters": [
@@ -4586,7 +4586,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 336
+            "line": 337
           },
           "name": "addEventBridgeDataSource",
           "parameters": [
@@ -4633,7 +4633,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 418
+            "line": 419
           },
           "name": "addFunction",
           "parameters": [
@@ -4668,7 +4668,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 347
+            "line": 348
           },
           "name": "addHttpDataSource",
           "parameters": [
@@ -4716,7 +4716,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 358
+            "line": 359
           },
           "name": "addLambdaDataSource",
           "parameters": [
@@ -4764,7 +4764,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 369
+            "line": 370
           },
           "name": "addNoneDataSource",
           "parameters": [
@@ -4803,7 +4803,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 380
+            "line": 381
           },
           "name": "addOpenSearchDataSource",
           "parameters": [
@@ -4851,7 +4851,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 393
+            "line": 394
           },
           "name": "addRdsDataSource",
           "parameters": [
@@ -4918,7 +4918,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 409
+            "line": 410
           },
           "name": "addResolver",
           "parameters": [
@@ -5092,7 +5092,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 771
+        "line": 775
       },
       "name": "AmplifyGraphqlApiCfnResources",
       "properties": [
@@ -5105,7 +5105,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 825
+            "line": 829
           },
           "name": "additionalCfnResources",
           "type": {
@@ -5126,7 +5126,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 810
+            "line": 814
           },
           "name": "amplifyDynamoDbTables",
           "type": {
@@ -5147,7 +5147,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 800
+            "line": 804
           },
           "name": "cfnDataSources",
           "type": {
@@ -5168,7 +5168,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 795
+            "line": 799
           },
           "name": "cfnFunctionConfigurations",
           "type": {
@@ -5189,7 +5189,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 820
+            "line": 824
           },
           "name": "cfnFunctions",
           "type": {
@@ -5210,7 +5210,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 775
+            "line": 779
           },
           "name": "cfnGraphqlApi",
           "type": {
@@ -5226,7 +5226,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 780
+            "line": 784
           },
           "name": "cfnGraphqlSchema",
           "type": {
@@ -5242,7 +5242,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 790
+            "line": 794
           },
           "name": "cfnResolvers",
           "type": {
@@ -5263,7 +5263,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 815
+            "line": 819
           },
           "name": "cfnRoles",
           "type": {
@@ -5284,7 +5284,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 805
+            "line": 809
           },
           "name": "cfnTables",
           "type": {
@@ -5305,7 +5305,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 785
+            "line": 789
           },
           "name": "cfnApiKey",
           "optional": true,
@@ -5328,7 +5328,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 688
+        "line": 692
       },
       "name": "AmplifyGraphqlApiProps",
       "properties": [
@@ -5342,7 +5342,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 705
+            "line": 709
           },
           "name": "authorizationModes",
           "type": {
@@ -5359,7 +5359,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 693
+            "line": 697
           },
           "name": "definition",
           "type": {
@@ -5376,7 +5376,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 699
+            "line": 703
           },
           "name": "apiName",
           "optional": true,
@@ -5395,7 +5395,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 720
+            "line": 724
           },
           "name": "conflictResolution",
           "optional": true,
@@ -5413,7 +5413,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 764
+            "line": 768
           },
           "name": "dataStoreConfiguration",
           "optional": true,
@@ -5433,7 +5433,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 713
+            "line": 717
           },
           "name": "functionNameMap",
           "optional": true,
@@ -5456,7 +5456,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 735
+            "line": 739
           },
           "name": "functionSlots",
           "optional": true,
@@ -5491,7 +5491,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 758
+            "line": 762
           },
           "name": "outputStorageStrategy",
           "optional": true,
@@ -5508,7 +5508,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 747
+            "line": 751
           },
           "name": "predictionsBucket",
           "optional": true,
@@ -5526,7 +5526,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 729
+            "line": 733
           },
           "name": "stackMappings",
           "optional": true,
@@ -5552,7 +5552,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 742
+            "line": 746
           },
           "name": "transformerPlugins",
           "optional": true,
@@ -5574,7 +5574,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 753
+            "line": 757
           },
           "name": "translationBehavior",
           "optional": true,
@@ -5597,7 +5597,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 832
+        "line": 836
       },
       "name": "AmplifyGraphqlApiResources",
       "properties": [
@@ -5610,7 +5610,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 856
+            "line": 860
           },
           "name": "cfnResources",
           "type": {
@@ -5626,7 +5626,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 851
+            "line": 855
           },
           "name": "functions",
           "type": {
@@ -5647,7 +5647,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 836
+            "line": 840
           },
           "name": "graphqlApi",
           "type": {
@@ -5663,7 +5663,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 861
+            "line": 865
           },
           "name": "nestedStacks",
           "type": {
@@ -5684,7 +5684,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 846
+            "line": 850
           },
           "name": "roles",
           "type": {
@@ -5705,7 +5705,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 841
+            "line": 845
           },
           "name": "tables",
           "type": {
@@ -6903,7 +6903,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 659
+        "line": 663
       },
       "name": "IBackendOutputEntry",
       "properties": [
@@ -6916,7 +6916,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 668
+            "line": 672
           },
           "name": "payload",
           "type": {
@@ -6937,7 +6937,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 663
+            "line": 667
           },
           "name": "version",
           "type": {
@@ -6957,7 +6957,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "src/types.ts",
-        "line": 674
+        "line": 678
       },
       "methods": [
         {
@@ -6968,7 +6968,7 @@
           },
           "locationInModule": {
             "filename": "src/types.ts",
-            "line": 681
+            "line": 685
           },
           "name": "addBackendOutputEntry",
           "parameters": [
@@ -9032,5 +9032,5 @@
     }
   },
   "version": "1.17.0",
-  "fingerprint": "vMrsRM5QtRUJHWxj4XZw8PdvYvthFhfQOzG5jhsO4SA="
+  "fingerprint": "g2oPXg4lKXPveD98CIYZq4+lkdXaMFG8EbYC7O5uFxA="
 }

--- a/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
+++ b/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
@@ -238,6 +238,7 @@ export class AmplifyGraphqlApi extends Construct {
           ...definition.referencedLambdaFunctions,
           ...functionNameMap,
         },
+        outputStorageStrategy,
       },
       authConfig,
       stackMapping: stackMappings ?? {},

--- a/packages/amplify-graphql-api-construct/src/types.ts
+++ b/packages/amplify-graphql-api-construct/src/types.ts
@@ -653,6 +653,10 @@ export interface IAmplifyGraphqlDefinition {
   readonly customSqlDataSourceStrategies?: CustomSqlDataSourceStrategy[];
 }
 
+// NOTE: These types are duplicated from packages/amplify-graphql-transformer-interfaces/src/backend-output.ts
+// - IBackendOutputEntry
+// - IBackendOutputStorageStrategy
+// Before updating these types, ensure that that changes can be, and are, reflected in the other file.
 /**
  * Entry representing the required output from the backend for codegen generate commands to work.
  */

--- a/packages/amplify-graphql-conversation-transformer/API.md
+++ b/packages/amplify-graphql-conversation-transformer/API.md
@@ -8,6 +8,7 @@ import { BelongsToTransformer } from '@aws-amplify/graphql-relational-transforme
 import { DirectiveNode } from 'graphql';
 import { FieldDefinitionNode } from 'graphql';
 import { HasManyTransformer } from '@aws-amplify/graphql-relational-transformer';
+import { IBackendOutputStorageStrategy } from '@aws-amplify/graphql-transformer-interfaces';
 import { InterfaceTypeDefinitionNode } from 'graphql';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
@@ -20,7 +21,7 @@ import { TransformerSchemaVisitStepContextProvider } from '@aws-amplify/graphql-
 
 // @public (undocumented)
 export class ConversationTransformer extends TransformerPluginBase {
-    constructor(modelTransformer: ModelTransformer, hasManyTransformer: HasManyTransformer, belongsToTransformer: BelongsToTransformer, authProvider: TransformerAuthProvider, functionNameMap?: Record<string, lambda.IFunction>);
+    constructor(modelTransformer: ModelTransformer, hasManyTransformer: HasManyTransformer, belongsToTransformer: BelongsToTransformer, authProvider: TransformerAuthProvider, outputStorageStrategy?: IBackendOutputStorageStrategy, functionNameMap?: Record<string, lambda.IFunction>);
     // (undocumented)
     field: (parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode, definition: FieldDefinitionNode, directive: DirectiveNode, context: TransformerSchemaVisitStepContextProvider) => void;
     // (undocumented)

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
@@ -324,7 +324,7 @@ function transform(
     hasManyTransformer,
     hasOneTransformer,
     belongsToTransformer,
-    new ConversationTransformer(modelTransformer, hasManyTransformer, belongsToTransformer, authTransformer, functionMap),
+    new ConversationTransformer(modelTransformer, hasManyTransformer, belongsToTransformer, authTransformer, undefined, functionMap),
     new GenerationTransformer(),
     authTransformer,
   ];

--- a/packages/amplify-graphql-conversation-transformer/src/grapqhl-conversation-transformer.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/grapqhl-conversation-transformer.ts
@@ -1,8 +1,9 @@
 import { ConversationDirective } from '@aws-amplify/graphql-directives';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { BelongsToTransformer, HasManyTransformer } from '@aws-amplify/graphql-relational-transformer';
-import { InvalidDirectiveError, TransformerPluginBase } from '@aws-amplify/graphql-transformer-core';
+import { TransformerPluginBase } from '@aws-amplify/graphql-transformer-core';
 import {
+  IBackendOutputStorageStrategy,
   TransformerAuthProvider,
   TransformerContextProvider,
   TransformerPrepareStepContextProvider,
@@ -28,12 +29,13 @@ export class ConversationTransformer extends TransformerPluginBase {
     hasManyTransformer: HasManyTransformer,
     belongsToTransformer: BelongsToTransformer,
     authProvider: TransformerAuthProvider,
+    outputStorageStrategy?: IBackendOutputStorageStrategy,
     functionNameMap?: Record<string, lambda.IFunction>,
   ) {
     super('amplify-conversation-transformer', ConversationDirective.definition);
     this.fieldHandler = new ConversationFieldHandler();
     this.prepareHandler = new ConversationPrepareHandler(modelTransformer, hasManyTransformer, belongsToTransformer, authProvider);
-    this.resolverGenerator = new ConversationResolverGenerator(functionNameMap);
+    this.resolverGenerator = new ConversationResolverGenerator(functionNameMap, outputStorageStrategy);
   }
 
   /**

--- a/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
@@ -1,7 +1,7 @@
 import { conversation } from '@aws-amplify/ai-constructs';
 import { overrideIndexAtCfnLevel } from '@aws-amplify/graphql-index-transformer';
 import { getModelDataSourceNameForTypeName, getTable, TransformerResolver } from '@aws-amplify/graphql-transformer-core';
-import { DataSourceProvider, TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { DataSourceProvider, IBackendOutputStorageStrategy, TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import * as cdk from 'aws-cdk-lib';
 import { IFunction } from 'aws-cdk-lib/aws-lambda';
 import { FunctionResourceIDs, ResourceConstants } from 'graphql-transformer-common';
@@ -27,7 +27,10 @@ import {
 } from '../resolvers';
 import { processTools } from '../tools/process-tools';
 export class ConversationResolverGenerator {
-  constructor(private readonly functionNameMap?: Record<string, IFunction>) {}
+  constructor(
+    private readonly functionNameMap?: Record<string, IFunction>,
+    private readonly outputStorageStrategy?: IBackendOutputStorageStrategy,
+  ) {}
 
   /**
    * Generates resolvers for all conversation directives.
@@ -189,6 +192,7 @@ export class ConversationResolverGenerator {
             modelId,
           },
         ],
+        outputStorageStrategy: this.outputStorageStrategy as any,
       },
     );
 

--- a/packages/amplify-graphql-transformer-interfaces/API.md
+++ b/packages/amplify-graphql-transformer-interfaces/API.md
@@ -218,6 +218,20 @@ export interface GraphQLAPIProvider extends IConstruct {
 }
 
 // @public (undocumented)
+export interface IBackendOutputEntry {
+    // (undocumented)
+    readonly payload: Record<string, string>;
+    // (undocumented)
+    readonly version: string;
+}
+
+// @public (undocumented)
+export interface IBackendOutputStorageStrategy {
+    // (undocumented)
+    addBackendOutputEntry(keyName: string, backendOutputEntry: IBackendOutputEntry): void;
+}
+
+// @public (undocumented)
 export interface ImportedAmplifyDynamoDbModelDataSourceStrategy {
     // (undocumented)
     readonly dbType: 'DYNAMODB';

--- a/packages/amplify-graphql-transformer-interfaces/src/backend-output.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/backend-output.ts
@@ -1,0 +1,29 @@
+// NOTE: These types are duplicated from packages/amplify-graphql-api-construct/src/types.ts
+// Before updating this file, ensure that that changes can be, and are, reflected in the other file.
+/**
+ * Entry representing the required output from the backend for codegen generate commands to work.
+ */
+export interface IBackendOutputEntry {
+  /**
+   * The protocol version for this backend output.
+   */
+  readonly version: string;
+
+  /**
+   * The string-map payload of generated config values.
+   */
+  readonly payload: Record<string, string>;
+}
+
+/**
+ * Backend output strategy used to write config required for codegen tasks.
+ */
+export interface IBackendOutputStorageStrategy {
+  /**
+   * Add an entry to backend output.
+   * @param keyName the key
+   * @param backendOutputEntry the record to store in the backend output
+   */
+  // eslint-disable-next-line @typescript-eslint/method-signature-style
+  addBackendOutputEntry(keyName: string, backendOutputEntry: IBackendOutputEntry): void;
+}

--- a/packages/amplify-graphql-transformer-interfaces/src/index.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/index.ts
@@ -1,4 +1,5 @@
 // eslint-disable-next-line import/no-cycle
+export type { IBackendOutputStorageStrategy, IBackendOutputEntry } from './backend-output';
 export * from './transformer-context';
 export { TransformerPluginProvider, TransformerPluginType } from './transformer-plugin-provider';
 export {

--- a/packages/amplify-graphql-transformer/API.md
+++ b/packages/amplify-graphql-transformer/API.md
@@ -9,6 +9,7 @@ import { AssetProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { Construct } from 'constructs';
 import type { DataSourceStrategiesProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
+import { IBackendOutputStorageStrategy } from '@aws-amplify/graphql-transformer-interfaces';
 import { IFunction } from 'aws-cdk-lib/aws-lambda';
 import { NestedStackProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import type { RDSLayerMappingProvider } from '@aws-amplify/graphql-transformer-interfaces';
@@ -56,6 +57,7 @@ export type TransformerFactoryArgs = {
     storageConfig?: any;
     customTransformers?: TransformerPluginProvider[];
     functionNameMap?: Record<string, IFunction>;
+    outputStorageStrategy?: IBackendOutputStorageStrategy;
 };
 
 // (No @packageDocumentation comment for this package)

--- a/packages/amplify-graphql-transformer/src/graphql-transformer.ts
+++ b/packages/amplify-graphql-transformer/src/graphql-transformer.ts
@@ -35,6 +35,7 @@ import { Construct } from 'constructs';
 import { IFunction } from 'aws-cdk-lib/aws-lambda';
 import { GenerationTransformer } from '@aws-amplify/graphql-generation-transformer';
 import { ConversationTransformer } from '@aws-amplify/graphql-conversation-transformer';
+import { IBackendOutputStorageStrategy } from '@aws-amplify/graphql-transformer-interfaces';
 
 /**
  * Arguments passed into a TransformerFactory
@@ -44,6 +45,7 @@ export type TransformerFactoryArgs = {
   storageConfig?: any;
   customTransformers?: TransformerPluginProvider[];
   functionNameMap?: Record<string, IFunction>;
+  outputStorageStrategy?: IBackendOutputStorageStrategy;
 };
 
 /**
@@ -78,7 +80,14 @@ export const constructTransformerChain = (options?: TransformerFactoryArgs): Tra
     hasOneTransformer,
     new ManyToManyTransformer(modelTransformer, indexTransformer, hasOneTransformer, authTransformer),
     belongsToTransformer,
-    new ConversationTransformer(modelTransformer, hasManyTransformer, belongsToTransformer, authTransformer, options?.functionNameMap),
+    new ConversationTransformer(
+      modelTransformer,
+      hasManyTransformer,
+      belongsToTransformer,
+      authTransformer,
+      options?.outputStorageStrategy,
+      options?.functionNameMap,
+    ),
     new GenerationTransformer(),
     new DefaultValueTransformer(),
     authTransformer,


### PR DESCRIPTION
## Problem
The default lambda handler deployed for conversation routes via `ai-constructs` doesn't stream function logs for sandbox deployments when using the `--stream-function-logs` flag ([documentation](https://docs.amplify.aws/react/build-a-backend/functions/streaming-logs/)).

## Description of changes
- Plumb `outputStorageStrategy` from `AmplifyGraphqlApi` through the `ConversationTransformer` to `ai-constructs`.

This allows `ai-constructs` to register the Lambda function for streaming. 

> [!NOTE]
> This change duplicates types (`IBackendOutputEntry` and `IBackendOutputStorageStrategy`) from `amplify-graphql-api-constructs/src/types.ts` ([reference](https://github.com/aws-amplify/amplify-category-api/pull/3014/files#diff-ef98cb0b62c49ed5489fb4cef99eb1cc9db60eaf53f71c816cc023558e726b8cR656-R659)) into `amplify-graphql-transformer-interfaces/src/backend-output.ts` ([reference](https://github.com/aws-amplify/amplify-category-api/pull/3014/files#diff-575d11f828920e775d36fb1cdb8b5836508804171411a0c98b8319225175fd6fR1-R29)). 
> 
> This was done because `amplify-api-construct` doesn't have a dependency on `amplify-graphql-transformer-interfaces` and `amplify-graphql-transformer` doesn't have a dependency on `amplify-graphql-api`.
>
> Inline comments were added in both sources to warn about making changes in isolation.

**Relevant Backend PR**
- https://github.com/aws-amplify/amplify-backend/pull/2073

### CDK / CloudFormation Parameters Changed
N/A

## Issue #, if available
N/A

## Description of how you validated changes
Manually tested. E2E test not feasible as construct only test; will look into options for automated testing in a follow up.

```bash
> npx ampx sandbox --identifier 'logs' --stream-function-logs
[Sandbox] Watching for file changes...
File written: amplify_outputs.json
# Send a message
[AssistantChatDefaultConversationHandler] 1:24:17 PM {"time":"2024-11-12T18:24:17.783Z","type":"platform.initStart","record":{"initializationType":"on-demand","phase":"init","runtimeVersion":"nodejs:18.v49","runtimeVersionArn":"arn:aws:lambda:us-east-1::runtime:13821268cdb8b1fd3647b6b7f047e6989fdfa500ddcef1d207cab3e8aa30c617","functionName":"amplify-aismoketest-logs--AssistantChatDefaultConv-UxEQSg3XTyhZ","functionVersion":"$LATEST"}}
[AssistantChatDefaultConversationHandler] 1:24:18 PM {"time":"2024-11-12T18:24:18.153Z","type":"platform.start","record":{"requestId":"a9007650-3fad-4370-990c-db6646476e8e","version":"$LATEST"}}
[AssistantChatDefaultConversationHandler] 1:24:18 PM {"timestamp":"2024-11-12T18:24:18.154Z","level":"INFO","requestId":"a9007650-3fad-4370-990c-db6646476e8e","message":"Handling conversation turn event, currentMessageId=cd831839-7a3e-42fb-8a45-eb302c33a5ca, conversationId=21c3ec83-c701-4ae9-8b7a-386e36f346b2"}
[AssistantChatDefaultConversationHandler] 1:24:18 PM {"timestamp":"2024-11-12T18:24:18.605Z","level":"INFO","requestId":"a9007650-3fad-4370-990c-db6646476e8e","message":"Sending Bedrock Converse Stream request"}
[AssistantChatDefaultConversationHandler] 1:24:18 PM {"timestamp":"2024-11-12T18:24:18.868Z","level":"INFO","requestId":"a9007650-3fad-4370-990c-db6646476e8e","message":"Received Bedrock Converse Stream response, requestId=a74da7bf-8f48-497d-8977-930d7f1a709b"}
[AssistantChatDefaultConversationHandler] 1:24:24 PM {"timestamp":"2024-11-12T18:24:24.254Z","level":"INFO","requestId":"a9007650-3fad-4370-990c-db6646476e8e","message":"Conversation turn event handled successfully, currentMessageId=cd831839-7a3e-42fb-8a45-eb302c33a5ca, conversationId=21c3ec83-c701-4ae9-8b7a-386e36f346b2"}
[AssistantChatDefaultConversationHandler] 1:24:24 PM {"time":"2024-11-12T18:24:24.257Z","type":"platform.report","record":{"requestId":"a9007650-3fad-4370-990c-db6646476e8e","metrics":{"durationMs":6104.742,"billedDurationMs":6105,"memorySizeMB":512,"maxMemoryUsedMB":124,"initDurationMs":368.411},"status":"success"}}
```

## Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
