### PR TITLE
fix(conversation): add padding to stream chunks

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/API.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/API.ts
@@ -2571,6 +2571,7 @@ export type OnCreateAssistantResponsePirateChatSubscription = {
     id: string;
     owner?: string | null;
     stopReason?: string | null;
+    p?: string | null;
   } | null;
 };
 

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/conversation.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/conversation.test.ts
@@ -116,6 +116,10 @@ describe('conversation', () => {
         // expect to receive the assistant response in the subscription
         for await (const event of subscription) {
           events.push(event.onCreateAssistantResponsePirateChat);
+          // expect event to contain `p`
+          expect(event.onCreateAssistantResponsePirateChat.p).toBeDefined();
+          expect(event.onCreateAssistantResponsePirateChat.p.length).toBeGreaterThanOrEqual(0);
+          expect(event.onCreateAssistantResponsePirateChat.p.length).toBeLessThanOrEqual(35);
           if (event.onCreateAssistantResponsePirateChat.stopReason) break;
         }
 

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/schema-conversation.graphql
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/schema-conversation.graphql
@@ -204,6 +204,7 @@ type AmplifyAIConversationMessageStreamPart @aws_cognito_user_pools {
   contentBlockDoneAtIndex: Int
   stopReason: String
   errors: [AmplifyAIConversationTurnError]
+  p: String
 }
 
 type AmplifyAIConversationTurnError @aws_cognito_user_pools {

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/subscriptions.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/conversations/graphql/subscriptions.ts
@@ -56,6 +56,7 @@ export const onCreateAssistantResponsePirateChat = /* GraphQL */ `subscription O
     id
     owner
     stopReason
+    p
   }
 }
 ` as GeneratedSubscription<

--- a/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-conversation-transformer/src/__tests__/__snapshots__/amplify-graphql-conversation-transformer.test.ts.snap
@@ -278,8 +278,10 @@ export function response(ctx) {
   const streamId = \`\${ctx.args.input.associatedUserMessageId}#stream\`;
   const { owner } = ctx.args;
   const event = ctx.args.input;
+  const padding = generateRandomPadding();
 
   const streamEvent = {
+    p: padding,
     ...event,
     __typename: 'ConversationMessageStreamPart',
     id: streamId,
@@ -293,7 +295,12 @@ export function response(ctx) {
 
   return streamEvent;
 }
-"
+
+function generateRandomPadding() {
+  const base = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const rand = Math.floor(Math.random() * 36);
+  return base.slice(0, rand);
+}"
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with inference configuration: AssistantResponseStreamMutation init slot function code 1`] = `
@@ -669,7 +676,7 @@ export function request(ctx) {
   const { graphqlApiEndpoint } = ctx.stash;
   const userAgent = createUserAgent(request);
 
-  const selectionSet = 'associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner errors { errorType message }';
+  const selectionSet = 'associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner errors { errorType message } p';
 
   const streamingResponseMutation = {
     name: 'createAssistantResponseStreamPirateChat',
@@ -1135,8 +1142,10 @@ export function response(ctx) {
   const streamId = \`\${ctx.args.input.associatedUserMessageId}#stream\`;
   const { owner } = ctx.args;
   const event = ctx.args.input;
+  const padding = generateRandomPadding();
 
   const streamEvent = {
+    p: padding,
     ...event,
     __typename: 'ConversationMessageStreamPart',
     id: streamId,
@@ -1150,7 +1159,12 @@ export function response(ctx) {
 
   return streamEvent;
 }
-"
+
+function generateRandomPadding() {
+  const base = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const rand = Math.floor(Math.random() * 36);
+  return base.slice(0, rand);
+}"
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with model query tool including relationships: AssistantResponseStreamMutation init slot function code 1`] = `
@@ -1526,7 +1540,7 @@ export function request(ctx) {
   const { graphqlApiEndpoint } = ctx.stash;
   const userAgent = createUserAgent(request);
 
-  const selectionSet = 'associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner errors { errorType message }';
+  const selectionSet = 'associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner errors { errorType message } p';
 
   const streamingResponseMutation = {
     name: 'createAssistantResponseStreamPirateChat',
@@ -1992,8 +2006,10 @@ export function response(ctx) {
   const streamId = \`\${ctx.args.input.associatedUserMessageId}#stream\`;
   const { owner } = ctx.args;
   const event = ctx.args.input;
+  const padding = generateRandomPadding();
 
   const streamEvent = {
+    p: padding,
     ...event,
     __typename: 'ConversationMessageStreamPart',
     id: streamId,
@@ -2007,7 +2023,12 @@ export function response(ctx) {
 
   return streamEvent;
 }
-"
+
+function generateRandomPadding() {
+  const base = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const rand = Math.floor(Math.random() * 36);
+  return base.slice(0, rand);
+}"
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with model query tool: AssistantResponseStreamMutation init slot function code 1`] = `
@@ -2383,7 +2404,7 @@ export function request(ctx) {
   const { graphqlApiEndpoint } = ctx.stash;
   const userAgent = createUserAgent(request);
 
-  const selectionSet = 'associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner errors { errorType message }';
+  const selectionSet = 'associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner errors { errorType message } p';
 
   const streamingResponseMutation = {
     name: 'createAssistantResponseStreamPirateChat',
@@ -2849,8 +2870,10 @@ export function response(ctx) {
   const streamId = \`\${ctx.args.input.associatedUserMessageId}#stream\`;
   const { owner } = ctx.args;
   const event = ctx.args.input;
+  const padding = generateRandomPadding();
 
   const streamEvent = {
+    p: padding,
     ...event,
     __typename: 'ConversationMessageStreamPart',
     id: streamId,
@@ -2864,7 +2887,12 @@ export function response(ctx) {
 
   return streamEvent;
 }
-"
+
+function generateRandomPadding() {
+  const base = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const rand = Math.floor(Math.random() * 36);
+  return base.slice(0, rand);
+}"
 `;
 
 exports[`ConversationTransformer valid schemas should transform conversation route with query tools: AssistantResponseStreamMutation init slot function code 1`] = `
@@ -3240,7 +3268,7 @@ export function request(ctx) {
   const { graphqlApiEndpoint } = ctx.stash;
   const userAgent = createUserAgent(request);
 
-  const selectionSet = 'associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner errors { errorType message }';
+  const selectionSet = 'associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner errors { errorType message } p';
 
   const streamingResponseMutation = {
     name: 'createAssistantResponseStreamPirateChat',

--- a/packages/amplify-graphql-conversation-transformer/src/graphql-types/message-model.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/graphql-types/message-model.ts
@@ -140,6 +140,7 @@ export const createAssistantResponseStreamingMutationInput = (messageModelName: 
       makeInputValueDefinition('stopReason', makeNamedType('String')),
       makeInputValueDefinition('accumulatedTurnContent', makeListType(makeNamedType('AmplifyAIContentBlockInput'))),
       makeInputValueDefinition('errors', makeListType(makeNamedType('AmplifyAIConversationTurnErrorInput'))),
+      makeInputValueDefinition('p', makeNamedType('String')),
     ],
   };
 };

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/send-message-pipeline-definition.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/send-message-pipeline-definition.ts
@@ -134,5 +134,4 @@ function templateGenerator(slotName: string) {
   return createS3AssetMappingTemplateGenerator('Mutation', slotName, fieldName);
 }
 
-const selectionSet = `id conversationId content { image { format source { bytes }} text toolUse { toolUseId name input } toolResult { status toolUseId content { json text image { format source { bytes }} document { format name source { bytes }} }}} role owner createdAt updatedAt`;
-const streamingSelectionSet = `associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner errors { errorType message }`;
+const streamingSelectionSet = `associatedUserMessageId contentBlockDeltaIndex contentBlockDoneAtIndex contentBlockIndex contentBlockText contentBlockToolUse { toolUseId name input } conversationId id stopReason owner errors { errorType message } p`;

--- a/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/assistant-streaming-mutation-resolver-fn.template.js
+++ b/packages/amplify-graphql-conversation-transformer/src/resolvers/templates/assistant-streaming-mutation-resolver-fn.template.js
@@ -76,8 +76,10 @@ export function response(ctx) {
   const streamId = `${ctx.args.input.associatedUserMessageId}#stream`;
   const { owner } = ctx.args;
   const event = ctx.args.input;
+  const padding = generateRandomPadding();
 
   const streamEvent = {
+    p: padding,
     ...event,
     __typename: 'ConversationMessageStreamPart',
     id: streamId,
@@ -90,4 +92,10 @@ export function response(ctx) {
   }
 
   return streamEvent;
+}
+
+function generateRandomPadding() {
+  const base = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const rand = Math.floor(Math.random() * 36);
+  return base.slice(0, rand);
 }


### PR DESCRIPTION
#### Description of changes
- Adds optional (for backwards compatibility) `p: String` field to the `CreateConversationMessage<RouteName>AssistantStreamingInput` type.
- Generates `p` value in `createAssistantResponseStream<RouteName>` resolver.

##### CDK / CloudFormation Parameters Changed
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes
Manually validated with example Gen 2 application that:
- `p` is returned in event chunk subscription.
- A `p` value provided in mutation input (from Lambda) gets precedence.

[E2E Full Run](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:616b2757-2f36-4e9b-a481-5c474c2ca3ed?region=us-east-1)
[E2E conversation run post test updates](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow%3Ac753f474-9c7a-49a6-931a-beb38c0ac7d9?region=us-east-1)

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [ ] ~Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)~
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~
- [ ] ~Any CDK or CloudFormation parameter changes are called out explicitly~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
