### PR TITLE
chore: dependabot alert fix #150

### DIFF
--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -32,7 +32,7 @@
     "moment": "^2.24.0"
   },
   "devDependencies": {
-    "@aws-amplify/amplify-appsync-simulator": "2.16.4",
+    "@aws-amplify/amplify-appsync-simulator": "2.16.7",
     "@aws-amplify/core": "^2.1.0",
     "@aws-amplify/graphql-default-value-transformer": "3.1.4",
     "@aws-amplify/graphql-index-transformer": "3.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,12 +43,12 @@
     xcode "^2.1.0"
     yargs "^15.1.0"
 
-"@aws-amplify/amplify-appsync-simulator@2.16.4":
-  version "2.16.4"
-  resolved "https://registry.npmjs.org/@aws-amplify/amplify-appsync-simulator/-/amplify-appsync-simulator-2.16.4.tgz#372be8358e847c43fc27f15e12c5aed07df1cd58"
-  integrity sha512-CFPIlCiNfOxJRoo35yS16kAgH9hdR8/HJp2sE3EyuNuyRAZKcN9vytACKDwQ7MyTkja1HZnfXCu4i46oRi/70g==
+"@aws-amplify/amplify-appsync-simulator@2.16.7":
+  version "2.16.7"
+  resolved "https://registry.npmjs.org/@aws-amplify/amplify-appsync-simulator/-/amplify-appsync-simulator-2.16.7.tgz#7f813aaedb309b1430374497a025af145bd72c8b"
+  integrity sha512-S234+do3gnJpYYzUt5d+3BDWTSh8NzqYbiaKPkzmSVmLDhP0pkKh45aJIINL3m1cNofMxKMK7L+/1FHVyPbmYA==
   dependencies:
-    "@aws-amplify/amplify-cli-core" "4.3.9"
+    "@aws-amplify/amplify-cli-core" "4.3.10"
     "@aws-amplify/amplify-prompts" "2.8.6"
     "@graphql-tools/schema" "^8.3.1"
     "@graphql-tools/utils" "^8.5.1"
@@ -57,12 +57,11 @@
     chalk "^4.1.1"
     cors "^2.8.5"
     dataloader "^2.0.0"
-    express "^4.17.3"
+    express "^4.21.1"
     get-port "^5.1.1"
     graphql "^15.5.0"
     graphql-iso-date "^3.6.1"
     graphql-subscriptions "^1.1.0"
-    ip "^1.1.9"
     js-string-escape "^1.0.1"
     jwt-decode "^2.2.0"
     libphonenumber-js "1.9.47"
@@ -85,43 +84,6 @@
     "@aws-amplify/amplify-function-plugin-interface" "1.12.1"
     "@aws-amplify/amplify-prompts" "2.8.6"
     "@aws-amplify/graphql-transformer-interfaces" "^3.10.1"
-    "@aws-sdk/util-arn-parser" "^3.310.0"
-    "@yarnpkg/lockfile" "^1.1.0"
-    ajv "^6.12.6"
-    aws-cdk-lib "~2.129.0"
-    chalk "^4.1.1"
-    ci-info "^3.8.0"
-    cli-table3 "^0.6.0"
-    cloudform-types "^4.2.0"
-    colors "1.4.0"
-    dotenv "^8.2.0"
-    ejs "^3.1.7"
-    execa "^5.1.1"
-    fs-extra "^8.1.0"
-    globby "^11.0.3"
-    hjson "^3.2.1"
-    inquirer "^7.3.3"
-    js-yaml "^4.0.0"
-    lodash "^4.17.21"
-    node-fetch "^2.6.7"
-    open "^8.4.0"
-    ora "^4.0.3"
-    proxy-agent "^6.3.0"
-    semver "^7.5.4"
-    typescript-json-schema "~0.52.0"
-    which "^2.0.2"
-    yaml "^2.2.2"
-    yauzl "^3.1.3"
-
-"@aws-amplify/amplify-cli-core@4.3.9":
-  version "4.3.9"
-  resolved "https://registry.npmjs.org/@aws-amplify/amplify-cli-core/-/amplify-cli-core-4.3.9.tgz#48feec280b22695dce144407beb7372713b1bb1a"
-  integrity sha512-J0YNhrajaziU38Amb+bh18VYk6gqNiV65QccwanQ99tRDen1iZ8IPJqR/k1FgnkgEbiocZKFSV0T/MeIoi0Ntg==
-  dependencies:
-    "@aws-amplify/amplify-cli-logger" "1.3.8"
-    "@aws-amplify/amplify-function-plugin-interface" "1.12.1"
-    "@aws-amplify/amplify-prompts" "2.8.6"
-    "@aws-amplify/graphql-transformer-interfaces" "^3.9.0"
     "@aws-sdk/util-arn-parser" "^3.310.0"
     "@yarnpkg/lockfile" "^1.1.0"
     ajv "^6.12.6"
@@ -357,7 +319,7 @@
     "@turf/boolean-clockwise" "6.5.0"
     camelcase-keys "6.2.2"
 
-"@aws-amplify/graphql-transformer-interfaces@^3.10.1", "@aws-amplify/graphql-transformer-interfaces@^3.9.0":
+"@aws-amplify/graphql-transformer-interfaces@^3.10.1":
   version "3.10.1"
   resolved "https://registry.npmjs.org/@aws-amplify/graphql-transformer-interfaces/-/graphql-transformer-interfaces-3.10.1.tgz#18283fe97be3abf58f8564f877b7871fc11f4b9b"
   integrity sha512-daf+cpOSw3lKiS+Tpc5Oo5H+FCkHi/8z+0mAR/greQGPJWzcHv9j2u1Jiy36UvI01ypOhHme58pAs/fKWLWDBQ==
@@ -10808,10 +10770,10 @@ exponential-backoff@^3.1.1:
   resolved "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
   integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
 
-express@^4.17.3:
-  version "4.21.1"
-  resolved "https://registry.npmjs.org/express/-/express-4.21.1.tgz#9dae5dda832f16b4eec941a4e44aa89ec481b281"
-  integrity sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==
+express@^4.21.1:
+  version "4.21.2"
+  resolved "https://registry.npmjs.org/express/-/express-4.21.2.tgz#cf250e48362174ead6cea4a566abef0162c1ec32"
+  integrity sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==
   dependencies:
     accepts "~1.3.8"
     array-flatten "1.1.1"
@@ -10832,7 +10794,7 @@ express@^4.17.3:
     methods "~1.1.2"
     on-finished "2.4.1"
     parseurl "~1.3.3"
-    path-to-regexp "0.1.10"
+    path-to-regexp "0.1.12"
     proxy-addr "~2.0.7"
     qs "6.13.0"
     range-parser "~1.2.1"
@@ -12069,11 +12031,6 @@ ip-address@^9.0.5:
   dependencies:
     jsbn "1.1.0"
     sprintf-js "^1.1.3"
-
-ip@^1.1.9:
-  version "1.1.9"
-  resolved "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz#8dfbcc99a754d07f425310b86a99546b1151e396"
-  integrity sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -15011,10 +14968,10 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-to-regexp@0.1.10:
-  version "0.1.10"
-  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz#67e9108c5c0551b9e5326064387de4763c4d5f8b"
-  integrity sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==
+path-to-regexp@0.1.12:
+  version "0.1.12"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
+  integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
 
 path-type@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Fix for [dependabot alert #150](https://github.com/aws-amplify/amplify-category-api/security/dependabot/150). `path-to-regexp` is used by package `@aws-amplify/amplify-appsync-simulator`, which is the dependency of `amplify-category-api-graphql-transformers-e2e-tests`.

`path-to-regexp` version is bumped to 0.1.12.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
