### PR TITLE
feat(graphql-model-transformer): add dsql support for sql lambda

### DIFF
--- a/packages/amplify-graphql-model-transformer/rds-lambda/dsql-helpers.ts
+++ b/packages/amplify-graphql-model-transformer/rds-lambda/dsql-helpers.ts
@@ -8,7 +8,7 @@ export const generateDSQLAuthToken = async (endpoint: string): Promise<string> =
     const token = await signer.getDbConnectAdminAuthToken();
     return token;
   } catch (error) {
-      throw error;
+    throw error;
   }
 }
 

--- a/packages/amplify-graphql-model-transformer/rds-lambda/dsql-helpers.ts
+++ b/packages/amplify-graphql-model-transformer/rds-lambda/dsql-helpers.ts
@@ -1,0 +1,17 @@
+import { DsqlSigner } from "@aws-sdk/dsql-signer";
+
+export const generateDSQLAuthToken = async (endpoint: string): Promise<string> => {
+  const signer = new DsqlSigner({
+    hostname: endpoint,
+  });
+  try {
+    const token = await signer.getDbConnectAdminAuthToken();
+    return token;
+  } catch (error) {
+      throw error;
+  }
+}
+
+export const isDSQLHostname = (endpoint: string): boolean => {
+  return endpoint.includes(".dsql.") && endpoint.endsWith(".on.aws");
+}

--- a/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
+++ b/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
@@ -210,7 +210,7 @@ const getDBConfig = async (): DBConfig => {
         database: 'postgres',
       }
       if (isDSQLHostname(config.host)) {
-        config = { ...defaultDSQLConfig };
+        config = { ...defaultDSQLConfig, ...config };
         config.password = await generateDSQLAuthToken(config.host);
         return config;
       }

--- a/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
+++ b/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
@@ -183,7 +183,7 @@ const retrieveSsmValueFromEnvPaths = async (path: string): Promise<string> => {
 };
 
 const getDBConfig = async (): DBConfig => {
-  const config: DBConfig = {};
+  let config: DBConfig = {};
 
   const sslCertificate = await getCustomSslCert();
   if (sslCertificate) {
@@ -203,12 +203,15 @@ const getDBConfig = async (): DBConfig => {
       // If the host is a DSQL hostname, generate an auth token
       const { hostname } = new URL(connectionString);
       config.host = decodeURIComponent(hostname);
+      const defaultDSQLConfig = {
+        username: 'admin',
+        engine: 'postgres',
+        port: 5432,
+        database: 'postgres',
+      }
       if (isDSQLHostname(config.host)) {
-        config.username = 'admin';
+        config = { ...defaultDSQLConfig };
         config.password = await generateDSQLAuthToken(config.host);
-        config.engine = 'postgres';
-        config.port = 5432;
-        config.database = 'postgres';
         return config;
       }
 

--- a/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
+++ b/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
@@ -2,6 +2,7 @@ import { SSMClient, GetParameterCommand, GetParameterCommandOutput } from '@aws-
 import { GetSecretValueCommand, SecretsManagerClient, GetSecretValueCommandOutput } from '@aws-sdk/client-secrets-manager';
 // @ts-ignore
 import { DBAdapter, DBConfig, getDBAdapter } from 'rds-query-processor';
+import { generateDSQLAuthToken, isDSQLHostname } from './dsql-helpers';
 
 let adapter: DBAdapter;
 let ssmClient: SSMClient;
@@ -52,7 +53,9 @@ const isRetryableError = (error: Error & {code?: string, errno?: string}): boole
   // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
   const mysqlRetryableError = error.errno === '1045';
 
-  return postgresRetryableError || mysqlRetryableError;
+  const dsqlRetryableError = error.code === '08006' && error.message?.includes('access denied');
+
+  return postgresRetryableError || mysqlRetryableError || dsqlRetryableError;
 }
 
 const createSSMClient = (): void => {
@@ -195,7 +198,23 @@ const getDBConfig = async (): DBConfig => {
 
     const jsonConnectionString = process.env.connectionString;
     if (jsonConnectionString) {
-      config.connectionString = await retrieveSsmValueFromEnvPaths(jsonConnectionString);
+      const connectionString = await retrieveSsmValueFromEnvPaths(jsonConnectionString);
+
+      // If the host is a DSQL hostname, generate an auth token
+      const { hostname } = new URL(connectionString);
+      config.host = decodeURIComponent(hostname);
+      if (isDSQLHostname(config.host)) {
+        config.username = 'admin';
+        config.password = await generateDSQLAuthToken(config.host);
+        config.engine = 'postgres';
+        config.port = 5432;
+        config.database = 'postgres';
+        return config;
+      }
+
+      // Fall back to the connection string if the host is not a DSQL hostname
+      delete config.host;
+      config.connectionString = connectionString;
       return config;
     }
 

--- a/packages/amplify-graphql-model-transformer/rds-lambda/package.json
+++ b/packages/amplify-graphql-model-transformer/rds-lambda/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "3.462.0",
     "@aws-sdk/client-ssm": "3.624.0",
+    "@aws-sdk/dsql-signer": "^3.726.1",
     "babel-jest": "^29.1.2",
     "bestzip": "^2.1.5",
     "jest": "^29.1.2",

--- a/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
@@ -469,7 +469,7 @@ export const createRdsLambdaRole = (
     new PolicyStatement({
       effect: Effect.ALLOW,
       resources: ['*'],
-      actions: ['ec2:CreateNetworkInterface', 'ec2:DescribeNetworkInterfaces', 'ec2:DeleteNetworkInterface'],
+      actions: ['ec2:CreateNetworkInterface', 'ec2:DescribeNetworkInterfaces', 'ec2:DeleteNetworkInterface', 'dsql:DbConnectAdmin'],
     }),
   );
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This PR introduces IAM-based authentication support for DSQL database connections in SQL lambda, enhancing our current authentication capabilities.

The implementation leverages existing SSM parameter to store the connection string, following our existing credential storage strategy for Gen2 brownfield support. Connection strings will follow the format `postgres://hostname:port/database`, with DSQL hosts identified by the `*.dsql.*.on.aws` domain pattern.

Authentication will use the default `admin` user, with database credentials dynamically generated using `DsqlSigner` helper methods provided by the SDK. This approach provides a flexible and secure method for establishing database connections while maintaining our infrastructure's existing patterns.

**Key Changes**
- Implement IAM authentication for DSQL databases
- Use existing SSM parameter to read connection string
- Dynamic credential generation
- DSQL host identification via domain pattern

##### CDK / CloudFormation Parameters Changed
NA
<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available
NA
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Manual test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
