### PR TITLE
test(conversation): add missing auth input in e2e test

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/schema-conversation.graphql
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/schema-conversation.graphql
@@ -17,7 +17,13 @@ type Mutation {
     content: [ContentBlockInput]
     aiContext: AWSJSON
     toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage @conversation(aiModel: "mistral.mistral-large-2407-v1:0", systemPrompt: "You are a helpful chatbot.")
+  ): ConversationMessage
+    @conversation(
+      aiModel: "mistral.mistral-large-2407-v1:0"
+      systemPrompt: "You are a helpful chatbot."
+      auth: { strategy: owner, provider: userPools }
+    )
+    @aws_cognito_user_pools
 }
 
 enum ConversationParticipantRole {


### PR DESCRIPTION
## Problem
One of the E2E test cases for the conversation transformer doesn't include the newly introduced (and required) `auth` directive argument (https://github.com/aws-amplify/amplify-category-api/pull/3007).

## Description of changes
Adds missing `auth` argument to E2E test case.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
- [E2E test run](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow%3A923382dd-b7cf-4d34-9857-cca5a58a2191?region=us-east-1)

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [ ] ~Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)~
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
