### PR TITLE
fix: plumb outputStorageStrategy through conversation transformer to handler

### DIFF
--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -4443,7 +4443,7 @@
         },
         "locationInModule": {
           "filename": "src/amplify-graphql-api.ts",
-          "line": 144
+          "line": 145
         },
         "parameters": [
           {
@@ -4478,7 +4478,7 @@
       "kind": "class",
       "locationInModule": {
         "filename": "src/amplify-graphql-api.ts",
-        "line": 85
+        "line": 86
       },
       "methods": [
         {
@@ -4490,7 +4490,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 314
+            "line": 316
           },
           "name": "addDynamoDbDataSource",
           "parameters": [
@@ -4539,7 +4539,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 326
+            "line": 328
           },
           "name": "addElasticsearchDataSource",
           "parameters": [
@@ -4586,7 +4586,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 336
+            "line": 338
           },
           "name": "addEventBridgeDataSource",
           "parameters": [
@@ -4633,7 +4633,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 418
+            "line": 420
           },
           "name": "addFunction",
           "parameters": [
@@ -4668,7 +4668,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 347
+            "line": 349
           },
           "name": "addHttpDataSource",
           "parameters": [
@@ -4716,7 +4716,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 358
+            "line": 360
           },
           "name": "addLambdaDataSource",
           "parameters": [
@@ -4764,7 +4764,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 369
+            "line": 371
           },
           "name": "addNoneDataSource",
           "parameters": [
@@ -4803,7 +4803,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 380
+            "line": 382
           },
           "name": "addOpenSearchDataSource",
           "parameters": [
@@ -4851,7 +4851,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 393
+            "line": 395
           },
           "name": "addRdsDataSource",
           "parameters": [
@@ -4918,7 +4918,7 @@
           },
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 409
+            "line": 411
           },
           "name": "addResolver",
           "parameters": [
@@ -4959,7 +4959,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 125
+            "line": 126
           },
           "name": "apiId",
           "type": {
@@ -4974,7 +4974,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 105
+            "line": 106
           },
           "name": "generatedFunctionSlots",
           "type": {
@@ -5007,7 +5007,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 110
+            "line": 111
           },
           "name": "graphqlUrl",
           "type": {
@@ -5023,7 +5023,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 115
+            "line": 116
           },
           "name": "realtimeUrl",
           "type": {
@@ -5038,7 +5038,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 89
+            "line": 90
           },
           "name": "resources",
           "type": {
@@ -5053,7 +5053,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 94
+            "line": 95
           },
           "name": "stack",
           "type": {
@@ -5069,7 +5069,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "src/amplify-graphql-api.ts",
-            "line": 120
+            "line": 121
           },
           "name": "apiKey",
           "optional": true,
@@ -9032,5 +9032,5 @@
     }
   },
   "version": "1.17.1",
-  "fingerprint": "//BSSrEX7ti8WNKCP2jaa/JFRVcC7l3Y6+6O2mrdq+4="
+  "fingerprint": "iFHfyfP4aubfl0p3fcXX4GHUInK1klyDXWLZuB4+OrY="
 }

--- a/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
+++ b/packages/amplify-graphql-api-construct/src/amplify-graphql-api.ts
@@ -51,6 +51,7 @@ import { getStackForScope, walkAndProcessNodes } from './internal/construct-tree
 import { getDataSourceStrategiesProvider } from './internal/data-source-config';
 import { getMetadataDataSources, getMetadataAuthorizationModes, getMetadataCustomOperations } from './internal/metadata';
 import { isImportedAmplifyDynamoDbModelDataSourceStrategy } from '@aws-amplify/graphql-transformer-core';
+import { BackendOutputStorageStrategy, BackendOutputEntry } from '@aws-amplify/plugin-types';
 
 /**
  * L3 Construct which invokes the Amplify Transformer Pattern over an input Graphql Schema.
@@ -238,6 +239,7 @@ export class AmplifyGraphqlApi extends Construct {
           ...definition.referencedLambdaFunctions,
           ...functionNameMap,
         },
+        outputStorageStrategy: outputStorageStrategy as BackendOutputStorageStrategy<BackendOutputEntry>,
       },
       authConfig,
       stackMapping: stackMappings ?? {},

--- a/packages/amplify-graphql-conversation-transformer/API.md
+++ b/packages/amplify-graphql-conversation-transformer/API.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+import { BackendOutputEntry } from '@aws-amplify/plugin-types';
+import { BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
 import { BelongsToTransformer } from '@aws-amplify/graphql-relational-transformer';
 import { DirectiveNode } from 'graphql';
 import { FieldDefinitionNode } from 'graphql';
@@ -20,7 +22,7 @@ import { TransformerSchemaVisitStepContextProvider } from '@aws-amplify/graphql-
 
 // @public (undocumented)
 export class ConversationTransformer extends TransformerPluginBase {
-    constructor(modelTransformer: ModelTransformer, hasManyTransformer: HasManyTransformer, belongsToTransformer: BelongsToTransformer, authProvider: TransformerAuthProvider, functionNameMap?: Record<string, lambda.IFunction>);
+    constructor(modelTransformer: ModelTransformer, hasManyTransformer: HasManyTransformer, belongsToTransformer: BelongsToTransformer, authProvider: TransformerAuthProvider, outputStorageStrategy?: BackendOutputStorageStrategy<BackendOutputEntry>, functionNameMap?: Record<string, lambda.IFunction>);
     // (undocumented)
     field: (parent: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode, definition: FieldDefinitionNode, directive: DirectiveNode, context: TransformerSchemaVisitStepContextProvider) => void;
     // (undocumented)

--- a/packages/amplify-graphql-conversation-transformer/package.json
+++ b/packages/amplify-graphql-conversation-transformer/package.json
@@ -35,7 +35,8 @@
     "graphql-mapping-template": "5.0.1",
     "graphql-transformer-common": "5.1.1",
     "immer": "^9.0.12",
-    "semver": "^7.6.3"
+    "semver": "^7.6.3",
+    "@aws-amplify/plugin-types": "^1.0.0"
   },
   "devDependencies": {
     "@aws-amplify/graphql-transformer-test-utils": "1.0.7",

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
@@ -324,7 +324,7 @@ function transform(
     hasManyTransformer,
     hasOneTransformer,
     belongsToTransformer,
-    new ConversationTransformer(modelTransformer, hasManyTransformer, belongsToTransformer, authTransformer, functionMap),
+    new ConversationTransformer(modelTransformer, hasManyTransformer, belongsToTransformer, authTransformer, undefined, functionMap),
     new GenerationTransformer(),
     authTransformer,
   ];

--- a/packages/amplify-graphql-conversation-transformer/src/grapqhl-conversation-transformer.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/grapqhl-conversation-transformer.ts
@@ -1,19 +1,21 @@
 import { ConversationDirective } from '@aws-amplify/graphql-directives';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { BelongsToTransformer, HasManyTransformer } from '@aws-amplify/graphql-relational-transformer';
-import { InvalidDirectiveError, TransformerPluginBase } from '@aws-amplify/graphql-transformer-core';
+import { TransformerPluginBase } from '@aws-amplify/graphql-transformer-core';
 import {
   TransformerAuthProvider,
   TransformerContextProvider,
   TransformerPrepareStepContextProvider,
   TransformerSchemaVisitStepContextProvider,
 } from '@aws-amplify/graphql-transformer-interfaces';
+import { BackendOutputEntry, BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { DirectiveNode, FieldDefinitionNode, InterfaceTypeDefinitionNode, ObjectTypeDefinitionNode } from 'graphql';
 import { ConversationDirectiveConfiguration } from './conversation-directive-configuration';
 import { ConversationFieldHandler } from './transformer-steps/conversation-field-handler';
 import { ConversationPrepareHandler } from './transformer-steps/conversation-prepare-handler';
 import { ConversationResolverGenerator } from './transformer-steps/conversation-resolver-generator';
+
 /**
  * Transformer for handling `@conversation` directives in GraphQL schemas
  */
@@ -28,12 +30,13 @@ export class ConversationTransformer extends TransformerPluginBase {
     hasManyTransformer: HasManyTransformer,
     belongsToTransformer: BelongsToTransformer,
     authProvider: TransformerAuthProvider,
+    outputStorageStrategy?: BackendOutputStorageStrategy<BackendOutputEntry>,
     functionNameMap?: Record<string, lambda.IFunction>,
   ) {
     super('amplify-conversation-transformer', ConversationDirective.definition);
     this.fieldHandler = new ConversationFieldHandler();
     this.prepareHandler = new ConversationPrepareHandler(modelTransformer, hasManyTransformer, belongsToTransformer, authProvider);
-    this.resolverGenerator = new ConversationResolverGenerator(functionNameMap);
+    this.resolverGenerator = new ConversationResolverGenerator(functionNameMap, outputStorageStrategy);
   }
 
   /**

--- a/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
@@ -2,6 +2,7 @@ import { conversation } from '@aws-amplify/ai-constructs';
 import { overrideIndexAtCfnLevel } from '@aws-amplify/graphql-index-transformer';
 import { getModelDataSourceNameForTypeName, getTable, TransformerResolver } from '@aws-amplify/graphql-transformer-core';
 import { DataSourceProvider, TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { BackendOutputEntry, BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
 import * as cdk from 'aws-cdk-lib';
 import { IFunction } from 'aws-cdk-lib/aws-lambda';
 import { FunctionResourceIDs, ResourceConstants } from 'graphql-transformer-common';
@@ -27,7 +28,10 @@ import {
 } from '../resolvers';
 import { processTools } from '../tools/process-tools';
 export class ConversationResolverGenerator {
-  constructor(private readonly functionNameMap?: Record<string, IFunction>) {}
+  constructor(
+    private readonly functionNameMap?: Record<string, IFunction>,
+    private readonly outputStorageStrategy?: BackendOutputStorageStrategy<BackendOutputEntry>,
+  ) {}
 
   /**
    * Generates resolvers for all conversation directives.
@@ -189,6 +193,7 @@ export class ConversationResolverGenerator {
             modelId,
           },
         ],
+        outputStorageStrategy: this.outputStorageStrategy,
       },
     );
 

--- a/packages/amplify-graphql-transformer/API.md
+++ b/packages/amplify-graphql-transformer/API.md
@@ -6,6 +6,8 @@
 
 import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-interfaces';
 import { AssetProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { BackendOutputEntry } from '@aws-amplify/plugin-types';
+import { BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
 import { Construct } from 'constructs';
 import type { DataSourceStrategiesProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
@@ -56,6 +58,7 @@ export type TransformerFactoryArgs = {
     storageConfig?: any;
     customTransformers?: TransformerPluginProvider[];
     functionNameMap?: Record<string, IFunction>;
+    outputStorageStrategy?: BackendOutputStorageStrategy<BackendOutputEntry>;
 };
 
 // (No @packageDocumentation comment for this package)

--- a/packages/amplify-graphql-transformer/package.json
+++ b/packages/amplify-graphql-transformer/package.json
@@ -43,7 +43,8 @@
     "@aws-amplify/graphql-searchable-transformer": "3.0.8",
     "@aws-amplify/graphql-sql-transformer": "0.4.8",
     "@aws-amplify/graphql-transformer-core": "3.3.0",
-    "@aws-amplify/graphql-transformer-interfaces": "4.2.0"
+    "@aws-amplify/graphql-transformer-interfaces": "4.2.0",
+    "@aws-amplify/plugin-types": "^1.0.0"
   },
   "devDependencies": {
     "@aws-amplify/graphql-transformer-test-utils": "1.0.7",

--- a/packages/amplify-graphql-transformer/src/graphql-transformer.ts
+++ b/packages/amplify-graphql-transformer/src/graphql-transformer.ts
@@ -35,7 +35,7 @@ import { Construct } from 'constructs';
 import { IFunction } from 'aws-cdk-lib/aws-lambda';
 import { GenerationTransformer } from '@aws-amplify/graphql-generation-transformer';
 import { ConversationTransformer } from '@aws-amplify/graphql-conversation-transformer';
-
+import { BackendOutputEntry, BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
 /**
  * Arguments passed into a TransformerFactory
  * Used to determine how to create a new GraphQLTransform
@@ -44,6 +44,7 @@ export type TransformerFactoryArgs = {
   storageConfig?: any;
   customTransformers?: TransformerPluginProvider[];
   functionNameMap?: Record<string, IFunction>;
+  outputStorageStrategy?: BackendOutputStorageStrategy<BackendOutputEntry>;
 };
 
 /**
@@ -78,7 +79,14 @@ export const constructTransformerChain = (options?: TransformerFactoryArgs): Tra
     hasOneTransformer,
     new ManyToManyTransformer(modelTransformer, indexTransformer, hasOneTransformer, authTransformer),
     belongsToTransformer,
-    new ConversationTransformer(modelTransformer, hasManyTransformer, belongsToTransformer, authTransformer, options?.functionNameMap),
+    new ConversationTransformer(
+      modelTransformer,
+      hasManyTransformer,
+      belongsToTransformer,
+      authTransformer,
+      options?.outputStorageStrategy,
+      options?.functionNameMap,
+    ),
     new GenerationTransformer(),
     new DefaultValueTransformer(),
     authTransformer,


### PR DESCRIPTION
## Problem
The default lambda handler deployed for conversation routes via `ai-constructs` doesn't stream function logs for sandbox deployments when using the `--stream-function-logs` flag ([documentation](https://docs.amplify.aws/react/build-a-backend/functions/streaming-logs/)).

## Description of changes
- Plumb `outputStorageStrategy` from `AmplifyGraphqlApi` through the `ConversationTransformer` to `ai-constructs`.

This allows `ai-constructs` to include the conversation handler Lambda function in the root stack outputs for streaming.

> [!NOTE]
> https://github.com/aws-amplify/amplify-category-api/pull/3014 contains an alternative approach that also works, but involves duplicating the types into `amplify-graphql-transformer-interfaces`.

**Relevant Backend PR**
- https://github.com/aws-amplify/amplify-backend/pull/2073

### CDK / CloudFormation Parameters Changed
N/A

## Issue #, if available
N/A

## Description of how you validated changes
Manually tested. E2E test not feasible as construct only test; will look into options for automated testing in a follow up.

```bash
> npx ampx sandbox --identifier 'logs' --stream-function-logs
[Sandbox] Watching for file changes...
File written: amplify_outputs.json
# Send a message
[AssistantChatDefaultConversationHandler] 1:24:17 PM {"time":"2024-11-12T18:24:17.783Z","type":"platform.initStart","record":{"initializationType":"on-demand","phase":"init","runtimeVersion":"nodejs:18.v49","runtimeVersionArn":"arn:aws:lambda:us-east-1::runtime:13821268cdb8b1fd3647b6b7f047e6989fdfa500ddcef1d207cab3e8aa30c617","functionName":"amplify-aismoketest-logs--AssistantChatDefaultConv-UxEQSg3XTyhZ","functionVersion":"$LATEST"}}
[AssistantChatDefaultConversationHandler] 1:24:18 PM {"time":"2024-11-12T18:24:18.153Z","type":"platform.start","record":{"requestId":"a9007650-3fad-4370-990c-db6646476e8e","version":"$LATEST"}}
[AssistantChatDefaultConversationHandler] 1:24:18 PM {"timestamp":"2024-11-12T18:24:18.154Z","level":"INFO","requestId":"a9007650-3fad-4370-990c-db6646476e8e","message":"Handling conversation turn event, currentMessageId=cd831839-7a3e-42fb-8a45-eb302c33a5ca, conversationId=21c3ec83-c701-4ae9-8b7a-386e36f346b2"}
[AssistantChatDefaultConversationHandler] 1:24:18 PM {"timestamp":"2024-11-12T18:24:18.605Z","level":"INFO","requestId":"a9007650-3fad-4370-990c-db6646476e8e","message":"Sending Bedrock Converse Stream request"}
[AssistantChatDefaultConversationHandler] 1:24:18 PM {"timestamp":"2024-11-12T18:24:18.868Z","level":"INFO","requestId":"a9007650-3fad-4370-990c-db6646476e8e","message":"Received Bedrock Converse Stream response, requestId=a74da7bf-8f48-497d-8977-930d7f1a709b"}
[AssistantChatDefaultConversationHandler] 1:24:24 PM {"timestamp":"2024-11-12T18:24:24.254Z","level":"INFO","requestId":"a9007650-3fad-4370-990c-db6646476e8e","message":"Conversation turn event handled successfully, currentMessageId=cd831839-7a3e-42fb-8a45-eb302c33a5ca, conversationId=21c3ec83-c701-4ae9-8b7a-386e36f346b2"}
[AssistantChatDefaultConversationHandler] 1:24:24 PM {"time":"2024-11-12T18:24:24.257Z","type":"platform.report","record":{"requestId":"a9007650-3fad-4370-990c-db6646476e8e","metrics":{"durationMs":6104.742,"billedDurationMs":6105,"memorySizeMB":512,"maxMemoryUsedMB":124,"initDurationMs":368.411},"status":"success"}}
```

## Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] ~E2E test run linked~
- [ ] ~Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)~
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
