### PR TITLE
chore: refresh creds in some long running e2e tests

### DIFF
--- a/packages/amplify-e2e-core/src/utils/credentials-rotator.ts
+++ b/packages/amplify-e2e-core/src/utils/credentials-rotator.ts
@@ -50,7 +50,9 @@ let isRotationBackgroundTaskAlreadyScheduled = false;
  * No-op if a background task has already been scheduled.
  */
 export const tryScheduleCredentialRefresh = () => {
-  if (!process.env.CI || !process.env.TEST_ACCOUNT_ROLE || process.env.CHILD_ACCOUNT_ROLE || isRotationBackgroundTaskAlreadyScheduled) {
+  console.log('Scheduling credentials refresh');
+  console.dir(process.env);
+  if (!process.env.CI || !(process.env.TEST_ACCOUNT_ROLE || process.env.CHILD_ACCOUNT_ROLE) || isRotationBackgroundTaskAlreadyScheduled) {
     return;
   }
 

--- a/packages/amplify-e2e-core/src/utils/credentials-rotator.ts
+++ b/packages/amplify-e2e-core/src/utils/credentials-rotator.ts
@@ -34,7 +34,7 @@ const refreshCredentials = async (roleArn: string, useCurrentCreds: boolean = fa
 };
 
 /**
- * Refresh the parent account
+ * Refresh the parent account. If child account is available, refresh that as well.
  */
 const tryRefreshCredentials = async (parentRoleArn: string, childRoleArn?: string) => {
   try {
@@ -65,18 +65,18 @@ export const tryScheduleCredentialRefresh = () => {
   }
 
   if (process.env.USE_PARENT_ACCOUNT) {
-    // Attempts to refresh credentials in background every 15 minutes.
+    // Attempts to refresh credentials in background every 10 minutes.
     setInterval(() => {
       void tryRefreshCredentials(process.env.TEST_ACCOUNT_ROLE);
-    }, 15 * 60 * 1000);
+    }, 10 * 60 * 1000);
 
     console.log('Test profile credentials refresh was scheduled for parent account');
     return;
   } else if (process.env.CHILD_ACCOUNT_ROLE) {
-    // Attempts to refresh credentials in background every 15 minutes.
+    // Attempts to refresh credentials in background every 10 minutes.
     setInterval(() => {
       void tryRefreshCredentials(process.env.TEST_ACCOUNT_ROLE, process.env.CHILD_ACCOUNT_ROLE);
-    }, 15 * 60 * 1000);
+    }, 10 * 60 * 1000);
 
     console.log('Test profile credentials refresh was scheduled for child account');
   } else {

--- a/packages/amplify-e2e-core/src/utils/credentials-rotator.ts
+++ b/packages/amplify-e2e-core/src/utils/credentials-rotator.ts
@@ -80,7 +80,7 @@ export const tryScheduleCredentialRefresh = () => {
   } else if (process.env.CHILD_ACCOUNT_ROLE) {
     // Attempts to refresh credentials in background every 15 minutes.
     setInterval(() => {
-      void tryRefreshCredentials(process.env.CHILD_ACCOUNT_ROLE);
+      void tryRefreshCredentials(process.env.TEST_ACCOUNT_ROLE, process.env.CHILD_ACCOUNT_ROLE);
     }, 15 * 60 * 1000);
 
     console.log('Test profile credentials refresh was scheduled for child account');

--- a/packages/amplify-e2e-core/src/utils/credentials-rotator.ts
+++ b/packages/amplify-e2e-core/src/utils/credentials-rotator.ts
@@ -40,10 +40,9 @@ const refreshCredentials = async (roleArn: string, useCurrentCreds: boolean = fa
 
 const tryRefreshCredentials = async (parentRoleArn: string, childRoleArn?: string) => {
   try {
+    await refreshCredentials(parentRoleArn);
     if (childRoleArn) {
       await refreshCredentials(childRoleArn, true);
-    } else {
-      await refreshCredentials(parentRoleArn);
     }
     console.log('Test profile credentials refreshed');
   } catch (e) {

--- a/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-oidc-fields.ts
+++ b/packages/amplify-e2e-tests/src/rds-v2-tests-common/rds-auth-oidc-fields.ts
@@ -12,6 +12,7 @@ import {
   initJSProjectWithProfile,
   setupRDSInstanceAndData,
   sleep,
+  tryScheduleCredentialRefresh,
   updateAuthAddUserGroups,
 } from 'amplify-category-api-e2e-core';
 import { existsSync, writeFileSync, removeSync } from 'fs-extra';
@@ -79,6 +80,7 @@ export const testOIDCFieldAuth = (engine: ImportedRDSType): void => {
       console.log(sqlCreateStatements(engine));
       projRoot = await createNewProjectDir(projName);
       await setupAmplifyProject();
+      tryScheduleCredentialRefresh();
     });
 
     afterAll(async () => {

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/migration/many-to-many-migration.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/migration/many-to-many-migration.test.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { createNewProjectDir, deleteProjectDir, deleteProject } from 'amplify-category-api-e2e-core';
+import { createNewProjectDir, deleteProjectDir, deleteProject, tryScheduleCredentialRefresh } from 'amplify-category-api-e2e-core';
 import { initCDKProject, cdkDeploy, cdkDestroy, createGen1ProjectForMigration, deleteDDBTables } from '../../commands';
 import { graphql } from '../../graphql-request';
 import { TestDefinition, writeStackConfig, writeTestDefinitions, writeOverrides } from '../../utils';
@@ -13,6 +13,10 @@ describe('Many-to-many Migration', () => {
   let gen1ProjFolderName: string;
   let gen2ProjFolderName: string;
   let dataSourceMapping: Record<string, string>;
+
+  beforeAll(() => {
+    tryScheduleCredentialRefresh();
+  });
 
   beforeEach(async () => {
     gen1ProjFolderName = 'mtmmigrationgen1';

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/migration/migration-validation.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/migration/migration-validation.test.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { createNewProjectDir, deleteProjectDir, deleteProject } from 'amplify-category-api-e2e-core';
+import { createNewProjectDir, deleteProjectDir, deleteProject, tryScheduleCredentialRefresh } from 'amplify-category-api-e2e-core';
 import { CloudFormationClient, ListStacksCommand, DescribeStackEventsCommand, StackEvent } from '@aws-sdk/client-cloudformation';
 import { initCDKProject, cdkDeploy, cdkDestroy, createGen1ProjectForMigration, deleteDDBTables } from '../../commands';
 import { TestDefinition, writeStackConfig, writeTestDefinitions, writeOverrides } from '../../utils';
@@ -15,6 +15,7 @@ describe('Migration table import validation', () => {
   let dataSourceMapping: Record<string, string>;
 
   beforeAll(async () => {
+    tryScheduleCredentialRefresh();
     gen1ProjFolderName = 'validategen1';
     gen1ProjRoot = await createNewProjectDir(gen1ProjFolderName);
 

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-pg-models.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-pg-models.test.ts
@@ -29,7 +29,6 @@ describe('CDK GraphQL Transformer deployments with Postgres SQL datasources', ()
   const resourceNames = getResourceNamesForStrategyName(strategyName);
 
   beforeAll(async () => {
-    tryScheduleCredentialRefresh();
     await databaseController.setupDatabase();
   });
 

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-pg-models.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/sql-pg-models.test.ts
@@ -5,6 +5,7 @@ import { TestOptions } from '../utils/sql-test-config-helper';
 import { DURATION_1_HOUR } from '../utils/duration-constants';
 import { testGraphQLAPI } from '../sql-tests-common/sql-models';
 import { sqlCreateStatements } from '../sql-tests-common/tests-sources/sql-models/provider';
+import { tryScheduleCredentialRefresh } from 'amplify-category-api-e2e-core';
 
 jest.setTimeout(DURATION_1_HOUR);
 
@@ -28,6 +29,7 @@ describe('CDK GraphQL Transformer deployments with Postgres SQL datasources', ()
   const resourceNames = getResourceNamesForStrategyName(strategyName);
 
   beforeAll(async () => {
+    tryScheduleCredentialRefresh();
     await databaseController.setupDatabase();
   });
 

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -417,11 +417,13 @@ function useChildAccountCredentials {
           echo "Unable to find a child account. Falling back to parent AWS account"
           return
         fi
-        creds=$(aws sts assume-role --role-arn arn:aws:iam::${pick_acct}:role/OrganizationAccountAccessRole --role-session-name testSession${session_id} --duration-seconds 3600)
+        account_role=arn:aws:iam::${pick_acct}:role/OrganizationAccountAccessRole
+        creds=$(aws sts assume-role --role-arn ${account_role} --role-session-name testSession${session_id} --duration-seconds 3600)
         if [ -z $(echo $creds | jq -c -r '.AssumedRoleUser.Arn') ]; then
             echo "Unable to assume child account role. Falling back to parent AWS account"
             return
         fi
+        export CHILD_ACCOUNT_ROLE=$account_role
         export ORGANIZATION_SIZE=$org_size
         export CREDS=$creds
         echo "Using account credentials for $(echo $creds | jq -c -r '.AssumedRoleUser.Arn')"


### PR DESCRIPTION
#### Description of changes

Some long running e2e tests can have their creds expire after an hour. Based on recent failures, add credentials refresher to those e2e tests.

Extend credentials rotator to refresh child AWS accounts as well.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
