### PR TITLE
fix(conversation): handle enums in data tool selection sets

### DIFF
--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -2402,7 +2402,7 @@ export function request(ctx) {
   const clientTools = args.toolConfiguration?.tools?.map((tool) => {
     return { ...tool.toolSpec };
   });
-  const dataTools = [{"name":"list_all_the_todos","description":"lists todos","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { content isDone id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listMyTodos"}}];
+  const dataTools = [{"name":"list_all_the_todos","description":"lists todos","inputSchema":{"json":{"type":"object","properties":{},"required":[]}},"graphqlRequestInputDescriptor":{"selectionSet":"items { content status id createdAt updatedAt owner } nextToken","propertyTypes":{},"queryName":"listMyTodos"}}];
   const toolsConfiguration = { dataTools, clientTools };
 
   const messageHistoryQuery = {

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool.graphql
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/schemas/conversation-route-model-query-tool.graphql
@@ -1,6 +1,12 @@
+enum Status {
+  TODO
+  IN_PROGRESS
+  DONE
+}
+
 type Todo @model(queries: { list: "listMyTodos" }) @auth(rules: [{ allow: owner }]) {
   content: String
-  isDone: Boolean
+  status: Status
 }
 
 type Mutation {


### PR DESCRIPTION
## Problem
An error is thrown at synth if a GraphQL enum field is included in the return type of a data tools used in conversation routes. When the selection set (used by conversation lambda handler) is generated, we're only checking `isScalar` to determine if we need to:
1.  use the `fieldName` by itself.
2. get the object type, then traverse that object's fields. Resulting in `fieldName { <nested fields> }`. 

If 2. we attempt to get the `ObjectTypeDefinitionNode` for that field's type name via `ctx.output.getObject(typeName)`. For enums this, logically, results in no `ObjectTypeDefinitionNode` found, where we throw an error `"Could not find type definition for <type-name>"`. 

## Description of changes
Change the applicable `isScalar` checks to `isScalarOrEnum`. 

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
- Updated schema for test case and snapshot
- [E2E test run](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:59f9e30b-81dc-4c5f-a17e-5652b4494b25?region=us-east-1)
- Manual verification with deployed Gen 2 backend.
```ts
const schema = a.schema({
  Todo: a.model({
    name: a.string(),
    status: a.ref('Status'),
  })
  .authorization((allow) => allow.owner()),

  Status: a.enum(['OPEN', 'IN_PROGRESS', 'DONE']),

  chat: a.conversation({
    aiModel: a.ai.model('Claude 3 Haiku'),
    systemPrompt: 'You are a helpful assistant.',
    tools: [
      a.ai.dataTool({
        name: "list_todos",
        model: a.ref('Todo'),
        modelOperation: 'list',
        description: "Provides a list of todos along with their status.",
      }),
    ],
  })
    .authorization((allow) => allow.owner()),
```


#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
