### PR TITLE
chore: merge main into release

### DIFF
--- a/packages/amplify-data-construct/.jsii
+++ b/packages/amplify-data-construct/.jsii
@@ -10,7 +10,7 @@
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.7",
-    "@aws-amplify/graphql-conversation-transformer": "1.1.0",
+    "@aws-amplify/graphql-conversation-transformer": "1.1.1",
     "@aws-amplify/graphql-default-value-transformer": "3.1.4",
     "@aws-amplify/graphql-directives": "2.6.0",
     "@aws-amplify/graphql-function-transformer": "3.1.6",
@@ -23,7 +23,7 @@
     "@aws-amplify/graphql-relational-transformer": "3.1.1",
     "@aws-amplify/graphql-searchable-transformer": "3.0.9",
     "@aws-amplify/graphql-sql-transformer": "0.4.9",
-    "@aws-amplify/graphql-transformer": "2.2.0",
+    "@aws-amplify/graphql-transformer": "2.2.1",
     "@aws-amplify/graphql-transformer-core": "3.3.1",
     "@aws-amplify/graphql-transformer-interfaces": "4.2.0",
     "@aws-amplify/platform-core": "^1.0.0",
@@ -130,7 +130,7 @@
     "zod": "^3.22.2"
   },
   "dependencies": {
-    "@aws-amplify/graphql-api-construct": "1.18.0",
+    "@aws-amplify/graphql-api-construct": "1.18.1",
     "aws-cdk-lib": "^2.158.0",
     "constructs": "^10.3.0"
   },
@@ -4026,6 +4026,6 @@
     }
   },
   "types": {},
-  "version": "1.14.0",
-  "fingerprint": "O9tbfsjr+oFjPs0QnyeyJp/+ohWA9xCM+E3XUv2PDGw="
+  "version": "1.14.1",
+  "fingerprint": "oNSxGQV+d3GiakpJHATahcIsnv2V1nIaZNu4vnRBxqU="
 }

--- a/packages/amplify-data-construct/.jsii
+++ b/packages/amplify-data-construct/.jsii
@@ -6,7 +6,7 @@
     ]
   },
   "bundled": {
-    "@aws-amplify/ai-constructs": "^0.8.1",
+    "@aws-amplify/ai-constructs": "^1.0.0",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.7",
@@ -4027,5 +4027,5 @@
   },
   "types": {},
   "version": "1.14.1",
-  "fingerprint": "oNSxGQV+d3GiakpJHATahcIsnv2V1nIaZNu4vnRBxqU="
+  "fingerprint": "I12zGofQM0FdW94WEX4bLGaTKxWbJrmMWOOt600DuM0="
 }

--- a/packages/amplify-data-construct/package.json
+++ b/packages/amplify-data-construct/package.json
@@ -157,7 +157,7 @@
     "semver"
   ],
   "dependencies": {
-    "@aws-amplify/ai-constructs": "^0.8.1",
+    "@aws-amplify/ai-constructs": "^1.0.0",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-api-construct": "1.18.1",

--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -10,7 +10,7 @@
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.7",
-    "@aws-amplify/graphql-conversation-transformer": "1.1.0",
+    "@aws-amplify/graphql-conversation-transformer": "1.1.1",
     "@aws-amplify/graphql-default-value-transformer": "3.1.4",
     "@aws-amplify/graphql-directives": "2.6.0",
     "@aws-amplify/graphql-function-transformer": "3.1.6",
@@ -23,7 +23,7 @@
     "@aws-amplify/graphql-relational-transformer": "3.1.1",
     "@aws-amplify/graphql-searchable-transformer": "3.0.9",
     "@aws-amplify/graphql-sql-transformer": "0.4.9",
-    "@aws-amplify/graphql-transformer": "2.2.0",
+    "@aws-amplify/graphql-transformer": "2.2.1",
     "@aws-amplify/graphql-transformer-core": "3.3.1",
     "@aws-amplify/graphql-transformer-interfaces": "4.2.0",
     "@aws-amplify/platform-core": "^1.0.0",
@@ -9031,6 +9031,6 @@
       "symbolId": "src/model-datasource-strategy-types:VpcConfig"
     }
   },
-  "version": "1.18.0",
-  "fingerprint": "z0rzJHCDSTpFx/GRBG2+htlUdGLnrEhuLsVbf5AbNdM="
+  "version": "1.18.1",
+  "fingerprint": "Q75/5bdwa1r/FHYeOihBgh1UTtRC+AxOW8D/7+KVqVQ="
 }

--- a/packages/amplify-graphql-api-construct/.jsii
+++ b/packages/amplify-graphql-api-construct/.jsii
@@ -6,7 +6,7 @@
     ]
   },
   "bundled": {
-    "@aws-amplify/ai-constructs": "^0.8.1",
+    "@aws-amplify/ai-constructs": "^1.0.0",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.7",
@@ -9032,5 +9032,5 @@
     }
   },
   "version": "1.18.1",
-  "fingerprint": "Q75/5bdwa1r/FHYeOihBgh1UTtRC+AxOW8D/7+KVqVQ="
+  "fingerprint": "rfugyE2tdSCCTEGdaiK6MOtkDBnDm1F6AwM5J/4Jb2w="
 }

--- a/packages/amplify-graphql-api-construct/package.json
+++ b/packages/amplify-graphql-api-construct/package.json
@@ -158,7 +158,7 @@
     "semver"
   ],
   "dependencies": {
-    "@aws-amplify/ai-constructs": "^0.8.1",
+    "@aws-amplify/ai-constructs": "^1.0.0",
     "@aws-amplify/backend-output-schemas": "^1.0.0",
     "@aws-amplify/backend-output-storage": "^1.0.0",
     "@aws-amplify/graphql-auth-transformer": "4.1.7",

--- a/packages/amplify-graphql-conversation-transformer/package.json
+++ b/packages/amplify-graphql-conversation-transformer/package.json
@@ -24,7 +24,7 @@
     "extract-api": "ts-node ../../scripts/extract-api.ts"
   },
   "dependencies": {
-    "@aws-amplify/ai-constructs": "^0.8.1",
+    "@aws-amplify/ai-constructs": "^1.0.0",
     "@aws-amplify/graphql-directives": "2.6.0",
     "@aws-amplify/graphql-index-transformer": "3.0.9",
     "@aws-amplify/graphql-model-transformer": "3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,10 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aws-amplify/ai-constructs@^0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/ai-constructs/-/ai-constructs-0.8.1.tgz#97250e681d70eae42736c71a5877cbd1c425ab11"
-  integrity sha512-JdgVJqPr7YGlP7MHmExKGv+82lJB53kPb2l6UR+ji/mozHImnLbcGPP0BW7rl13wOwA7ZqIcQWAqQsxgWW37Fg==
+"@aws-amplify/ai-constructs@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/@aws-amplify/ai-constructs/-/ai-constructs-1.0.0.tgz#3cf60199bf4550e5e4ab7a43e2590d6e0179cbd7"
+  integrity sha512-gLOKpt3/Qq89/7wMPVu1anpmptFNxgV2K6DJe+6uYfuL+GW8T3XYgMNq5Wyty07MGel0F95zaHrfysuwx43Q6w==
   dependencies:
     "@aws-amplify/backend-output-schemas" "^1.4.0"
     "@aws-amplify/platform-core" "^1.2.0"


### PR DESCRIPTION
PR to initiate API construct release.

The only change here is
- https://github.com/aws-amplify/amplify-category-api/pull/3040

Full E2E was run on the PR ([reference)](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow%3A68a6b480-0d76-4c87-80d2-fbc9f9cf3e8d?region=us-east-1). All tests passed with the exception of `PredictionsTransformerV2Tests`, which is an unrelated failure that is addressed in https://github.com/aws-amplify/amplify-category-api/pull/3041.

```
> git rev-parse origin/main^
022b19ef3b739f4cbdf6ed0bcb1cfc18ee38ef92
> git rev-parse origin/bump-ai-constructs^
022b19ef3b739f4cbdf6ed0bcb1cfc18ee38ef92
```