### PR TITLE
fix: bump ai-constructs to ^1.0.0

### DIFF
--- a/packages/amplify-data-construct/.jsii
+++ b/packages/amplify-data-construct/.jsii
@@ -6,7 +6,7 @@
     ]
   },
   "bundled": {
-    "@aws-amplify/ai-constructs": "^0.8.1",
+    "@aws-amplify/ai-constructs": "^1.0.0",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.7",
@@ -4027,5 +4027,5 @@
   },
   "types": {},
   "version": "1.14.1",
-  "fingerprint": "oNSxGQV+d3GiakpJHATahcIsnv2V1nIaZNu4vnRBxqU="
+  "fingerprint": "I12zGofQM0FdW94WEX4bLGaTKxWbJrmMWOOt600DuM0="
 }

--- a/packages/amplify-data-construct/package.json
+++ b/packages/amplify-data-construct/package.json
@@ -157,7 +157,7 @@
     "semver"
   ],
   "dependencies": {
-    "@aws-amplify/ai-constructs": "^0.8.1",
+    "@aws-amplify/ai-constructs": "^1.0.0",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-api-construct": "1.18.1",

--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -6,7 +6,7 @@
     ]
   },
   "bundled": {
-    "@aws-amplify/ai-constructs": "^0.8.1",
+    "@aws-amplify/ai-constructs": "^1.0.0",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.7",
@@ -9032,5 +9032,5 @@
     }
   },
   "version": "1.18.1",
-  "fingerprint": "Q75/5bdwa1r/FHYeOihBgh1UTtRC+AxOW8D/7+KVqVQ="
+  "fingerprint": "rfugyE2tdSCCTEGdaiK6MOtkDBnDm1F6AwM5J/4Jb2w="
 }

--- a/packages/amplify-graphql-api-construct/package.json
+++ b/packages/amplify-graphql-api-construct/package.json
@@ -158,7 +158,7 @@
     "semver"
   ],
   "dependencies": {
-    "@aws-amplify/ai-constructs": "^0.8.1",
+    "@aws-amplify/ai-constructs": "^1.0.0",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.7",

--- a/packages/amplify-graphql-conversation-transformer/package.json
+++ b/packages/amplify-graphql-conversation-transformer/package.json
@@ -24,7 +24,7 @@
     "extract-api": "ts-node ../../scripts/extract-api.ts"
   },
   "dependencies": {
-    "@aws-amplify/ai-constructs": "^0.8.1",
+    "@aws-amplify/ai-constructs": "^1.0.0",
     "@aws-amplify/graphql-directives": "2.6.0",
     "@aws-amplify/graphql-index-transformer": "3.0.9",
     "@aws-amplify/graphql-model-transformer": "3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,10 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aws-amplify/ai-constructs@^0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/ai-constructs/-/ai-constructs-0.8.1.tgz#97250e681d70eae42736c71a5877cbd1c425ab11"
-  integrity sha512-JdgVJqPr7YGlP7MHmExKGv+82lJB53kPb2l6UR+ji/mozHImnLbcGPP0BW7rl13wOwA7ZqIcQWAqQsxgWW37Fg==
+"@aws-amplify/ai-constructs@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/@aws-amplify/ai-constructs/-/ai-constructs-1.0.0.tgz#3cf60199bf4550e5e4ab7a43e2590d6e0179cbd7"
+  integrity sha512-gLOKpt3/Qq89/7wMPVu1anpmptFNxgV2K6DJe+6uYfuL+GW8T3XYgMNq5Wyty07MGel0F95zaHrfysuwx43Q6w==
   dependencies:
     "@aws-amplify/backend-output-schemas" "^1.4.0"
     "@aws-amplify/platform-core" "^1.2.0"


### PR DESCRIPTION
#### Description of changes
Bumps `ai-constructs` dependency to `^1.0.0`.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
- [E2E test run](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:68a6b480-0d76-4c87-80d2-fbc9f9cf3e8d?region=us-east-1)

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [ ] ~Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)~
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
