### PR TITLE
feat: add e2e tests for validate directive

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/validate-transformer/app.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/validate-transformer/app.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { AmplifyGraphqlApi, AmplifyGraphqlDefinition } from '@aws-amplify/graphql-api-construct';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const packageJson = require('../package.json');
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, packageJson.name.replace(/_/g, '-'));
+
+new AmplifyGraphqlApi(stack, 'GraphqlApi', {
+  definition: AmplifyGraphqlDefinition.fromString(/* GraphQL */ `
+    type User @model @auth(rules: [{ allow: public }]) {
+      id: ID!
+      score: Float @validate(type: gt, value: "0") @validate(type: lt, value: "100")
+      age: Int @validate(type: gte, value: "18") @validate(type: lte, value: "65")
+      username: String @validate(type: minLength, value: "3") @validate(type: maxLength, value: "10")
+      prefix: String @validate(type: startsWith, value: "user_")
+      filename: String @validate(type: endsWith, value: ".txt")
+      email: String @validate(type: matches, value: "^[A-Za-z0-9+_.-]+@(.+)$", errorMessage: "Invalid email format")
+    }
+
+    type Product @model @auth(rules: [{ allow: public }]) {
+      id: ID!
+      name: String
+        @validate(type: minLength, value: "5")
+        @validate(type: maxLength, value: "50")
+        @validate(type: matches, value: "^[a-zA-Z0-9\\\\s-]+$", errorMessage: "Only alphanumeric characters, spaces, and hyphens allowed")
+
+      price: Float @validate(type: gt, value: "0") @validate(type: lt, value: "10000")
+
+      stockQuantity: Int @validate(type: gte, value: "0") @validate(type: lte, value: "1000")
+
+      sku: String
+        @validate(type: startsWith, value: "PRD-")
+        @validate(type: matches, value: "^PRD-[A-Z0-9]{8}$", errorMessage: "SKU must be PRD- followed by 8 alphanumeric characters")
+        @validate(type: minLength, value: "12")
+
+      description: String
+        @validate(type: minLength, value: "20")
+        @validate(type: maxLength, value: "500")
+        @validate(type: matches, value: "^[\\\\w\\\\s.,!?-]+$", errorMessage: "Invalid characters in description")
+
+      category: String
+        @validate(type: minLength, value: "4")
+        @validate(type: matches, value: "^[A-Z][a-z]+$", errorMessage: "Category must be capitalized")
+    }
+  `),
+  authorizationModes: { apiKeyConfig: { expires: cdk.Duration.days(7) } },
+});

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/validate-transformer/__templates__/README.md
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/validate-transformer/__templates__/README.md
@@ -1,6 +1,6 @@
 # Test Templates Directory
 
-This directory is used by `validate-transformer.test.ts` to store temporary VTL templates and context files during test execution.
+This directory is used by `validate-transformer-evaluate-mapping.test.ts` to store temporary VTL templates and context files during test execution.
 
 ## Directory Structure
 

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/validate-transformer/validate-transformer-e2e.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/validate-transformer/validate-transformer-e2e.test.ts
@@ -1,0 +1,475 @@
+import * as path from 'path';
+import { createNewProjectDir, deleteProjectDir } from 'amplify-category-api-e2e-core';
+import { initCDKProject, cdkDeploy, cdkDestroy } from '../../commands';
+import { DURATION_30_MINUTES } from '../../utils/duration-constants';
+import { E2ETestCase, createE2ETestCases, runE2eTest } from '../../utils/validate-transformer-helper';
+
+jest.setTimeout(DURATION_30_MINUTES);
+
+describe('Validate Transformer', () => {
+  let projRoot: string;
+  let apiEndpoint: string;
+  let apiKey: string;
+
+  beforeAll(async () => {
+    projRoot = await createNewProjectDir('validate-transformer-e2e');
+    const templatePath = path.resolve(path.join(__dirname, '..', 'backends', 'validate-transformer'));
+    const name = await initCDKProject(projRoot, templatePath);
+    const outputs = await cdkDeploy(projRoot, '--all');
+
+    apiEndpoint = outputs[name].awsAppsyncApiEndpoint;
+    apiKey = outputs[name].awsAppsyncApiKey;
+  });
+
+  afterAll(async () => {
+    try {
+      await cdkDestroy(projRoot, '--all');
+    } catch (_) {
+      /* No-op */
+    }
+    deleteProjectDir(projRoot);
+  });
+
+  // User test cases
+  const userTypeValidCreateTestCases: E2ETestCase[] = [
+    {
+      description: 'should create user with valid score',
+      input: { score: 75 },
+    },
+    {
+      description: 'should create user with valid age',
+      input: { age: 30 },
+    },
+    {
+      description: 'should create user with valid username',
+      input: { username: 'validUser' },
+    },
+    {
+      description: 'should create user with valid email',
+      input: { email: 'user_test@example.com' },
+    },
+    {
+      description: 'should create user with valid filename',
+      input: { filename: 'document.txt' },
+    },
+    {
+      description: 'should create user with valid prefix',
+      input: { prefix: 'user_test' },
+    },
+    {
+      // This test case creates a user with id 'test-id' for testing update operation below
+      description: 'should create user with all valid fields',
+      input: {
+        id: 'test-id',
+        score: 85,
+        age: 25,
+        username: 'testUser',
+        email: 'user_test@example.com',
+        filename: 'report.txt',
+        prefix: 'user_john',
+      },
+    },
+  ];
+
+  const userTypeValidUpdateTestCases: E2ETestCase[] = [
+    {
+      description: 'should update user with valid score',
+      input: { id: 'test-id', score: 80 },
+    },
+    {
+      description: 'should update user with valid age',
+      input: { id: 'test-id', age: 35 },
+    },
+    {
+      description: 'should update user with valid username',
+      input: { id: 'test-id', username: 'newUser' },
+    },
+    {
+      description: 'should update user with valid email',
+      input: { id: 'test-id', email: 'user_new@example.com' },
+    },
+    {
+      description: 'should update user with valid filename',
+      input: { id: 'test-id', filename: 'updated.txt' },
+    },
+    {
+      description: 'should update user with valid prefix',
+      input: { id: 'test-id', prefix: 'user_new' },
+    },
+    {
+      description: 'should update user with all valid fields',
+      input: {
+        id: 'test-id',
+        score: 90,
+        age: 30,
+        username: 'updatedUsr',
+        email: 'user_updated@example.com',
+        filename: 'updated.txt',
+        prefix: 'user_updated',
+      },
+    },
+  ];
+
+  const userTypeInvalidCreateTestCases: E2ETestCase[] = [
+    {
+      description: 'should fail with score above maximum',
+      input: { score: 150 },
+    },
+    {
+      description: 'should fail with score below minimum',
+      input: { score: 0 },
+    },
+    {
+      description: 'should fail with age below minimum',
+      input: { age: 17 },
+    },
+    {
+      description: 'should fail with age above maximum',
+      input: { age: 66 },
+    },
+    {
+      description: 'should fail with username too short',
+      input: { username: 'ab' },
+    },
+    {
+      description: 'should fail with username too long',
+      input: { username: 'thisusernameiswaytoolong' },
+    },
+    {
+      description: 'should fail with invalid email format',
+      input: { email: 'invalid-email' },
+    },
+    {
+      description: 'should fail with filename not ending in .txt',
+      input: { filename: 'document.pdf' },
+    },
+    {
+      description: 'should fail with prefix not starting with user_',
+      input: { prefix: 'test_user' },
+    },
+    {
+      description: 'should fail at the first invalid field when there are multiple invalid fields',
+      input: {
+        score: 150,
+        age: 15,
+        username: 'a',
+        email: 'invalid',
+        filename: 'doc.pdf',
+        prefix: 'invalid',
+      },
+    },
+  ];
+
+  const userTypeInvalidUpdateTestCases: E2ETestCase[] = [
+    {
+      description: 'should fail to update user with score above maximum',
+      input: { id: 'test-id', score: 150 },
+    },
+    {
+      description: 'should fail to update user with age below minimum',
+      input: { id: 'test-id', age: 15 },
+    },
+    {
+      description: 'should fail to update user with username too short',
+      input: { id: 'test-id', username: 'ab' },
+    },
+    {
+      description: 'should fail to update user with invalid email format',
+      input: { id: 'test-id', email: 'invalid-email' },
+    },
+    {
+      description: 'should fail to update user with filename not ending in .txt',
+      input: { id: 'test-id', filename: 'doc.pdf' },
+    },
+    {
+      description: 'should fail to update user with prefix not starting with user_',
+      input: { id: 'test-id', prefix: 'invalid_prefix' },
+    },
+    {
+      description: 'should fail to update user with multiple invalid fields',
+      input: {
+        id: 'test-id',
+        score: 150,
+        age: 15,
+        username: 'a',
+        email: 'invalid',
+        filename: 'doc.pdf',
+        prefix: 'invalid',
+      },
+    },
+  ];
+
+  // Product test cases
+  const productTypeValidCreateTestCases: E2ETestCase[] = [
+    {
+      description: 'should create product with valid name',
+      input: { name: 'Gaming Laptop' },
+    },
+    {
+      description: 'should create product with valid price',
+      input: { name: 'Basic Product', price: 99.99 },
+    },
+    {
+      description: 'should create product with valid stock quantity',
+      input: { name: 'Basic Product', stockQuantity: 500 },
+    },
+    {
+      description: 'should create product with valid SKU',
+      input: { name: 'Basic Product', sku: 'PRD-12345678' },
+    },
+    {
+      description: 'should create product with valid description',
+      input: {
+        name: 'Basic Product',
+        description: 'This is a very detailed product description with proper punctuation!',
+      },
+    },
+    {
+      description: 'should create product with valid category',
+      input: { name: 'Basic Product', category: 'Electronics' },
+    },
+    {
+      // This test case creates a product with id 'test-id' for testing update operation below
+      description: 'should create product with all valid fields',
+      input: {
+        id: 'test-id',
+        name: 'Premium Gaming Laptop',
+        price: 1299.99,
+        stockQuantity: 50,
+        sku: 'PRD-ABCD1234',
+        description: 'High-performance gaming laptop with advanced cooling system. Perfect for modern games!',
+        category: 'Electronics',
+      },
+    },
+  ];
+
+  const productTypeValidUpdateTestCases: E2ETestCase[] = [
+    {
+      description: 'should update product with valid name',
+      input: { id: 'test-id', name: 'Updated Laptop' },
+    },
+    {
+      description: 'should update product with valid price',
+      input: { id: 'test-id', name: 'Basic Product', price: 199.99 },
+    },
+    {
+      description: 'should update product with valid stock quantity',
+      input: { id: 'test-id', name: 'Basic Product', stockQuantity: 750 },
+    },
+    {
+      description: 'should update product with valid SKU',
+      input: { id: 'test-id', name: 'Basic Product', sku: 'PRD-87654321' },
+    },
+    {
+      description: 'should update product with valid description',
+      input: {
+        id: 'test-id',
+        name: 'Basic Product',
+        description: 'Updated product description with new features and improvements!',
+      },
+    },
+    {
+      description: 'should update product with valid category',
+      input: { id: 'test-id', name: 'Basic Product', category: 'Computers' },
+    },
+    {
+      description: 'should update product with all valid fields',
+      input: {
+        id: 'test-id',
+        name: 'Updated Gaming Laptop',
+        price: 1499.99,
+        stockQuantity: 100,
+        sku: 'PRD-XYZ98765',
+        description: 'Latest model with upgraded specs and enhanced cooling system. Perfect for modern gaming!',
+        category: 'Gaming',
+      },
+    },
+  ];
+
+  const productTypeInvalidCreateTestCases: E2ETestCase[] = [
+    {
+      description: 'should fail to create product with name too short',
+      input: { name: 'Test' },
+    },
+    {
+      description: 'should fail to create product with name too long',
+      input: { name: 'This product name is way too long and exceeds the maximum length of fifty characters' },
+    },
+    {
+      description: 'should fail to create product with invalid name characters',
+      input: { name: 'Product@#$%' },
+    },
+    {
+      description: 'should fail to create product with negative price',
+      input: { name: 'Basic Product', price: -10 },
+    },
+    {
+      description: 'should fail to create product with price exceeding maximum',
+      input: { name: 'Basic Product', price: 15000 },
+    },
+    {
+      description: 'should fail to create product with negative stock quantity',
+      input: { name: 'Basic Product', stockQuantity: -1 },
+    },
+    {
+      description: 'should fail to create product with stock quantity exceeding maximum',
+      input: { name: 'Basic Product', stockQuantity: 1500 },
+    },
+    {
+      description: 'should fail to create product with invalid SKU format',
+      input: { name: 'Basic Product', sku: 'INVALID-SKU' },
+    },
+    {
+      description: 'should fail to create product with SKU too short',
+      input: { name: 'Basic Product', sku: 'PRD-123' },
+    },
+    {
+      description: 'should fail to create product with description too short',
+      input: { name: 'Basic Product', description: 'Too short desc' },
+    },
+    {
+      description: 'should fail to create product with description too long',
+      input: {
+        name: 'Basic Product',
+        description: 'A'.repeat(501),
+      },
+    },
+    {
+      description: 'should fail to create product with invalid description characters',
+      input: {
+        name: 'Basic Product',
+        description: 'Contains invalid characters like @ and $',
+      },
+    },
+    {
+      description: 'should fail to create product with invalid category format',
+      input: { name: 'Basic Product', category: 'electronics' },
+    },
+    {
+      description: 'should fail to create product with category too short',
+      input: { name: 'Basic Product', category: 'Cat' },
+    },
+    {
+      description: 'should fail to create product with multiple invalid fields',
+      input: {
+        name: 'A',
+        price: -1,
+        stockQuantity: -1,
+        sku: 'INVALID',
+        description: 'Short',
+        category: 'invalid',
+      },
+    },
+  ];
+
+  const productTypeInvalidUpdateTestCases: E2ETestCase[] = [
+    {
+      description: 'should fail to update product with name too short',
+      input: { id: 'test-id', name: 'Test' },
+    },
+    {
+      description: 'should fail to update product with name too long',
+      input: { id: 'test-id', name: 'This updated product name is way too long and exceeds the maximum length of fifty characters' },
+    },
+    {
+      description: 'should fail to update product with negative price',
+      input: { id: 'test-id', name: 'Basic Product', price: -50 },
+    },
+    {
+      description: 'should fail to update product with stock quantity exceeding maximum',
+      input: { id: 'test-id', name: 'Basic Product', stockQuantity: 2000 },
+    },
+    {
+      description: 'should fail to update product with invalid SKU format',
+      input: { id: 'test-id', name: 'Basic Product', sku: 'INVALID-SKU' },
+    },
+    {
+      description: 'should fail to update product with description too short',
+      input: { id: 'test-id', name: 'Basic Product', description: 'Too short update' },
+    },
+    {
+      description: 'should fail to update product with invalid category format',
+      input: { id: 'test-id', name: 'Basic Product', category: 'invalid category' },
+    },
+    {
+      description: 'should fail to update product with multiple invalid fields',
+      input: {
+        id: 'test-id',
+        name: 'A',
+        price: -1,
+        stockQuantity: 2000,
+        sku: 'INVALID',
+        description: 'Short',
+        category: 'invalid',
+      },
+    },
+  ];
+
+  describe('User Type Tests', () => {
+    describe('Valid Cases', () => {
+      describe('Create Operations', () => {
+        const e2eTestCases = createE2ETestCases(userTypeValidCreateTestCases, true);
+        test.each(e2eTestCases)('$description', async (testCase) => {
+          await runE2eTest(apiEndpoint, apiKey, testCase, 'User', 'Create');
+        });
+      });
+
+      describe('Update Operations', () => {
+        const e2eTestCases = createE2ETestCases(userTypeValidUpdateTestCases, true);
+        test.each(e2eTestCases)('$description', async (testCase) => {
+          await runE2eTest(apiEndpoint, apiKey, testCase, 'User', 'Update');
+        });
+      });
+    });
+
+    describe('Invalid Cases', () => {
+      describe('Create Operations', () => {
+        const e2eTestCases = createE2ETestCases(userTypeInvalidCreateTestCases, false);
+        test.each(e2eTestCases)('$description', async (testCase) => {
+          await runE2eTest(apiEndpoint, apiKey, testCase, 'User', 'Create');
+        });
+      });
+
+      describe('Update Operations', () => {
+        const e2eTestCases = createE2ETestCases(userTypeInvalidUpdateTestCases, false);
+        test.each(e2eTestCases)('$description', async (testCase) => {
+          await runE2eTest(apiEndpoint, apiKey, testCase, 'User', 'Update');
+        });
+      });
+    });
+  });
+
+  describe('Product Type Tests', () => {
+    describe('Valid Cases', () => {
+      describe('Create Operations', () => {
+        const e2eTestCases = createE2ETestCases(productTypeValidCreateTestCases, true);
+        test.each(e2eTestCases)('$description', async (testCase) => {
+          await runE2eTest(apiEndpoint, apiKey, testCase, 'Product', 'Create');
+        });
+      });
+
+      describe('Update Operations', () => {
+        const e2eTestCases = createE2ETestCases(productTypeValidUpdateTestCases, true);
+        test.each(e2eTestCases)('$description', async (testCase) => {
+          await runE2eTest(apiEndpoint, apiKey, testCase, 'Product', 'Update');
+        });
+      });
+    });
+
+    describe('Invalid Cases', () => {
+      describe('Create Operations', () => {
+        const e2eTestCases = createE2ETestCases(productTypeInvalidCreateTestCases, false);
+        test.each(e2eTestCases)('$description', async (testCase) => {
+          await runE2eTest(apiEndpoint, apiKey, testCase, 'Product', 'Create');
+        });
+      });
+
+      describe('Update Operations', () => {
+        const e2eTestCases = createE2ETestCases(productTypeInvalidUpdateTestCases, false);
+        test.each(e2eTestCases)('$description', async (testCase) => {
+          await runE2eTest(apiEndpoint, apiKey, testCase, 'Product', 'Update');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
#### Description of changes

This PR adds e2e tests that send CREATE/UPDATE mutation queries to verify the validation logic. 
- Added a CDK app with USER and PRODUCT model types with a lot of validate directives
- Added some e2e helpers and e2e tests with the following structure:
```
   User Type Tests
   ├── Valid Cases
   │   ├── Create Operations
   │   └── Update Operations
   └── Invalid Cases
       ├── Create Operations
       └── Update Operations

   Product Type Tests
   ├── Valid Cases
   │   ├── Create Operations
   │   └── Update Operations
   └── Invalid Cases
       ├── Create Operations
       └── Update Operations
```

Small changes:
- Updated [`__templates__/README.md`](https://github.com/aws-amplify/amplify-category-api/pull/3165/files#diff-5afe0b49a420bd18cd39610a1cb38a62b0d62baacab5669efd31f5d5b207fafe)

#### Description of how you validated changes

- [e2e (`validate_transformer_evaluate_mapping` and `validate_transformer_e2e`)](https://tiny.amazon.com/1jupyd6o1/IsenLink)

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
