### PR TITLE
chore: bump ai-constructs to ^0.8.1

### DIFF
--- a/packages/amplify-data-construct/.jsii
+++ b/packages/amplify-data-construct/.jsii
@@ -6,7 +6,7 @@
     ]
   },
   "bundled": {
-    "@aws-amplify/ai-constructs": "0.8.0",
+    "@aws-amplify/ai-constructs": "^0.8.1",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.6",
@@ -4027,5 +4027,5 @@
   },
   "types": {},
   "version": "1.13.0",
-  "fingerprint": "w9N8Wh8VuGabmdPlzxIN/EaMq9GHx7CtiCsk68FOmIY="
+  "fingerprint": "ak3PmJUh5Mkk2Ka4p/lao1ADPaGPXuFRvaeLSxuEBAE="
 }

--- a/packages/amplify-data-construct/package.json
+++ b/packages/amplify-data-construct/package.json
@@ -157,7 +157,7 @@
     "semver"
   ],
   "dependencies": {
-    "@aws-amplify/ai-constructs": "0.8.0",
+    "@aws-amplify/ai-constructs": "^0.8.1",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-api-construct": "1.17.0",

--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -6,7 +6,7 @@
     ]
   },
   "bundled": {
-    "@aws-amplify/ai-constructs": "0.8.0",
+    "@aws-amplify/ai-constructs": "^0.8.1",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.6",
@@ -9032,5 +9032,5 @@
     }
   },
   "version": "1.17.0",
-  "fingerprint": "0ejr9BEQir1BFZjmpTJaywPg0Y9bAdc0FnIMkamI7FU="
+  "fingerprint": "vMrsRM5QtRUJHWxj4XZw8PdvYvthFhfQOzG5jhsO4SA="
 }

--- a/packages/amplify-graphql-api-construct/package.json
+++ b/packages/amplify-graphql-api-construct/package.json
@@ -158,7 +158,7 @@
     "semver"
   ],
   "dependencies": {
-    "@aws-amplify/ai-constructs": "0.8.0",
+    "@aws-amplify/ai-constructs": "^0.8.1",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.6",

--- a/packages/amplify-graphql-conversation-transformer/package.json
+++ b/packages/amplify-graphql-conversation-transformer/package.json
@@ -24,7 +24,7 @@
     "extract-api": "ts-node ../../scripts/extract-api.ts"
   },
   "dependencies": {
-    "@aws-amplify/ai-constructs": "0.8.0",
+    "@aws-amplify/ai-constructs": "^0.8.1",
     "@aws-amplify/graphql-directives": "2.5.0",
     "@aws-amplify/graphql-index-transformer": "3.0.8",
     "@aws-amplify/graphql-model-transformer": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,13 +10,13 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aws-amplify/ai-constructs@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/ai-constructs/-/ai-constructs-0.8.0.tgz#c84e6c608684649ec9fb670af4c65921385b2f25"
-  integrity sha512-DP+M73Iy8Dbm/Rp8QosQlCDLuR9U2fOWg+q6uPAksuaVuCdnqNvTHsQ0XEQMmslEx32vEdvn0ttiMbzD++ukSw==
+"@aws-amplify/ai-constructs@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/ai-constructs/-/ai-constructs-0.8.1.tgz#97250e681d70eae42736c71a5877cbd1c425ab11"
+  integrity sha512-JdgVJqPr7YGlP7MHmExKGv+82lJB53kPb2l6UR+ji/mozHImnLbcGPP0BW7rl13wOwA7ZqIcQWAqQsxgWW37Fg==
   dependencies:
     "@aws-amplify/backend-output-schemas" "^1.4.0"
-    "@aws-amplify/platform-core" "^1.1.0"
+    "@aws-amplify/platform-core" "^1.2.0"
     "@aws-amplify/plugin-types" "^1.3.1"
     "@aws-sdk/client-bedrock-runtime" "^3.622.0"
     "@smithy/types" "^3.3.0"
@@ -380,10 +380,23 @@
     fflate "0.7.3"
     pako "2.0.4"
 
-"@aws-amplify/platform-core@^1.0.0", "@aws-amplify/platform-core@^1.0.6", "@aws-amplify/platform-core@^1.1.0":
+"@aws-amplify/platform-core@^1.0.0", "@aws-amplify/platform-core@^1.0.6":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@aws-amplify/platform-core/-/platform-core-1.1.0.tgz#85002b14e37caeb8f90916554e57f7809582e94a"
   integrity sha512-9iOM+dpht1f52WUHPyaXyeF8Z27TNgqBS86JmIhcsqWltUsCqoQDKPVjaTj8No05oMzm+icWc96dPG/EZIE3jw==
+  dependencies:
+    "@aws-amplify/plugin-types" "^1.2.1"
+    "@aws-sdk/client-sts" "^3.624.0"
+    is-ci "^3.0.1"
+    lodash.mergewith "^4.6.2"
+    semver "^7.6.3"
+    uuid "^9.0.1"
+    zod "^3.22.2"
+
+"@aws-amplify/platform-core@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/platform-core/-/platform-core-1.2.0.tgz#329c7a0fd87b04c9cbfd8dc489ba4516508eea42"
+  integrity sha512-/bRCU8NxcsSH0BlY/iDFFdmhqdZcPmHg0LCek/swL4XczNmwOMXYqP3wqqA+75PqamRmDSTC5Dj67iZUjw68bw==
   dependencies:
     "@aws-amplify/plugin-types" "^1.2.1"
     "@aws-sdk/client-sts" "^3.624.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,20 +380,7 @@
     fflate "0.7.3"
     pako "2.0.4"
 
-"@aws-amplify/platform-core@^1.0.0", "@aws-amplify/platform-core@^1.0.6":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@aws-amplify/platform-core/-/platform-core-1.1.0.tgz#85002b14e37caeb8f90916554e57f7809582e94a"
-  integrity sha512-9iOM+dpht1f52WUHPyaXyeF8Z27TNgqBS86JmIhcsqWltUsCqoQDKPVjaTj8No05oMzm+icWc96dPG/EZIE3jw==
-  dependencies:
-    "@aws-amplify/plugin-types" "^1.2.1"
-    "@aws-sdk/client-sts" "^3.624.0"
-    is-ci "^3.0.1"
-    lodash.mergewith "^4.6.2"
-    semver "^7.6.3"
-    uuid "^9.0.1"
-    zod "^3.22.2"
-
-"@aws-amplify/platform-core@^1.2.0":
+"@aws-amplify/platform-core@^1.0.0", "@aws-amplify/platform-core@^1.0.6", "@aws-amplify/platform-core@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@aws-amplify/platform-core/-/platform-core-1.2.0.tgz#329c7a0fd87b04c9cbfd8dc489ba4516508eea42"
   integrity sha512-/bRCU8NxcsSH0BlY/iDFFdmhqdZcPmHg0LCek/swL4XczNmwOMXYqP3wqqA+75PqamRmDSTC5Dj67iZUjw68bw==


### PR DESCRIPTION
#### Description of changes
- Bumps `ai-constructs` to `^0.8.1`.

**Relevant `ai-constructs` PR:**
- https://github.com/aws-amplify/amplify-backend/pull/2195

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
N/A

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] ~E2E test run linked~
- [ ] ~Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)~
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
