### PR TITLE
fix: make canary deps compatible with node 18

### DIFF
--- a/client-test-apps/js/api-model-relationship-app/package.json
+++ b/client-test-apps/js/api-model-relationship-app/package.json
@@ -34,7 +34,9 @@
     "web-vitals": "^2.1.4"
   },
   "resolutions": {
-    "joi": "17.7.0"
+    "joi": "17.7.0",
+    "glob": "10.4.5",
+    "rimraf": "5.0.10"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -209,6 +209,7 @@ function _setupNodeVersion {
   [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
   
   # Install and use the specified Node.js version
+  nvm unalias default
   nvm install "$version"
   nvm use "$version"
   
@@ -355,11 +356,10 @@ function _runCanaryTest {
     echo RUN Canary Test
     loadCacheFromBuildJob
     loadCache verdaccio-cache $CODEBUILD_SRC_DIR/../verdaccio-cache
+    _setupNodeVersion $CLIENT_CANARY_NODE_VERSION
     _installCLIFromLocalRegistry  
     _loadTestAccountCredentials
     _setShell
-    nvm install "$CLIENT_CANARY_NODE_VERSION"
-    nvm use "$CLIENT_CANARY_NODE_VERSION"
     cd client-test-apps/js/api-model-relationship-app
     yarn --network-timeout 180000
     retry yarn test:ci

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -358,7 +358,8 @@ function _runCanaryTest {
     _installCLIFromLocalRegistry  
     _loadTestAccountCredentials
     _setShell
-    _setupNodeVersion $CLIENT_CANARY_NODE_VERSION
+    nvm install "$CLIENT_CANARY_NODE_VERSION"
+    nvm use "$CLIENT_CANARY_NODE_VERSION"
     cd client-test-apps/js/api-model-relationship-app
     yarn --network-timeout 180000
     retry yarn test:ci

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -209,7 +209,6 @@ function _setupNodeVersion {
   [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
   
   # Install and use the specified Node.js version
-  nvm unalias default
   nvm install "$version"
   nvm use "$version"
   

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 AMPLIFY_NODE_VERSION=18.20.4
+CLIENT_CANARY_NODE_VERSION=20.18.0
 
 # set exit on error to true
 set -e
@@ -357,6 +358,7 @@ function _runCanaryTest {
     _installCLIFromLocalRegistry  
     _loadTestAccountCredentials
     _setShell
+    _setupNodeVersion $CLIENT_CANARY_NODE_VERSION
     cd client-test-apps/js/api-model-relationship-app
     yarn --network-timeout 180000
     retry yarn test:ci

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 AMPLIFY_NODE_VERSION=18.20.4
-CLIENT_CANARY_NODE_VERSION=20.18.0
 
 # set exit on error to true
 set -e
@@ -355,7 +354,6 @@ function _runCanaryTest {
     echo RUN Canary Test
     loadCacheFromBuildJob
     loadCache verdaccio-cache $CODEBUILD_SRC_DIR/../verdaccio-cache
-    _setupNodeVersion $CLIENT_CANARY_NODE_VERSION
     _installCLIFromLocalRegistry  
     _loadTestAccountCredentials
     _setShell

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -354,6 +354,8 @@ function _runCanaryTest {
     echo RUN Canary Test
     loadCacheFromBuildJob
     loadCache verdaccio-cache $CODEBUILD_SRC_DIR/../verdaccio-cache
+    # Set Node.js version to $AMPLIFY_NODE_VERSION as one of the package requires version ">= 18.18.0"
+    _setupNodeVersion $AMPLIFY_NODE_VERSION
     _installCLIFromLocalRegistry  
     _loadTestAccountCredentials
     _setShell


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The transitive dependencies for the client canary test app now require atleast v20 node. This PR pins these deps to versions that allow us to test min CLI supported version i.e node 18.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Running `yarn` with updated version installs dependencies successfully.
Also re-ran the canary flow with latest change and it succeeds.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
