### PR TITLE
test: exclude unsupported region for PredictionsTransformerV2 E2E

### DIFF
--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -1718,99 +1718,108 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        NonModelAuthV2Function_TransformerOptionsV2_PredictionsTransformerV2Tests_DefaultValueTransformer_PerFieldAuthV2TransformerWith
+        NonModelAuthV2Function_TransformerOptionsV2_DefaultValueTransformer_PerFieldAuthV2TransformerWithFF_PerFieldAuthV2Transformer
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           NODE_OPTIONS: '--max-old-space-size=14848'
           TEST_SUITE: >-
-            src/__tests__/NonModelAuthV2Function.e2e.test.ts|src/__tests__/TransformerOptionsV2.e2e.test.ts|src/__tests__/PredictionsTransformerV2Tests.e2e.test.ts|src/__tests__/DefaultValueTransformer.e2e.test.ts|src/__tests__/PerFieldAuthV2TransformerWithFF.e2e.test.ts
-          CLI_REGION: ap-northeast-3
-      depend-on:
-        - publish_to_local_registry
-    - identifier: >-
-        PerFieldAuthV2Transformer_BelongsToTransformerV2_RelationalWithAuthV2WithFF_IndexWithAuthV2_IndexWithAuthV2WithFF
-      buildspec: codebuild_specs/graphql_e2e_tests.yml
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          NODE_OPTIONS: '--max-old-space-size=14848'
-          TEST_SUITE: >-
-            src/__tests__/PerFieldAuthV2Transformer.e2e.test.ts|src/__tests__/BelongsToTransformerV2.e2e.test.ts|src/__tests__/RelationalWithAuthV2WithFF.e2e.test.ts|src/__tests__/IndexWithAuthV2.e2e.test.ts|src/__tests__/IndexWithAuthV2WithFF.e2e.test.ts
+            src/__tests__/NonModelAuthV2Function.e2e.test.ts|src/__tests__/TransformerOptionsV2.e2e.test.ts|src/__tests__/DefaultValueTransformer.e2e.test.ts|src/__tests__/PerFieldAuthV2TransformerWithFF.e2e.test.ts|src/__tests__/PerFieldAuthV2Transformer.e2e.test.ts
           CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        SubscriptionsWithAuthV2WithFF_MultiAuthV2Transformer_ModelTransformer_SubscriptionsWithAuthV2_RelationalWithAuthV2
+        BelongsToTransformerV2_RelationalWithAuthV2WithFF_IndexWithAuthV2_IndexWithAuthV2WithFF_SubscriptionsWithAuthV2WithFF
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           NODE_OPTIONS: '--max-old-space-size=14848'
           TEST_SUITE: >-
-            src/__tests__/SubscriptionsWithAuthV2WithFF.e2e.test.ts|src/__tests__/MultiAuthV2Transformer.e2e.test.ts|src/__tests__/ModelTransformer.e2e.test.ts|src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts|src/__tests__/RelationalWithAuthV2.e2e.test.ts
+            src/__tests__/BelongsToTransformerV2.e2e.test.ts|src/__tests__/RelationalWithAuthV2WithFF.e2e.test.ts|src/__tests__/IndexWithAuthV2.e2e.test.ts|src/__tests__/IndexWithAuthV2WithFF.e2e.test.ts|src/__tests__/SubscriptionsWithAuthV2WithFF.e2e.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        MapsToTransformer_MultiAuthV2TransformerWithFF_AuthV2Transformer_AuthV2ExhaustiveT1B_AuthV2ExhaustiveT1A
+        MultiAuthV2Transformer_ModelTransformer_SubscriptionsWithAuthV2_RelationalWithAuthV2_MapsToTransformer
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           NODE_OPTIONS: '--max-old-space-size=14848'
           TEST_SUITE: >-
-            src/__tests__/MapsToTransformer.e2e.test.ts|src/__tests__/MultiAuthV2TransformerWithFF.e2e.test.ts|src/__tests__/AuthV2Transformer.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT1B.test.ts|src/__tests__/AuthV2ExhaustiveT1A.test.ts
+            src/__tests__/MultiAuthV2Transformer.e2e.test.ts|src/__tests__/ModelTransformer.e2e.test.ts|src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts|src/__tests__/RelationalWithAuthV2.e2e.test.ts|src/__tests__/MapsToTransformer.e2e.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        AuthV2TransformerWithFF_SubscriptionsRuntimeFiltering_AuthV2ExhaustiveT2A_AuthV2ExhaustiveT1C_AuthV2ExhaustiveT1D
+        MultiAuthV2TransformerWithFF_AuthV2Transformer_AuthV2ExhaustiveT1B_AuthV2ExhaustiveT1A_AuthV2TransformerWithFF
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           NODE_OPTIONS: '--max-old-space-size=14848'
           TEST_SUITE: >-
-            src/__tests__/AuthV2TransformerWithFF.e2e.test.ts|src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT2A.test.ts|src/__tests__/AuthV2ExhaustiveT1C.test.ts|src/__tests__/AuthV2ExhaustiveT1D.test.ts
+            src/__tests__/MultiAuthV2TransformerWithFF.e2e.test.ts|src/__tests__/AuthV2Transformer.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT1B.test.ts|src/__tests__/AuthV2ExhaustiveT1A.test.ts|src/__tests__/AuthV2TransformerWithFF.e2e.test.ts
           CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        AuthV2ExhaustiveT2B_AuthV2ExhaustiveT2D_AuthV2ExhaustiveT2C_RelationalWithAuthV2Redacted_RelationalWithAuthV2NonRedacted
+        SubscriptionsRuntimeFiltering_AuthV2ExhaustiveT2A_AuthV2ExhaustiveT1C_AuthV2ExhaustiveT1D_AuthV2ExhaustiveT2B
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           NODE_OPTIONS: '--max-old-space-size=14848'
           TEST_SUITE: >-
-            src/__tests__/AuthV2ExhaustiveT2B.test.ts|src/__tests__/AuthV2ExhaustiveT2D.test.ts|src/__tests__/AuthV2ExhaustiveT2C.test.ts|src/__tests__/RelationalWithAuthV2Redacted.e2e.test.ts|src/__tests__/RelationalWithAuthV2NonRedacted.e2e.test.ts
+            src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT2A.test.ts|src/__tests__/AuthV2ExhaustiveT1C.test.ts|src/__tests__/AuthV2ExhaustiveT1D.test.ts|src/__tests__/AuthV2ExhaustiveT2B.test.ts
           CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        AuthV2TransformerIAM_AuthV2ExhaustiveT3D_AuthV2ExhaustiveT3C_AuthV2ExhaustiveT3B_AuthV2ExhaustiveT3A
+        AuthV2ExhaustiveT2D_AuthV2ExhaustiveT2C_RelationalWithAuthV2Redacted_RelationalWithAuthV2NonRedacted_AuthV2TransformerIAM
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           NODE_OPTIONS: '--max-old-space-size=14848'
           TEST_SUITE: >-
-            src/__tests__/AuthV2TransformerIAM.test.ts|src/__tests__/AuthV2ExhaustiveT3D.test.ts|src/__tests__/AuthV2ExhaustiveT3C.test.ts|src/__tests__/AuthV2ExhaustiveT3B.test.ts|src/__tests__/AuthV2ExhaustiveT3A.test.ts
+            src/__tests__/AuthV2ExhaustiveT2D.test.ts|src/__tests__/AuthV2ExhaustiveT2C.test.ts|src/__tests__/RelationalWithAuthV2Redacted.e2e.test.ts|src/__tests__/RelationalWithAuthV2NonRedacted.e2e.test.ts|src/__tests__/AuthV2TransformerIAM.test.ts
           CLI_REGION: eu-north-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        SearchableModelTransformerV2_SearchableWithAuthV2WithFF_SearchableWithAuthV2
+        AuthV2ExhaustiveT3D_AuthV2ExhaustiveT3C_AuthV2ExhaustiveT3B_AuthV2ExhaustiveT3A_SearchableModelTransformerV2
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           NODE_OPTIONS: '--max-old-space-size=14848'
           TEST_SUITE: >-
-            src/__tests__/SearchableModelTransformerV2.e2e.test.ts|src/__tests__/SearchableWithAuthV2WithFF.e2e.test.ts|src/__tests__/SearchableWithAuthV2.e2e.test.ts
+            src/__tests__/AuthV2ExhaustiveT3D.test.ts|src/__tests__/AuthV2ExhaustiveT3C.test.ts|src/__tests__/AuthV2ExhaustiveT3B.test.ts|src/__tests__/AuthV2ExhaustiveT3A.test.ts|src/__tests__/SearchableModelTransformerV2.e2e.test.ts
           CLI_REGION: eu-west-2
+      depend-on:
+        - publish_to_local_registry
+    - identifier: SearchableWithAuthV2WithFF_SearchableWithAuthV2
+      buildspec: codebuild_specs/graphql_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          NODE_OPTIONS: '--max-old-space-size=14848'
+          TEST_SUITE: >-
+            src/__tests__/SearchableWithAuthV2WithFF.e2e.test.ts|src/__tests__/SearchableWithAuthV2.e2e.test.ts
+          CLI_REGION: eu-west-3
+      depend-on:
+        - publish_to_local_registry
+    - identifier: PredictionsTransformerV2Tests
+      buildspec: codebuild_specs/graphql_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          NODE_OPTIONS: '--max-old-space-size=6656'
+          TEST_SUITE: src/__tests__/PredictionsTransformerV2Tests.e2e.test.ts
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: FunctionTransformerTestsV2
@@ -1820,7 +1829,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/FunctionTransformerTestsV2.e2e.test.ts
-          CLI_REGION: ap-northeast-3
+          CLI_REGION: ap-south-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -1831,7 +1840,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/HttpTransformerV2.e2e.test.ts
-          CLI_REGION: ap-northeast-3
+          CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: cleanup_e2e_resources

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -154,6 +154,8 @@ const RUN_SOLO: (string | RegExp)[] = [
   'src/__tests__/generations/generation.test.ts',
   // Conversation tests
   'src/__tests__/conversations/conversation.test.ts',
+  // Predictions tests
+  'src/__tests__/PredictionsTransformerV2Tests.e2e.test.ts',
 ];
 
 const RUN_IN_ALL_REGIONS = [
@@ -183,6 +185,11 @@ const RUN_IN_COGNITO_REGIONS: (string | RegExp)[] = [
   /src\/__tests__\/AuthV2ExhaustiveT3D.test.ts/,
   /src\/__tests__\/AuthV2ExhaustiveT3C.test.ts/,
 ];
+
+const TEST_REGION_EXCLUSIONS: Record<string, string[]> = {
+  // Rekognition is not supported in ap-northeast-3
+  'src/__tests__/PredictionsTransformerV2Tests.e2e.test.ts': ['ap-northeast-3'],
+};
 
 const RUN_IN_V1_TRANSFORMER_REGIONS = ['src/__tests__/schema-searchable.test.ts'];
 
@@ -349,6 +356,11 @@ const setJobRegion = (test: string, job: CandidateJob, jobIdx: number, useBetaLa
 
 const filterCandidateRegions = (test: string, candidateRegions: string[], useBetaLayer: boolean): string[] => {
   let resolvedRegions = [...candidateRegions];
+
+  const excludedRegions = TEST_REGION_EXCLUSIONS[test];
+  if (excludedRegions) {
+    resolvedRegions = resolvedRegions.filter((region) => !excludedRegions.includes(region));
+  }
 
   // Parent E2E account does not have opt-in regions. Choose non-opt-in region.
   const shouldUseParentAccount = USE_PARENT_ACCOUNT.some((usesParent) => test.startsWith(usesParent));


### PR DESCRIPTION
## Problem
The `PredictionsTransformerV2Tests` E2E test case always passes locally buy has consistently failed in CI for a while now with the error:
```
    TypeError: Invalid URL
      18 |
      19 |   async query(query: string, variables: any = {}): Promise<GraphQLResponse> {
    > 20 |     const axRes = await axios.post<GraphQLResponse>(
         |                               ^
      21 |       this.url,
      22 |       {
      23 |         query,
      at dispatchHttpRequest (../../node_modules/axios/lib/adapters/http.js:232:20)
      at ../../node_modules/axios/lib/adapters/http.js:152:5
      at wrapAsync (../../node_modules/axios/lib/adapters/http.js:132:10)
      at http (../../node_modules/axios/lib/adapters/http.js:170:10)
      at Axios.dispatchRequest (../../node_modules/axios/lib/core/dispatchRequest.js:51:10)
      at Axios._request (../../node_modules/axios/lib/core/Axios.js:173:33)
      at Axios.request (../../node_modules/axios/lib/core/Axios.js:40:25)
      at Axios.httpMethod [as post] (../../node_modules/axios/lib/core/Axios.js:212:19)
      at Function.wrap (../../node_modules/axios/lib/helpers/bind.js:5:15)
      at GraphQLClient.query (src/GraphQLClient.ts:20:31)
      at Object.<anonymous> (src/__tests__/PredictionsTransformerV2Tests.e2e.test.ts:173:41)
```

This happens because our current e2e_workflow.yml has this test running in ap-northeast-3 ([reference](https://github.com/aws-amplify/amplify-category-api/blob/022b19ef3b739f4cbdf6ed0bcb1cfc18ee38ef92/codebuild_specs/e2e_workflow.yml#L1720-L1731)), a region unsupported by Amazon Rekognition ([reference](https://docs.aws.amazon.com/general/latest/gr/rekognition.html)).

The deployment fails and the GraphQL endpoint is invalid.

## Description of changes

Updates `scripts/split-e2e-tests.ts` to prevent `PredictionsTransformerV2Tests` from running in ap-northeast-3. This is done by:
- Forcing `PredictionsTransformerV2Tests` to run by itself.
- Adding a `TEST_REGION_EXCLUSIONS` map that removes excluded regions from the candidate regions.

### CDK / CloudFormation Parameters Changed
N/A

## Issue #, if available
**Related docs PR**
- https://github.com/aws-amplify/docs/pull/8111

#### Description of how you validated changes
- [E2E test run](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:60a1bd34-6acf-4dcb-a86e-c6b8e1b652cf?region=us-east-1)

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
