### PR TITLE
fix: sort table description properties before comparing

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/__tests__/import-table.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/import-table.test.ts
@@ -140,6 +140,43 @@ describe('import-table', () => {
         expect(() => validateImportedTableProperties(getImportedTableComparisonProperties(actual), expected)).not.toThrow();
       });
 
+      test('AttributeDefinitions with different order', () => {
+        const actual: TableDescription = {
+          AttributeDefinitions: [
+            {
+              AttributeName: 'name',
+              AttributeType: 'S',
+            },
+            {
+              AttributeName: 'todoId',
+              AttributeType: 'S',
+            },
+            {
+              AttributeName: 'name2',
+              AttributeType: 'S',
+            },
+          ],
+        };
+        const expected: TableComparisonProperties = {
+          AttributeDefinitions: [
+            {
+              AttributeName: 'todoId',
+              AttributeType: 'S',
+            },
+            {
+              AttributeName: 'name',
+              AttributeType: 'S',
+            },
+            {
+              AttributeName: 'name2',
+              AttributeType: 'S',
+            },
+          ],
+        };
+
+        expect(() => validateImportedTableProperties(getImportedTableComparisonProperties(actual), expected)).not.toThrow();
+      });
+
       test('KeySchema', () => {
         const actual: TableDescription = {
           KeySchema: [
@@ -153,6 +190,35 @@ describe('import-table', () => {
               // @ts-expect-error Attribute should be ignored in comparison. AWS SDK may add additional fields in the future
               foo: 'bar',
               baz: undefined,
+            },
+          ],
+        };
+        const expected: TableComparisonProperties = {
+          KeySchema: [
+            {
+              AttributeName: 'todoId',
+              KeyType: 'HASH',
+            },
+            {
+              AttributeName: 'name',
+              KeyType: 'RANGE',
+            },
+          ],
+        };
+
+        expect(() => validateImportedTableProperties(getImportedTableComparisonProperties(actual), expected)).not.toThrow();
+      });
+
+      test('KeySchema with different order', () => {
+        const actual: TableDescription = {
+          KeySchema: [
+            {
+              AttributeName: 'name',
+              KeyType: 'RANGE',
+            },
+            {
+              AttributeName: 'todoId',
+              KeyType: 'HASH',
             },
           ],
         };
@@ -201,6 +267,91 @@ describe('import-table', () => {
             {
               IndexName: 'byName2',
               KeySchema: [
+                {
+                  AttributeName: 'name2',
+                  KeyType: 'HASH',
+                },
+              ],
+              Projection: {
+                ProjectionType: 'ALL',
+              },
+              ProvisionedThroughput: {
+                ReadCapacityUnits: 5,
+                WriteCapacityUnits: 5,
+              },
+            },
+          ],
+        };
+
+        expect(() => validateImportedTableProperties(getImportedTableComparisonProperties(actual), expected)).not.toThrow();
+      });
+
+      test('GlobalSecondaryIndexes with different order', () => {
+        const actual: TableDescription = {
+          GlobalSecondaryIndexes: [
+            {
+              IndexName: 'byName2',
+              KeySchema: [
+                {
+                  AttributeName: 'name2',
+                  KeyType: 'HASH',
+                },
+                {
+                  AttributeName: 'name3',
+                  KeyType: 'RANGE',
+                },
+              ],
+              Projection: {
+                ProjectionType: 'ALL',
+              },
+              ProvisionedThroughput: {
+                ReadCapacityUnits: 5,
+                WriteCapacityUnits: 5,
+              },
+            },
+            {
+              IndexName: 'byName',
+              KeySchema: [
+                {
+                  AttributeName: 'name',
+                  KeyType: 'HASH',
+                },
+              ],
+              Projection: {
+                ProjectionType: 'ALL',
+              },
+              ProvisionedThroughput: {
+                ReadCapacityUnits: 5,
+                WriteCapacityUnits: 5,
+              },
+            },
+          ],
+        };
+        const expected: TableComparisonProperties = {
+          GlobalSecondaryIndexes: [
+            {
+              IndexName: 'byName',
+              KeySchema: [
+                {
+                  AttributeName: 'name',
+                  KeyType: 'HASH',
+                },
+              ],
+              Projection: {
+                ProjectionType: 'ALL',
+              },
+              ProvisionedThroughput: {
+                ReadCapacityUnits: 5,
+                WriteCapacityUnits: 5,
+              },
+            },
+            {
+              IndexName: 'byName2',
+              KeySchema: [
+                {
+                  AttributeName: 'name3',
+                  KeyType: 'RANGE',
+                },
                 {
                   AttributeName: 'name2',
                   KeyType: 'HASH',
@@ -358,8 +509,51 @@ describe('import-table', () => {
           .toThrowErrorMatchingInlineSnapshot(`
           "Imported table properties did not match the expected table properties.
           AttributeDefinitions does not match the expected value.
-          Imported Value: [{\\"AttributeName\\":\\"todoId\\",\\"AttributeType\\":\\"S\\"},{\\"AttributeName\\":\\"name\\",\\"AttributeType\\":\\"S\\"},{\\"AttributeName\\":\\"name2\\",\\"AttributeType\\":\\"S\\"}]
-          Expected: [{\\"AttributeName\\":\\"todoId\\",\\"AttributeType\\":\\"S\\"},{\\"AttributeName\\":\\"differentName\\",\\"AttributeType\\":\\"S\\"},{\\"AttributeName\\":\\"name2\\",\\"AttributeType\\":\\"S\\"}]"
+          Imported Value: [{\\"AttributeName\\":\\"name\\",\\"AttributeType\\":\\"S\\"},{\\"AttributeName\\":\\"name2\\",\\"AttributeType\\":\\"S\\"},{\\"AttributeName\\":\\"todoId\\",\\"AttributeType\\":\\"S\\"}]
+          Expected: [{\\"AttributeName\\":\\"differentName\\",\\"AttributeType\\":\\"S\\"},{\\"AttributeName\\":\\"name2\\",\\"AttributeType\\":\\"S\\"},{\\"AttributeName\\":\\"todoId\\",\\"AttributeType\\":\\"S\\"}]"
+        `);
+      });
+
+      test('AttributeDefinitions with different order', () => {
+        const actual: TableDescription = {
+          AttributeDefinitions: [
+            {
+              AttributeName: 'name',
+              AttributeType: 'S',
+            },
+            {
+              AttributeName: 'todoId',
+              AttributeType: 'S',
+            },
+            {
+              AttributeName: 'name2',
+              AttributeType: 'S',
+            },
+          ],
+        };
+        const expected: TableComparisonProperties = {
+          AttributeDefinitions: [
+            {
+              AttributeName: 'todoId',
+              AttributeType: 'S',
+            },
+            {
+              AttributeName: 'name',
+              AttributeType: 'S',
+            },
+            {
+              AttributeName: 'differentName',
+              AttributeType: 'S',
+            },
+          ],
+        };
+
+        expect(() => validateImportedTableProperties(getImportedTableComparisonProperties(actual), expected))
+          .toThrowErrorMatchingInlineSnapshot(`
+          "Imported table properties did not match the expected table properties.
+          AttributeDefinitions does not match the expected value.
+          Imported Value: [{\\"AttributeName\\":\\"name\\",\\"AttributeType\\":\\"S\\"},{\\"AttributeName\\":\\"name2\\",\\"AttributeType\\":\\"S\\"},{\\"AttributeName\\":\\"todoId\\",\\"AttributeType\\":\\"S\\"}]
+          Expected: [{\\"AttributeName\\":\\"differentName\\",\\"AttributeType\\":\\"S\\"},{\\"AttributeName\\":\\"name\\",\\"AttributeType\\":\\"S\\"},{\\"AttributeName\\":\\"todoId\\",\\"AttributeType\\":\\"S\\"}]"
         `);
       });
 
@@ -396,8 +590,43 @@ describe('import-table', () => {
           .toThrowErrorMatchingInlineSnapshot(`
           "Imported table properties did not match the expected table properties.
           KeySchema does not match the expected value.
-          Imported Value: [{\\"AttributeName\\":\\"todoId\\",\\"KeyType\\":\\"HASH\\"},{\\"AttributeName\\":\\"name\\",\\"KeyType\\":\\"RANGE\\"}]
-          Expected: [{\\"AttributeName\\":\\"todoId\\",\\"KeyType\\":\\"HASH\\"},{\\"AttributeName\\":\\"differentName\\",\\"KeyType\\":\\"RANGE\\"}]"
+          Imported Value: [{\\"AttributeName\\":\\"name\\",\\"KeyType\\":\\"RANGE\\"},{\\"AttributeName\\":\\"todoId\\",\\"KeyType\\":\\"HASH\\"}]
+          Expected: [{\\"AttributeName\\":\\"differentName\\",\\"KeyType\\":\\"RANGE\\"},{\\"AttributeName\\":\\"todoId\\",\\"KeyType\\":\\"HASH\\"}]"
+        `);
+      });
+
+      test('KeySchema with different order', () => {
+        const actual: TableDescription = {
+          KeySchema: [
+            {
+              AttributeName: 'name',
+              KeyType: 'RANGE',
+            },
+            {
+              AttributeName: 'todoId',
+              KeyType: 'HASH',
+            },
+          ],
+        };
+        const expected: TableComparisonProperties = {
+          KeySchema: [
+            {
+              AttributeName: 'todoId',
+              KeyType: 'HASH',
+            },
+            {
+              AttributeName: 'differentName',
+              KeyType: 'RANGE',
+            },
+          ],
+        };
+
+        expect(() => validateImportedTableProperties(getImportedTableComparisonProperties(actual), expected))
+          .toThrowErrorMatchingInlineSnapshot(`
+          "Imported table properties did not match the expected table properties.
+          KeySchema does not match the expected value.
+          Imported Value: [{\\"AttributeName\\":\\"name\\",\\"KeyType\\":\\"RANGE\\"},{\\"AttributeName\\":\\"todoId\\",\\"KeyType\\":\\"HASH\\"}]
+          Expected: [{\\"AttributeName\\":\\"differentName\\",\\"KeyType\\":\\"RANGE\\"},{\\"AttributeName\\":\\"todoId\\",\\"KeyType\\":\\"HASH\\"}]"
         `);
       });
 
@@ -452,6 +681,97 @@ describe('import-table', () => {
           GlobalSecondaryIndexes does not match the expected value.
           Imported Value: [{\\"IndexName\\":\\"byName2\\",\\"KeySchema\\":[{\\"AttributeName\\":\\"name2\\",\\"KeyType\\":\\"HASH\\"}],\\"Projection\\":{\\"ProjectionType\\":\\"ALL\\"},\\"ProvisionedThroughput\\":{\\"ReadCapacityUnits\\":5,\\"WriteCapacityUnits\\":5}}]
           Expected: [{\\"IndexName\\":\\"byName2\\",\\"KeySchema\\":[{\\"AttributeName\\":\\"name2\\",\\"KeyType\\":\\"HASH\\"}],\\"Projection\\":{\\"ProjectionType\\":\\"ALL\\"},\\"ProvisionedThroughput\\":{\\"ReadCapacityUnits\\":5,\\"WriteCapacityUnits\\":10}}]"
+        `);
+      });
+
+      test('GlobalSecondaryIndexes with different order', () => {
+        const actual: TableDescription = {
+          GlobalSecondaryIndexes: [
+            {
+              IndexName: 'byName2',
+              KeySchema: [
+                {
+                  AttributeName: 'name2',
+                  KeyType: 'HASH',
+                },
+                {
+                  AttributeName: 'name3',
+                  KeyType: 'RANGE',
+                },
+              ],
+              Projection: {
+                ProjectionType: 'ALL',
+              },
+              ProvisionedThroughput: {
+                ReadCapacityUnits: 10,
+                WriteCapacityUnits: 5,
+              },
+            },
+            {
+              IndexName: 'byName',
+              KeySchema: [
+                {
+                  AttributeName: 'name',
+                  KeyType: 'HASH',
+                },
+              ],
+              Projection: {
+                ProjectionType: 'ALL',
+              },
+              ProvisionedThroughput: {
+                ReadCapacityUnits: 5,
+                WriteCapacityUnits: 5,
+              },
+            },
+          ],
+        };
+        const expected: TableComparisonProperties = {
+          GlobalSecondaryIndexes: [
+            {
+              IndexName: 'byName',
+              KeySchema: [
+                {
+                  AttributeName: 'name',
+                  KeyType: 'HASH',
+                },
+              ],
+              Projection: {
+                ProjectionType: 'ALL',
+              },
+              ProvisionedThroughput: {
+                ReadCapacityUnits: 5,
+                WriteCapacityUnits: 5,
+              },
+            },
+            {
+              IndexName: 'byName2',
+              KeySchema: [
+                {
+                  AttributeName: 'name3',
+                  KeyType: 'RANGE',
+                },
+                {
+                  AttributeName: 'name2',
+                  KeyType: 'HASH',
+                },
+              ],
+              Projection: {
+                ProjectionType: 'ALL',
+              },
+              ProvisionedThroughput: {
+                ReadCapacityUnits: 5,
+                WriteCapacityUnits: 5,
+              },
+            },
+          ],
+        };
+
+        expect(() => validateImportedTableProperties(getImportedTableComparisonProperties(actual), expected))
+          .toThrowErrorMatchingInlineSnapshot(`
+          "Imported table properties did not match the expected table properties.
+          GlobalSecondaryIndexes does not match the expected value.
+          Imported Value: [{\\"IndexName\\":\\"byName\\",\\"KeySchema\\":[{\\"AttributeName\\":\\"name\\",\\"KeyType\\":\\"HASH\\"}],\\"Projection\\":{\\"ProjectionType\\":\\"ALL\\"},\\"ProvisionedThroughput\\":{\\"ReadCapacityUnits\\":5,\\"WriteCapacityUnits\\":5}},{\\"IndexName\\":\\"byName2\\",\\"KeySchema\\":[{\\"AttributeName\\":\\"name2\\",\\"KeyType\\":\\"HASH\\"},{\\"AttributeName\\":\\"name3\\",\\"KeyType\\":\\"RANGE\\"}],\\"Projection\\":{\\"ProjectionType\\":\\"ALL\\"},\\"ProvisionedThroughput\\":{\\"ReadCapacityUnits\\":10,\\"WriteCapacityUnits\\":5}}]
+          Expected: [{\\"IndexName\\":\\"byName\\",\\"KeySchema\\":[{\\"AttributeName\\":\\"name\\",\\"KeyType\\":\\"HASH\\"}],\\"Projection\\":{\\"ProjectionType\\":\\"ALL\\"},\\"ProvisionedThroughput\\":{\\"ReadCapacityUnits\\":5,\\"WriteCapacityUnits\\":5}},{\\"IndexName\\":\\"byName2\\",\\"KeySchema\\":[{\\"AttributeName\\":\\"name2\\",\\"KeyType\\":\\"HASH\\"},{\\"AttributeName\\":\\"name3\\",\\"KeyType\\":\\"RANGE\\"}],\\"Projection\\":{\\"ProjectionType\\":\\"ALL\\"},\\"ProvisionedThroughput\\":{\\"ReadCapacityUnits\\":5,\\"WriteCapacityUnits\\":5}}]"
         `);
       });
 

--- a/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-table-manager-lambda/import-table.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-table-manager-lambda/import-table.ts
@@ -1,5 +1,5 @@
 import isEqual from 'lodash.isequal';
-import { DynamoDB, TableDescription, CreateTableCommandInput } from '@aws-sdk/client-dynamodb';
+import { DynamoDB, TableDescription, CreateTableCommandInput, AttributeDefinition, KeySchemaElement } from '@aws-sdk/client-dynamodb';
 
 /**
  * Imports an existing DDB table.
@@ -57,12 +57,10 @@ export const validateImportedTableProperties = (
     }
   };
 
-  // remove undefined attributes from the objects
-  // lodash isEqual treats undefined as a value when comparing objects
-  // example isEqual({ a: undefined }, {}) returns false
-  const sanitizedImportedTableProperties = JSON.parse(JSON.stringify(importedTableProperties));
-  const sanitizedExpectedTableProperties = JSON.parse(JSON.stringify(expectedTableProperties));
+  const sanitizedImportedTableProperties = sanitizeTableProperties(importedTableProperties);
+  const sanitizedExpectedTableProperties = sanitizeTableProperties(expectedTableProperties);
 
+  // TODO: need to sort some properties
   assertEqual(
     'AttributeDefinitions',
     sanitizedImportedTableProperties.AttributeDefinitions,
@@ -292,4 +290,55 @@ const getDeletionProtectionEnabledForComparison = (
   importedTable: TableDescription,
 ): TableComparisonProperties['DeletionProtectionEnabled'] => {
   return importedTable.DeletionProtectionEnabled;
+};
+
+/**
+ * Remove undefined attributes from the objects.
+ * lodash isEqual treats undefined as a value when comparing objects
+ * Example: isEqual({ a: undefined }, {}) returns false
+ *
+ * Any property that is an array will need to be sorted so that the order of the elements does not affect the comparison
+ * The sorted Fields are: AttributeDefinitions, KeySchema, and GlobalSecondaryIndexes
+ *
+ * @param tableProperties table properties to sanitize
+ * @returns sanitized table properties with array properties sorted
+ */
+const sanitizeTableProperties = (tableProperties: TableComparisonProperties): TableComparisonProperties => {
+  const tablePropertiesUndefinedRemoved: TableComparisonProperties = JSON.parse(JSON.stringify(tableProperties));
+  if (tablePropertiesUndefinedRemoved.AttributeDefinitions) {
+    // The typescript type allows for fields on AttributeDefinition, KeySchemaElement, and GlobalSecondaryIndex to be undefined.
+    // But the docs state these fields as required so we can safely assume they will not be undefined
+
+    // https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_AttributeDefinition.html
+    tablePropertiesUndefinedRemoved.AttributeDefinitions.sort((a, b) =>
+      // AttributeName will never be the same
+      (a.AttributeName ?? '').localeCompare(b.AttributeName ?? ''),
+    );
+  }
+
+  // https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_KeySchemaElement.html
+  const sortKeySchema = (a: KeySchemaElement, b: KeySchemaElement): number =>
+    // AttributeName will never be the same
+    (a.AttributeName ?? '').localeCompare(b.AttributeName ?? '');
+
+  if (tablePropertiesUndefinedRemoved.KeySchema) {
+    tablePropertiesUndefinedRemoved.KeySchema.sort(sortKeySchema);
+  }
+
+  // https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_GlobalSecondaryIndex.html
+  if (tablePropertiesUndefinedRemoved.GlobalSecondaryIndexes) {
+    tablePropertiesUndefinedRemoved.GlobalSecondaryIndexes.sort((a, b) =>
+      // IndexName will never be the same
+      (a.IndexName ?? '').localeCompare(b.IndexName ?? ''),
+    );
+
+    // sort the KeySchema in each GSI
+    tablePropertiesUndefinedRemoved.GlobalSecondaryIndexes.forEach((gsi) => {
+      if (gsi.KeySchema) {
+        gsi.KeySchema.sort(sortKeySchema);
+      }
+    });
+  }
+
+  return tablePropertiesUndefinedRemoved;
 };

--- a/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-table-manager-lambda/import-table.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-table-manager-lambda/import-table.ts
@@ -303,7 +303,7 @@ const getDeletionProtectionEnabledForComparison = (
  * @param tableProperties table properties to sanitize
  * @returns sanitized table properties with array properties sorted
  */
-const sanitizeTableProperties = (tableProperties: TableComparisonProperties): TableComparisonProperties => {
+export const sanitizeTableProperties = (tableProperties: TableComparisonProperties): TableComparisonProperties => {
   const tablePropertiesUndefinedRemoved: TableComparisonProperties = JSON.parse(JSON.stringify(tableProperties));
   if (tablePropertiesUndefinedRemoved.AttributeDefinitions) {
     // The typescript type allows for fields on AttributeDefinition, KeySchemaElement, and GlobalSecondaryIndex to be undefined.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Sort table description properties before comparing. `lodash.isEqual` is order sensitive when comparing arrays. Some properties on the TableDescription are arrays and can be given in a non-deterministic order. This change ensures the comparison is correct by sorting AttributeDefinitions, KeySchema, and GlobalSecondaryIndexes properties on the imported and expected description before comparing.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

N/A

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

* Unit tests
* I didn't add E2E tests for this because it is difficult (maybe not possible) to ensure the order in E2E tests.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:9e4335c6-d3ba-4ee7-ace7-f105c7a59dd4?region=us-east-1


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
