### PR TITLE
fix(conversation): prefix supporting types with AmplifyAI 

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/API.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/API.ts
@@ -20,84 +20,85 @@ export type ModelConversationMessageDisabledModelChatConnection = {
 export type ConversationMessageDisabledModelChat = {
   aiContext?: string | null;
   associatedUserMessageId?: string | null;
-  content?: Array<ContentBlock | null> | null;
+  content?: Array<AmplifyAIContentBlock | null> | null;
   conversation?: ConversationDisabledModelChat | null;
   conversationId: string;
   createdAt: string;
   id: string;
   owner?: string | null;
-  role?: ConversationParticipantRole | null;
-  toolConfiguration?: ToolConfiguration | null;
+  role?: AmplifyAIConversationParticipantRole | null;
+  toolConfiguration?: AmplifyAIToolConfiguration | null;
   updatedAt: string;
+};
+
+export type AmplifyAIConversationMessage = {
+  aiContext?: string | null;
+  associatedUserMessageId?: string | null;
+  content?: Array<AmplifyAIContentBlock | null> | null;
+  conversationId: string;
+  createdAt?: string | null;
+  id: string;
+  owner?: string | null;
+  role?: AmplifyAIConversationParticipantRole | null;
+  toolConfiguration?: AmplifyAIToolConfiguration | null;
+  updatedAt?: string | null;
 };
 
 export type ConversationMessagePirateChat = {
   aiContext?: string | null;
   associatedUserMessageId?: string | null;
-  content?: Array<ContentBlock | null> | null;
+  content?: Array<AmplifyAIContentBlock | null> | null;
   conversation?: ConversationPirateChat | null;
   conversationId: string;
   createdAt: string;
   id: string;
   owner?: string | null;
-  role?: ConversationParticipantRole | null;
-  toolConfiguration?: ToolConfiguration | null;
+  role?: AmplifyAIConversationParticipantRole | null;
+  toolConfiguration?: AmplifyAIToolConfiguration | null;
   updatedAt: string;
 };
 
-export type ConversationMessage = {
-  aiContext?: string | null;
-  content?: Array<ContentBlock | null> | null;
-  conversationId: string;
-  createdAt?: string | null;
-  id: string;
-  owner?: string | null;
-  role?: ConversationParticipantRole | null;
-  toolConfiguration?: ToolConfiguration | null;
-  updatedAt?: string | null;
-};
-
-export type ContentBlock = {
-  document?: DocumentBlock | null;
-  image?: ImageBlock | null;
+export type AmplifyAIContentBlock = {
+  document?: AmplifyAIDocumentBlock | null;
+  image?: AmplifyAIImageBlock | null;
   text?: string | null;
-  toolResult?: ToolResultBlock | null;
-  toolUse?: ToolUseBlock | null;
+  toolResult?: AmplifyAIToolResultBlock | null;
+  toolUse?: AmplifyAIToolUseBlock | null;
 };
 
-export type DocumentBlock = {
+export type AmplifyAIDocumentBlock = {
   format: string;
   name: string;
-  source: DocumentBlockSource;
+  source: AmplifyAIDocumentBlockSource;
 };
 
-export type DocumentBlockSource = {
+export type AmplifyAIDocumentBlockSource = {
   bytes?: string | null;
 };
 
-export type ImageBlock = {
+export type AmplifyAIImageBlock = {
   format: string;
-  source: ImageBlockSource;
+  source: AmplifyAIImageBlockSource;
 };
 
-export type ImageBlockSource = {
+export type AmplifyAIImageBlockSource = {
   bytes?: string | null;
 };
 
-export type ToolResultBlock = {
-  content: Array<ToolResultContentBlock>;
+export type AmplifyAIToolResultBlock = {
+  content: Array<AmplifyAIToolResultContentBlock>;
   status?: string | null;
   toolUseId: string;
 };
 
-export type ToolResultContentBlock = {
-  document?: DocumentBlock | null;
-  image?: ImageBlock | null;
+export type AmplifyAIToolResultContentBlock = {
+  document?: AmplifyAIDocumentBlock | null;
+  image?: AmplifyAIImageBlock | null;
   json?: string | null;
   text?: string | null;
 };
 
-export type ToolUseBlock = {
+export type AmplifyAIToolUseBlock = {
   input: string;
   name: string;
   toolUseId: string;
@@ -118,26 +119,26 @@ export type ModelConversationMessagePirateChatConnection = {
   nextToken?: string | null;
 };
 
-export enum ConversationParticipantRole {
+export enum AmplifyAIConversationParticipantRole {
   assistant = 'assistant',
   user = 'user',
 }
 
-export type ToolConfiguration = {
-  tools?: Array<Tool | null> | null;
+export type AmplifyAIToolConfiguration = {
+  tools?: Array<AmplifyAITool | null> | null;
 };
 
-export type Tool = {
-  toolSpec?: ToolSpecification | null;
+export type AmplifyAITool = {
+  toolSpec?: AmplifyAIToolSpecification | null;
 };
 
-export type ToolSpecification = {
+export type AmplifyAIToolSpecification = {
   description?: string | null;
-  inputSchema: ToolInputSchema;
+  inputSchema: AmplifyAIToolInputSchema;
   name: string;
 };
 
-export type ToolInputSchema = {
+export type AmplifyAIToolInputSchema = {
   json?: string | null;
 };
 
@@ -150,20 +151,6 @@ export type ModelConversationDisabledModelChatFilterInput = {
   not?: ModelConversationDisabledModelChatFilterInput | null;
   or?: Array<ModelConversationDisabledModelChatFilterInput | null> | null;
   owner?: ModelStringInput | null;
-  updatedAt?: ModelStringInput | null;
-};
-
-export type ModelConversationMessagePirateChatFilterInput = {
-  aiContext?: ModelStringInput | null;
-  and?: Array<ModelConversationMessagePirateChatFilterInput | null> | null;
-  associatedUserMessageId?: ModelIDInput | null;
-  conversationId?: ModelIDInput | null;
-  createdAt?: ModelStringInput | null;
-  id?: ModelIDInput | null;
-  not?: ModelConversationMessagePirateChatFilterInput | null;
-  or?: Array<ModelConversationMessagePirateChatFilterInput | null> | null;
-  owner?: ModelStringInput | null;
-  role?: ModelConversationParticipantRoleInput | null;
   updatedAt?: ModelStringInput | null;
 };
 
@@ -237,13 +224,27 @@ export type ModelConversationMessageDisabledModelChatFilterInput = {
   not?: ModelConversationMessageDisabledModelChatFilterInput | null;
   or?: Array<ModelConversationMessageDisabledModelChatFilterInput | null> | null;
   owner?: ModelStringInput | null;
-  role?: ModelConversationParticipantRoleInput | null;
+  role?: ModelAmplifyAIConversationParticipantRoleInput | null;
   updatedAt?: ModelStringInput | null;
 };
 
-export type ModelConversationParticipantRoleInput = {
-  eq?: ConversationParticipantRole | null;
-  ne?: ConversationParticipantRole | null;
+export type ModelAmplifyAIConversationParticipantRoleInput = {
+  eq?: AmplifyAIConversationParticipantRole | null;
+  ne?: AmplifyAIConversationParticipantRole | null;
+};
+
+export type ModelConversationMessagePirateChatFilterInput = {
+  aiContext?: ModelStringInput | null;
+  and?: Array<ModelConversationMessagePirateChatFilterInput | null> | null;
+  associatedUserMessageId?: ModelIDInput | null;
+  conversationId?: ModelIDInput | null;
+  createdAt?: ModelStringInput | null;
+  id?: ModelIDInput | null;
+  not?: ModelConversationMessagePirateChatFilterInput | null;
+  or?: Array<ModelConversationMessagePirateChatFilterInput | null> | null;
+  owner?: ModelStringInput | null;
+  role?: ModelAmplifyAIConversationParticipantRoleInput | null;
+  updatedAt?: ModelStringInput | null;
 };
 
 export type ModelConversationPirateChatFilterInput = {
@@ -265,133 +266,110 @@ export type ModelConversationPirateChatConnection = {
 
 export type CreateConversationMessageDisabledModelChatAssistantInput = {
   associatedUserMessageId?: string | null;
-  content?: Array<ContentBlockInput | null> | null;
+  content?: Array<AmplifyAIContentBlockInput | null> | null;
   conversationId?: string | null;
 };
 
-export type CreateConversationMessagePirateChatAssistantInput = {
-  associatedUserMessageId?: string | null;
-  content?: Array<ContentBlockInput | null> | null;
-  conversationId?: string | null;
-};
-
-export type ContentBlockInput = {
-  document?: DocumentBlockInput | null;
-  image?: ImageBlockInput | null;
+export type AmplifyAIContentBlockInput = {
+  document?: AmplifyAIDocumentBlockInput | null;
+  image?: AmplifyAIImageBlockInput | null;
   text?: string | null;
-  toolResult?: ToolResultBlockInput | null;
-  toolUse?: ToolUseBlockInput | null;
+  toolResult?: AmplifyAIToolResultBlockInput | null;
+  toolUse?: AmplifyAIToolUseBlockInput | null;
 };
 
-export type DocumentBlockInput = {
+export type AmplifyAIDocumentBlockInput = {
   format: string;
   name: string;
-  source: DocumentBlockSourceInput;
+  source: AmplifyAIDocumentBlockSourceInput;
 };
 
-export type DocumentBlockSourceInput = {
+export type AmplifyAIDocumentBlockSourceInput = {
   bytes?: string | null;
 };
 
-export type ImageBlockInput = {
+export type AmplifyAIImageBlockInput = {
   format: string;
-  source: ImageBlockSourceInput;
+  source: AmplifyAIImageBlockSourceInput;
 };
 
-export type ImageBlockSourceInput = {
+export type AmplifyAIImageBlockSourceInput = {
   bytes?: string | null;
 };
 
-export type ToolResultBlockInput = {
-  content: Array<ToolResultContentBlockInput>;
+export type AmplifyAIToolResultBlockInput = {
+  content: Array<AmplifyAIToolResultContentBlockInput>;
   status?: string | null;
   toolUseId: string;
 };
 
-export type ToolResultContentBlockInput = {
-  document?: DocumentBlockInput | null;
-  image?: ImageBlockInput | null;
+export type AmplifyAIToolResultContentBlockInput = {
+  document?: AmplifyAIDocumentBlockInput | null;
+  image?: AmplifyAIImageBlockInput | null;
   json?: string | null;
   text?: string | null;
 };
 
-export type ToolUseBlockInput = {
+export type AmplifyAIToolUseBlockInput = {
   input: string;
   name: string;
   toolUseId: string;
 };
 
-export type CreateConversationMessagePirateChatAssistantStreamingInput = {
-  accumulatedTurnContent?: Array<ContentBlockInput | null> | null;
-  associatedUserMessageId: string;
-  contentBlockDeltaIndex?: number | null;
-  contentBlockDoneAtIndex?: number | null;
-  contentBlockIndex: number;
-  contentBlockText?: string | null;
-  contentBlockToolUse?: string | null;
-  conversationId: string;
-  errors?: Array<ConversationTurnErrorInput | null> | null;
-  stopReason?: string | null;
+export type CreateConversationMessagePirateChatAssistantInput = {
+  associatedUserMessageId?: string | null;
+  content?: Array<AmplifyAIContentBlockInput | null> | null;
+  conversationId?: string | null;
 };
 
 export type CreateConversationMessageDisabledModelChatAssistantStreamingInput = {
-  accumulatedTurnContent?: Array<ContentBlockInput | null> | null;
+  accumulatedTurnContent?: Array<AmplifyAIContentBlockInput | null> | null;
   associatedUserMessageId: string;
   contentBlockDeltaIndex?: number | null;
   contentBlockDoneAtIndex?: number | null;
-  contentBlockIndex: number;
+  contentBlockIndex?: number | null;
   contentBlockText?: string | null;
   contentBlockToolUse?: string | null;
   conversationId: string;
-  errors?: Array<ConversationTurnErrorInput | null> | null;
+  errors?: Array<AmplifyAIConversationTurnErrorInput | null> | null;
   stopReason?: string | null;
 };
 
-export type ConversationTurnErrorInput = {
+export type AmplifyAIConversationTurnErrorInput = {
   errorType: string;
   message: string;
 };
 
-export type ConversationMessageStreamPart = {
+export type AmplifyAIConversationMessageStreamPart = {
   associatedUserMessageId: string;
   contentBlockDeltaIndex?: number | null;
   contentBlockDoneAtIndex?: number | null;
-  contentBlockIndex: number;
+  contentBlockIndex?: number | null;
   contentBlockText?: string | null;
-  contentBlockToolUse?: ToolUseBlock | null;
+  contentBlockToolUse?: AmplifyAIToolUseBlock | null;
   conversationId: string;
-  errors?: Array<ConversationTurnError | null> | null;
+  errors?: Array<AmplifyAIConversationTurnError | null> | null;
   id: string;
   owner?: string | null;
   stopReason?: string | null;
 };
 
-export type ConversationTurnError = {
+export type AmplifyAIConversationTurnError = {
   errorType: string;
   message: string;
 };
 
-export type ModelConversationMessagePirateChatConditionInput = {
-  aiContext?: ModelStringInput | null;
-  and?: Array<ModelConversationMessagePirateChatConditionInput | null> | null;
-  associatedUserMessageId?: ModelIDInput | null;
-  conversationId?: ModelIDInput | null;
-  createdAt?: ModelStringInput | null;
-  not?: ModelConversationMessagePirateChatConditionInput | null;
-  or?: Array<ModelConversationMessagePirateChatConditionInput | null> | null;
-  owner?: ModelStringInput | null;
-  role?: ModelConversationParticipantRoleInput | null;
-  updatedAt?: ModelStringInput | null;
-};
-
-export type CreateConversationMessagePirateChatInput = {
-  aiContext?: string | null;
-  associatedUserMessageId?: string | null;
-  content?: Array<ContentBlockInput | null> | null;
+export type CreateConversationMessagePirateChatAssistantStreamingInput = {
+  accumulatedTurnContent?: Array<AmplifyAIContentBlockInput | null> | null;
+  associatedUserMessageId: string;
+  contentBlockDeltaIndex?: number | null;
+  contentBlockDoneAtIndex?: number | null;
+  contentBlockIndex?: number | null;
+  contentBlockText?: string | null;
+  contentBlockToolUse?: string | null;
   conversationId: string;
-  id?: string | null;
-  role?: ConversationParticipantRole | null;
-  toolConfiguration?: ToolConfigurationInput | null;
+  errors?: Array<AmplifyAIConversationTurnErrorInput | null> | null;
+  stopReason?: string | null;
 };
 
 export type ModelConversationDisabledModelChatConditionInput = {
@@ -420,36 +398,59 @@ export type ModelConversationMessageDisabledModelChatConditionInput = {
   not?: ModelConversationMessageDisabledModelChatConditionInput | null;
   or?: Array<ModelConversationMessageDisabledModelChatConditionInput | null> | null;
   owner?: ModelStringInput | null;
-  role?: ModelConversationParticipantRoleInput | null;
+  role?: ModelAmplifyAIConversationParticipantRoleInput | null;
   updatedAt?: ModelStringInput | null;
 };
 
 export type CreateConversationMessageDisabledModelChatInput = {
   aiContext?: string | null;
   associatedUserMessageId?: string | null;
-  content?: Array<ContentBlockInput | null> | null;
+  content?: Array<AmplifyAIContentBlockInput | null> | null;
   conversationId: string;
   id?: string | null;
-  role?: ConversationParticipantRole | null;
-  toolConfiguration?: ToolConfigurationInput | null;
+  role?: AmplifyAIConversationParticipantRole | null;
+  toolConfiguration?: AmplifyAIToolConfigurationInput | null;
 };
 
-export type ToolConfigurationInput = {
-  tools?: Array<ToolInput | null> | null;
+export type AmplifyAIToolConfigurationInput = {
+  tools?: Array<AmplifyAIToolInput | null> | null;
 };
 
-export type ToolInput = {
-  toolSpec?: ToolSpecificationInput | null;
+export type AmplifyAIToolInput = {
+  toolSpec?: AmplifyAIToolSpecificationInput | null;
 };
 
-export type ToolSpecificationInput = {
+export type AmplifyAIToolSpecificationInput = {
   description?: string | null;
-  inputSchema: ToolInputSchemaInput;
+  inputSchema: AmplifyAIToolInputSchemaInput;
   name: string;
 };
 
-export type ToolInputSchemaInput = {
+export type AmplifyAIToolInputSchemaInput = {
   json?: string | null;
+};
+
+export type ModelConversationMessagePirateChatConditionInput = {
+  aiContext?: ModelStringInput | null;
+  and?: Array<ModelConversationMessagePirateChatConditionInput | null> | null;
+  associatedUserMessageId?: ModelIDInput | null;
+  conversationId?: ModelIDInput | null;
+  createdAt?: ModelStringInput | null;
+  not?: ModelConversationMessagePirateChatConditionInput | null;
+  or?: Array<ModelConversationMessagePirateChatConditionInput | null> | null;
+  owner?: ModelStringInput | null;
+  role?: ModelAmplifyAIConversationParticipantRoleInput | null;
+  updatedAt?: ModelStringInput | null;
+};
+
+export type CreateConversationMessagePirateChatInput = {
+  aiContext?: string | null;
+  associatedUserMessageId?: string | null;
+  content?: Array<AmplifyAIContentBlockInput | null> | null;
+  conversationId: string;
+  id?: string | null;
+  role?: AmplifyAIConversationParticipantRole | null;
+  toolConfiguration?: AmplifyAIToolConfigurationInput | null;
 };
 
 export type ModelConversationPirateChatConditionInput = {
@@ -510,19 +511,6 @@ export type ModelSubscriptionConversationMessageDisabledModelChatFilterInput = {
   updatedAt?: ModelSubscriptionStringInput | null;
 };
 
-export type ModelSubscriptionConversationMessagePirateChatFilterInput = {
-  aiContext?: ModelSubscriptionStringInput | null;
-  and?: Array<ModelSubscriptionConversationMessagePirateChatFilterInput | null> | null;
-  associatedUserMessageId?: ModelSubscriptionIDInput | null;
-  conversationId?: ModelSubscriptionIDInput | null;
-  createdAt?: ModelSubscriptionStringInput | null;
-  id?: ModelSubscriptionIDInput | null;
-  or?: Array<ModelSubscriptionConversationMessagePirateChatFilterInput | null> | null;
-  owner?: ModelStringInput | null;
-  role?: ModelSubscriptionStringInput | null;
-  updatedAt?: ModelSubscriptionStringInput | null;
-};
-
 export type ModelSubscriptionStringInput = {
   beginsWith?: string | null;
   between?: Array<string | null> | null;
@@ -553,33 +541,17 @@ export type ModelSubscriptionIDInput = {
   notIn?: Array<string | null> | null;
 };
 
-export type GetConversationMessagePirateChatQueryVariables = {
-  id: string;
-};
-
-export type GetConversationMessagePirateChatQuery = {
-  getConversationMessagePirateChat?: {
-    aiContext?: string | null;
-    associatedUserMessageId?: string | null;
-    content?: Array<{
-      text?: string | null;
-    } | null> | null;
-    conversation?: {
-      createdAt: string;
-      id: string;
-      metadata?: string | null;
-      name?: string | null;
-      owner?: string | null;
-      updatedAt: string;
-    } | null;
-    conversationId: string;
-    createdAt: string;
-    id: string;
-    owner?: string | null;
-    role?: ConversationParticipantRole | null;
-    toolConfiguration?: {} | null;
-    updatedAt: string;
-  } | null;
+export type ModelSubscriptionConversationMessagePirateChatFilterInput = {
+  aiContext?: ModelSubscriptionStringInput | null;
+  and?: Array<ModelSubscriptionConversationMessagePirateChatFilterInput | null> | null;
+  associatedUserMessageId?: ModelSubscriptionIDInput | null;
+  conversationId?: ModelSubscriptionIDInput | null;
+  createdAt?: ModelSubscriptionStringInput | null;
+  id?: ModelSubscriptionIDInput | null;
+  or?: Array<ModelSubscriptionConversationMessagePirateChatFilterInput | null> | null;
+  owner?: ModelStringInput | null;
+  role?: ModelSubscriptionStringInput | null;
+  updatedAt?: ModelSubscriptionStringInput | null;
 };
 
 export type GetConversationDisabledModelChatQueryVariables = {
@@ -591,24 +563,49 @@ export type GetConversationDisabledModelChatQuery = {
     createdAt: string;
     id: string;
     messages?: {
-      nextToken?: string | null;
-    } | null;
-    metadata?: string | null;
-    name?: string | null;
-    owner?: string | null;
-    updatedAt: string;
-  } | null;
-};
-
-export type GetConversationPirateChatQueryVariables = {
-  id: string;
-};
-
-export type GetConversationPirateChatQuery = {
-  getConversationPirateChat?: {
-    createdAt: string;
-    id: string;
-    messages?: {
+      items: Array<{
+        aiContext?: string | null;
+        associatedUserMessageId?: string | null;
+        content?: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          text?: string | null;
+          toolResult?: {
+            status?: string | null;
+            toolUseId: string;
+          } | null;
+          toolUse?: {
+            input: string;
+            name: string;
+            toolUseId: string;
+          } | null;
+        } | null> | null;
+        conversation?: {
+          createdAt: string;
+          id: string;
+          messages?: {
+            nextToken?: string | null;
+          } | null;
+          metadata?: string | null;
+          name?: string | null;
+          owner?: string | null;
+          updatedAt: string;
+        } | null;
+        conversationId: string;
+        createdAt: string;
+        id: string;
+        owner?: string | null;
+        role?: AmplifyAIConversationParticipantRole | null;
+        toolConfiguration?: {
+          tools?: Array<{} | null> | null;
+        } | null;
+        updatedAt: string;
+      } | null>;
       nextToken?: string | null;
     } | null;
     metadata?: string | null;
@@ -627,15 +624,69 @@ export type GetConversationMessageDisabledModelChatQuery = {
     aiContext?: string | null;
     associatedUserMessageId?: string | null;
     content?: Array<{
+      document?: {
+        format: string;
+        name: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
+      image?: {
+        format: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
       text?: string | null;
-      document?: DocumentBlock | null;
-      image?: ImageBlock | null;
-      toolResult?: ToolResultBlock | null;
-      toolUse?: ToolUseBlock | null;
+      toolResult?: {
+        content: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          json?: string | null;
+          text?: string | null;
+        }>;
+        status?: string | null;
+        toolUseId: string;
+      } | null;
+      toolUse?: {
+        input: string;
+        name: string;
+        toolUseId: string;
+      } | null;
     } | null> | null;
     conversation?: {
       createdAt: string;
       id: string;
+      messages?: {
+        items: Array<{
+          aiContext?: string | null;
+          associatedUserMessageId?: string | null;
+          content?: Array<{
+            text?: string | null;
+          } | null> | null;
+          conversation?: {
+            createdAt: string;
+            id: string;
+            metadata?: string | null;
+            name?: string | null;
+            owner?: string | null;
+            updatedAt: string;
+          } | null;
+          conversationId: string;
+          createdAt: string;
+          id: string;
+          owner?: string | null;
+          role?: AmplifyAIConversationParticipantRole | null;
+          toolConfiguration?: {} | null;
+          updatedAt: string;
+        } | null>;
+        nextToken?: string | null;
+      } | null;
       metadata?: string | null;
       name?: string | null;
       owner?: string | null;
@@ -645,8 +696,176 @@ export type GetConversationMessageDisabledModelChatQuery = {
     createdAt: string;
     id: string;
     owner?: string | null;
-    role?: ConversationParticipantRole | null;
-    toolConfiguration?: {} | null;
+    role?: AmplifyAIConversationParticipantRole | null;
+    toolConfiguration?: {
+      tools?: Array<{
+        toolSpec?: {
+          description?: string | null;
+          inputSchema: {
+            json?: string | null;
+          };
+          name: string;
+        } | null;
+      } | null> | null;
+    } | null;
+    updatedAt: string;
+  } | null;
+};
+
+export type GetConversationMessagePirateChatQueryVariables = {
+  id: string;
+};
+
+export type GetConversationMessagePirateChatQuery = {
+  getConversationMessagePirateChat?: {
+    aiContext?: string | null;
+    associatedUserMessageId?: string | null;
+    content?: Array<{
+      document?: {
+        format: string;
+        name: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
+      image?: {
+        format: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
+      text?: string | null;
+      toolResult?: {
+        content: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          json?: string | null;
+          text?: string | null;
+        }>;
+        status?: string | null;
+        toolUseId: string;
+      } | null;
+      toolUse?: {
+        input: string;
+        name: string;
+        toolUseId: string;
+      } | null;
+    } | null> | null;
+    conversation?: {
+      createdAt: string;
+      id: string;
+      messages?: {
+        items: Array<{
+          aiContext?: string | null;
+          associatedUserMessageId?: string | null;
+          content?: Array<{
+            text?: string | null;
+          } | null> | null;
+          conversation?: {
+            createdAt: string;
+            id: string;
+            metadata?: string | null;
+            name?: string | null;
+            owner?: string | null;
+            updatedAt: string;
+          } | null;
+          conversationId: string;
+          createdAt: string;
+          id: string;
+          owner?: string | null;
+          role?: AmplifyAIConversationParticipantRole | null;
+          toolConfiguration?: {} | null;
+          updatedAt: string;
+        } | null>;
+        nextToken?: string | null;
+      } | null;
+      metadata?: string | null;
+      name?: string | null;
+      owner?: string | null;
+      updatedAt: string;
+    } | null;
+    conversationId: string;
+    createdAt: string;
+    id: string;
+    owner?: string | null;
+    role?: AmplifyAIConversationParticipantRole | null;
+    toolConfiguration?: {
+      tools?: Array<{
+        toolSpec?: {
+          description?: string | null;
+          inputSchema: {
+            json?: string | null;
+          };
+          name: string;
+        } | null;
+      } | null> | null;
+    } | null;
+    updatedAt: string;
+  } | null;
+};
+
+export type GetConversationPirateChatQueryVariables = {
+  id: string;
+};
+
+export type GetConversationPirateChatQuery = {
+  getConversationPirateChat?: {
+    createdAt: string;
+    id: string;
+    messages?: {
+      items: Array<{
+        aiContext?: string | null;
+        associatedUserMessageId?: string | null;
+        content?: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          text?: string | null;
+          toolResult?: {
+            status?: string | null;
+            toolUseId: string;
+          } | null;
+          toolUse?: {
+            input: string;
+            name: string;
+            toolUseId: string;
+          } | null;
+        } | null> | null;
+        conversation?: {
+          createdAt: string;
+          id: string;
+          messages?: {
+            nextToken?: string | null;
+          } | null;
+          metadata?: string | null;
+          name?: string | null;
+          owner?: string | null;
+          updatedAt: string;
+        } | null;
+        conversationId: string;
+        createdAt: string;
+        id: string;
+        owner?: string | null;
+        role?: AmplifyAIConversationParticipantRole | null;
+        toolConfiguration?: {
+          tools?: Array<{} | null> | null;
+        } | null;
+        updatedAt: string;
+      } | null>;
+      nextToken?: string | null;
+    } | null;
+    metadata?: string | null;
+    name?: string | null;
+    owner?: string | null;
     updatedAt: string;
   } | null;
 };
@@ -662,6 +881,31 @@ export type ListConversationDisabledModelChatsQuery = {
     items: Array<{
       createdAt: string;
       id: string;
+      messages?: {
+        items: Array<{
+          aiContext?: string | null;
+          associatedUserMessageId?: string | null;
+          content?: Array<{
+            text?: string | null;
+          } | null> | null;
+          conversation?: {
+            createdAt: string;
+            id: string;
+            metadata?: string | null;
+            name?: string | null;
+            owner?: string | null;
+            updatedAt: string;
+          } | null;
+          conversationId: string;
+          createdAt: string;
+          id: string;
+          owner?: string | null;
+          role?: AmplifyAIConversationParticipantRole | null;
+          toolConfiguration?: {} | null;
+          updatedAt: string;
+        } | null>;
+        nextToken?: string | null;
+      } | null;
       metadata?: string | null;
       name?: string | null;
       owner?: string | null;
@@ -681,19 +925,70 @@ export type ListConversationMessageDisabledModelChatsQuery = {
   listConversationMessageDisabledModelChats?: {
     items: Array<{
       aiContext?: string | null;
-      content?: Array<{
-        text?: string | null;
-        document?: DocumentBlock | null;
-        image?: ImageBlock | null;
-        toolResult?: ToolResultBlock | null;
-        toolUse?: ToolUseBlock | null;
-      } | null> | null;
       associatedUserMessageId?: string | null;
+      content?: Array<{
+        document?: {
+          format: string;
+          name: string;
+          source: {
+            bytes?: string | null;
+          };
+        } | null;
+        image?: {
+          format: string;
+          source: {
+            bytes?: string | null;
+          };
+        } | null;
+        text?: string | null;
+        toolResult?: {
+          content: Array<{
+            json?: string | null;
+            text?: string | null;
+          }>;
+          status?: string | null;
+          toolUseId: string;
+        } | null;
+        toolUse?: {
+          input: string;
+          name: string;
+          toolUseId: string;
+        } | null;
+      } | null> | null;
+      conversation?: {
+        createdAt: string;
+        id: string;
+        messages?: {
+          items: Array<{
+            aiContext?: string | null;
+            associatedUserMessageId?: string | null;
+            conversationId: string;
+            createdAt: string;
+            id: string;
+            owner?: string | null;
+            role?: AmplifyAIConversationParticipantRole | null;
+            updatedAt: string;
+          } | null>;
+          nextToken?: string | null;
+        } | null;
+        metadata?: string | null;
+        name?: string | null;
+        owner?: string | null;
+        updatedAt: string;
+      } | null;
       conversationId: string;
       createdAt: string;
       id: string;
       owner?: string | null;
-      role?: ConversationParticipantRole | null;
+      role?: AmplifyAIConversationParticipantRole | null;
+      toolConfiguration?: {
+        tools?: Array<{
+          toolSpec?: {
+            description?: string | null;
+            name: string;
+          } | null;
+        } | null> | null;
+      } | null;
       updatedAt: string;
     } | null>;
     nextToken?: string | null;
@@ -710,19 +1005,70 @@ export type ListConversationMessagePirateChatsQuery = {
   listConversationMessagePirateChats?: {
     items: Array<{
       aiContext?: string | null;
-      content?: Array<{
-        text?: string | null;
-        document?: DocumentBlock | null;
-        image?: ImageBlock | null;
-        toolResult?: ToolResultBlock | null;
-        toolUse?: ToolUseBlock | null;
-      } | null> | null;
       associatedUserMessageId?: string | null;
+      content?: Array<{
+        document?: {
+          format: string;
+          name: string;
+          source: {
+            bytes?: string | null;
+          };
+        } | null;
+        image?: {
+          format: string;
+          source: {
+            bytes?: string | null;
+          };
+        } | null;
+        text?: string | null;
+        toolResult?: {
+          content: Array<{
+            json?: string | null;
+            text?: string | null;
+          }>;
+          status?: string | null;
+          toolUseId: string;
+        } | null;
+        toolUse?: {
+          input: string;
+          name: string;
+          toolUseId: string;
+        } | null;
+      } | null> | null;
+      conversation?: {
+        createdAt: string;
+        id: string;
+        messages?: {
+          items: Array<{
+            aiContext?: string | null;
+            associatedUserMessageId?: string | null;
+            conversationId: string;
+            createdAt: string;
+            id: string;
+            owner?: string | null;
+            role?: AmplifyAIConversationParticipantRole | null;
+            updatedAt: string;
+          } | null>;
+          nextToken?: string | null;
+        } | null;
+        metadata?: string | null;
+        name?: string | null;
+        owner?: string | null;
+        updatedAt: string;
+      } | null;
       conversationId: string;
       createdAt: string;
       id: string;
       owner?: string | null;
-      role?: ConversationParticipantRole | null;
+      role?: AmplifyAIConversationParticipantRole | null;
+      toolConfiguration?: {
+        tools?: Array<{
+          toolSpec?: {
+            description?: string | null;
+            name: string;
+          } | null;
+        } | null> | null;
+      } | null;
       updatedAt: string;
     } | null>;
     nextToken?: string | null;
@@ -740,6 +1086,31 @@ export type ListConversationPirateChatsQuery = {
     items: Array<{
       createdAt: string;
       id: string;
+      messages?: {
+        items: Array<{
+          aiContext?: string | null;
+          associatedUserMessageId?: string | null;
+          content?: Array<{
+            text?: string | null;
+          } | null> | null;
+          conversation?: {
+            createdAt: string;
+            id: string;
+            metadata?: string | null;
+            name?: string | null;
+            owner?: string | null;
+            updatedAt: string;
+          } | null;
+          conversationId: string;
+          createdAt: string;
+          id: string;
+          owner?: string | null;
+          role?: AmplifyAIConversationParticipantRole | null;
+          toolConfiguration?: {} | null;
+          updatedAt: string;
+        } | null>;
+        nextToken?: string | null;
+      } | null;
       metadata?: string | null;
       name?: string | null;
       owner?: string | null;
@@ -758,11 +1129,69 @@ export type CreateAssistantResponseDisabledModelChatMutation = {
     aiContext?: string | null;
     associatedUserMessageId?: string | null;
     content?: Array<{
+      document?: {
+        format: string;
+        name: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
+      image?: {
+        format: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
       text?: string | null;
+      toolResult?: {
+        content: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          json?: string | null;
+          text?: string | null;
+        }>;
+        status?: string | null;
+        toolUseId: string;
+      } | null;
+      toolUse?: {
+        input: string;
+        name: string;
+        toolUseId: string;
+      } | null;
     } | null> | null;
     conversation?: {
       createdAt: string;
       id: string;
+      messages?: {
+        items: Array<{
+          aiContext?: string | null;
+          associatedUserMessageId?: string | null;
+          content?: Array<{
+            text?: string | null;
+          } | null> | null;
+          conversation?: {
+            createdAt: string;
+            id: string;
+            metadata?: string | null;
+            name?: string | null;
+            owner?: string | null;
+            updatedAt: string;
+          } | null;
+          conversationId: string;
+          createdAt: string;
+          id: string;
+          owner?: string | null;
+          role?: AmplifyAIConversationParticipantRole | null;
+          toolConfiguration?: {} | null;
+          updatedAt: string;
+        } | null>;
+        nextToken?: string | null;
+      } | null;
       metadata?: string | null;
       name?: string | null;
       owner?: string | null;
@@ -772,8 +1201,18 @@ export type CreateAssistantResponseDisabledModelChatMutation = {
     createdAt: string;
     id: string;
     owner?: string | null;
-    role?: ConversationParticipantRole | null;
-    toolConfiguration?: {} | null;
+    role?: AmplifyAIConversationParticipantRole | null;
+    toolConfiguration?: {
+      tools?: Array<{
+        toolSpec?: {
+          description?: string | null;
+          inputSchema: {
+            json?: string | null;
+          };
+          name: string;
+        } | null;
+      } | null> | null;
+    } | null;
     updatedAt: string;
   } | null;
 };
@@ -787,11 +1226,69 @@ export type CreateAssistantResponsePirateChatMutation = {
     aiContext?: string | null;
     associatedUserMessageId?: string | null;
     content?: Array<{
+      document?: {
+        format: string;
+        name: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
+      image?: {
+        format: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
       text?: string | null;
+      toolResult?: {
+        content: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          json?: string | null;
+          text?: string | null;
+        }>;
+        status?: string | null;
+        toolUseId: string;
+      } | null;
+      toolUse?: {
+        input: string;
+        name: string;
+        toolUseId: string;
+      } | null;
     } | null> | null;
     conversation?: {
       createdAt: string;
       id: string;
+      messages?: {
+        items: Array<{
+          aiContext?: string | null;
+          associatedUserMessageId?: string | null;
+          content?: Array<{
+            text?: string | null;
+          } | null> | null;
+          conversation?: {
+            createdAt: string;
+            id: string;
+            metadata?: string | null;
+            name?: string | null;
+            owner?: string | null;
+            updatedAt: string;
+          } | null;
+          conversationId: string;
+          createdAt: string;
+          id: string;
+          owner?: string | null;
+          role?: AmplifyAIConversationParticipantRole | null;
+          toolConfiguration?: {} | null;
+          updatedAt: string;
+        } | null>;
+        nextToken?: string | null;
+      } | null;
       metadata?: string | null;
       name?: string | null;
       owner?: string | null;
@@ -801,8 +1298,18 @@ export type CreateAssistantResponsePirateChatMutation = {
     createdAt: string;
     id: string;
     owner?: string | null;
-    role?: ConversationParticipantRole | null;
-    toolConfiguration?: {} | null;
+    role?: AmplifyAIConversationParticipantRole | null;
+    toolConfiguration?: {
+      tools?: Array<{
+        toolSpec?: {
+          description?: string | null;
+          inputSchema: {
+            json?: string | null;
+          };
+          name: string;
+        } | null;
+      } | null> | null;
+    } | null;
     updatedAt: string;
   } | null;
 };
@@ -816,7 +1323,7 @@ export type CreateAssistantResponseStreamDisabledModelChatMutation = {
     associatedUserMessageId: string;
     contentBlockDeltaIndex?: number | null;
     contentBlockDoneAtIndex?: number | null;
-    contentBlockIndex: number;
+    contentBlockIndex?: number | null;
     contentBlockText?: string | null;
     contentBlockToolUse?: {
       input: string;
@@ -843,7 +1350,7 @@ export type CreateAssistantResponseStreamPirateChatMutation = {
     associatedUserMessageId: string;
     contentBlockDeltaIndex?: number | null;
     contentBlockDoneAtIndex?: number | null;
-    contentBlockIndex: number;
+    contentBlockIndex?: number | null;
     contentBlockText?: string | null;
     contentBlockToolUse?: {
       input: string;
@@ -861,36 +1368,6 @@ export type CreateAssistantResponseStreamPirateChatMutation = {
   } | null;
 };
 
-export type CreateConversationMessagePirateChatMutationVariables = {
-  condition?: ModelConversationMessagePirateChatConditionInput | null;
-  input: CreateConversationMessagePirateChatInput;
-};
-
-export type CreateConversationMessagePirateChatMutation = {
-  createConversationMessagePirateChat?: {
-    aiContext?: string | null;
-    associatedUserMessageId?: string | null;
-    content?: Array<{
-      text?: string | null;
-    } | null> | null;
-    conversation?: {
-      createdAt: string;
-      id: string;
-      metadata?: string | null;
-      name?: string | null;
-      owner?: string | null;
-      updatedAt: string;
-    } | null;
-    conversationId: string;
-    createdAt: string;
-    id: string;
-    owner?: string | null;
-    role?: ConversationParticipantRole | null;
-    toolConfiguration?: {} | null;
-    updatedAt: string;
-  } | null;
-};
-
 export type CreateConversationDisabledModelChatMutationVariables = {
   condition?: ModelConversationDisabledModelChatConditionInput | null;
   input: CreateConversationDisabledModelChatInput;
@@ -901,6 +1378,49 @@ export type CreateConversationDisabledModelChatMutation = {
     createdAt: string;
     id: string;
     messages?: {
+      items: Array<{
+        aiContext?: string | null;
+        associatedUserMessageId?: string | null;
+        content?: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          text?: string | null;
+          toolResult?: {
+            status?: string | null;
+            toolUseId: string;
+          } | null;
+          toolUse?: {
+            input: string;
+            name: string;
+            toolUseId: string;
+          } | null;
+        } | null> | null;
+        conversation?: {
+          createdAt: string;
+          id: string;
+          messages?: {
+            nextToken?: string | null;
+          } | null;
+          metadata?: string | null;
+          name?: string | null;
+          owner?: string | null;
+          updatedAt: string;
+        } | null;
+        conversationId: string;
+        createdAt: string;
+        id: string;
+        owner?: string | null;
+        role?: AmplifyAIConversationParticipantRole | null;
+        toolConfiguration?: {
+          tools?: Array<{} | null> | null;
+        } | null;
+        updatedAt: string;
+      } | null>;
       nextToken?: string | null;
     } | null;
     metadata?: string | null;
@@ -920,11 +1440,69 @@ export type CreateConversationMessageDisabledModelChatMutation = {
     aiContext?: string | null;
     associatedUserMessageId?: string | null;
     content?: Array<{
+      document?: {
+        format: string;
+        name: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
+      image?: {
+        format: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
       text?: string | null;
+      toolResult?: {
+        content: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          json?: string | null;
+          text?: string | null;
+        }>;
+        status?: string | null;
+        toolUseId: string;
+      } | null;
+      toolUse?: {
+        input: string;
+        name: string;
+        toolUseId: string;
+      } | null;
     } | null> | null;
     conversation?: {
       createdAt: string;
       id: string;
+      messages?: {
+        items: Array<{
+          aiContext?: string | null;
+          associatedUserMessageId?: string | null;
+          content?: Array<{
+            text?: string | null;
+          } | null> | null;
+          conversation?: {
+            createdAt: string;
+            id: string;
+            metadata?: string | null;
+            name?: string | null;
+            owner?: string | null;
+            updatedAt: string;
+          } | null;
+          conversationId: string;
+          createdAt: string;
+          id: string;
+          owner?: string | null;
+          role?: AmplifyAIConversationParticipantRole | null;
+          toolConfiguration?: {} | null;
+          updatedAt: string;
+        } | null>;
+        nextToken?: string | null;
+      } | null;
       metadata?: string | null;
       name?: string | null;
       owner?: string | null;
@@ -934,8 +1512,116 @@ export type CreateConversationMessageDisabledModelChatMutation = {
     createdAt: string;
     id: string;
     owner?: string | null;
-    role?: ConversationParticipantRole | null;
-    toolConfiguration?: {} | null;
+    role?: AmplifyAIConversationParticipantRole | null;
+    toolConfiguration?: {
+      tools?: Array<{
+        toolSpec?: {
+          description?: string | null;
+          inputSchema: {
+            json?: string | null;
+          };
+          name: string;
+        } | null;
+      } | null> | null;
+    } | null;
+    updatedAt: string;
+  } | null;
+};
+
+export type CreateConversationMessagePirateChatMutationVariables = {
+  condition?: ModelConversationMessagePirateChatConditionInput | null;
+  input: CreateConversationMessagePirateChatInput;
+};
+
+export type CreateConversationMessagePirateChatMutation = {
+  createConversationMessagePirateChat?: {
+    aiContext?: string | null;
+    associatedUserMessageId?: string | null;
+    content?: Array<{
+      document?: {
+        format: string;
+        name: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
+      image?: {
+        format: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
+      text?: string | null;
+      toolResult?: {
+        content: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          json?: string | null;
+          text?: string | null;
+        }>;
+        status?: string | null;
+        toolUseId: string;
+      } | null;
+      toolUse?: {
+        input: string;
+        name: string;
+        toolUseId: string;
+      } | null;
+    } | null> | null;
+    conversation?: {
+      createdAt: string;
+      id: string;
+      messages?: {
+        items: Array<{
+          aiContext?: string | null;
+          associatedUserMessageId?: string | null;
+          content?: Array<{
+            text?: string | null;
+          } | null> | null;
+          conversation?: {
+            createdAt: string;
+            id: string;
+            metadata?: string | null;
+            name?: string | null;
+            owner?: string | null;
+            updatedAt: string;
+          } | null;
+          conversationId: string;
+          createdAt: string;
+          id: string;
+          owner?: string | null;
+          role?: AmplifyAIConversationParticipantRole | null;
+          toolConfiguration?: {} | null;
+          updatedAt: string;
+        } | null>;
+        nextToken?: string | null;
+      } | null;
+      metadata?: string | null;
+      name?: string | null;
+      owner?: string | null;
+      updatedAt: string;
+    } | null;
+    conversationId: string;
+    createdAt: string;
+    id: string;
+    owner?: string | null;
+    role?: AmplifyAIConversationParticipantRole | null;
+    toolConfiguration?: {
+      tools?: Array<{
+        toolSpec?: {
+          description?: string | null;
+          inputSchema: {
+            json?: string | null;
+          };
+          name: string;
+        } | null;
+      } | null> | null;
+    } | null;
     updatedAt: string;
   } | null;
 };
@@ -950,11 +1636,214 @@ export type CreateConversationPirateChatMutation = {
     createdAt: string;
     id: string;
     messages?: {
+      items: Array<{
+        aiContext?: string | null;
+        associatedUserMessageId?: string | null;
+        content?: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          text?: string | null;
+          toolResult?: {
+            status?: string | null;
+            toolUseId: string;
+          } | null;
+          toolUse?: {
+            input: string;
+            name: string;
+            toolUseId: string;
+          } | null;
+        } | null> | null;
+        conversation?: {
+          createdAt: string;
+          id: string;
+          messages?: {
+            nextToken?: string | null;
+          } | null;
+          metadata?: string | null;
+          name?: string | null;
+          owner?: string | null;
+          updatedAt: string;
+        } | null;
+        conversationId: string;
+        createdAt: string;
+        id: string;
+        owner?: string | null;
+        role?: AmplifyAIConversationParticipantRole | null;
+        toolConfiguration?: {
+          tools?: Array<{} | null> | null;
+        } | null;
+        updatedAt: string;
+      } | null>;
       nextToken?: string | null;
     } | null;
     metadata?: string | null;
     name?: string | null;
     owner?: string | null;
+    updatedAt: string;
+  } | null;
+};
+
+export type DeleteConversationDisabledModelChatMutationVariables = {
+  condition?: ModelConversationDisabledModelChatConditionInput | null;
+  input: DeleteConversationDisabledModelChatInput;
+};
+
+export type DeleteConversationDisabledModelChatMutation = {
+  deleteConversationDisabledModelChat?: {
+    createdAt: string;
+    id: string;
+    messages?: {
+      items: Array<{
+        aiContext?: string | null;
+        associatedUserMessageId?: string | null;
+        content?: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          text?: string | null;
+          toolResult?: {
+            status?: string | null;
+            toolUseId: string;
+          } | null;
+          toolUse?: {
+            input: string;
+            name: string;
+            toolUseId: string;
+          } | null;
+        } | null> | null;
+        conversation?: {
+          createdAt: string;
+          id: string;
+          messages?: {
+            nextToken?: string | null;
+          } | null;
+          metadata?: string | null;
+          name?: string | null;
+          owner?: string | null;
+          updatedAt: string;
+        } | null;
+        conversationId: string;
+        createdAt: string;
+        id: string;
+        owner?: string | null;
+        role?: AmplifyAIConversationParticipantRole | null;
+        toolConfiguration?: {
+          tools?: Array<{} | null> | null;
+        } | null;
+        updatedAt: string;
+      } | null>;
+      nextToken?: string | null;
+    } | null;
+    metadata?: string | null;
+    name?: string | null;
+    owner?: string | null;
+    updatedAt: string;
+  } | null;
+};
+
+export type DeleteConversationMessageDisabledModelChatMutationVariables = {
+  condition?: ModelConversationMessageDisabledModelChatConditionInput | null;
+  input: DeleteConversationMessageDisabledModelChatInput;
+};
+
+export type DeleteConversationMessageDisabledModelChatMutation = {
+  deleteConversationMessageDisabledModelChat?: {
+    aiContext?: string | null;
+    associatedUserMessageId?: string | null;
+    content?: Array<{
+      document?: {
+        format: string;
+        name: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
+      image?: {
+        format: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
+      text?: string | null;
+      toolResult?: {
+        content: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          json?: string | null;
+          text?: string | null;
+        }>;
+        status?: string | null;
+        toolUseId: string;
+      } | null;
+      toolUse?: {
+        input: string;
+        name: string;
+        toolUseId: string;
+      } | null;
+    } | null> | null;
+    conversation?: {
+      createdAt: string;
+      id: string;
+      messages?: {
+        items: Array<{
+          aiContext?: string | null;
+          associatedUserMessageId?: string | null;
+          content?: Array<{
+            text?: string | null;
+          } | null> | null;
+          conversation?: {
+            createdAt: string;
+            id: string;
+            metadata?: string | null;
+            name?: string | null;
+            owner?: string | null;
+            updatedAt: string;
+          } | null;
+          conversationId: string;
+          createdAt: string;
+          id: string;
+          owner?: string | null;
+          role?: AmplifyAIConversationParticipantRole | null;
+          toolConfiguration?: {} | null;
+          updatedAt: string;
+        } | null>;
+        nextToken?: string | null;
+      } | null;
+      metadata?: string | null;
+      name?: string | null;
+      owner?: string | null;
+      updatedAt: string;
+    } | null;
+    conversationId: string;
+    createdAt: string;
+    id: string;
+    owner?: string | null;
+    role?: AmplifyAIConversationParticipantRole | null;
+    toolConfiguration?: {
+      tools?: Array<{
+        toolSpec?: {
+          description?: string | null;
+          inputSchema: {
+            json?: string | null;
+          };
+          name: string;
+        } | null;
+      } | null> | null;
+    } | null;
     updatedAt: string;
   } | null;
 };
@@ -969,11 +1858,69 @@ export type DeleteConversationMessagePirateChatMutation = {
     aiContext?: string | null;
     associatedUserMessageId?: string | null;
     content?: Array<{
+      document?: {
+        format: string;
+        name: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
+      image?: {
+        format: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
       text?: string | null;
+      toolResult?: {
+        content: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          json?: string | null;
+          text?: string | null;
+        }>;
+        status?: string | null;
+        toolUseId: string;
+      } | null;
+      toolUse?: {
+        input: string;
+        name: string;
+        toolUseId: string;
+      } | null;
     } | null> | null;
     conversation?: {
       createdAt: string;
       id: string;
+      messages?: {
+        items: Array<{
+          aiContext?: string | null;
+          associatedUserMessageId?: string | null;
+          content?: Array<{
+            text?: string | null;
+          } | null> | null;
+          conversation?: {
+            createdAt: string;
+            id: string;
+            metadata?: string | null;
+            name?: string | null;
+            owner?: string | null;
+            updatedAt: string;
+          } | null;
+          conversationId: string;
+          createdAt: string;
+          id: string;
+          owner?: string | null;
+          role?: AmplifyAIConversationParticipantRole | null;
+          toolConfiguration?: {} | null;
+          updatedAt: string;
+        } | null>;
+        nextToken?: string | null;
+      } | null;
       metadata?: string | null;
       name?: string | null;
       owner?: string | null;
@@ -983,8 +1930,18 @@ export type DeleteConversationMessagePirateChatMutation = {
     createdAt: string;
     id: string;
     owner?: string | null;
-    role?: ConversationParticipantRole | null;
-    toolConfiguration?: {} | null;
+    role?: AmplifyAIConversationParticipantRole | null;
+    toolConfiguration?: {
+      tools?: Array<{
+        toolSpec?: {
+          description?: string | null;
+          inputSchema: {
+            json?: string | null;
+          };
+          name: string;
+        } | null;
+      } | null> | null;
+    } | null;
     updatedAt: string;
   } | null;
 };
@@ -999,6 +1956,49 @@ export type DeleteConversationPirateChatMutation = {
     createdAt: string;
     id: string;
     messages?: {
+      items: Array<{
+        aiContext?: string | null;
+        associatedUserMessageId?: string | null;
+        content?: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          text?: string | null;
+          toolResult?: {
+            status?: string | null;
+            toolUseId: string;
+          } | null;
+          toolUse?: {
+            input: string;
+            name: string;
+            toolUseId: string;
+          } | null;
+        } | null> | null;
+        conversation?: {
+          createdAt: string;
+          id: string;
+          messages?: {
+            nextToken?: string | null;
+          } | null;
+          metadata?: string | null;
+          name?: string | null;
+          owner?: string | null;
+          updatedAt: string;
+        } | null;
+        conversationId: string;
+        createdAt: string;
+        id: string;
+        owner?: string | null;
+        role?: AmplifyAIConversationParticipantRole | null;
+        toolConfiguration?: {
+          tools?: Array<{} | null> | null;
+        } | null;
+        updatedAt: string;
+      } | null>;
       nextToken?: string | null;
     } | null;
     metadata?: string | null;
@@ -1010,67 +2010,451 @@ export type DeleteConversationPirateChatMutation = {
 
 export type DisabledModelChatMutationVariables = {
   aiContext?: string | null;
-  content?: Array<ContentBlockInput | null> | null;
+  content?: Array<AmplifyAIContentBlockInput | null> | null;
   conversationId: string;
-  toolConfiguration?: ToolConfigurationInput | null;
+  toolConfiguration?: AmplifyAIToolConfigurationInput | null;
 };
 
 export type DisabledModelChatMutation = {
-  disabledModelChat: {
-    aiContext?: string | null;
-    content?: Array<{
-      text?: string | null;
-      toolResult?: ToolResultBlockInput | null;
-    } | null> | null;
-    conversationId: string;
-    createdAt?: string | null;
-    id: string;
-    owner?: string | null;
-    role?: ConversationParticipantRole | null;
-    toolConfiguration?: {} | null;
-    updatedAt?: string | null;
-    associatedUserMessageId?: string | null;
-    conversation?: {
-      createdAt: string;
-      id: string;
-      metadata?: string | null;
-      name?: string | null;
-      owner?: string | null;
-      updatedAt: string;
-    } | null;
-  } | null;
+  disabledModelChat:
+    | (
+        | {
+            aiContext?: string | null;
+            associatedUserMessageId?: string | null;
+            content?: Array<{
+              document?: {
+                format: string;
+                name: string;
+                source: {
+                  bytes?: string | null;
+                };
+              } | null;
+              image?: {
+                format: string;
+                source: {
+                  bytes?: string | null;
+                };
+              } | null;
+              text?: string | null;
+              toolResult?: {
+                content: Array<{
+                  document?: {
+                    format: string;
+                    name: string;
+                  } | null;
+                  image?: {
+                    format: string;
+                  } | null;
+                  json?: string | null;
+                  text?: string | null;
+                }>;
+                status?: string | null;
+                toolUseId: string;
+              } | null;
+              toolUse?: {
+                input: string;
+                name: string;
+                toolUseId: string;
+              } | null;
+            } | null> | null;
+            conversationId: string;
+            createdAt?: string | null;
+            id: string;
+            owner?: string | null;
+            role?: AmplifyAIConversationParticipantRole | null;
+            toolConfiguration?: {
+              tools?: Array<{
+                toolSpec?: {
+                  description?: string | null;
+                  inputSchema: {
+                    json?: string | null;
+                  };
+                  name: string;
+                } | null;
+              } | null> | null;
+            } | null;
+            updatedAt?: string | null;
+            conversation?: {
+              createdAt: string;
+              id: string;
+              messages?: {
+                items: Array<{
+                  aiContext?: string | null;
+                  associatedUserMessageId?: string | null;
+                  content?: Array<{
+                    text?: string | null;
+                  } | null> | null;
+                  conversation?: {
+                    createdAt: string;
+                    id: string;
+                    metadata?: string | null;
+                    name?: string | null;
+                    owner?: string | null;
+                    updatedAt: string;
+                  } | null;
+                  conversationId: string;
+                  createdAt: string;
+                  id: string;
+                  owner?: string | null;
+                  role?: AmplifyAIConversationParticipantRole | null;
+                  toolConfiguration?: {} | null;
+                  updatedAt: string;
+                } | null>;
+                nextToken?: string | null;
+              } | null;
+              metadata?: string | null;
+              name?: string | null;
+              owner?: string | null;
+              updatedAt: string;
+            } | null;
+          }
+        | {
+            aiContext?: string | null;
+            associatedUserMessageId?: string | null;
+            content?: Array<{
+              document?: {
+                format: string;
+                name: string;
+                source: {
+                  bytes?: string | null;
+                };
+              } | null;
+              image?: {
+                format: string;
+                source: {
+                  bytes?: string | null;
+                };
+              } | null;
+              text?: string | null;
+              toolResult?: {
+                content: Array<{
+                  document?: {
+                    format: string;
+                    name: string;
+                  } | null;
+                  image?: {
+                    format: string;
+                  } | null;
+                  json?: string | null;
+                  text?: string | null;
+                }>;
+                status?: string | null;
+                toolUseId: string;
+              } | null;
+              toolUse?: {
+                input: string;
+                name: string;
+                toolUseId: string;
+              } | null;
+            } | null> | null;
+            conversationId: string;
+            createdAt?: string | null;
+            id: string;
+            owner?: string | null;
+            role?: AmplifyAIConversationParticipantRole | null;
+            toolConfiguration?: {
+              tools?: Array<{
+                toolSpec?: {
+                  description?: string | null;
+                  inputSchema: {
+                    json?: string | null;
+                  };
+                  name: string;
+                } | null;
+              } | null> | null;
+            } | null;
+            updatedAt?: string | null;
+            conversation?: {
+              createdAt: string;
+              id: string;
+              messages?: {
+                items: Array<{
+                  aiContext?: string | null;
+                  associatedUserMessageId?: string | null;
+                  content?: Array<{
+                    text?: string | null;
+                  } | null> | null;
+                  conversation?: {
+                    createdAt: string;
+                    id: string;
+                    metadata?: string | null;
+                    name?: string | null;
+                    owner?: string | null;
+                    updatedAt: string;
+                  } | null;
+                  conversationId: string;
+                  createdAt: string;
+                  id: string;
+                  owner?: string | null;
+                  role?: AmplifyAIConversationParticipantRole | null;
+                  toolConfiguration?: {} | null;
+                  updatedAt: string;
+                } | null>;
+                nextToken?: string | null;
+              } | null;
+              metadata?: string | null;
+              name?: string | null;
+              owner?: string | null;
+              updatedAt: string;
+            } | null;
+          }
+      )
+    | null;
 };
 
 export type PirateChatMutationVariables = {
   aiContext?: string | null;
-  content?: Array<ContentBlockInput | null> | null;
+  content?: Array<AmplifyAIContentBlockInput | null> | null;
   conversationId: string;
-  toolConfiguration?: ToolConfigurationInput | null;
+  toolConfiguration?: AmplifyAIToolConfigurationInput | null;
 };
 
 export type PirateChatMutation = {
-  pirateChat: {
-    aiContext?: string | null;
-    content?: Array<{
-      text?: string | null;
-      toolResult?: ToolResultBlockInput | null;
-    } | null> | null;
-    conversationId: string;
-    createdAt?: string | null;
+  pirateChat:
+    | (
+        | {
+            aiContext?: string | null;
+            associatedUserMessageId?: string | null;
+            content?: Array<{
+              document?: {
+                format: string;
+                name: string;
+                source: {
+                  bytes?: string | null;
+                };
+              } | null;
+              image?: {
+                format: string;
+                source: {
+                  bytes?: string | null;
+                };
+              } | null;
+              text?: string | null;
+              toolResult?: {
+                content: Array<{
+                  document?: {
+                    format: string;
+                    name: string;
+                  } | null;
+                  image?: {
+                    format: string;
+                  } | null;
+                  json?: string | null;
+                  text?: string | null;
+                }>;
+                status?: string | null;
+                toolUseId: string;
+              } | null;
+              toolUse?: {
+                input: string;
+                name: string;
+                toolUseId: string;
+              } | null;
+            } | null> | null;
+            conversationId: string;
+            createdAt?: string | null;
+            id: string;
+            owner?: string | null;
+            role?: AmplifyAIConversationParticipantRole | null;
+            toolConfiguration?: {
+              tools?: Array<{
+                toolSpec?: {
+                  description?: string | null;
+                  inputSchema: {
+                    json?: string | null;
+                  };
+                  name: string;
+                } | null;
+              } | null> | null;
+            } | null;
+            updatedAt?: string | null;
+            conversation?: {
+              createdAt: string;
+              id: string;
+              messages?: {
+                items: Array<{
+                  aiContext?: string | null;
+                  associatedUserMessageId?: string | null;
+                  content?: Array<{
+                    text?: string | null;
+                  } | null> | null;
+                  conversation?: {
+                    createdAt: string;
+                    id: string;
+                    metadata?: string | null;
+                    name?: string | null;
+                    owner?: string | null;
+                    updatedAt: string;
+                  } | null;
+                  conversationId: string;
+                  createdAt: string;
+                  id: string;
+                  owner?: string | null;
+                  role?: AmplifyAIConversationParticipantRole | null;
+                  toolConfiguration?: {} | null;
+                  updatedAt: string;
+                } | null>;
+                nextToken?: string | null;
+              } | null;
+              metadata?: string | null;
+              name?: string | null;
+              owner?: string | null;
+              updatedAt: string;
+            } | null;
+          }
+        | {
+            aiContext?: string | null;
+            associatedUserMessageId?: string | null;
+            content?: Array<{
+              document?: {
+                format: string;
+                name: string;
+                source: {
+                  bytes?: string | null;
+                };
+              } | null;
+              image?: {
+                format: string;
+                source: {
+                  bytes?: string | null;
+                };
+              } | null;
+              text?: string | null;
+              toolResult?: {
+                content: Array<{
+                  document?: {
+                    format: string;
+                    name: string;
+                  } | null;
+                  image?: {
+                    format: string;
+                  } | null;
+                  json?: string | null;
+                  text?: string | null;
+                }>;
+                status?: string | null;
+                toolUseId: string;
+              } | null;
+              toolUse?: {
+                input: string;
+                name: string;
+                toolUseId: string;
+              } | null;
+            } | null> | null;
+            conversationId: string;
+            createdAt?: string | null;
+            id: string;
+            owner?: string | null;
+            role?: AmplifyAIConversationParticipantRole | null;
+            toolConfiguration?: {
+              tools?: Array<{
+                toolSpec?: {
+                  description?: string | null;
+                  inputSchema: {
+                    json?: string | null;
+                  };
+                  name: string;
+                } | null;
+              } | null> | null;
+            } | null;
+            updatedAt?: string | null;
+            conversation?: {
+              createdAt: string;
+              id: string;
+              messages?: {
+                items: Array<{
+                  aiContext?: string | null;
+                  associatedUserMessageId?: string | null;
+                  content?: Array<{
+                    text?: string | null;
+                  } | null> | null;
+                  conversation?: {
+                    createdAt: string;
+                    id: string;
+                    metadata?: string | null;
+                    name?: string | null;
+                    owner?: string | null;
+                    updatedAt: string;
+                  } | null;
+                  conversationId: string;
+                  createdAt: string;
+                  id: string;
+                  owner?: string | null;
+                  role?: AmplifyAIConversationParticipantRole | null;
+                  toolConfiguration?: {} | null;
+                  updatedAt: string;
+                } | null>;
+                nextToken?: string | null;
+              } | null;
+              metadata?: string | null;
+              name?: string | null;
+              owner?: string | null;
+              updatedAt: string;
+            } | null;
+          }
+      )
+    | null;
+};
+
+export type UpdateConversationDisabledModelChatMutationVariables = {
+  condition?: ModelConversationDisabledModelChatConditionInput | null;
+  input: UpdateConversationDisabledModelChatInput;
+};
+
+export type UpdateConversationDisabledModelChatMutation = {
+  updateConversationDisabledModelChat?: {
+    createdAt: string;
     id: string;
-    owner?: string | null;
-    role?: ConversationParticipantRole | null;
-    toolConfiguration?: {} | null;
-    updatedAt?: string | null;
-    associatedUserMessageId?: string | null;
-    conversation?: {
-      createdAt: string;
-      id: string;
-      metadata?: string | null;
-      name?: string | null;
-      owner?: string | null;
-      updatedAt: string;
+    messages?: {
+      items: Array<{
+        aiContext?: string | null;
+        associatedUserMessageId?: string | null;
+        content?: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          text?: string | null;
+          toolResult?: {
+            status?: string | null;
+            toolUseId: string;
+          } | null;
+          toolUse?: {
+            input: string;
+            name: string;
+            toolUseId: string;
+          } | null;
+        } | null> | null;
+        conversation?: {
+          createdAt: string;
+          id: string;
+          messages?: {
+            nextToken?: string | null;
+          } | null;
+          metadata?: string | null;
+          name?: string | null;
+          owner?: string | null;
+          updatedAt: string;
+        } | null;
+        conversationId: string;
+        createdAt: string;
+        id: string;
+        owner?: string | null;
+        role?: AmplifyAIConversationParticipantRole | null;
+        toolConfiguration?: {
+          tools?: Array<{} | null> | null;
+        } | null;
+        updatedAt: string;
+      } | null>;
+      nextToken?: string | null;
     } | null;
+    metadata?: string | null;
+    name?: string | null;
+    owner?: string | null;
+    updatedAt: string;
   } | null;
 };
 
@@ -1084,6 +2468,49 @@ export type UpdateConversationPirateChatMutation = {
     createdAt: string;
     id: string;
     messages?: {
+      items: Array<{
+        aiContext?: string | null;
+        associatedUserMessageId?: string | null;
+        content?: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          text?: string | null;
+          toolResult?: {
+            status?: string | null;
+            toolUseId: string;
+          } | null;
+          toolUse?: {
+            input: string;
+            name: string;
+            toolUseId: string;
+          } | null;
+        } | null> | null;
+        conversation?: {
+          createdAt: string;
+          id: string;
+          messages?: {
+            nextToken?: string | null;
+          } | null;
+          metadata?: string | null;
+          name?: string | null;
+          owner?: string | null;
+          updatedAt: string;
+        } | null;
+        conversationId: string;
+        createdAt: string;
+        id: string;
+        owner?: string | null;
+        role?: AmplifyAIConversationParticipantRole | null;
+        toolConfiguration?: {
+          tools?: Array<{} | null> | null;
+        } | null;
+        updatedAt: string;
+      } | null>;
       nextToken?: string | null;
     } | null;
     metadata?: string | null;
@@ -1102,7 +2529,7 @@ export type OnCreateAssistantResponseDisabledModelChatSubscription = {
     associatedUserMessageId: string;
     contentBlockDeltaIndex?: number | null;
     contentBlockDoneAtIndex?: number | null;
-    contentBlockIndex: number;
+    contentBlockIndex?: number | null;
     contentBlockText?: string | null;
     contentBlockToolUse?: {
       input: string;
@@ -1129,7 +2556,7 @@ export type OnCreateAssistantResponsePirateChatSubscription = {
     associatedUserMessageId: string;
     contentBlockDeltaIndex?: number | null;
     contentBlockDoneAtIndex?: number | null;
-    contentBlockIndex: number;
+    contentBlockIndex?: number | null;
     contentBlockText?: string | null;
     contentBlockToolUse?: {
       input: string;
@@ -1147,6 +2574,104 @@ export type OnCreateAssistantResponsePirateChatSubscription = {
   } | null;
 };
 
+export type OnCreateConversationMessageDisabledModelChatSubscriptionVariables = {
+  filter?: ModelSubscriptionConversationMessageDisabledModelChatFilterInput | null;
+  owner?: string | null;
+};
+
+export type OnCreateConversationMessageDisabledModelChatSubscription = {
+  onCreateConversationMessageDisabledModelChat?: {
+    aiContext?: string | null;
+    associatedUserMessageId?: string | null;
+    content?: Array<{
+      document?: {
+        format: string;
+        name: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
+      image?: {
+        format: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
+      text?: string | null;
+      toolResult?: {
+        content: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          json?: string | null;
+          text?: string | null;
+        }>;
+        status?: string | null;
+        toolUseId: string;
+      } | null;
+      toolUse?: {
+        input: string;
+        name: string;
+        toolUseId: string;
+      } | null;
+    } | null> | null;
+    conversation?: {
+      createdAt: string;
+      id: string;
+      messages?: {
+        items: Array<{
+          aiContext?: string | null;
+          associatedUserMessageId?: string | null;
+          content?: Array<{
+            text?: string | null;
+          } | null> | null;
+          conversation?: {
+            createdAt: string;
+            id: string;
+            metadata?: string | null;
+            name?: string | null;
+            owner?: string | null;
+            updatedAt: string;
+          } | null;
+          conversationId: string;
+          createdAt: string;
+          id: string;
+          owner?: string | null;
+          role?: AmplifyAIConversationParticipantRole | null;
+          toolConfiguration?: {} | null;
+          updatedAt: string;
+        } | null>;
+        nextToken?: string | null;
+      } | null;
+      metadata?: string | null;
+      name?: string | null;
+      owner?: string | null;
+      updatedAt: string;
+    } | null;
+    conversationId: string;
+    createdAt: string;
+    id: string;
+    owner?: string | null;
+    role?: AmplifyAIConversationParticipantRole | null;
+    toolConfiguration?: {
+      tools?: Array<{
+        toolSpec?: {
+          description?: string | null;
+          inputSchema: {
+            json?: string | null;
+          };
+          name: string;
+        } | null;
+      } | null> | null;
+    } | null;
+    updatedAt: string;
+  } | null;
+};
+
 export type OnCreateConversationMessagePirateChatSubscriptionVariables = {
   filter?: ModelSubscriptionConversationMessagePirateChatFilterInput | null;
   owner?: string | null;
@@ -1157,11 +2682,69 @@ export type OnCreateConversationMessagePirateChatSubscription = {
     aiContext?: string | null;
     associatedUserMessageId?: string | null;
     content?: Array<{
+      document?: {
+        format: string;
+        name: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
+      image?: {
+        format: string;
+        source: {
+          bytes?: string | null;
+        };
+      } | null;
       text?: string | null;
+      toolResult?: {
+        content: Array<{
+          document?: {
+            format: string;
+            name: string;
+          } | null;
+          image?: {
+            format: string;
+          } | null;
+          json?: string | null;
+          text?: string | null;
+        }>;
+        status?: string | null;
+        toolUseId: string;
+      } | null;
+      toolUse?: {
+        input: string;
+        name: string;
+        toolUseId: string;
+      } | null;
     } | null> | null;
     conversation?: {
       createdAt: string;
       id: string;
+      messages?: {
+        items: Array<{
+          aiContext?: string | null;
+          associatedUserMessageId?: string | null;
+          content?: Array<{
+            text?: string | null;
+          } | null> | null;
+          conversation?: {
+            createdAt: string;
+            id: string;
+            metadata?: string | null;
+            name?: string | null;
+            owner?: string | null;
+            updatedAt: string;
+          } | null;
+          conversationId: string;
+          createdAt: string;
+          id: string;
+          owner?: string | null;
+          role?: AmplifyAIConversationParticipantRole | null;
+          toolConfiguration?: {} | null;
+          updatedAt: string;
+        } | null>;
+        nextToken?: string | null;
+      } | null;
       metadata?: string | null;
       name?: string | null;
       owner?: string | null;
@@ -1171,8 +2754,18 @@ export type OnCreateConversationMessagePirateChatSubscription = {
     createdAt: string;
     id: string;
     owner?: string | null;
-    role?: ConversationParticipantRole | null;
-    toolConfiguration?: {} | null;
+    role?: AmplifyAIConversationParticipantRole | null;
+    toolConfiguration?: {
+      tools?: Array<{
+        toolSpec?: {
+          description?: string | null;
+          inputSchema: {
+            json?: string | null;
+          };
+          name: string;
+        } | null;
+      } | null> | null;
+    } | null;
     updatedAt: string;
   } | null;
 };

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/conversation.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/conversation.test.ts
@@ -8,10 +8,10 @@ import { createCognitoUser, signInCognitoUser, TestDefinition, writeStackConfig,
 import { AppSyncSubscriptionClient, mergeNamedAsyncIterators } from '../../utils/appsync-graphql/subscription';
 import { DURATION_20_MINUTES, DURATION_5_MINUTES, ONE_MINUTE } from '../../utils/duration-constants';
 import {
-  ContentBlock,
-  ConversationMessageStreamPart,
+  AmplifyAIContentBlock,
+  AmplifyAIConversationMessageStreamPart,
   OnCreateAssistantResponsePirateChatSubscription,
-  ToolConfigurationInput,
+  AmplifyAIToolConfigurationInput,
 } from './API';
 import { onCreateAssistantResponseDisabledModelChat, onCreateAssistantResponsePirateChat } from './graphql/subscriptions';
 import {
@@ -112,7 +112,7 @@ describe('conversation', () => {
         expect(message.content[0].text).toEqual('Hello, world!');
         expect(message.conversationId).toEqual(conversationId);
 
-        const events: ConversationMessageStreamPart[] = [];
+        const events: AmplifyAIConversationMessageStreamPart[] = [];
         // expect to receive the assistant response in the subscription
         for await (const event of subscription) {
           events.push(event.onCreateAssistantResponsePirateChat);
@@ -247,7 +247,7 @@ describe('conversation', () => {
         });
 
         // define the client tool configuration
-        const toolConfiguration: ToolConfigurationInput = {
+        const toolConfiguration: AmplifyAIToolConfigurationInput = {
           tools: [
             {
               toolSpec: {
@@ -287,7 +287,7 @@ describe('conversation', () => {
         expect(message1.toolConfiguration).toEqual(toolConfiguration);
 
         // expect to receive the assistant response including a toolUse block in the subscription
-        const events: ConversationMessageStreamPart[] = [];
+        const events: AmplifyAIConversationMessageStreamPart[] = [];
         for await (const event of subscription) {
           events.push(event.onCreateAssistantResponsePirateChat);
           if (event.onCreateAssistantResponsePirateChat.stopReason) break;
@@ -608,7 +608,7 @@ const deployCdk = async (projRoot: string): Promise<{ apiEndpoint: string; userP
   return { apiEndpoint: awsAppsyncApiEndpoint, userPoolClientId: UserPoolClientId, userPoolId: UserPoolId };
 };
 
-const reconcileStreamEvents = (events: ConversationMessageStreamPart[]): ContentBlock[] => {
+const reconcileStreamEvents = (events: AmplifyAIConversationMessageStreamPart[]): AmplifyAIContentBlock[] => {
   return events
     .sort((a, b) => {
       let aValue = a.contentBlockIndex * 1000 + (a.contentBlockDeltaIndex || 0);
@@ -626,5 +626,5 @@ const reconcileStreamEvents = (events: ConversationMessageStreamPart[]): Content
         acc[event.contentBlockIndex] = { toolUse: event.contentBlockToolUse };
       }
       return acc;
-    }, [] as ContentBlock[]);
+    }, [] as AmplifyAIContentBlock[]);
 };

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/mutations.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/mutations.ts
@@ -320,9 +320,9 @@ export const deleteConversationPirateChat = /* GraphQL */ `mutation DeleteConver
 
 export const disabledModelChat = /* GraphQL */ `mutation DisabledModelChat(
   $aiContext: AWSJSON
-  $content: [ContentBlockInput]
+  $content: [AmplifyAIContentBlockInput]
   $conversationId: ID!
-  $toolConfiguration: ToolConfigurationInput
+  $toolConfiguration: AmplifyAIToolConfigurationInput
 ) {
   disabledModelChat(
     aiContext: $aiContext
@@ -408,9 +408,9 @@ export const disabledModelChat = /* GraphQL */ `mutation DisabledModelChat(
 
 export const pirateChat = /* GraphQL */ `mutation PirateChat(
   $aiContext: AWSJSON
-  $content: [ContentBlockInput]
+  $content: [AmplifyAIContentBlockInput]
   $conversationId: ID!
-  $toolConfiguration: ToolConfigurationInput
+  $toolConfiguration: AmplifyAIToolConfigurationInput
 ) {
   pirateChat(
     aiContext: $aiContext

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/schema-conversation.graphql
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/schema-conversation.graphql
@@ -1,10 +1,10 @@
 type Mutation {
   pirateChat(
     conversationId: ID!
-    content: [ContentBlockInput]
+    content: [AmplifyAIContentBlockInput]
     aiContext: AWSJSON
-    toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage
+    toolConfiguration: AmplifyAIToolConfigurationInput
+  ): AmplifyAIConversationMessage
     @conversation(
       aiModel: "anthropic.claude-3-haiku-20240307-v1:0"
       systemPrompt: "You are a helpful chatbot that responds in the voice and tone of a pirate. Respond in 20 words or less."
@@ -14,10 +14,10 @@ type Mutation {
 
   disabledModelChat(
     conversationId: ID!
-    content: [ContentBlockInput]
+    content: [AmplifyAIContentBlockInput]
     aiContext: AWSJSON
-    toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage
+    toolConfiguration: AmplifyAIToolConfigurationInput
+  ): AmplifyAIConversationMessage
     @conversation(
       aiModel: "mistral.mistral-large-2407-v1:0"
       systemPrompt: "You are a helpful chatbot."
@@ -26,172 +26,173 @@ type Mutation {
     @aws_cognito_user_pools
 }
 
-enum ConversationParticipantRole {
+enum AmplifyAIConversationParticipantRole {
   user
   assistant
 }
 
-interface ConversationMessage {
+interface AmplifyAIConversationMessage {
   id: ID!
   conversationId: ID!
-  role: ConversationParticipantRole
-  content: [ContentBlock]
+  associatedUserMessageId: ID
+  role: AmplifyAIConversationParticipantRole
+  content: [AmplifyAIContentBlock]
   aiContext: AWSJSON
-  toolConfiguration: ToolConfiguration
+  toolConfiguration: AmplifyAIToolConfiguration
   createdAt: AWSDateTime
   updatedAt: AWSDateTime
   owner: String
 }
 
-input DocumentBlockSourceInput {
+input AmplifyAIDocumentBlockSourceInput {
   bytes: String
 }
 
-input DocumentBlockInput {
+input AmplifyAIDocumentBlockInput {
   format: String!
   name: String!
-  source: DocumentBlockSourceInput!
+  source: AmplifyAIDocumentBlockSourceInput!
 }
 
-input ImageBlockSourceInput {
+input AmplifyAIImageBlockSourceInput {
   bytes: String
 }
 
-input ImageBlockInput {
+input AmplifyAIImageBlockInput {
   format: String!
-  source: ImageBlockSourceInput!
+  source: AmplifyAIImageBlockSourceInput!
 }
 
-input ToolUseBlockInput {
+input AmplifyAIToolUseBlockInput {
   toolUseId: String!
   name: String!
   input: AWSJSON!
 }
 
-input ToolResultContentBlockInput {
-  document: DocumentBlockInput
-  image: ImageBlockInput
+input AmplifyAIToolResultContentBlockInput {
+  document: AmplifyAIDocumentBlockInput
+  image: AmplifyAIImageBlockInput
   json: AWSJSON
   text: String
 }
 
-input ToolResultBlockInput {
-  content: [ToolResultContentBlockInput!]!
+input AmplifyAIToolResultBlockInput {
+  content: [AmplifyAIToolResultContentBlockInput!]!
   toolUseId: String!
   status: String
 }
 
-type DocumentBlockSource {
+type AmplifyAIDocumentBlockSource {
   bytes: String
 }
 
-type DocumentBlock {
+type AmplifyAIDocumentBlock {
   format: String!
   name: String!
-  source: DocumentBlockSource!
+  source: AmplifyAIDocumentBlockSource!
 }
 
-type ImageBlock {
+type AmplifyAIImageBlock {
   format: String!
-  source: ImageBlockSource!
+  source: AmplifyAIImageBlockSource!
 }
 
-type ImageBlockSource {
+type AmplifyAIImageBlockSource {
   bytes: String
 }
 
-type ToolUseBlock {
+type AmplifyAIToolUseBlock {
   toolUseId: String!
   name: String!
   input: AWSJSON!
 }
 
-type ToolResultContentBlock {
-  document: DocumentBlock
-  image: ImageBlock
+type AmplifyAIToolResultContentBlock {
+  document: AmplifyAIDocumentBlock
+  image: AmplifyAIImageBlock
   json: AWSJSON
   text: String
 }
 
-type ToolResultBlock {
-  content: [ToolResultContentBlock!]!
+type AmplifyAIToolResultBlock {
+  content: [AmplifyAIToolResultContentBlock!]!
   toolUseId: String!
   status: String
 }
 
-type ContentBlockText {
+type AmplifyAIContentBlockText {
   text: String
 }
 
-type ContentBlockImage {
-  image: ImageBlock
+type AmplifyAIContentBlockImage {
+  image: AmplifyAIImageBlock
 }
 
-type ContentBlockDocument {
-  document: DocumentBlock
+type AmplifyAIContentBlockDocument {
+  document: AmplifyAIDocumentBlock
 }
 
-type ContentBlockToolUse {
-  toolUse: ToolUseBlock
+type AmplifyAIContentBlockToolUse {
+  toolUse: AmplifyAIToolUseBlock
 }
 
-type ContentBlockToolResult {
-  toolResult: ToolResultBlock
+type AmplifyAIContentBlockToolResult {
+  toolResult: AmplifyAIToolResultBlock
 }
 
-input ContentBlockInput {
+input AmplifyAIContentBlockInput {
   text: String
-  document: DocumentBlockInput
-  image: ImageBlockInput
-  toolResult: ToolResultBlockInput
-  toolUse: ToolUseBlockInput
+  document: AmplifyAIDocumentBlockInput
+  image: AmplifyAIImageBlockInput
+  toolResult: AmplifyAIToolResultBlockInput
+  toolUse: AmplifyAIToolUseBlockInput
 }
 
-type ContentBlock {
+type AmplifyAIContentBlock {
   text: String
-  document: DocumentBlock
-  image: ImageBlock
-  toolResult: ToolResultBlock
-  toolUse: ToolUseBlock
+  document: AmplifyAIDocumentBlock
+  image: AmplifyAIImageBlock
+  toolResult: AmplifyAIToolResultBlock
+  toolUse: AmplifyAIToolUseBlock
 }
 
-input ToolConfigurationInput {
-  tools: [ToolInput]
+input AmplifyAIToolConfigurationInput {
+  tools: [AmplifyAIToolInput]
 }
 
-input ToolInput {
-  toolSpec: ToolSpecificationInput
+input AmplifyAIToolInput {
+  toolSpec: AmplifyAIToolSpecificationInput
 }
 
-input ToolSpecificationInput {
+input AmplifyAIToolSpecificationInput {
   name: String!
   description: String
-  inputSchema: ToolInputSchemaInput!
+  inputSchema: AmplifyAIToolInputSchemaInput!
 }
 
-input ToolInputSchemaInput {
+input AmplifyAIToolInputSchemaInput {
   json: AWSJSON
 }
 
-type ToolConfiguration {
-  tools: [Tool]
+type AmplifyAIToolConfiguration {
+  tools: [AmplifyAITool]
 }
 
-type Tool {
-  toolSpec: ToolSpecification
+type AmplifyAITool {
+  toolSpec: AmplifyAIToolSpecification
 }
 
-type ToolSpecification {
+type AmplifyAIToolSpecification {
   name: String!
   description: String
-  inputSchema: ToolInputSchema!
+  inputSchema: AmplifyAIToolInputSchema!
 }
 
-type ToolInputSchema {
+type AmplifyAIToolInputSchema {
   json: AWSJSON
 }
 
-type ConversationMessageStreamPart {
+type AmplifyAIConversationMessageStreamPart @aws_cognito_user_pools {
   id: ID!
   owner: String
   conversationId: ID!
@@ -199,13 +200,13 @@ type ConversationMessageStreamPart {
   contentBlockIndex: Int
   contentBlockText: String
   contentBlockDeltaIndex: Int
-  contentBlockToolUse: ToolUseBlock
+  contentBlockToolUse: AmplifyAIToolUseBlock
   contentBlockDoneAtIndex: Int
   stopReason: String
-  errors: [ConversationTurnError]
+  errors: [AmplifyAIConversationTurnError]
 }
 
-type ConversationTurnError {
+type AmplifyAIConversationTurnError @aws_cognito_user_pools {
   message: String!
   errorType: String!
 }

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/test-implementations.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/test-implementations.ts
@@ -1,6 +1,6 @@
 import { AppSyncGraphqlResponse, doAppSyncGraphqlOperation, doAppSyncGraphqlQuery } from '../../utils';
 import {
-  ContentBlockInput,
+  AmplifyAIContentBlockInput,
   CreateConversationDisabledModelChatMutation,
   CreateConversationPirateChatMutation,
   DisabledModelChatMutation,
@@ -8,7 +8,7 @@ import {
   ListConversationMessagePirateChatsQuery,
   ListConversationPirateChatsQuery,
   PirateChatMutation,
-  ToolConfigurationInput,
+  AmplifyAIToolConfigurationInput,
   UpdateConversationPirateChatMutation,
 } from './API';
 import {
@@ -88,8 +88,8 @@ export const doSendMessagePirateChat = async (input: {
   apiEndpoint: string;
   accessToken: string;
   conversationId: string;
-  content: ContentBlockInput[];
-  toolConfiguration?: ToolConfigurationInput;
+  content: AmplifyAIContentBlockInput[];
+  toolConfiguration?: AmplifyAIToolConfigurationInput;
 }): Promise<AppSyncGraphqlResponse<PirateChatMutation>> => {
   const { apiEndpoint, accessToken, conversationId, content, toolConfiguration } = input;
   return doAppSyncGraphqlOperation({
@@ -108,8 +108,8 @@ export const doSendMessageDisabledModelChat = async (input: {
   apiEndpoint: string;
   accessToken: string;
   conversationId: string;
-  content: ContentBlockInput[];
-  toolConfiguration?: ToolConfigurationInput;
+  content: AmplifyAIContentBlockInput[];
+  toolConfiguration?: AmplifyAIToolConfigurationInput;
 }): Promise<AppSyncGraphqlResponse<DisabledModelChatMutation>> => {
   const { apiEndpoint, accessToken, conversationId, content, toolConfiguration } = input;
   return doAppSyncGraphqlOperation({

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
@@ -95,7 +95,7 @@ describe('ConversationTransformer', () => {
   describe('invalid schemas', () => {
     it('should throw an error if the return type is not ConversationMessage', () => {
       const inputSchema = getSchema('conversation-route-invalid-return-type.graphql');
-      expect(() => transform(inputSchema)).toThrow('@conversation return type must be ConversationMessage');
+      expect(() => transform(inputSchema)).toThrow('@conversation return type must be AmplifyAIConversationMessage');
     });
 
     it.each([

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/conversation-field-handler.test.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/conversation-field-handler.test.ts
@@ -41,7 +41,7 @@ describe('ConversationFieldHandler', () => {
   describe('getDirectiveConfig', () => {
     it('should throw an error if parent is not Mutation', () => {
       const parent = createMockParent('Query');
-      const field = createMockField('testField', 'ConversationMessage');
+      const field = createMockField('testField', 'AmplifyAIConversationMessage');
       const directive = createMockDirective();
 
       expect(() => handler.getDirectiveConfig(parent, field, directive, mockContext)).toThrow(InvalidDirectiveError);
@@ -49,7 +49,7 @@ describe('ConversationFieldHandler', () => {
 
     it('should return a valid configuration for a correct setup', () => {
       const parent = createMockParent('Mutation');
-      const field = createMockField('testField', 'ConversationMessage');
+      const field = createMockField('testField', 'AmplifyAIConversationMessage');
       const directive = createMockDirective();
 
       const config = handler.getDirectiveConfig(parent, field, directive, mockContext);
@@ -71,7 +71,7 @@ describe('ConversationFieldHandler', () => {
   describe('createModels', () => {
     it('should create message and conversation models with correct names', () => {
       const parent = createMockParent('Mutation');
-      const field = createMockField('testField', 'ConversationMessage');
+      const field = createMockField('testField', 'AmplifyAIConversationMessage');
       const directive = createMockDirective();
 
       const { message, conversation } = handler.getDirectiveConfig(parent, field, directive, mockContext);

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-handler-deprecated.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-handler-deprecated.graphql
@@ -1,10 +1,10 @@
 type Mutation {
   ROUTE_NAME(
     conversationId: ID!,
-    content: [ContentBlockInput],
+    content: [AmplifyAIContentBlockInput],
     aiContext: AWSJSON,
-    toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage
+    toolConfiguration: AmplifyAIToolConfigurationInput
+  ): AmplifyAIConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     auth: { strategy: owner, provider: userPools },

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-handler.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-handler.graphql
@@ -1,10 +1,10 @@
 type Mutation {
   ROUTE_NAME(
     conversationId: ID!,
-    content: [ContentBlockInput],
+    content: [AmplifyAIContentBlockInput],
     aiContext: AWSJSON,
-    toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage
+    toolConfiguration: AmplifyAIToolConfigurationInput
+  ): AmplifyAIConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     auth: { strategy: owner, provider: userPools },

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-query-tool.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-custom-query-tool.graphql
@@ -11,10 +11,10 @@ type Query {
 type Mutation {
   ROUTE_NAME(
     conversationId: ID!,
-    content: [ContentBlockInput],
+    content: [AmplifyAIContentBlockInput],
     aiContext: AWSJSON,
-    toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage
+    toolConfiguration: AmplifyAIToolConfigurationInput
+  ): AmplifyAIConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-inference-configuration-template.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-inference-configuration-template.graphql
@@ -1,10 +1,10 @@
 type Mutation {
   testChat(
     conversationId: ID!,
-    content: [ContentBlockInput],
+    content: [AmplifyAIContentBlockInput],
     aiContext: AWSJSON,
-    toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage
+    toolConfiguration: AmplifyAIToolConfigurationInput
+  ): AmplifyAIConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-custom-handler-event-version.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-custom-handler-event-version.graphql
@@ -1,10 +1,10 @@
 type Mutation {
   ROUTE_NAME(
     conversationId: ID!,
-    content: [ContentBlockInput],
+    content: [AmplifyAIContentBlockInput],
     aiContext: AWSJSON,
-    toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage
+    toolConfiguration: AmplifyAIToolConfigurationInput
+  ): AmplifyAIConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     auth: { strategy: owner, provider: userPools },

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-custom-handler-function-name-and-handler-provided.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-custom-handler-function-name-and-handler-provided.graphql
@@ -1,10 +1,10 @@
 type Mutation {
   ROUTE_NAME(
     conversationId: ID!,
-    content: [ContentBlockInput],
+    content: [AmplifyAIContentBlockInput],
     aiContext: AWSJSON,
-    toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage
+    toolConfiguration: AmplifyAIToolConfigurationInput
+  ): AmplifyAIConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     auth: { strategy: owner, provider: userPools },

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-missing-ai-model.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-missing-ai-model.graphql
@@ -1,10 +1,10 @@
 type Mutation {
   invalidChat(
     conversationId: ID!,
-    content: [ContentBlockInput],
+    content: [AmplifyAIContentBlockInput],
     aiContext: AWSJSON,
-    toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage
+    toolConfiguration: AmplifyAIToolConfigurationInput
+  ): AmplifyAIConversationMessage
   @conversation(
     systemPrompt: "You are a helpful chatbot.",
     auth: { strategy: owner, provider: userPools },

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-missing-system-prompt.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-missing-system-prompt.graphql
@@ -1,10 +1,10 @@
 type Mutation {
   invalidChat(
     conversationId: ID!,
-    content: [ContentBlockInput],
+    content: [AmplifyAIContentBlockInput],
     aiContext: AWSJSON,
-    toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage
+    toolConfiguration: AmplifyAIToolConfigurationInput
+  ): AmplifyAIConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     auth: { strategy: owner, provider: userPools },

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-return-type.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-return-type.graphql
@@ -1,9 +1,9 @@
 type Mutation {
   invalidChat(
     conversationId: ID!,
-    content: [ContentBlockInput],
+    content: [AmplifyAIContentBlockInput],
     aiContext: AWSJSON,
-    toolConfiguration: ToolConfigurationInput
+    toolConfiguration: AmplifyAIToolConfigurationInput
   ): String
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-tool-definition-missing-fields.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-tool-definition-missing-fields.graphql
@@ -1,10 +1,10 @@
 type Mutation {
   ROUTE_NAME(
     conversationId: ID!,
-    content: [ContentBlockInput],
+    content: [AmplifyAIContentBlockInput],
     aiContext: AWSJSON,
-    toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage
+    toolConfiguration: AmplifyAIToolConfigurationInput
+  ): AmplifyAIConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-tool-definition-mixed-fields.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-tool-definition-mixed-fields.graphql
@@ -5,10 +5,10 @@ type Query {
 type Mutation {
   ROUTE_NAME(
     conversationId: ID!,
-    content: [ContentBlockInput],
+    content: [AmplifyAIContentBlockInput],
     aiContext: AWSJSON,
-    toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage
+    toolConfiguration: AmplifyAIToolConfigurationInput
+  ): AmplifyAIConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-tool-name.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-invalid-tool-name.graphql
@@ -1,10 +1,10 @@
 type Mutation {
   ROUTE_NAME(
     conversationId: ID!,
-    content: [ContentBlockInput],
+    content: [AmplifyAIContentBlockInput],
     aiContext: AWSJSON,
-    toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage
+    toolConfiguration: AmplifyAIToolConfigurationInput
+  ): AmplifyAIConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-mixed-tools.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-mixed-tools.graphql
@@ -10,10 +10,10 @@ type Todo @model @auth(rules: [{ allow: owner }]) {
 type Mutation {
   ROUTE_NAME(
     conversationId: ID!,
-    content: [ContentBlockInput],
+    content: [AmplifyAIContentBlockInput],
     aiContext: AWSJSON,
-    toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage
+    toolConfiguration: AmplifyAIToolConfigurationInput
+  ): AmplifyAIConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool-with-relationships.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool-with-relationships.graphql
@@ -25,10 +25,10 @@ type Order @model @auth(rules: [{ allow: owner }]) {
 type Mutation {
   ROUTE_NAME(
     conversationId: ID!,
-    content: [ContentBlockInput],
+    content: [AmplifyAIContentBlockInput],
     aiContext: AWSJSON,
-    toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage
+    toolConfiguration: AmplifyAIToolConfigurationInput
+  ): AmplifyAIConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool.graphql
@@ -6,10 +6,10 @@ type Todo @model(queries: { list: "listMyTodos" }) @auth(rules: [{ allow: owner 
 type Mutation {
   ROUTE_NAME(
     conversationId: ID!,
-    content: [ContentBlockInput],
+    content: [AmplifyAIContentBlockInput],
     aiContext: AWSJSON,
-    toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage
+    toolConfiguration: AmplifyAIToolConfigurationInput
+  ): AmplifyAIConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-with-inference-configuration.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-with-inference-configuration.graphql
@@ -1,10 +1,10 @@
 type Mutation {
   ROUTE_NAME(
     conversationId: ID!,
-    content: [ContentBlockInput],
+    content: [AmplifyAIContentBlockInput],
     aiContext: AWSJSON,
-    toolConfiguration: ToolConfigurationInput
-  ): ConversationMessage
+    toolConfiguration: AmplifyAIToolConfigurationInput
+  ): AmplifyAIConversationMessage
   @conversation(
     aiModel: "anthropic.claude-3-haiku-20240307-v1:0",
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-schema-types.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-schema-types.graphql
@@ -1,161 +1,170 @@
-enum ConversationParticipantRole {
+enum AmplifyAIConversationParticipantRole {
   user
   assistant
 }
 
-interface ConversationMessage {
+interface AmplifyAIConversationMessage {
   id: ID!
   conversationId: ID!
-  role: ConversationParticipantRole
-  content: [ContentBlock]
-  context: AWSJSON
-  toolConfiguration: ToolConfiguration
   associatedUserMessageId: ID
+  role: AmplifyAIConversationParticipantRole
+  content: [AmplifyAIContentBlock]
+  aiContext: AWSJSON
+  toolConfiguration: AmplifyAIToolConfiguration
+  createdAt: AWSDateTime
+  updatedAt: AWSDateTime
+  owner: String
 }
 
-input DocumentBlockSourceInput {
+input AmplifyAIDocumentBlockSourceInput {
   bytes: String
 }
 
-input DocumentBlockInput {
+input AmplifyAIDocumentBlockInput {
   format: String!
   name: String!
-  source: DocumentBlockSourceInput!
+  source: AmplifyAIDocumentBlockSourceInput!
 }
 
-input ImageBlockSourceInput {
+input AmplifyAIImageBlockSourceInput {
   bytes: String
 }
 
-input ImageBlockInput {
+input AmplifyAIImageBlockInput {
   format: String!
-  source: ImageBlockSourceInput!
+  source: AmplifyAIImageBlockSourceInput!
 }
 
-input ToolResultContentBlockInput {
-  document: DocumentBlockInput
-  image: ImageBlockInput
-  json: AWSJSON
-  text: String
-}
-
-input ToolResultBlockInput {
-  content: [ToolResultContentBlockInput!]!
-  toolUseId: String!
-  status: String
-}
-
-type DocumentBlockSource {
-  bytes: String
-}
-
-type DocumentBlock {
-  format: String!
-  name: String!
-  source: DocumentBlockSource!
-}
-
-type ImageBlock {
-  format: String!
-  source: ImageBlockSource!
-}
-
-type ImageBlockSource {
-  bytes: String
-}
-
-type ToolUseBlock {
+input AmplifyAIToolUseBlockInput {
   toolUseId: String!
   name: String!
   input: AWSJSON!
 }
 
-type ToolResultContentBlock {
-  document: DocumentBlock
-  image: ImageBlock
+input AmplifyAIToolResultContentBlockInput {
+  document: AmplifyAIDocumentBlockInput
+  image: AmplifyAIImageBlockInput
   json: AWSJSON
   text: String
 }
 
-type ToolResultBlock {
-  content: [ToolResultContentBlock!]!
+input AmplifyAIToolResultBlockInput {
+  content: [AmplifyAIToolResultContentBlockInput!]!
   toolUseId: String!
   status: String
 }
 
-type ContentBlockText {
+type AmplifyAIDocumentBlockSource {
+  bytes: String
+}
+
+type AmplifyAIDocumentBlock {
+  format: String!
+  name: String!
+  source: AmplifyAIDocumentBlockSource!
+}
+
+type AmplifyAIImageBlock {
+  format: String!
+  source: AmplifyAIImageBlockSource!
+}
+
+type AmplifyAIImageBlockSource {
+  bytes: String
+}
+
+type AmplifyAIToolUseBlock {
+  toolUseId: String!
+  name: String!
+  input: AWSJSON!
+}
+
+type AmplifyAIToolResultContentBlock {
+  document: AmplifyAIDocumentBlock
+  image: AmplifyAIImageBlock
+  json: AWSJSON
   text: String
 }
 
-type ContentBlockImage {
-  image: ImageBlock
+type AmplifyAIToolResultBlock {
+  content: [AmplifyAIToolResultContentBlock!]!
+  toolUseId: String!
+  status: String
 }
 
-type ContentBlockDocument {
-  document: DocumentBlock
-}
-
-type ContentBlockToolUse {
-  toolUse: ToolUseBlock
-}
-
-type ContentBlockToolResult {
-  toolResult: ToolResultBlock
-}
-
-input ContentBlockInput {
+type AmplifyAIContentBlockText {
   text: String
-  document: DocumentBlockInput
-  image: ImageBlockInput
-  toolResult: ToolResultBlockInput
 }
 
-type ContentBlock {
+type AmplifyAIContentBlockImage {
+  image: AmplifyAIImageBlock
+}
+
+type AmplifyAIContentBlockDocument {
+  document: AmplifyAIDocumentBlock
+}
+
+type AmplifyAIContentBlockToolUse {
+  toolUse: AmplifyAIToolUseBlock
+}
+
+type AmplifyAIContentBlockToolResult {
+  toolResult: AmplifyAIToolResultBlock
+}
+
+input AmplifyAIContentBlockInput {
   text: String
-  document: DocumentBlock
-  image: ImageBlock
-  toolResult: ToolResultBlock
-  toolUse: ToolUseBlock
+  document: AmplifyAIDocumentBlockInput
+  image: AmplifyAIImageBlockInput
+  toolResult: AmplifyAIToolResultBlockInput
+  toolUse: AmplifyAIToolUseBlockInput
 }
 
-## Tools
-input ToolConfigurationInput {
-  tools: [ToolInput]
+type AmplifyAIContentBlock {
+  text: String
+  document: AmplifyAIDocumentBlock
+  image: AmplifyAIImageBlock
+  toolResult: AmplifyAIToolResultBlock
+  toolUse: AmplifyAIToolUseBlock
 }
 
-input ToolInput {
-  toolSpec: ToolSpecificationInput
+input AmplifyAIToolConfigurationInput {
+  tools: [AmplifyAIToolInput]
 }
 
-input ToolSpecificationInput {
+input AmplifyAIToolInput {
+  toolSpec: AmplifyAIToolSpecificationInput
+}
+
+input AmplifyAIToolSpecificationInput {
   name: String!
   description: String
-  inputSchema: ToolInputSchemaInput!
+  inputSchema: AmplifyAIToolInputSchemaInput!
 }
 
-input ToolInputSchemaInput {
+input AmplifyAIToolInputSchemaInput {
   json: AWSJSON
 }
 
-type ToolConfiguration {
-  tools: [Tool]
+type AmplifyAIToolConfiguration {
+  tools: [AmplifyAITool]
 }
 
-type Tool {
-  toolSpec: ToolSpecification
+type AmplifyAITool {
+  toolSpec: AmplifyAIToolSpecification
 }
 
-type ToolSpecification {
+type AmplifyAIToolSpecification {
   name: String!
   description: String
-  inputSchema: ToolInputSchema!
+  inputSchema: AmplifyAIToolInputSchema!
 }
 
-type ToolInputSchema {
+type AmplifyAIToolInputSchema {
   json: AWSJSON
 }
 
-type ConversationMessageStreamPart {
+type AmplifyAIConversationMessageStreamPart @aws_cognito_user_pools {
   id: ID!
   owner: String
   conversationId: ID!
@@ -163,13 +172,13 @@ type ConversationMessageStreamPart {
   contentBlockIndex: Int
   contentBlockText: String
   contentBlockDeltaIndex: Int
-  contentBlockToolUse: ToolUseBlock
+  contentBlockToolUse: AmplifyAIToolUseBlock
   contentBlockDoneAtIndex: Int
   stopReason: String
-  errors: [ConversationTurnError]
+  errors: [AmplifyAIConversationTurnError]
 }
 
-type ConversationTurnError {
+type AmplifyAIConversationTurnError @aws_cognito_user_pools {
   message: String!
   errorType: String!
 }

--- a/packages/amplify-graphql-conversation-transformer/src/graphql-types/message-model.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/graphql-types/message-model.ts
@@ -118,7 +118,7 @@ export const createAssistantResponseMutationInput = (messageName: string): Input
     name: { kind: 'Name', value: inputName },
     fields: [
       makeInputValueDefinition('conversationId', makeNamedType('ID')),
-      makeInputValueDefinition('content', makeListType(makeNamedType('ContentBlockInput'))),
+      makeInputValueDefinition('content', makeListType(makeNamedType('AmplifyAIContentBlockInput'))),
       makeInputValueDefinition('associatedUserMessageId', makeNamedType('ID')),
     ],
   };
@@ -138,8 +138,8 @@ export const createAssistantResponseStreamingMutationInput = (messageModelName: 
       makeInputValueDefinition('contentBlockToolUse', makeNamedType('AWSJSON')),
       makeInputValueDefinition('contentBlockDoneAtIndex', makeNamedType('Int')),
       makeInputValueDefinition('stopReason', makeNamedType('String')),
-      makeInputValueDefinition('accumulatedTurnContent', makeListType(makeNamedType('ContentBlockInput'))),
-      makeInputValueDefinition('errors', makeListType(makeNamedType('ConversationTurnErrorInput'))),
+      makeInputValueDefinition('accumulatedTurnContent', makeListType(makeNamedType('AmplifyAIContentBlockInput'))),
+      makeInputValueDefinition('errors', makeListType(makeNamedType('AmplifyAIConversationTurnErrorInput'))),
     ],
   };
 };
@@ -147,7 +147,7 @@ export const createAssistantResponseStreamingMutationInput = (messageModelName: 
 export const createConversationTurnErrorInput = (): InputObjectTypeDefinitionNode => {
   return {
     kind: 'InputObjectTypeDefinition',
-    name: { kind: 'Name', value: 'ConversationTurnErrorInput' },
+    name: { kind: 'Name', value: 'AmplifyAIConversationTurnErrorInput' },
     fields: [
       makeInputValueDefinition('errorType', makeNonNullType(makeNamedType('String'))),
       makeInputValueDefinition('message', makeNonNullType(makeNamedType('String'))),
@@ -276,10 +276,10 @@ const constructConversationMessageModel = (
 ): ObjectTypeDefinitionNode => {
   const id = makeField('id', [], wrapNonNull(makeNamedType('ID')));
   const conversationId = makeField(referenceFieldName, [], wrapNonNull(makeNamedType('ID')));
-  const role = makeField('role', [], makeNamedType('ConversationParticipantRole'));
-  const content = makeField('content', [], makeListType(makeNamedType('ContentBlock')));
+  const role = makeField('role', [], makeNamedType('AmplifyAIConversationParticipantRole'));
+  const content = makeField('content', [], makeListType(makeNamedType('AmplifyAIContentBlock')));
   const context = makeField('aiContext', [], makeNamedType('AWSJSON'));
-  const uiComponents = makeField('toolConfiguration', [], makeNamedType('ToolConfiguration'));
+  const uiComponents = makeField('toolConfiguration', [], makeNamedType('AmplifyAIToolConfiguration'));
   const associatedUserMessageId = makeField('associatedUserMessageId', [], makeNamedType('ID'));
 
   const object = {
@@ -292,7 +292,7 @@ const constructConversationMessageModel = (
   return object;
 };
 
-const STREAM_RESPONSE_TYPE_NAME = 'ConversationMessageStreamPart';
+const STREAM_RESPONSE_TYPE_NAME = 'AmplifyAIConversationMessageStreamPart';
 
 export const constructStreamResponseType = (): ObjectTypeDefinitionNode => {
   return {

--- a/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-field-handler.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-field-handler.ts
@@ -108,8 +108,8 @@ export class ConversationFieldHandler {
     config: ConversationDirectiveConfiguration,
     definition: FieldDefinitionNode,
   ): { message: MessageModel; conversation: ConversationModel } {
-    if (definition.type.kind !== 'NamedType' || definition.type.name.value !== 'ConversationMessage') {
-      throw new InvalidDirectiveError('@conversation return type must be ConversationMessage');
+    if (definition.type.kind !== 'NamedType' || definition.type.name.value !== 'AmplifyAIConversationMessage') {
+      throw new InvalidDirectiveError('@conversation return type must be AmplifyAIConversationMessage');
     }
 
     const conversationMessageTypeName = getConversationMessageTypeName(config);
@@ -231,8 +231,8 @@ export class ConversationFieldHandler {
   private validateReturnType(config: ConversationDirectiveConfiguration): void {
     // TODO: validate that the other supporting types are present.
     const { field } = config;
-    if (field.type.kind !== 'NamedType' || field.type.name.value !== 'ConversationMessage') {
-      throw new InvalidDirectiveError('@conversation return type must be ConversationMessage');
+    if (field.type.kind !== 'NamedType' || field.type.name.value !== 'AmplifyAIConversationMessage') {
+      throw new InvalidDirectiveError('@conversation return type must be AmplifyAIConversationMessage');
     }
   }
 


### PR DESCRIPTION
## Related PRs
- https://github.com/aws-amplify/amplify-api-next/pull/395
- https://github.com/aws-amplify/amplify-codegen/pull/907

## Problem
Conversation routes add several GraphQL types (type, input, enum, interface) to the GraphQL schema. These types are only added if a conversation route is defined via the `@conversation` directive and are conversation route agnostic (only added once per GraphQL schema regardless of the amount of conversation routes).

These types have generic enough names that they can conflict with customer defined types. 

<details>
<summary>GraphQL Types</summary>

```graphql
enum ConversationParticipantRole {
  user
  assistant
}

interface ConversationMessage {
  id: ID!
  conversationId: ID!
  associatedUserMessageId: ID
  role: ConversationParticipantRole
  content: [ContentBlock]
  aiContext: AWSJSON
  toolConfiguration: ToolConfiguration
  createdAt: AWSDateTime
  updatedAt: AWSDateTime
  owner: String
}

input DocumentBlockSourceInput {
  bytes: String
}

input DocumentBlockInput {
  format: String!
  name: String!
  source: DocumentBlockSourceInput!
}

input ImageBlockSourceInput {
  bytes: String
}

input ImageBlockInput {
  format: String!
  source: ImageBlockSourceInput!
}

input ToolUseBlockInput {
  toolUseId: String!
  name: String!
  input: AWSJSON!
}

input ToolResultContentBlockInput {
  document: DocumentBlockInput
  image: ImageBlockInput
  json: AWSJSON
  text: String
}

input ToolResultBlockInput {
  content: [ToolResultContentBlockInput!]!
  toolUseId: String!
  status: String
}

type DocumentBlockSource {
  bytes: String
}

type DocumentBlock {
  format: String!
  name: String!
  source: DocumentBlockSource!
}

type ImageBlock {
  format: String!
  source: ImageBlockSource!
}

type ImageBlockSource {
  bytes: String
}

type ToolUseBlock {
  toolUseId: String!
  name: String!
  input: AWSJSON!
}

type ToolResultContentBlock {
  document: DocumentBlock
  image: ImageBlock
  json: AWSJSON
  text: String
}

type ToolResultBlock {
  content: [ToolResultContentBlock!]!
  toolUseId: String!
  status: String
}

type ContentBlockText {
  text: String
}

type ContentBlockImage {
  image: ImageBlock
}

type ContentBlockDocument {
  document: DocumentBlock
}

type ContentBlockToolUse {
  toolUse: ToolUseBlock
}

type ContentBlockToolResult {
  toolResult: ToolResultBlock
}

input ContentBlockInput {
  text: String
  document: DocumentBlockInput
  image: ImageBlockInput
  toolResult: ToolResultBlockInput
  toolUse: ToolUseBlockInput
}

type ContentBlock {
  text: String
  document: DocumentBlock
  image: ImageBlock
  toolResult: ToolResultBlock
  toolUse: ToolUseBlock
}

input ToolConfigurationInput {
  tools: [ToolInput]
}

input ToolInput {
  toolSpec: ToolSpecificationInput
}

input ToolSpecificationInput {
  name: String!
  description: String
  inputSchema: ToolInputSchemaInput!
}
```
</details>

## Description of changes
Prefixes all supporting types with `"AmplifyAI"`.

The supporting types themselves are defined in `data-schema` (see related PR https://github.com/aws-amplify/amplify-api-next/pull/395). 

This PR updates the conversation transformer as a consumer of these types. This is necessary because the `@model`s generated by the conversation transformer have fields using the supporting types.

### CDK / CloudFormation Parameters Changed
N/A

## Issue #, if available
See https://github.com/aws-amplify/amplify-ui/issues/5773#issuecomment-2365309568
> 3b. I was already using Tool is my data model. It seems like any reserved words should be prefixed with a Namespace to prevent conflict.

## Description of how you validated changes
Mix of manual and automated testing through tagged releases:
- @aws-amplify/appsync-modelgen-plugin@2.15.1-ai-next.0
- @aws-amplify/data-schema@0.0.0-ai-next-20241113232635
- @aws-amplify/graphql-api-construct@1.17.2-ai-next.1

[E2E test run](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:5094ea7a-cb4a-420b-a092-91824a5b6e83?region=us-east-1)

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
