### PR TITLE
chore: fix override test.

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -149,7 +149,7 @@ function _verifyAmplifyBackendCompatability {
   echo "Verify Amplify Backend Compatibility"
   loadCacheFromBuildJob
 
-  # Unset container credentials environment variables since some of the tests in packages/cli/src/command_middleware.test.ts 
+  # Unset container credentials environment variables since some of the tests in packages/cli/src/command_middleware.test.ts
   # expect not to fetch the credentials. This is to avoid the tests from failing.
   echo "Unsetting container credentials environment variables"
   unset AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
@@ -162,7 +162,7 @@ function _verifyAmplifyBackendCompatability {
   echo "Emulating Publish Shell"
   # Clean Verdaccio cache and prepare for publishing
   rm -rf ../verdaccio-cache && mkdir ../verdaccio-cache
-  # Create a new local branch for testing 
+  # Create a new local branch for testing
   git checkout -B validate-amplify-backend
   # Dummy git config to avoid errors
   git config user.email not@used.com
@@ -198,20 +198,20 @@ function _verifyAmplifyBackendCompatability {
 }
 function _setupNodeVersion {
   local version=$1  # Version number passed as an argument
-  
+
   echo "Installing NVM and setting Node.js version to $version"
-  
+
   # Install NVM
   curl -o - https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash
-  
+
   # Load NVM
   export NVM_DIR="$HOME/.nvm"
   [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-  
+
   # Install and use the specified Node.js version
   nvm install "$version"
   nvm use "$version"
-  
+
   # Verify the Node.js version in use
   echo "Node.js version in use:"
   node -v
@@ -238,7 +238,7 @@ function _publishToLocalRegistry {
     fi
 
     git checkout $BRANCH_NAME
-  
+
     # Fetching git tags from upstream
     # For forked repo only
     # Can be removed when using team account
@@ -316,6 +316,8 @@ function _setupE2ETestsLinux {
     echo "Setup E2E Tests Linux"
     loadCacheFromBuildJob
     loadCache verdaccio-cache $CODEBUILD_SRC_DIR/../verdaccio-cache
+    # Ignore engines while we're still on Node 18.x
+    yarn config set ignore-engines true
     _installCLIFromLocalRegistry
     _loadTestAccountCredentials
     _setShell
@@ -357,7 +359,7 @@ function _runCanaryTest {
     loadCache verdaccio-cache $CODEBUILD_SRC_DIR/../verdaccio-cache
     # Set Node.js version to $AMPLIFY_NODE_VERSION as one of the package requires version ">= 18.18.0"
     _setupNodeVersion $AMPLIFY_NODE_VERSION
-    _installCLIFromLocalRegistry  
+    _installCLIFromLocalRegistry
     _loadTestAccountCredentials
     _setShell
     cd client-test-apps/js/api-model-relationship-app


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Fixes e2e test that uses overrides.

The root cause is that:
1. We're still running e2e tests on node 18.x
2. Yarn is failing on engine mismatch when installing dependencies.

#### Description of how you validated changes

By running e2e tests.

<img width="1005" height="85" alt="image" src="https://github.com/user-attachments/assets/b358db93-7c64-4b05-8639-3e4d5a178c53" />


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
