### PR TITLE
chore: update .jsii assembly

### DIFF
--- a/packages/amplify-data-construct/.jsii
+++ b/packages/amplify-data-construct/.jsii
@@ -130,7 +130,7 @@
     "zod": "^3.22.2"
   },
   "dependencies": {
-    "@aws-amplify/graphql-api-construct": "1.17.0",
+    "@aws-amplify/graphql-api-construct": "1.17.1",
     "aws-cdk-lib": "^2.158.0",
     "constructs": "^10.3.0"
   },
@@ -4026,6 +4026,6 @@
     }
   },
   "types": {},
-  "version": "1.13.0",
-  "fingerprint": "ak3PmJUh5Mkk2Ka4p/lao1ADPaGPXuFRvaeLSxuEBAE="
+  "version": "1.13.1",
+  "fingerprint": "oCRj2fQkJZ589jGX91YGGvYib4KcigtzJ2u2AlEHuFU="
 }

--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -9031,6 +9031,6 @@
       "symbolId": "src/model-datasource-strategy-types:VpcConfig"
     }
   },
-  "version": "1.17.0",
-  "fingerprint": "vMrsRM5QtRUJHWxj4XZw8PdvYvthFhfQOzG5jhsO4SA="
+  "version": "1.17.1",
+  "fingerprint": "//BSSrEX7ti8WNKCP2jaa/JFRVcC7l3Y6+6O2mrdq+4="
 }


### PR DESCRIPTION
## Problem
`release` was manually synced back to `main` with https://github.com/aws-amplify/amplify-category-api/commit/9530eabc669d519eed397ecdcc2bc94f8c54585d.

This didn't trigger the typical `chore: update .jsii assembly` flow.

## Description of changes
Updates the .jsii assembly for graphql-api-construct and data-construct.

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
