### PR TITLE
chore: increase npm fetch retry timeouts

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -290,8 +290,8 @@ function _installCLIFromLocalRegistry {
     # set longer timeout to avoid socket timeout error
     npm config set fetch-retries 5
     npm config set fetch-timeout 600000
-    npm config set fetch-retry-mintimeout 30000
-    npm config set fetch-retry-maxtimeout 180000
+    npm config set fetch-retry-mintimeout 40000
+    npm config set fetch-retry-maxtimeout 240000
     npm config set maxsockets 1
     npm install -g @aws-amplify/cli-internal
     echo "using Amplify CLI version: "$(amplify --version)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

- Increase npm fetch retry min timeout from 30 seconds to 40 seconds
- Increase npm fetch retry max timeout from 3 minutes to 4 minutes
