### PR TITLE
feat: make ElasticSearch server-side encryption configurable

### DIFF
--- a/packages/amplify-graphql-api-construct/src/internal/default-parameters.ts
+++ b/packages/amplify-graphql-api-construct/src/internal/default-parameters.ts
@@ -17,6 +17,7 @@ export const defaultTranslationBehavior: TranslationBehavior = {
   enableAutoIndexQueryNames: true,
   respectPrimaryKeyAttributesOnConnectionField: true,
   enableSearchNodeToNodeEncryption: false,
+  enableSearchEncryptionAtRest: false,
   enableTransformerCfnOutputs: false,
   allowDestructiveGraphqlSchemaUpdates: false,
   replaceTableUponGsiUpdate: false,

--- a/packages/amplify-graphql-api-construct/src/types.ts
+++ b/packages/amplify-graphql-api-construct/src/types.ts
@@ -550,6 +550,8 @@ export interface TranslationBehavior {
 
   readonly enableSearchNodeToNodeEncryption: boolean;
 
+  readonly enableSearchEncryptionAtRest: boolean;
+
   /**
    * When enabled, internal cfn outputs which existed in Amplify-generated apps will continue to be emitted.
    * @default false

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
@@ -12,6 +12,7 @@ export const createSearchableDomain = (
   parameterMap: Map<string, CfnParameter>,
   apiId: string,
   nodeToNodeEncryption: boolean,
+  encryptionAtRest: boolean,
 ): Domain => {
   const { OpenSearchEBSVolumeGB, OpenSearchInstanceType, OpenSearchInstanceCount } = ResourceConstants.PARAMETERS;
   const { OpenSearchDomainLogicalID } = ResourceConstants.RESOURCES;
@@ -26,6 +27,9 @@ export const createSearchableDomain = (
       volumeSize: parameterMap.get(OpenSearchEBSVolumeGB)?.valueAsNumber,
     },
     nodeToNodeEncryption,
+    encryptionAtRest: {
+      enabled: encryptionAtRest,
+    },
     zoneAwareness: {
       enabled: false,
     },

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-streaming-lambda.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-streaming-lambda.ts
@@ -30,7 +30,7 @@ export const createLambda = (
     `functions/${OpenSearchStreamingLambdaFunctionLogicalID}.zip`,
     parameterMap.get(OpenSearchStreamingLambdaHandlerName)!.valueAsString,
     path.resolve(__dirname, '..', '..', 'lib', 'streaming-lambda.zip'),
-    Runtime.PYTHON_3_8,
+    Runtime.PYTHON_3_13,
     [
       LayerVersion.fromLayerVersionArn(
         scope,

--- a/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
@@ -314,6 +314,7 @@ export class SearchableModelTransformer extends TransformerPluginBase {
       parameterMap,
       context.api.apiId,
       context.transformParameters.enableSearchNodeToNodeEncryption,
+      context.transformParameters.enableSearchEncryptionAtRest,
     );
 
     const openSearchRole = createSearchableDomainRole(context, stack, parameterMap);

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/transform-parameters.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/transform-parameters.ts
@@ -27,4 +27,5 @@ export const defaultTransformParameters: TransformParameters = {
 
   // Search Params
   enableSearchNodeToNodeEncryption: false,
+  enableSearchEncryptionAtRest: false,
 };

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transform-parameters.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transform-parameters.ts
@@ -31,4 +31,5 @@ export type TransformParameters = {
 
   // Search Params
   enableSearchNodeToNodeEncryption: boolean;
+  enableSearchEncryptionAtRest: boolean;
 };


### PR DESCRIPTION
"node to node" encryption is currently configurable for ElasticSearch domains, but not "encryption at rest".

Add a parameter for that option.

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
