### PR TITLE
fix(conversation): model list tool query name infinite recursion

### DIFF
--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -1545,7 +1545,7 @@ export function request(ctx) {
   const clientTools = args.toolConfiguration?.tools?.map((tool) => {
     return { ...tool.toolSpec };
   });
-  const dataTools = [{"name":"list_customers","description":"Provides data about the customer sending a message","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { name email activeCart { products { name price } customerId id createdAt updatedAt owner } orderHistory { items { products { name price } customerId id createdAt updatedAt owner } nextToken } id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listCustomers"}}];
+  const dataTools = [{"name":"random_name","description":"Provides data about the customer sending a message","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { name email activeCart { products { name price } customerId id createdAt updatedAt owner } orderHistory { items { products { name price } customerId id createdAt updatedAt owner } nextToken } id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listCustomers"}}];
   const toolsConfiguration = { dataTools, clientTools };
 
   const messageHistoryQuery = {

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool-with-relationships.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool-with-relationships.graphql
@@ -34,7 +34,7 @@ type Mutation {
     systemPrompt: "You are a helpful chatbot. Answer questions to the best of your ability.",
     tools: [
       {
-        name: "list_customers",
+        name: "random_name",
         description: "Provides data about the customer sending a message",
         modelName: "Customer",
         modelOperation: list,

--- a/packages/amplify-graphql-conversation-transformer/src/tools/process-tools.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/tools/process-tools.ts
@@ -160,13 +160,13 @@ const createTool = (input: {
   const { type: returnType, arguments: fieldArguments } = queryField;
 
   // Generate tool properties and required fields
-  const { properties, required } = generateToolProperties(fieldArguments, ctx, toolName, returnType);
+  const { properties, required } = generateToolProperties(fieldArguments, ctx, queryField.name.value, returnType);
 
   // Generate selection set for the return type
   const selectionSet = generateSelectionSet(returnType, ctx).trim();
 
   // Generate property types for GraphQL request input
-  const propertyTypes = generatePropertyTypes(fieldArguments, toolName, returnType);
+  const propertyTypes = generatePropertyTypes(fieldArguments, queryField.name.value, returnType);
 
   // Create GraphQL request input descriptor
   const graphqlRequestInputDescriptor: GraphQLRequestInputDescriptor = {
@@ -199,14 +199,14 @@ const createTool = (input: {
 const generateToolProperties = (
   fieldArguments: readonly InputValueDefinitionNode[] | undefined,
   ctx: TransformerContextProvider,
-  toolName: string,
+  queryName: string,
   returnType: TypeNode,
 ): { properties: Record<string, JSONSchema>; required: string[] } => {
   if (!fieldArguments || fieldArguments.length === 0) {
     return { properties: {}, required: [] };
   }
 
-  if (isModelListOperation(toolName, returnType)) {
+  if (isModelListOperation(queryName, returnType)) {
     return { properties: {}, required: [] };
   }
 
@@ -233,14 +233,14 @@ const generateToolProperties = (
  */
 const generatePropertyTypes = (
   fieldArguments: readonly InputValueDefinitionNode[] | undefined,
-  toolName: string,
+  queryName: string,
   returnType: TypeNode,
 ): Record<string, string> => {
   if (!fieldArguments || fieldArguments.length === 0) {
     return {};
   }
 
-  if (isModelListOperation(toolName, returnType)) {
+  if (isModelListOperation(queryName, returnType)) {
     return {};
   }
 
@@ -252,8 +252,8 @@ const generatePropertyTypes = (
   }, {} as Record<string, string>);
 };
 
-const isModelListOperation = (toolName: string, responseType: TypeNode): boolean => {
-  return getBaseType(responseType).startsWith('Model') && toolName.startsWith('list');
+const isModelListOperation = (queryName: string, responseType: TypeNode): boolean => {
+  return getBaseType(responseType).startsWith('Model') && queryName.startsWith('list');
 };
 
 const modelListQueryName = (modelTool: ModelOperationTool, ctx: TransformerContextProvider): string => {


### PR DESCRIPTION
## Problem

The tool definition input for the `@conversation` directive allows customers to specify a `model` and `modelOperation`. For example:

```ts
const schema = a.schema({
  Appointment: a.model({
    time: a.timestamp(),
  }).authorization((allow) => [allow.authenticated()]),

  appointmentChat: a.conversation({
    aiModel: a.ai.model("Claude 3.5 Sonnet"),
    systemPrompt: `You are a friendly pet groomer who is helping with giving advice and selling clients on booking appointments.
    You like grooming pets in creative ways, such as technicolor dye jobs, fun shaped cuts, and nail polish.
    You should ask me more questions to learn about what I need in a grooming appointment.`,
    tools: [
      a.ai.dataTool({
        name: 'getAppointmentTimes',
        description: 'Searches for available appointments',
        model: a.ref('Appointment'),
        modelOperation: 'list',
      }),
    ],
  }).authorization((allow) => allow.owner()),
});
```

Model list query GraphQL inputs are always optional. We currently don't include any of those input types in the JSONSchema tool definition because there's a bug in the implementation that results in a blown stack due to infinite recursion. As a temporary workaround, we do a rudimentary check in the conversation transformer ([reference](https://github.com/aws-amplify/amplify-category-api/blob/b51f7908c86466bc1c666823c863ad38b7e118a6/packages/amplify-graphql-conversation-transformer/src/tools/process-tools.ts#L255-L257)) to ensure they're not included. This check depends, in part, on the name of the query field to determine if it's a model list query. 

https://github.com/aws-amplify/amplify-category-api/pull/3013 introduced a change in the `@conversation` directive API that (intentionally) allows the name of a tool to differ from the name of a query field.

The check is now operating on the tool name rather than the query field name as it should. This is problematic because the name of a model list query tool must start with `"list"` for the check to behave as expected.

Unfortunately this was missed because the test case that would've caught it has a tool named `list_customers`. ([reference](https://github.com/aws-amplify/amplify-category-api/pull/3037/files#diff-d2c0a1f0c50cc44895f2e2c9dfcf85424e98d4715cf79bffd4898635cec0a962L37))

## Description of changes
Determines whether a tool is a model list query tool based on the directive input.

A follow up PR will remove the need for this check all together. It will also add some E2E tests around model list query tools. However that's a large enough behavioral change that it needs to go out separately from this fix.

##### CDK / CloudFormation Parameters Changed
N/A

## Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- [updated unit test case](https://github.com/aws-amplify/amplify-category-api/pull/3037/files#diff-d2c0a1f0c50cc44895f2e2c9dfcf85424e98d4715cf79bffd4898635cec0a962L37)
- [E2E test run](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:8756e2b4-f150-4a8f-880f-cb8b7f886b31?region=us-east-1)
- manual testing

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
