### PR TITLE
add directive ordering enforcement between `@validate` and `@default`

### DIFF
--- a/packages/amplify-graphql-validate-transformer/src/__tests__/invalid-directive-use.test.ts
+++ b/packages/amplify-graphql-validate-transformer/src/__tests__/invalid-directive-use.test.ts
@@ -229,23 +229,23 @@ describe('Validation Type Compatibility with Field Type', () => {
   });
 });
 
-type DirectiveOrderTestCase = {
-  name: string;
-  directives: string[];
-  shouldPass: boolean;
-};
-
-const createDirectiveOrderSchema = (directives: string[]): string => {
-  const directiveString = directives.join(' ');
-  return /* GraphQL */ `
-    type Post @model {
-      id: ID!
-      title: String! ${directiveString}
-    }
-  `;
-};
-
 describe('Directive order enforcement for @validate and @default', () => {
+  type DirectiveOrderTestCase = {
+    name: string;
+    directives: string[];
+    shouldPass: boolean;
+  };
+  
+  const createDirectiveOrderSchema = (directives: string[]): string => {
+    const directiveString = directives.join(' ');
+    return /* GraphQL */ `
+      type Post @model {
+        id: ID!
+        title: String! ${directiveString}
+      }
+    `;
+  };
+
   const testCases: DirectiveOrderTestCase[] = [
     {
       name: 'rejects "@validate @default" ordering',
@@ -263,6 +263,18 @@ describe('Directive order enforcement for @validate and @default', () => {
       shouldPass: false,
     },
     {
+      name: 'rejects "@validate @validate @validate @validate @validate @default" ordering',
+      directives: [
+        '@validate(type: minLength, value: "5")',
+        '@validate(type: maxLength, value: "10")',
+        '@validate(type: startsWith, value: "prefix")',
+        '@validate(type: endsWith, value: "suffix")',
+        '@validate(type: matches, value: "regex")',
+        '@default(value: "default")',
+      ],
+      shouldPass: false,
+    },
+    {
       name: 'accepts "@default @validate" ordering',
       directives: ['@default(value: "default")', '@validate(type: minLength, value: "5")'],
       shouldPass: true,
@@ -270,6 +282,18 @@ describe('Directive order enforcement for @validate and @default', () => {
     {
       name: 'accepts "@default @validate @validate" ordering',
       directives: ['@default(value: "default")', '@validate(type: minLength, value: "5")', '@validate(type: maxLength, value: "10")'],
+      shouldPass: true,
+    },
+    {
+      name: 'accepts "@default @validate @validate @validate @validate @validate" ordering',
+      directives: [
+        '@default(value: "default")',
+        '@validate(type: minLength, value: "5")',
+        '@validate(type: maxLength, value: "10")',
+        '@validate(type: startsWith, value: "prefix")',
+        '@validate(type: endsWith, value: "suffix")',
+        '@validate(type: matches, value: "regex")',
+      ],
       shouldPass: true,
     },
   ];

--- a/packages/amplify-graphql-validate-transformer/src/__tests__/invalid-directive-use.test.ts
+++ b/packages/amplify-graphql-validate-transformer/src/__tests__/invalid-directive-use.test.ts
@@ -235,7 +235,7 @@ describe('Directive order enforcement for @validate and @default', () => {
     directives: string[];
     shouldPass: boolean;
   };
-  
+
   const createDirectiveOrderSchema = (directives: string[]): string => {
     const directiveString = directives.join(' ');
     return /* GraphQL */ `

--- a/packages/amplify-graphql-validate-transformer/src/__tests__/invalid-directive-use.test.ts
+++ b/packages/amplify-graphql-validate-transformer/src/__tests__/invalid-directive-use.test.ts
@@ -228,3 +228,58 @@ describe('Validation Type Compatibility with Field Type', () => {
     });
   });
 });
+
+type DirectiveOrderTestCase = {
+  name: string;
+  directives: string[];
+  shouldPass: boolean;
+};
+
+const createDirectiveOrderSchema = (directives: string[]): string => {
+  const directiveString = directives.join(' ');
+  return /* GraphQL */ `
+    type Post @model {
+      id: ID!
+      title: String! ${directiveString}
+    }
+  `;
+};
+
+describe('Directive order enforcement for @validate and @default', () => {
+  const testCases: DirectiveOrderTestCase[] = [
+    {
+      name: 'rejects "@validate @default" ordering',
+      directives: ['@validate(type: minLength, value: "5")', '@default(value: "default")'],
+      shouldPass: false,
+    },
+    {
+      name: 'rejects "@validate @default @validate" ordering',
+      directives: ['@validate(type: minLength, value: "5")', '@default(value: "default")', '@validate(type: maxLength, value: "10")'],
+      shouldPass: false,
+    },
+    {
+      name: 'rejects "@validate @validate @default" ordering',
+      directives: ['@validate(type: minLength, value: "5")', '@validate(type: maxLength, value: "10")', '@default(value: "default")'],
+      shouldPass: false,
+    },
+    {
+      name: 'accepts "@default @validate" ordering',
+      directives: ['@default(value: "default")', '@validate(type: minLength, value: "5")'],
+      shouldPass: true,
+    },
+    {
+      name: 'accepts "@default @validate @validate" ordering',
+      directives: ['@default(value: "default")', '@validate(type: minLength, value: "5")', '@validate(type: maxLength, value: "10")'],
+      shouldPass: true,
+    },
+  ];
+
+  test.each(testCases)('$name', ({ directives, shouldPass }) => {
+    const schema = createDirectiveOrderSchema(directives);
+    if (shouldPass) {
+      runTransformTest(schema);
+    } else {
+      runTransformTest(schema, '@validate directive must be specified after @default directive');
+    }
+  });
+});

--- a/packages/amplify-graphql-validate-transformer/src/__tests__/test-utils.ts
+++ b/packages/amplify-graphql-validate-transformer/src/__tests__/test-utils.ts
@@ -79,7 +79,7 @@ export const runTransformTest = (schema: string, expectError?: string): void => 
   const modelTransformer = new ModelTransformer();
   const validateTransformer = new ValidateTransformer();
   const defaultTransformer = new DefaultValueTransformer();
-  
+
   if (expectError) {
     expect(() => {
       testTransform({

--- a/packages/amplify-graphql-validate-transformer/src/__tests__/test-utils.ts
+++ b/packages/amplify-graphql-validate-transformer/src/__tests__/test-utils.ts
@@ -1,6 +1,7 @@
 import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { ValidateTransformer } from '..';
+import { DefaultValueTransformer } from '../../../amplify-graphql-default-value-transformer/src';
 
 export const NUMERIC_FIELD_TYPES = ['Int', 'Float'] as const;
 export const STRING_FIELD_TYPES = ['String'] as const;
@@ -75,19 +76,22 @@ export const createValidationTestCases = (
  * @param expectError Optional error message to expect (if testing for failure)
  */
 export const runTransformTest = (schema: string, expectError?: string): void => {
-  const transformer = new ValidateTransformer();
+  const modelTransformer = new ModelTransformer();
+  const validateTransformer = new ValidateTransformer();
+  const defaultTransformer = new DefaultValueTransformer();
+  
   if (expectError) {
     expect(() => {
       testTransform({
         schema,
-        transformers: [new ModelTransformer(), transformer],
+        transformers: [modelTransformer, validateTransformer, defaultTransformer],
       });
     }).toThrow(expectError);
   } else {
     expect(() => {
       testTransform({
         schema,
-        transformers: [new ModelTransformer(), transformer],
+        transformers: [modelTransformer, validateTransformer, defaultTransformer],
       });
     }).not.toThrow();
   }

--- a/packages/amplify-graphql-validate-transformer/src/validators.ts
+++ b/packages/amplify-graphql-validate-transformer/src/validators.ts
@@ -65,14 +65,11 @@ const validateNoListFieldValidation = (fieldNode: FieldDefinitionNode): void => 
  */
 const validateOrderingWithDefaultDirective = (fieldNode: FieldDefinitionNode, currentDirective: DirectiveNode): void => {
   const directives = fieldNode.directives!;
-  const validateIndex = directives.indexOf(currentDirective);
-  const defaultDirective = directives.find((d) => d.name.value === 'default');
+  const validateDirectiveIndex = directives.indexOf(currentDirective);
+  const defaultDirectiveIndex = directives.findIndex((d) => d.name.value === 'default');
 
-  if (defaultDirective) {
-    const defaultIndex = directives.indexOf(defaultDirective);
-    if (validateIndex < defaultIndex) {
-      throw new InvalidDirectiveError('@validate directive must be specified after @default directive');
-    }
+  if (defaultDirectiveIndex !== -1 && validateDirectiveIndex < defaultDirectiveIndex) {
+    throw new InvalidDirectiveError('@validate directive must be specified after @default directive');
   }
 };
 

--- a/packages/amplify-graphql-validate-transformer/src/validators.ts
+++ b/packages/amplify-graphql-validate-transformer/src/validators.ts
@@ -25,6 +25,7 @@ export const validate = (
 ): void => {
   validateModelType(parentNode);
   validateNoListFieldValidation(fieldNode);
+  validateOrderingWithDefaultDirective(fieldNode, directive);
   validateNoDuplicateTypes(fieldNode, directive, config.type as ValidationType);
   validateTypeCompatibility(fieldNode, config.type as ValidationType);
 
@@ -54,6 +55,24 @@ const validateModelType = (parentNode: ObjectTypeDefinitionNode): void => {
 const validateNoListFieldValidation = (fieldNode: FieldDefinitionNode): void => {
   if (isListType(fieldNode.type)) {
     throw new InvalidDirectiveError(`@validate directive cannot be used on list field '${fieldNode.name.value}'`);
+  }
+};
+
+/**
+ * Validates that `@validate` directive is not placed before a `@default` directive.
+ * @param fieldNode - The field definition node that the directive is applied to
+ * @param currentDirective - The current `@validate` directive node
+ */
+const validateOrderingWithDefaultDirective = (fieldNode: FieldDefinitionNode, currentDirective: DirectiveNode): void => {
+  const directives = fieldNode.directives!;
+  const validateIndex = directives.indexOf(currentDirective);
+  const defaultDirective = directives.find((d) => d.name.value === 'default');
+
+  if (defaultDirective) {
+    const defaultIndex = directives.indexOf(defaultDirective);
+    if (validateIndex < defaultIndex) {
+      throw new InvalidDirectiveError('@validate directive must be specified after @default directive');
+    }
   }
 };
 


### PR DESCRIPTION
#### Description of changes
- add `validateOrderingWithDefaultDirective` to throw `InvalidDirectiveError` if `@validate` comes before `@default`
- updat `test-utils.ts` to include default transformer for testing

#### Description of how you validated changes
- unit tests added to test different combinations of ordering `@validate` and `@default`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
