### PR TITLE
fix: typo on enableGen2Migration

### DIFF
--- a/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v1.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/transform-graphql-schema-v1.ts
@@ -373,7 +373,7 @@ export async function transformGraphQLSchemaV1(context, options) {
   const allowDestructiveUpdates = context?.input?.options?.[DESTRUCTIVE_UPDATES_FLAG] || context?.input?.options?.force;
   const sanityCheckRulesList = getSanityCheckRules(isNewAppSyncAPI, ff, allowDestructiveUpdates);
 
-  if (ff.getBoolean('enableGen2Migrations')) {
+  if (ff.getBoolean('enableGen2Migration')) {
     throw new Error('V1 transformer is not supported for Amplify Gen 2 migrations. Migrate to V2 transformer first.');
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

There is a typo on one occurrence of `enableGen2Migration` feature flag with an extra `s` on the end causing canaries to fail.

```
Flag 'enablegen2migrations' within 'graphqltransformer' is not registered in feature provider
```

There is no production impact currently because the package has not been updated in the CLI yet.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
