### PR TITLE
feat: add ddb deletion protection on imported tables

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/migration/migration-validation.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/migration/migration-validation.test.ts
@@ -156,10 +156,10 @@ describe('Migration table import validation', () => {
 
         export const applyOverrides = (api: AmplifyGraphqlApi): void => {
           const todoTable = api.resources.cfnResources.additionalCfnResources['Todo'];
-          todoTable.addOverride('Properties.deletionProtectionEnabled', true);
+          todoTable.addOverride('Properties.deletionProtectionEnabled', false);
         };
       `,
-      ['DeletionProtectionEnabled does not match the expected value.\nImported Value: false\nExpected: true'],
+      ['DeletionProtectionEnabled does not match the expected value.\nImported Value: true\nExpected: false'],
     ],
   ];
   test.each(testCases)('%s', async (testCaseName, overrides, expectedErrors) => {

--- a/packages/amplify-graphql-api-construct-tests/src/commands.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/commands.ts
@@ -11,7 +11,7 @@ import {
   sleep,
   updateApiSchema,
 } from 'amplify-category-api-e2e-core';
-import { DynamoDBClient, DeleteTableCommand, ListTablesCommand } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient, DeleteTableCommand, ListTablesCommand, UpdateTableCommand } from '@aws-sdk/client-dynamodb';
 
 /**
  * Retrieve the path to the `npx` executable for interacting with the aws-cdk cli.
@@ -248,5 +248,9 @@ export const createGen1ProjectForMigration = async (
  */
 export const deleteDDBTables = async (tableNames: string[]): Promise<void> => {
   const client = new DynamoDBClient({ region: process.env.CLI_REGION || 'us-west-2' });
+  // disable deletion protection before deleting the tables
+  await Promise.allSettled(
+    tableNames.map((tableName) => client.send(new UpdateTableCommand({ TableName: tableName, DeletionProtectionEnabled: false }))),
+  );
   await Promise.allSettled(tableNames.map((tableName) => client.send(new DeleteTableCommand({ TableName: tableName }))));
 };

--- a/packages/amplify-graphql-api-construct-tests/src/commands.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/commands.ts
@@ -256,9 +256,12 @@ export const createGen1ProjectForMigration = async (
  */
 export const deleteDDBTables = async (tableNames: string[]): Promise<void> => {
   const client = new DynamoDBClient({ region: process.env.CLI_REGION || 'us-west-2' });
+  // TODO: GEN1_GEN2_MIGRATION
   // disable deletion protection before deleting the tables
+  // start block
   await Promise.allSettled(
     tableNames.map((tableName) => client.send(new UpdateTableCommand({ TableName: tableName, DeletionProtectionEnabled: false }))),
   );
+  // end block
   await Promise.allSettled(tableNames.map((tableName) => client.send(new DeleteTableCommand({ TableName: tableName }))));
 };

--- a/packages/amplify-graphql-model-transformer/src/__tests__/amplify-dynamodb-table-generator.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/amplify-dynamodb-table-generator.test.ts
@@ -72,6 +72,7 @@ describe('ModelTransformer:', () => {
     expect(authorTable.DeletionPolicy).toBe('Retain');
     expect(authorTable.Properties.isImported).toBe(true);
     expect(authorTable.Properties.tableName).toBe('Author-myApiId-myEnv');
+    expect(authorTable.Properties.deletionProtectionEnabled).toBe(true);
     validateModelSchema(parse(out.schema));
 
     // Outputs should contain a reference to the Arn to the entry point (onEventHandler)

--- a/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-dynamo-model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-dynamo-model-resource-generator.ts
@@ -204,6 +204,7 @@ export class AmplifyDynamoModelResourceGenerator extends DynamoModelResourceGene
       stream: StreamViewType.NEW_AND_OLD_IMAGES,
       encryption: TableEncryption.DEFAULT,
       removalPolicy,
+      deletionProtection: isTableImported,
       ...(context.isProjectUsingDataStore() ? { timeToLiveAttribute: '_ttl' } : undefined),
       ...(isTableImported ? { isImported: true } : undefined),
     });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Add ddb deletion protection on imported tables

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

See above.

The deletionProtection param does not seem to be exposed for non-imported tables. This PR does not change that.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

Add unit tests.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:808dd391-97c5-4d15-987c-006362aa5ada?region=us-east-1


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
