### PR TITLE
test: mock package version in conversation and generation for snapshot tests

### DIFF
--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -743,7 +743,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'amplify-graphql-conversation-transformer#0.7.1';
+  const packageMetadata = 'amplify-graphql-conversation-transformer#0.0.0';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;
@@ -1600,7 +1600,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'amplify-graphql-conversation-transformer#0.7.1';
+  const packageMetadata = 'amplify-graphql-conversation-transformer#0.0.0';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;
@@ -2457,7 +2457,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'amplify-graphql-conversation-transformer#0.7.1';
+  const packageMetadata = 'amplify-graphql-conversation-transformer#0.0.0';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;
@@ -3314,7 +3314,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'amplify-graphql-conversation-transformer#0.7.1';
+  const packageMetadata = 'amplify-graphql-conversation-transformer#0.0.0';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/amplify-graphql-conversation-transformer.test.ts
@@ -13,6 +13,14 @@ import { toUpper } from 'graphql-transformer-common';
 import * as path from 'path';
 import { ConversationTransformer } from '..';
 
+jest.mock(
+  '../../package.json',
+  () => ({
+    version: '0.0.0',
+  }),
+  { virtual: true },
+);
+
 const conversationSchemaTypes = fs.readFileSync(path.join(__dirname, 'schemas/conversation-schema-types.graphql'), 'utf8');
 
 const getSchema = (fileName: string, substitutions: Record<string, string> = {}) => {

--- a/packages/amplify-graphql-generation-transformer/src/__tests__/__snapshots__/amplify-graphql-generation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-generation-transformer/src/__tests__/__snapshots__/amplify-graphql-generation-transformer.test.ts.snap
@@ -127,7 +127,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'amplify-graphql-generation-transformer#0.2.7';
+  const packageMetadata = 'amplify-graphql-generation-transformer#0.0.0';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;
@@ -267,7 +267,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'amplify-graphql-generation-transformer#0.2.7';
+  const packageMetadata = 'amplify-graphql-generation-transformer#0.0.0';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;
@@ -406,7 +406,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'amplify-graphql-generation-transformer#0.2.7';
+  const packageMetadata = 'amplify-graphql-generation-transformer#0.0.0';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;
@@ -558,7 +558,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'amplify-graphql-generation-transformer#0.2.7';
+  const packageMetadata = 'amplify-graphql-generation-transformer#0.0.0';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;
@@ -639,7 +639,7 @@ export function response(ctx) {
 }
 
 function createUserAgent(request) {
-  const packageMetadata = 'amplify-graphql-generation-transformer#0.2.7';
+  const packageMetadata = 'amplify-graphql-generation-transformer#0.0.0';
   let userAgent = request.headers['x-amz-user-agent'];
   if (userAgent) {
     userAgent = \`\${userAgent} md/\${packageMetadata}\`;

--- a/packages/amplify-graphql-generation-transformer/src/__tests__/amplify-graphql-generation-transformer.test.ts
+++ b/packages/amplify-graphql-generation-transformer/src/__tests__/amplify-graphql-generation-transformer.test.ts
@@ -8,6 +8,14 @@ import { parse } from 'graphql';
 import { GenerationTransformer } from '..';
 import { BelongsToTransformer, HasManyTransformer, HasOneTransformer } from '@aws-amplify/graphql-relational-transformer';
 
+jest.mock(
+  '../../package.json',
+  () => ({
+    version: '0.0.0',
+  }),
+  { virtual: true },
+);
+
 const todoModel = `
 type Todo @model {
   content: String
@@ -316,6 +324,7 @@ describe('generation route invalid inference configuration', () => {
     );
   });
 });
+// });
 
 const getResolverResource = (queryName: string, resources?: Record<string, any>): Record<string, any> => {
   const resolverName = `Query${queryName}Resolver`;


### PR DESCRIPTION
#### Description of changes
https://github.com/aws-amplify/amplify-category-api/pull/3029 introduced an issue with snapshot tests where they'll fail whenever a new version is used.

This fixes that by mocking the package version.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
