### PR TITLE
bump code build node version from 18 to 20

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-AMPLIFY_NODE_VERSION=18.20.4
+AMPLIFY_NODE_VERSION=20.18.1
 
 # set exit on error to true
 set -e


### PR DESCRIPTION
#### Description of changes

Bumped code build node version from 18 to 20 due to a recent error that fails canary workflow:
```
error glob@11.0.0: The engine "node" is incompatible with this module. Expected version "20 || >=22". Got "18.15.0"
211
```

#### Description of how you validated changes

[E2E](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:5a734992-739a-4084-aa1f-f29a1455ef38?region=us-east-1)

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [x] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
