### PR TITLE
chore: remove node modules before loading cache in shared scripts

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -43,6 +43,7 @@ function storeCacheForBuildJob {
 }
 function loadCacheFromBuildJob {
   # download [repo, .cache] from s3
+  rm -rf node_modules
   loadCache repo $CODEBUILD_SRC_DIR
   loadCache .cache $HOME/.cache
 }


### PR DESCRIPTION
#### Description of changes
- `Create-api-category-api canary` fails as it is not able to access `node_modules` from `S3` cache folder
- adding `rm -rf node_modules` to `loadCacheFromBuildJob` to fix the issue

#### Description of how you validated changes
- Validated changes on Code Build [test run](https://594813022831-qxxvc3uq.us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-createapi-canary-workflow/batch/amplify-category-api-createapi-canary-workflow%3A5ddb2a32-b9e7-421c-ac3a-38f0c75b40f8?region=us-east-1)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] E2E test run linked

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
