### PR TITLE
chore[@aws-amplify/graphql-category-api]: suppress reexport and type-only files from coverage metrics

### DIFF
--- a/packages/amplify-graphql-api-construct/jest.config.js
+++ b/packages/amplify-graphql-api-construct/jest.config.js
@@ -2,11 +2,4 @@ const baseConfig = require('../../jest.config.base.js'); // eslint-disable-line 
 
 module.exports = {
   ...baseConfig,
-  coverageThreshold: {
-    global: {
-      branches: 89,
-      functions: 89,
-      lines: 81,
-    },
-  },
 };

--- a/packages/amplify-graphql-api-construct/src/__tests__/index-import.test.ts
+++ b/packages/amplify-graphql-api-construct/src/__tests__/index-import.test.ts
@@ -1,4 +1,8 @@
-// This exists only to provide coverage metrics for various export files
+// ############################################################################
+// This exists only to provide coverage metrics for various export files. If
+// you include executable code in any of the referenced files, you must test it
+// separately in a dedicated *.test.ts file.
+// ############################################################################
 
 import * as src from '../index';
 import * as types from '../types';

--- a/packages/amplify-graphql-api-construct/src/index.ts
+++ b/packages/amplify-graphql-api-construct/src/index.ts
@@ -1,7 +1,18 @@
+// ############################################################################
+// Note that sections of this file are excluded from test coverage metrics with
+// 'c8 ignore' comments. If you add code to this file, suppress non-executable
+// code from coverage metrics by using a `c8 ignore`. If the code is
+// executable, you MUST NOT suppress it from coverage metrics.
+//
+// `ignore` statements must only span a single block of code. Do not apply an
+// `ignore` statement to multiple blocks, or the entire file.
+// ############################################################################
+
 /* ATTENTION
  *
  * If you modify this file you must also modify packages/amplify-data-construct/src/index.ts to have the same exports
  */
+/* c8 ignore start */
 export type {
   IAMAuthorizationConfig,
   IdentityPoolAuthorizationConfig,
@@ -34,8 +45,17 @@ export type {
   IBackendOutputEntry,
   AddFunctionProps,
 } from './types';
+/* c8 ignore stop */
+
+/* c8 ignore start */
 export { AmplifyGraphqlApi } from './amplify-graphql-api';
+/* c8 ignore stop */
+
+/* c8 ignore start */
 export { AmplifyGraphqlDefinition } from './amplify-graphql-definition';
+/* c8 ignore stop */
+
+/* c8 ignore start */
 export {
   AmplifyDynamoDbTableWrapper,
   TimeToLiveSpecification,
@@ -44,7 +64,20 @@ export {
   SSEType,
   StreamSpecification,
 } from './amplify-dynamodb-table-wrapper';
+/* c8 ignore stop */
+
+/* c8 ignore start */
 export { SQLLambdaModelDataSourceStrategyFactory } from './sql-model-datasource-strategy';
+/* c8 ignore stop */
+
+/* c8 ignore start */
 export * from './model-datasource-strategy-types';
+/* c8 ignore stop */
+
+/* c8 ignore start */
 export type { LogConfig, Logging } from './log-config-types';
+/* c8 ignore stop */
+
+/* c8 ignore start */
 export { FieldLogLevel, RetentionDays } from './log-config-types';
+/* c8 ignore stop */

--- a/packages/amplify-graphql-api-construct/src/types.ts
+++ b/packages/amplify-graphql-api-construct/src/types.ts
@@ -1,4 +1,18 @@
+// ############################################################################
+// Note that sections of this file are excluded from test coverage metrics with
+// 'c8 ignore' comments. If you add code to this file, suppress non-executable
+// code from coverage metrics by using a `c8 ignore`. If the code is
+// executable, you MUST NOT suppress it from coverage metrics.
+//
+// `ignore` statements must only span a single block of code. Do not apply an
+// `ignore` statement to multiple blocks, or the entire file.
+// ############################################################################
+
+/* c8 ignore start */
 import { Duration, CfnResource, NestedStack } from 'aws-cdk-lib';
+/* c8 ignore stop */
+
+/* c8 ignore start */
 import {
   CfnGraphQLApi,
   CfnGraphQLSchema,
@@ -12,18 +26,45 @@ import {
   Code,
   FunctionRuntime,
 } from 'aws-cdk-lib/aws-appsync';
+/* c8 ignore stop */
+
+/* c8 ignore start */
 import { CfnTable, ITable } from 'aws-cdk-lib/aws-dynamodb';
+/* c8 ignore stop */
+
+/* c8 ignore start */
 import { IRole, CfnRole } from 'aws-cdk-lib/aws-iam';
+/* c8 ignore stop */
+
+/* c8 ignore start */
 import { IUserPool } from 'aws-cdk-lib/aws-cognito';
+/* c8 ignore stop */
+
+/* c8 ignore start */
 import { IFunction, CfnFunction } from 'aws-cdk-lib/aws-lambda';
+/* c8 ignore stop */
+
+/* c8 ignore start */
 import { IBucket } from 'aws-cdk-lib/aws-s3';
+/* c8 ignore stop */
+
+/* c8 ignore start */
 import { AmplifyDynamoDbTableWrapper } from './amplify-dynamodb-table-wrapper';
+/* c8 ignore stop */
+
+/* c8 ignore start */
 import { CustomSqlDataSourceStrategy, ModelDataSourceStrategy } from './model-datasource-strategy-types';
+/* c8 ignore stop */
+
+/* c8 ignore start */
 import { Logging } from './log-config-types';
+/* c8 ignore stop */
+
 /**
  * Configuration for IAM Authorization on the Graphql Api.
  * @struct - required since this interface begins with an 'I'
  */
+/* c8 ignore start */
 export interface IAMAuthorizationConfig {
   /**
    * ID for the Cognito Identity Pool vending auth and unauth roles.
@@ -69,11 +110,13 @@ export interface IAMAuthorizationConfig {
    */
   readonly enableIamAuthorizationMode?: boolean;
 }
+/* c8 ignore stop */
 
 /**
  * Configuration for Cognito Identity Pool Authorization on the Graphql Api.
  * @struct - required since this interface begins with an 'I'
  */
+/* c8 ignore start */
 export interface IdentityPoolAuthorizationConfig {
   /**
    * ID for the Cognito Identity Pool vending auth and unauth roles.
@@ -91,20 +134,24 @@ export interface IdentityPoolAuthorizationConfig {
    */
   readonly unauthenticatedUserRole: IRole;
 }
+/* c8 ignore stop */
 
 /**
  * Configuration for Cognito UserPool Authorization on the Graphql Api.
  */
+/* c8 ignore start */
 export interface UserPoolAuthorizationConfig {
   /**
    * The Cognito User Pool which is used to authenticated JWT tokens, and vends group and user information.
    */
   readonly userPool: IUserPool;
 }
+/* c8 ignore stop */
 
 /**
  * Configuration for OpenId Connect Authorization on the Graphql Api.
  */
+/* c8 ignore start */
 export interface OIDCAuthorizationConfig {
   /**
    * The issuer for the OIDC configuration.
@@ -134,10 +181,12 @@ export interface OIDCAuthorizationConfig {
    */
   readonly tokenExpiryFromIssue: Duration;
 }
+/* c8 ignore stop */
 
 /**
  * Configuration for Api Keys on the Graphql Api.
  */
+/* c8 ignore start */
 export interface ApiKeyAuthorizationConfig {
   /**
    * Optional description for the Api Key to attach to the Api.
@@ -149,10 +198,12 @@ export interface ApiKeyAuthorizationConfig {
    */
   readonly expires: Duration;
 }
+/* c8 ignore stop */
 
 /**
  * Configuration for Custom Lambda authorization on the Graphql Api.
  */
+/* c8 ignore start */
 export interface LambdaAuthorizationConfig {
   /**
    * The authorizer lambda function.
@@ -164,12 +215,14 @@ export interface LambdaAuthorizationConfig {
    */
   readonly ttl: Duration;
 }
+/* c8 ignore stop */
 
 /**
  * Authorization Modes to apply to the Api.
  * At least one modes must be provided, and if more than one are provided a defaultAuthorizationMode must be specified.
  * For more information on Amplify Api auth, refer to https://docs.amplify.aws/cli/graphql/authorization-rules/#authorization-strategies
  */
+/* c8 ignore start */
 export interface AuthorizationModes {
   /**
    * Default auth mode to provide to the Api, required if more than one config type is specified.
@@ -220,25 +273,31 @@ export interface AuthorizationModes {
    */
   readonly adminRoles?: IRole[];
 }
+/* c8 ignore stop */
 
 /**
  * Whether or not to use a version field to track conflict detection.
  */
+/* c8 ignore start */
 export type ConflictDetectionType = 'VERSION' | 'NONE';
+/* c8 ignore stop */
 
 /**
  * Common parameters for conflict resolution.
  */
+/* c8 ignore start */
 export interface ConflictResolutionStrategyBase {
   /**
    * The conflict detection type used for resolution.
    */
   readonly detectionType: ConflictDetectionType;
 }
+/* c8 ignore stop */
 
 /**
  * Enable optimistic concurrency on the project.
  */
+/* c8 ignore start */
 export interface AutomergeConflictResolutionStrategy extends ConflictResolutionStrategyBase {
   /**
    * This conflict resolution strategy executes an auto-merge.
@@ -246,10 +305,12 @@ export interface AutomergeConflictResolutionStrategy extends ConflictResolutionS
    */
   readonly handlerType: 'AUTOMERGE';
 }
+/* c8 ignore stop */
 
 /**
  * Enable automerge on the project.
  */
+/* c8 ignore start */
 export interface OptimisticConflictResolutionStrategy extends ConflictResolutionStrategyBase {
   /**
    * This conflict resolution strategy the _version to perform optimistic concurrency.
@@ -257,10 +318,12 @@ export interface OptimisticConflictResolutionStrategy extends ConflictResolution
    */
   readonly handlerType: 'OPTIMISTIC_CONCURRENCY';
 }
+/* c8 ignore stop */
 
 /**
  * Enable custom sync on the project, powered by a lambda.
  */
+/* c8 ignore start */
 export interface CustomConflictResolutionStrategy extends ConflictResolutionStrategyBase {
   /**
    * This conflict resolution strategy uses a lambda handler type.
@@ -278,20 +341,26 @@ export interface CustomConflictResolutionStrategy extends ConflictResolutionStra
 /**
  * Conflict Resolution Strategy to apply to the project or a particular model.
  */
+/* c8 ignore start */
 export type ConflictResolutionStrategy =
   | AutomergeConflictResolutionStrategy
   | OptimisticConflictResolutionStrategy
   | CustomConflictResolutionStrategy;
+/* c8 ignore stop */
 
 /**
  * Project level configuration for conflict resolution.
  * @deprecated use DataStoreConfiguration instead.
  */
+/* c8 ignore start */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ConflictResolution extends DataStoreConfiguration {}
+/* c8 ignore stop */
 
 /**
  * Project level configuration for DataStore
  */
+/* c8 ignore start */
 export interface DataStoreConfiguration {
   /**
    * Project-wide config for conflict resolution. Applies to all non-overridden models.
@@ -303,11 +372,13 @@ export interface DataStoreConfiguration {
    */
   readonly models?: Record<string, ConflictResolutionStrategy>;
 }
+/* c8 ignore stop */
 
 /**
  * Params exposed to support configuring and overriding pipelined slots. This allows configuration of the underlying function,
  * including the request and response mapping templates.
  */
+/* c8 ignore start */
 export interface FunctionSlotOverride {
   /**
    * Override request mapping template for the function slot. Executed before the datasource is invoked.
@@ -319,10 +390,12 @@ export interface FunctionSlotOverride {
    */
   readonly responseMappingTemplate?: MappingTemplate;
 }
+/* c8 ignore stop */
 
 /**
  * Common slot parameters.
  */
+/* c8 ignore start */
 export interface FunctionSlotBase {
   /**
    * The field to attach this function to on the Api definition.
@@ -340,10 +413,12 @@ export interface FunctionSlotBase {
    */
   readonly function: FunctionSlotOverride;
 }
+/* c8 ignore stop */
 
 /**
  * Slot types for Mutation Resolvers.
  */
+/* c8 ignore start */
 export interface MutationFunctionSlot extends FunctionSlotBase {
   /**
    * This slot type applies to the Mutation type on the Api definition.
@@ -356,10 +431,12 @@ export interface MutationFunctionSlot extends FunctionSlotBase {
    */
   readonly slotName: 'init' | 'preAuth' | 'auth' | 'postAuth' | 'preUpdate' | 'postUpdate' | 'finish';
 }
+/* c8 ignore stop */
 
 /**
  * Slot types for Query Resolvers.
  */
+/* c8 ignore start */
 export interface QueryFunctionSlot extends FunctionSlotBase {
   /**
    * This slot type applies to the Query type on the Api definition.
@@ -372,10 +449,12 @@ export interface QueryFunctionSlot extends FunctionSlotBase {
    */
   readonly slotName: 'init' | 'preAuth' | 'auth' | 'postAuth' | 'preDataLoad' | 'postDataLoad' | 'finish';
 }
+/* c8 ignore stop */
 
 /**
  * Slot types for Subscription Resolvers.
  */
+/* c8 ignore start */
 export interface SubscriptionFunctionSlot extends FunctionSlotBase {
   /**
    * This slot type applies to the Subscription type on the Api definition.
@@ -388,11 +467,14 @@ export interface SubscriptionFunctionSlot extends FunctionSlotBase {
    */
   readonly slotName: 'init' | 'preAuth' | 'auth' | 'postAuth' | 'preSubscribe';
 }
+/* c8 ignore stop */
 
 /**
  * Input params to uniquely identify the slot which is being overridden.
  */
+/* c8 ignore start */
 export type FunctionSlot = MutationFunctionSlot | QueryFunctionSlot | SubscriptionFunctionSlot;
+/* c8 ignore stop */
 
 /**
  * Strongly typed set of shared parameters for all transformers, and core layer.
@@ -400,6 +482,7 @@ export type FunctionSlot = MutationFunctionSlot | QueryFunctionSlot | Subscripti
  * a single location, and isn't spread around the transformers, where they can
  * have different default behaviors.
  */
+/* c8 ignore start */
 export interface TranslationBehavior {
   /**
    * Restore parity w/ GQLv1 @model parameter behavior, where setting a single field doesn't implicitly set the other fields to null.
@@ -497,10 +580,12 @@ export interface TranslationBehavior {
    */
   readonly replaceTableUponGsiUpdate: boolean;
 }
+/* c8 ignore stop */
 
 /**
  * A utility interface equivalent to Partial<TranslationBehavior>.
  */
+/* c8 ignore start */
 export interface PartialTranslationBehavior {
   /**
    * Restore parity w/ GQLv1 @model parameter behavior, where setting a single field doesn't implicitly set the other fields to null.
@@ -615,10 +700,12 @@ export interface PartialTranslationBehavior {
    */
   readonly _provisionHotswapFriendlyResources?: boolean;
 }
+/* c8 ignore stop */
 
 /**
  * Graphql Api definition, which can be implemented in multiple ways.
  */
+/* c8 ignore start */
 export interface IAmplifyGraphqlDefinition {
   /**
    * Return the schema definition as a graphql string, with amplify directives allowed.
@@ -652,10 +739,12 @@ export interface IAmplifyGraphqlDefinition {
    */
   readonly customSqlDataSourceStrategies?: CustomSqlDataSourceStrategy[];
 }
+/* c8 ignore stop */
 
 /**
  * Entry representing the required output from the backend for codegen generate commands to work.
  */
+/* c8 ignore start */
 export interface IBackendOutputEntry {
   /**
    * The protocol version for this backend output.
@@ -667,10 +756,12 @@ export interface IBackendOutputEntry {
    */
   readonly payload: Record<string, string>;
 }
+/* c8 ignore stop */
 
 /**
  * Backend output strategy used to write config required for codegen tasks.
  */
+/* c8 ignore start */
 export interface IBackendOutputStorageStrategy {
   /**
    * Add an entry to backend output.
@@ -680,11 +771,13 @@ export interface IBackendOutputStorageStrategy {
   // eslint-disable-next-line @typescript-eslint/method-signature-style
   addBackendOutputEntry(keyName: string, backendOutputEntry: IBackendOutputEntry): void;
 }
+/* c8 ignore stop */
 
 /**
  * Input props for the AmplifyGraphqlApi construct. Specifies what the input to transform into an Api, and configurations for
  * the transformation process.
  */
+/* c8 ignore start */
 export interface AmplifyGraphqlApiProps {
   /**
    * The definition to transform in a full Api.
@@ -768,11 +861,13 @@ export interface AmplifyGraphqlApiProps {
    */
   readonly logging?: Logging;
 }
+/* c8 ignore stop */
 
 /**
  * L1 CDK resources from the Api which were generated as part of the transform.
  * These are potentially stored under nested stacks, but presented organized by type instead.
  */
+/* c8 ignore start */
 export interface AmplifyGraphqlApiCfnResources {
   /**
    * The Generated AppSync Api L1 Resource
@@ -829,11 +924,13 @@ export interface AmplifyGraphqlApiCfnResources {
    */
   readonly additionalCfnResources: Record<string, CfnResource>;
 }
+/* c8 ignore stop */
 
 /**
  * Accessible resources from the Api which were generated as part of the transform.
  * These are potentially stored under nested stacks, but presented organized by type instead.
  */
+/* c8 ignore start */
 export interface AmplifyGraphqlApiResources {
   /**
    * The Generated AppSync Api L2 Resource, includes the Schema.
@@ -865,11 +962,13 @@ export interface AmplifyGraphqlApiResources {
    */
   readonly nestedStacks: Record<string, NestedStack>;
 }
+/* c8 ignore stop */
 
 /**
  * Input type properties when adding a new appsync.AppsyncFunction to the generated API.
  * This is equivalent to the Omit<appsync.AppsyncFunctionProps, 'api'>.
  */
+/* c8 ignore start */
 export interface AddFunctionProps {
   /**
    * the data source linked to this AppSync Function
@@ -916,3 +1015,4 @@ export interface AddFunctionProps {
    */
   readonly code?: Code;
 }
+/* c8 ignore stop */


### PR DESCRIPTION
#### Description of changes

Suppress reexport and type-only files from coverage metrics in specified package.

#### Description of how you validated changes

Local test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
