### PR TITLE
fix: use aws owned key as default for ddb sse

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/amplify-table-1.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/amplify-table-1.test.ts
@@ -34,6 +34,8 @@ describe('CDK amplify table 1', () => {
     expect(table).toBeDefined();
     expect(table.Table.BillingModeSummary.BillingMode).toBe('PAY_PER_REQUEST');
     expect(table.Table.GlobalSecondaryIndexes[0].IndexName).toBe('byName');
+    // Important: When SSE is undefined or set to false,
+    // it doesn't mean SSE is disabled, it means that the table is using AWS owned key for SSE.
     expect(table.Table.SSEDescription).toBeUndefined();
     expect(table.Table.StreamSpecification.StreamViewType).toBe('NEW_AND_OLD_IMAGES');
 

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/amplify-table-1.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/amplify-table-1.test.ts
@@ -34,7 +34,7 @@ describe('CDK amplify table 1', () => {
     expect(table).toBeDefined();
     expect(table.Table.BillingModeSummary.BillingMode).toBe('PAY_PER_REQUEST');
     expect(table.Table.GlobalSecondaryIndexes[0].IndexName).toBe('byName');
-    expect(table.Table.SSEDescription.Status).toBe('ENABLED');
+    expect(table.Table.SSEDescription).toBeUndefined();
     expect(table.Table.StreamSpecification.StreamViewType).toBe('NEW_AND_OLD_IMAGES');
 
     // Verify the tags on the table
@@ -56,7 +56,7 @@ describe('CDK amplify table 1', () => {
     expect(updatedTable).toBeDefined();
     expect(updatedTable.Table.BillingModeSummary.BillingMode).toBe('PROVISIONED');
     expect(updatedTable.Table.GlobalSecondaryIndexes[0].IndexName).toBe('byName2');
-    expect(updatedTable.Table.SSEDescription).toBeUndefined();
+    expect(updatedTable.Table.SSEDescription.Status).toBe('ENABLED');
     expect(updatedTable.Table.StreamSpecification.StreamViewType).toBe('KEYS_ONLY');
 
     // Verify the tags on the table after update

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/amplify-table/simple-todo/updateIndex/app.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/amplify-table/simple-todo/updateIndex/app.ts
@@ -49,7 +49,7 @@ todoTable.setGlobalSecondaryIndexProvisionedThroughput('byName2', {
   writeCapacityUnits: 4,
 });
 todoTable.pointInTimeRecoveryEnabled = true;
-todoTable.sseSpecification = { sseEnabled: false };
+todoTable.sseSpecification = { sseEnabled: true };
 todoTable.streamSpecification = { streamViewType: StreamViewType.KEYS_ONLY };
 
 Tags.of(stack).add('created-by', 'amplify-updated');

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/migration/migration-validation.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/migration/migration-validation.test.ts
@@ -145,7 +145,17 @@ describe('Migration table import validation', () => {
     ],
     [
       'sseDescription',
-      '',
+      `
+        import { AmplifyGraphqlApi } from '@aws-amplify/graphql-api-construct';
+        import { BillingMode } from 'aws-cdk-lib/aws-dynamodb';
+
+        export const applyOverrides = (api: AmplifyGraphqlApi): void => {
+          const todoTable = api.resources.cfnResources.additionalCfnResources['Todo'];
+          todoTable.addOverride('Properties.sseSpecification', {
+            sseEnabled: true
+          });
+        };
+      `,
       ['SSEDescription does not match the expected value.\nImported Value: undefined\nExpected: {"SSEType":"KMS","Status":"ENABLED"}'],
     ],
     [

--- a/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-dynamo-model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-dynamo-model-resource-generator.ts
@@ -173,14 +173,11 @@ export class AmplifyDynamoModelResourceGenerator extends DynamoModelResourceGene
     const tableName = isTableImported ? strategy.tableName : context.resourceHelper.generateTableName(modelName);
 
     // Add parameters.
-    const { readIops, writeIops, billingMode, pointInTimeRecovery, enableSSE } = this.createDynamoDBParameters(scope, true);
+    const { readIops, writeIops, billingMode, pointInTimeRecovery } = this.createDynamoDBParameters(scope, true);
 
     // Add conditions.
     new cdk.CfnCondition(scope, ResourceConstants.CONDITIONS.HasEnvironmentParameter, {
       expression: cdk.Fn.conditionNot(cdk.Fn.conditionEquals(context.synthParameters.amplifyEnvironmentName, ResourceConstants.NONE)),
-    });
-    const useSSE = new cdk.CfnCondition(scope, ResourceConstants.CONDITIONS.ShouldUseServerSideEncryption, {
-      expression: cdk.Fn.conditionEquals(enableSSE, 'true'),
     });
     const usePayPerRequestBilling = new cdk.CfnCondition(scope, ResourceConstants.CONDITIONS.ShouldUsePayPerRequestBilling, {
       expression: cdk.Fn.conditionEquals(billingMode, 'PAY_PER_REQUEST'),
@@ -231,9 +228,6 @@ export class AmplifyDynamoModelResourceGenerator extends DynamoModelResourceGene
       'billingMode',
       cdk.Fn.conditionIf(usePayPerRequestBilling.logicalId, 'PAY_PER_REQUEST', cdk.Fn.ref('AWS::NoValue')).toString(),
     );
-    cfnTable.addPropertyOverride('sseSpecification', {
-      sseEnabled: cdk.Fn.conditionIf(useSSE.logicalId, true, false),
-    });
 
     const streamArnOutputId = `GetAtt${ModelResourceIDs.ModelTableStreamArn(def!.name.value)}`;
     if (table.tableStreamArn) {


### PR DESCRIPTION
#### Description of changes

Change the DynamoDB tables SSE config to use the AWS owned key instead of AWS managed key by default.

**Reason:** AWS managed keys incur additional charges and it is not the best option to be the default.

> **Note:** When SSE is undefined, it doesn't mean SSE is disabled, it means DynamoDB will use AWS owned key.

##### CDK / CloudFormation Parameters Changed

NA

#### Issue #, if available
NA

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
