### PR TITLE
fix(ai): forward user-agent with package metadata in generation and conversation requests

### DIFF
--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -667,6 +667,7 @@ exports[`ConversationTransformer valid schemas should transform conversation rou
 export function request(ctx) {
   const { args, request } = ctx;
   const { graphqlApiEndpoint } = ctx.stash;
+  const userAgent = createUserAgent(request);
 
   const selectionSet = 'associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner errors { errorType message }';
 
@@ -705,7 +706,12 @@ export function request(ctx) {
     responseMutation: streamingResponseMutation,
     graphqlApiEndpoint,
     modelConfiguration,
-    request: { headers: { authorization: authHeader } },
+    request: {
+      headers: {
+        authorization: authHeader,
+        'x-amz-user-agent': userAgent,
+      }
+    },
     messageHistoryQuery,
     toolsConfiguration,
     streamResponse: true,
@@ -735,7 +741,17 @@ export function response(ctx) {
   };
   return response;
 }
-"
+
+function createUserAgent(request) {
+  const packageMetadata = 'graphql-conversation-transformer#0.7.1';
+  let userAgent = request.headers['x-amz-user-agent'];
+  if (userAgent) {
+    userAgent = \`\${userAgent} md/\${packageMetadata}\`;
+  } else {
+    userAgent = \`lib/\${packageMetadata}\`;
+  }
+  return userAgent;
+}"
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: SendMessageMutation resolver code 1`] = `
@@ -1508,6 +1524,7 @@ exports[`ConversationTransformer valid schemas should transform conversation rou
 export function request(ctx) {
   const { args, request } = ctx;
   const { graphqlApiEndpoint } = ctx.stash;
+  const userAgent = createUserAgent(request);
 
   const selectionSet = 'associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner errors { errorType message }';
 
@@ -1546,7 +1563,12 @@ export function request(ctx) {
     responseMutation: streamingResponseMutation,
     graphqlApiEndpoint,
     modelConfiguration,
-    request: { headers: { authorization: authHeader } },
+    request: {
+      headers: {
+        authorization: authHeader,
+        'x-amz-user-agent': userAgent,
+      }
+    },
     messageHistoryQuery,
     toolsConfiguration,
     streamResponse: true,
@@ -1576,7 +1598,17 @@ export function response(ctx) {
   };
   return response;
 }
-"
+
+function createUserAgent(request) {
+  const packageMetadata = 'graphql-conversation-transformer#0.7.1';
+  let userAgent = request.headers['x-amz-user-agent'];
+  if (userAgent) {
+    userAgent = \`\${userAgent} md/\${packageMetadata}\`;
+  } else {
+    userAgent = \`lib/\${packageMetadata}\`;
+  }
+  return userAgent;
+}"
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: SendMessageMutation resolver code 1`] = `
@@ -2349,6 +2381,7 @@ exports[`ConversationTransformer valid schemas should transform conversation rou
 export function request(ctx) {
   const { args, request } = ctx;
   const { graphqlApiEndpoint } = ctx.stash;
+  const userAgent = createUserAgent(request);
 
   const selectionSet = 'associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner errors { errorType message }';
 
@@ -2387,7 +2420,12 @@ export function request(ctx) {
     responseMutation: streamingResponseMutation,
     graphqlApiEndpoint,
     modelConfiguration,
-    request: { headers: { authorization: authHeader } },
+    request: {
+      headers: {
+        authorization: authHeader,
+        'x-amz-user-agent': userAgent,
+      }
+    },
     messageHistoryQuery,
     toolsConfiguration,
     streamResponse: true,
@@ -2417,7 +2455,17 @@ export function response(ctx) {
   };
   return response;
 }
-"
+
+function createUserAgent(request) {
+  const packageMetadata = 'graphql-conversation-transformer#0.7.1';
+  let userAgent = request.headers['x-amz-user-agent'];
+  if (userAgent) {
+    userAgent = \`\${userAgent} md/\${packageMetadata}\`;
+  } else {
+    userAgent = \`lib/\${packageMetadata}\`;
+  }
+  return userAgent;
+}"
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: SendMessageMutation resolver code 1`] = `
@@ -3190,6 +3238,7 @@ exports[`ConversationTransformer valid schemas should transform conversation rou
 export function request(ctx) {
   const { args, request } = ctx;
   const { graphqlApiEndpoint } = ctx.stash;
+  const userAgent = createUserAgent(request);
 
   const selectionSet = 'associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner errors { errorType message }';
 
@@ -3228,7 +3277,12 @@ export function request(ctx) {
     responseMutation: streamingResponseMutation,
     graphqlApiEndpoint,
     modelConfiguration,
-    request: { headers: { authorization: authHeader } },
+    request: {
+      headers: {
+        authorization: authHeader,
+        'x-amz-user-agent': userAgent,
+      }
+    },
     messageHistoryQuery,
     toolsConfiguration,
     streamResponse: true,
@@ -3258,7 +3312,17 @@ export function response(ctx) {
   };
   return response;
 }
-"
+
+function createUserAgent(request) {
+  const packageMetadata = 'graphql-conversation-transformer#0.7.1';
+  let userAgent = request.headers['x-amz-user-agent'];
+  if (userAgent) {
+    userAgent = \`\${userAgent} md/\${packageMetadata}\`;
+  } else {
+    userAgent = \`lib/\${packageMetadata}\`;
+  }
+  return userAgent;
+}"
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with query tools: SendMessageMutation resolver code 1`] = `

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -743,7 +743,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'graphql-conversation-transformer#0.7.1';
+  const packageMetadata = 'amplify-graphql-conversation-transformer#0.7.1';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;
@@ -1600,7 +1600,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'graphql-conversation-transformer#0.7.1';
+  const packageMetadata = 'amplify-graphql-conversation-transformer#0.7.1';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;
@@ -2457,7 +2457,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'graphql-conversation-transformer#0.7.1';
+  const packageMetadata = 'amplify-graphql-conversation-transformer#0.7.1';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;
@@ -3314,7 +3314,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'graphql-conversation-transformer#0.7.1';
+  const packageMetadata = 'amplify-graphql-conversation-transformer#0.7.1';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/send-message-pipeline-definition.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/send-message-pipeline-definition.ts
@@ -93,6 +93,9 @@ function invokeLambda(): ResolverFunctionDefinition {
   });
 }
 
+const packageName = 'graphql-conversation-transformer';
+const packageVersion = require('../../package.json').version;
+
 /**
  * The substitutions for the invoke lambda resolver function.
  */
@@ -113,6 +116,7 @@ function invokeLambdaResolverSubstitutions(config: ConversationDirectiveConfigur
     LIST_QUERY_LIMIT: 'undefined',
     STREAMING_RESPONSE_MUTATION_NAME: config.assistantResponseStreamingMutation.field.name.value,
     STREAMING_RESPONSE_MUTATION_INPUT_TYPE_NAME: config.assistantResponseStreamingMutation.input.name.value,
+    PACKAGE_METADATA: `'${packageName}#${packageVersion}'`,
   };
 }
 

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/send-message-pipeline-definition.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/send-message-pipeline-definition.ts
@@ -93,7 +93,7 @@ function invokeLambda(): ResolverFunctionDefinition {
   });
 }
 
-const packageName = 'graphql-conversation-transformer';
+const packageName = 'amplify-graphql-conversation-transformer';
 const packageVersion = require('../../package.json').version;
 
 /**

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/invoke-lambda-resolver-fn.template.js
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/invoke-lambda-resolver-fn.template.js
@@ -3,6 +3,7 @@ import { util } from '@aws-appsync/utils';
 export function request(ctx) {
   const { args, request } = ctx;
   const { graphqlApiEndpoint } = ctx.stash;
+  const userAgent = createUserAgent(request);
 
   const selectionSet = '[[SELECTION_SET]]';
 
@@ -41,7 +42,12 @@ export function request(ctx) {
     responseMutation: streamingResponseMutation,
     graphqlApiEndpoint,
     modelConfiguration,
-    request: { headers: { authorization: authHeader } },
+    request: {
+      headers: {
+        authorization: authHeader,
+        'x-amz-user-agent': userAgent,
+      }
+    },
     messageHistoryQuery,
     toolsConfiguration,
     streamResponse: true,
@@ -70,4 +76,15 @@ export function response(ctx) {
     updatedAt: ctx.stash.defaultValues.updatedAt,
   };
   return response;
+}
+
+function createUserAgent(request) {
+  const packageMetadata = [[PACKAGE_METADATA]];
+  let userAgent = request.headers['x-amz-user-agent'];
+  if (userAgent) {
+    userAgent = `${userAgent} md/${packageMetadata}`;
+  } else {
+    userAgent = `lib/${packageMetadata}`;
+  }
+  return userAgent;
 }

--- a/packages/amplify-graphql-generation-transformer/src/__tests__/__snapshots__/amplify-graphql-generation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-generation-transformer/src/__tests__/__snapshots__/amplify-graphql-generation-transformer.test.ts.snap
@@ -127,7 +127,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'graphql-generation-transformer#0.2.7';
+  const packageMetadata = 'amplify-graphql-generation-transformer#0.2.7';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;
@@ -135,7 +135,8 @@ function createUserAgent(request) {
     userAgent = \`lib/\${packageMetadata}\`;
   }
   return userAgent;
-}",
+}
+",
 }
 `;
 
@@ -266,7 +267,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'graphql-generation-transformer#0.2.7';
+  const packageMetadata = 'amplify-graphql-generation-transformer#0.2.7';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;
@@ -274,7 +275,8 @@ function createUserAgent(request) {
     userAgent = \`lib/\${packageMetadata}\`;
   }
   return userAgent;
-}",
+}
+",
 }
 `;
 
@@ -404,7 +406,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'graphql-generation-transformer#0.2.7';
+  const packageMetadata = 'amplify-graphql-generation-transformer#0.2.7';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;
@@ -412,7 +414,8 @@ function createUserAgent(request) {
     userAgent = \`lib/\${packageMetadata}\`;
   }
   return userAgent;
-}"
+}
+"
 `;
 
 exports[`generation route scalar type 1`] = `
@@ -555,7 +558,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'graphql-generation-transformer#0.2.7';
+  const packageMetadata = 'amplify-graphql-generation-transformer#0.2.7';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;
@@ -563,7 +566,8 @@ function createUserAgent(request) {
     userAgent = \`lib/\${packageMetadata}\`;
   }
   return userAgent;
-}",
+}
+",
 }
 `;
 
@@ -635,7 +639,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'graphql-generation-transformer#0.2.7';
+  const packageMetadata = 'amplify-graphql-generation-transformer#0.2.7';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;
@@ -643,6 +647,7 @@ function createUserAgent(request) {
     userAgent = \`lib/\${packageMetadata}\`;
   }
   return userAgent;
-}",
+}
+",
 }
 `;

--- a/packages/amplify-graphql-generation-transformer/src/__tests__/__snapshots__/amplify-graphql-generation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-generation-transformer/src/__tests__/__snapshots__/amplify-graphql-generation-transformer.test.ts.snap
@@ -64,12 +64,16 @@ export function request(ctx) {
   const prompt = "";
   const args = JSON.stringify(ctx.args);
   const inferenceConfig = undefined;
+  const userAgent = createUserAgent(ctx.request);
 
   return {
     resourcePath: '/model/anthropic.claude-3-haiku-20240307-v1:0/converse',
     method: 'POST',
     params: {
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-amz-user-agent': userAgent,
+      },
       body: {
         messages: [
           {
@@ -121,7 +125,17 @@ export function response(ctx) {
   }
   return value;
 }
-",
+
+function createUserAgent(request) {
+  const packageMetadata = 'graphql-generation-transformer#0.2.7';
+  let userAgent = request.headers['x-amz-user-agent'];
+  if (userAgent) {
+    userAgent = \`\${userAgent} md/\${packageMetadata}\`;
+  } else {
+    userAgent = \`lib/\${packageMetadata}\`;
+  }
+  return userAgent;
+}",
 }
 `;
 
@@ -189,12 +203,16 @@ export function request(ctx) {
   const prompt = "You are a helpful assistant that generates recipes.";
   const args = JSON.stringify(ctx.args);
   const inferenceConfig = undefined;
+  const userAgent = createUserAgent(ctx.request);
 
   return {
     resourcePath: '/model/anthropic.claude-3-haiku-20240307-v1:0/converse',
     method: 'POST',
     params: {
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-amz-user-agent': userAgent,
+      },
       body: {
         messages: [
           {
@@ -246,7 +264,17 @@ export function response(ctx) {
   }
   return value;
 }
-",
+
+function createUserAgent(request) {
+  const packageMetadata = 'graphql-generation-transformer#0.2.7';
+  let userAgent = request.headers['x-amz-user-agent'];
+  if (userAgent) {
+    userAgent = \`\${userAgent} md/\${packageMetadata}\`;
+  } else {
+    userAgent = \`lib/\${packageMetadata}\`;
+  }
+  return userAgent;
+}",
 }
 `;
 
@@ -313,12 +341,16 @@ export function request(ctx) {
   const prompt = "Make a string based on the description.";
   const args = JSON.stringify(ctx.args);
   const inferenceConfig = undefined;
+  const userAgent = createUserAgent(ctx.request);
 
   return {
     resourcePath: '/model/anthropic.claude-3-haiku-20240307-v1:0/converse',
     method: 'POST',
     params: {
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-amz-user-agent': userAgent,
+      },
       body: {
         messages: [
           {
@@ -370,7 +402,17 @@ export function response(ctx) {
   }
   return value;
 }
-"
+
+function createUserAgent(request) {
+  const packageMetadata = 'graphql-generation-transformer#0.2.7';
+  let userAgent = request.headers['x-amz-user-agent'];
+  if (userAgent) {
+    userAgent = \`\${userAgent} md/\${packageMetadata}\`;
+  } else {
+    userAgent = \`lib/\${packageMetadata}\`;
+  }
+  return userAgent;
+}"
 `;
 
 exports[`generation route scalar type 1`] = `
@@ -454,12 +496,16 @@ export function request(ctx) {
   const prompt = "Make a string based on the description.";
   const args = JSON.stringify(ctx.args);
   const inferenceConfig = undefined;
+  const userAgent = createUserAgent(ctx.request);
 
   return {
     resourcePath: '/model/anthropic.claude-3-haiku-20240307-v1:0/converse',
     method: 'POST',
     params: {
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-amz-user-agent': userAgent,
+      },
       body: {
         messages: [
           {
@@ -507,7 +553,17 @@ export function response(ctx) {
   
   return value;
 }
-",
+
+function createUserAgent(request) {
+  const packageMetadata = 'graphql-generation-transformer#0.2.7';
+  let userAgent = request.headers['x-amz-user-agent'];
+  if (userAgent) {
+    userAgent = \`\${userAgent} md/\${packageMetadata}\`;
+  } else {
+    userAgent = \`lib/\${packageMetadata}\`;
+  }
+  return userAgent;
+}",
 }
 `;
 
@@ -520,12 +576,16 @@ export function request(ctx) {
   const prompt = "Generate a string based on the description.";
   const args = JSON.stringify(ctx.args);
   const inferenceConfig = { inferenceConfig: {"maxTokens":100,"temperature":0.7,"topP":0.9} };
+  const userAgent = createUserAgent(ctx.request);
 
   return {
     resourcePath: '/model/anthropic.claude-3-haiku-20240307-v1:0/converse',
     method: 'POST',
     params: {
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-amz-user-agent': userAgent,
+      },
       body: {
         messages: [
           {
@@ -573,6 +633,16 @@ export function response(ctx) {
   
   return value;
 }
-",
+
+function createUserAgent(request) {
+  const packageMetadata = 'graphql-generation-transformer#0.2.7';
+  let userAgent = request.headers['x-amz-user-agent'];
+  if (userAgent) {
+    userAgent = \`\${userAgent} md/\${packageMetadata}\`;
+  } else {
+    userAgent = \`lib/\${packageMetadata}\`;
+  }
+  return userAgent;
+}",
 }
 `;

--- a/packages/amplify-graphql-generation-transformer/src/resolvers/invoke-bedrock-resolver-fn.template.js
+++ b/packages/amplify-graphql-generation-transformer/src/resolvers/invoke-bedrock-resolver-fn.template.js
@@ -5,12 +5,16 @@ export function request(ctx) {
   const prompt = [[SYSTEM_PROMPT]];
   const args = JSON.stringify(ctx.args);
   const inferenceConfig = [[INFERENCE_CONFIG]];
+  const userAgent = createUserAgent(ctx.request);
 
   return {
     resourcePath: '/model/[[AI_MODEL]]/converse',
     method: 'POST',
     params: {
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-amz-user-agent': userAgent,
+      },
       body: {
         messages: [
           {
@@ -57,4 +61,15 @@ export function response(ctx) {
 
   [[NON_STRING_RESPONSE_HANDLING]]
   return value;
+}
+
+function createUserAgent(request) {
+  const packageMetadata = [[PACKAGE_METADATA]];
+  let userAgent = request.headers['x-amz-user-agent'];
+  if (userAgent) {
+    userAgent = `${userAgent} md/${packageMetadata}`;
+  } else {
+    userAgent = `lib/${packageMetadata}`;
+  }
+  return userAgent;
 }

--- a/packages/amplify-graphql-generation-transformer/src/resolvers/invoke-bedrock.ts
+++ b/packages/amplify-graphql-generation-transformer/src/resolvers/invoke-bedrock.ts
@@ -5,6 +5,9 @@ import fs from 'fs';
 import path from 'path';
 import { getBaseType } from 'graphql-transformer-common';
 
+const packageName = 'graphql-generation-transformer';
+const packageVersion = require('../../package.json').version;
+
 /**
  * Creates the resolver functions for invoking Amazon Bedrock.
  *
@@ -26,12 +29,15 @@ export const createInvokeBedrockResolverFunction = (config: GenerationConfigurat
     return JSON.parse(value);
   }`;
 
+  const PACKAGE_METADATA = `'${packageName}#${packageVersion}'`;
+
   const resolver = generateResolver('invoke-bedrock-resolver-fn.template.js', {
     AI_MODEL,
     TOOL_CONFIG,
     SYSTEM_PROMPT,
     INFERENCE_CONFIG,
     NON_STRING_RESPONSE_HANDLING,
+    PACKAGE_METADATA,
   });
 
   const templateName = `${field.name.value}-invoke-bedrock-fn`;

--- a/packages/amplify-graphql-generation-transformer/src/resolvers/invoke-bedrock.ts
+++ b/packages/amplify-graphql-generation-transformer/src/resolvers/invoke-bedrock.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import { getBaseType } from 'graphql-transformer-common';
 
-const packageName = 'graphql-generation-transformer';
+const packageName = 'amplify-graphql-generation-transformer';
 const packageVersion = require('../../package.json').version;
 
 /**


### PR DESCRIPTION
## Problem
The `x-amz-user-agent` header is sent by the data client to AppSync queries and mutations. These headers are not forwarded to the underlying data sources.

## Description of changes
AppSync resolver includes `x-amz-user-agent` header in requests to applicable underlying data sources:
- **Generation Route:** Amazon Bedrock via HTTP Data Source
- **Conversation Route:** AWS Lambda function*
 
> *Lambda function already includes `x-amz-user-agent` header in requests to Bedrock and back to AppSync
> See https://github.com/aws-amplify/amplify-backend/pull/2181 and https://github.com/aws-amplify/amplify-backend/pull/2086

For requests made from the data client, an `x-amz-user-agent` header is included ([reference](https://github.com/aws-amplify/amplify-api-next/pull/339)).

The resolver function for conversation and generation routes checks to see if an `x-amz-user-agent` header is included in the request. 
- If it is included in the request, `md/<package-name>/<package-version>` is appended to the value. 
- If it is **not** included in the request, the `x-amz-user-agent` is set to `lib/<package-name>/package-version>`. 

AppSync doesn't support setting headers on requests invoking Lambda function data sources. Similar to the authorization header, we work around this by included the `x-amz-user-agent` in the payload.

### CDK / CloudFormation Parameters Changed
N/A

### Issue #, if available
N/A

## Description of how you validated changes
- [E2E test run](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:d70ef5c6-4b31-4135-9cce-0d6f03f73fd8?region=us-east-1)

## Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [ ] ~Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)~
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
