### PR TITLE
Added cognito group parsing

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/group-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/group-auth.test.ts.snap
@@ -1,5 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Group field as part of secondary index correct generation of auth rules using @hasMany directive linking parent to child where GSI is also auth groupField 1`] = `
+"## [Start] Authorization Steps. **
+$util.qr($ctx.stash.put(\\"hasAuth\\", true))
+#set( $isAuthorized = false )
+#if( $util.authType() == \\"User Pool Authorization\\" )
+  #if( !$isAuthorized )
+    #set( $primaryRole0 = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), null) )
+    #if( !$util.isNull($primaryRole0) )
+
+      #set( $ownerClaimsList0 = [] )
+      #if( $util.isString($primaryRole0) )
+        #if( $util.isList($util.parseJson($primaryRole0)) )
+          #set( $ownerClaimsList0 = $util.parseJson($primaryRole0) )
+        #else
+          #set( $ownerClaimsList0 = [$primaryRole0] )
+        #end
+      #else
+        #set( $ownerClaimsList0 = $primaryRole0 )
+      #end
+      #if( (!$util.isNull($ctx.source.id)) && (($ctx.source.id == $primaryRole0) || $ownerClaimsList0.contains($ctx.source.id)) )
+        #set( $isAuthorized = true )
+        $util.qr($ctx.stash.put(\\"authFilter\\", null))
+      #else
+        #if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) )
+          $util.qr($ctx.stash.connectionAttributes.put(\\"id\\", $primaryRole0))
+          #set( $isAuthorized = true )
+        #end
+      #end
+    #end
+  #end
+#end
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) )
+$util.unauthorized()
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Authorization Steps. **"
+`;
+
 exports[`Group field as part of secondary index group field as GSI field 1`] = `
 "## [Start] Authorization Steps. **
 $util.qr($ctx.stash.put(\\"hasAuth\\", true))

--- a/packages/amplify-graphql-auth-transformer/src/vtl-generator/ddb/resolvers/query.ts
+++ b/packages/amplify-graphql-auth-transformer/src/vtl-generator/ddb/resolvers/query.ts
@@ -96,6 +96,15 @@ const generateAuthOnRelationalModelQueryExpression = (
             generateOwnerMultiClaimExpression(role.claim!, `primaryRole${idx}`),
             generateOwnerClaimListExpression(role.claim!, `ownerClaimsList${idx}`),
             ifElse(
+              methodCall(ref('util.isString'), ref(`primaryRole${idx}`)),
+              ifElse(
+                methodCall(ref('util.isList'), methodCall(ref('util.parseJson'), ref(`primaryRole${idx}`))),
+                set(ref(`ownerClaimsList${idx}`), methodCall(ref('util.parseJson'), ref(`primaryRole${idx}`))),
+                set(ref(`ownerClaimsList${idx}`), list([ref(`primaryRole${idx}`)])),
+              ),
+              set(ref(`ownerClaimsList${idx}`), ref(`primaryRole${idx}`)),
+            ),
+            ifElse(
               and([
                 parens(not(ref(`util.isNull($ctx.${claim}.${field})`))),
                 parens(


### PR DESCRIPTION
#### Description of changes

- When resolving a child model from a parent model using the `@auth` directive to specify a dynamic group where the `groupsField` referenced is the same field as the `@index` directive being used by the parent model's `@hasMany` directive, an error occurs because the VTL template does not correctly parse the information from the context `indentity.claims.cognito:groups`
- This commit adds correct parsing to the VTL generated in this circumstance
- No linting fixes have been applied to the edited `query` file because I did not wish to pollute the PR with other changes

##### CDK / CloudFormation Parameters Changed

- None

#### Issue #, if available

- Potentially #110 

#### Description of how you validated changes

- A test has been added to check the content of the VTL auth file generated
- This change has been tested manually within an existing production project that I manage and has fixed an issue I was having with the authorisation.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
