### PR TITLE
fix: remove aws_iam directive incorrectly added to interfaces

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/iam-custom-operations.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/iam-custom-operations.test.ts
@@ -514,6 +514,45 @@ describe('Custom operations have @aws_iam directives when enableIamAuthorization
       expect(out.schema).toMatch(/type EventInvocationResponse.*@aws_iam/);
     });
 
+    test('Does not add @aws_iam to interfaces', () => {
+      const strategy = makeStrategy(strategyType);
+      const schema = /* GraphQL */ `
+        interface FooInterface {
+          id: ID!
+        }
+        type Foo {
+          description: String
+        }
+        type EventInvocationResponse @aws_api_key {
+          success: Boolean!
+        }
+        type Query {
+          getFooCustom: Foo
+        }
+        type Mutation {
+          updateFooCustom: Foo
+          doSomethingAsync(body: String!): EventInvocationResponse
+            @function(name: "FnDoSomethingAsync", invocationType: Event)
+            @auth(rules: [{ allow: public, provider: apiKey }])
+        }
+        type Subscription {
+          onUpdateFooCustom: Foo @aws_subscribe(mutations: ["updateFooCustom"])
+        }
+      `;
+
+      const out = testTransform({
+        schema,
+        dataSourceStrategies: constructDataSourceStrategies(schema, strategy),
+        authConfig: makeAuthConfig(),
+        synthParameters: makeSynthParameters(),
+        transformers: makeTransformers(),
+        sqlDirectiveDataSourceStrategies: makeSqlDirectiveDataSourceStrategies(schema, strategy),
+      });
+
+      // Also expect the custom type referenced by the custom operation to be authorized
+      expect(out.schema).not.toMatch(/interface FooInterface.*@aws_iam/);
+    });
+
     test('Does not add duplicate @aws_iam directive to custom type if already present', () => {
       const strategy = makeStrategy(strategyType);
       const schema = /* GraphQL */ `

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -394,10 +394,15 @@ export class AuthTransformer extends TransformerAuthBase implements TransformerA
       return !type.directives?.some((dir) => dir.name.value === 'model');
     };
 
+    const isNotInterface = (type: TypeDefinitionNode): boolean => {
+      return type.kind !== Kind.INTERFACE_TYPE_DEFINITION;
+    };
+
     ctx.inputDocument.definitions
       .filter(isObjectTypeDefinitionNode)
       .filter(isNonModelType)
       .filter(needsAwsIamDirective)
+      .filter(isNotInterface)
       .forEach((def) => extendTypeWithDirectives(ctx, def.name.value, [makeDirective('aws_iam', [])]));
   };
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
