### PR TITLE
feat: add grantStreamRead to amplify managed table

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/__tests__/amplify-dynamodb-table-generator.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/amplify-dynamodb-table-generator.test.ts
@@ -156,8 +156,7 @@ describe('ModelTransformer:', () => {
     type Post @model @searchable {
       id: ID!
       title: String!
-    }
-  `;
+    }`;
 
     const out = testTransform({
       schema: validSchema,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Add grantStreamRead to amplify managed table. This allows searchable to be used on Amplify managed tables for the purpose of migrations. The function does the same thing as the one on the Table construct: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_dynamodb.Table.html#grantwbrstreamwbrreadgrantee

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

* Unit tests
* Manual tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
