### PR TITLE
chore: update github workflow to use `.` instead of `source`

### DIFF
--- a/.github/workflows/run-pr-e2e.yaml
+++ b/.github/workflows/run-pr-e2e.yaml
@@ -11,5 +11,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: cloud-e2e
+        shell: bash
         run: |
           yarn cloud-e2e

--- a/.github/workflows/run-pr-e2e.yaml
+++ b/.github/workflows/run-pr-e2e.yaml
@@ -12,4 +12,4 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: cloud-e2e
         run: |
-          yarn cloud-e2e
+          . scripts/cloud-utils.sh && cloudE2E

--- a/.github/workflows/run-pr-e2e.yaml
+++ b/.github/workflows/run-pr-e2e.yaml
@@ -12,4 +12,4 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: cloud-e2e
         run: |
-          . scripts/cloud-utils.sh && cloudE2E
+          yarn cloud-e2e

--- a/.github/workflows/run-pr-e2e.yaml
+++ b/.github/workflows/run-pr-e2e.yaml
@@ -1,5 +1,6 @@
 name: run-pr-e2e
 on:
+  workflow_dispatch:
   pull_request:
     types: [labeled]
 


### PR DESCRIPTION
#### Description of changes

This PR fixes the consistent failure of `run-pr-e2e` GitHub action by specifying `bash` shell. 

#### Description of how you validated changes

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
