### PR TITLE
chore: turn `console.warn` + expect pattern into an error

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/log-config.test.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/log-config.test.ts
@@ -48,8 +48,7 @@ const getAccountId = async (): Promise<string> => {
     const accountDetails = await sts.getCallerIdentity({}).promise();
     return accountDetails?.Account;
   } catch (e) {
-    console.warn(`Could not get current AWS account ID: ${e}`);
-    expect(true).toEqual(false);
+    throw new Error(`Could not get current AWS account ID: ${e}`);
   }
 };
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2Transformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2Transformer.e2e.test.ts
@@ -382,8 +382,7 @@ describe('@model with @auth', () => {
       const idToken3 = authRes3AfterGroup.getIdToken().getJwtToken();
       GRAPHQL_CLIENT_3 = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: idToken3 });
     } catch (e) {
-      console.error(`Could not setup transformer ${e}`);
-      expect(true).toBe(false);
+      throw new Error(`Could not setup transformer ${e}`);
     }
   });
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2TransformerWithFF.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2TransformerWithFF.e2e.test.ts
@@ -427,8 +427,7 @@ describe('@model with @auth', () => {
       GRAPHQL_CLIENT_3 = new GraphQLClient(GRAPHQL_ENDPOINT, { Authorization: idToken3 });
       USER_3_SUB = authRes3AfterGroup.idToken.payload.sub;
     } catch (e) {
-      console.error(`Could not setup transformer ${e}`);
-      expect(true).toBe(false);
+      throw new Error(`Could not setup transformer ${e}`);
     }
   });
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/HttpTransformerV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/HttpTransformerV2.e2e.test.ts
@@ -139,8 +139,7 @@ beforeAll(async () => {
   try {
     await customS3Client.createBucket(BUCKET_NAME);
   } catch (e) {
-    console.error(`Failed to create bucket: ${e}`);
-    expect(true).toEqual(false);
+    throw new Error(`Failed to create bucket: ${e}`);
   }
 
   const out = testTransform({
@@ -179,8 +178,7 @@ beforeAll(async () => {
 
     GRAPHQL_CLIENT = new GraphQLClient(endpoint, { 'x-api-key': apiKey });
   } catch (e) {
-    console.error(e);
-    expect(true).toEqual(false);
+    throw new Error(`${e}`);
   }
 });
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthV2Transformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthV2Transformer.e2e.test.ts
@@ -247,8 +247,7 @@ beforeAll(async () => {
     // "The security token included in the request is invalid" errors
     await new Promise<void>((res) => setTimeout(() => res(), 5000));
   } catch (e) {
-    console.error(e);
-    expect(true).toEqual(false);
+    throw new Error(`${e}`);
   }
 });
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthV2TransformerWithFF.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/PerFieldAuthV2TransformerWithFF.e2e.test.ts
@@ -243,8 +243,7 @@ beforeAll(async () => {
     // "The security token included in the request is invalid" errors
     await new Promise<void>((res) => setTimeout(() => res(), 5000));
   } catch (e) {
-    console.error(e);
-    expect(true).toEqual(false);
+    throw new Error(`${e}`);
   }
 });
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2.e2e.test.ts
@@ -146,14 +146,12 @@ beforeAll(async () => {
       },
     });
   } catch (e) {
-    console.error(`Failed to transform schema: ${e}`);
-    expect(true).toEqual(false);
+    throw new Error(`Failed to transform schema: ${e}`);
   }
   try {
     await customS3Client.createBucket(BUCKET_NAME);
   } catch (e) {
-    console.error(`Failed to create S3 bucket: ${e}`);
-    expect(true).toEqual(false);
+    throw new Error(`Failed to create S3 bucket: ${e}`);
   }
   const userPoolResponse = await createUserPool(cognitoClient, `UserPool${STACK_NAME}`);
   USER_POOL_ID = userPoolResponse.UserPool.Id;
@@ -215,8 +213,7 @@ beforeAll(async () => {
     // "The security token included in the request is invalid" errors
     await new Promise<void>((res) => setTimeout(() => res(), 5000));
   } catch (e) {
-    console.error(e);
-    expect(true).toEqual(false);
+    throw new Error(`${e}`);
   }
 });
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2NonRedacted.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2NonRedacted.e2e.test.ts
@@ -162,14 +162,12 @@ beforeAll(async () => {
       ],
     });
   } catch (e) {
-    console.error(`Failed to transform schema: ${e}`);
-    expect(true).toEqual(false);
+    throw new Error(`Failed to transform schema: ${e}`);
   }
   try {
     await customS3Client.createBucket(BUCKET_NAME);
   } catch (e) {
-    console.error(`Failed to create S3 bucket: ${e}`);
-    expect(true).toEqual(false);
+    throw new Error(`Failed to create S3 bucket: ${e}`);
   }
   const userPoolResponse = await createUserPool(cognitoClient, `UserPool${STACK_NAME}`);
   USER_POOL_ID = userPoolResponse.UserPool.Id;
@@ -231,8 +229,7 @@ beforeAll(async () => {
     // "The security token included in the request is invalid" errors
     await new Promise<void>((res) => setTimeout(() => res(), 5000));
   } catch (e) {
-    console.error(e);
-    expect(true).toEqual(false);
+    throw new Error(`${e}`);
   }
 });
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2Redacted.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2Redacted.e2e.test.ts
@@ -162,14 +162,12 @@ beforeAll(async () => {
       ],
     });
   } catch (e) {
-    console.error(`Failed to transform schema: ${e}`);
-    expect(true).toEqual(false);
+    throw new Error(`Failed to transform schema: ${e}`);
   }
   try {
     await customS3Client.createBucket(BUCKET_NAME);
   } catch (e) {
-    console.error(`Failed to create S3 bucket: ${e}`);
-    expect(true).toEqual(false);
+    throw new Error(`Failed to create S3 bucket: ${e}`);
   }
   const userPoolResponse = await createUserPool(cognitoClient, `UserPool${STACK_NAME}`);
   USER_POOL_ID = userPoolResponse.UserPool.Id;
@@ -231,8 +229,7 @@ beforeAll(async () => {
     // "The security token included in the request is invalid" errors
     await new Promise<void>((res) => setTimeout(() => res(), 5000));
   } catch (e) {
-    console.error(e);
-    expect(true).toEqual(false);
+    throw new Error(`${e}`);
   }
 });
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2WithFF.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalWithAuthV2WithFF.e2e.test.ts
@@ -141,14 +141,12 @@ beforeAll(async () => {
       ],
     });
   } catch (e) {
-    console.error(`Failed to transform schema: ${e}`);
-    expect(true).toEqual(false);
+    throw new Error(`Failed to transform schema: ${e}`);
   }
   try {
     await customS3Client.createBucket(BUCKET_NAME);
   } catch (e) {
-    console.error(`Failed to create S3 bucket: ${e}`);
-    expect(true).toEqual(false);
+    throw new Error(`Failed to create S3 bucket: ${e}`);
   }
   const userPoolResponse = await createUserPool(cognitoClient, `UserPool${STACK_NAME}`);
   USER_POOL_ID = userPoolResponse.UserPool.Id;
@@ -210,8 +208,7 @@ beforeAll(async () => {
     // "The security token included in the request is invalid" errors
     await new Promise<void>((res) => setTimeout(() => res(), 5000));
   } catch (e) {
-    console.error(e);
-    expect(true).toEqual(false);
+    throw new Error(`${e}`);
   }
 });
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/TransformerOptionsV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/TransformerOptionsV2.e2e.test.ts
@@ -136,8 +136,7 @@ describe('V2 transformer options', () => {
 
           configureAmplify(USER_POOL_ID, userPoolClientId);
         } catch (e) {
-          console.error(`Could not setup tests ${e}`);
-          expect(true).toBe(false);
+          throw new Error(`Could not setup tests ${e}`);
         }
       });
 


### PR DESCRIPTION
In many places the code does `console.warn` followed by `expect(true).toEqual(false)`.

Turn this into a `throw new Error`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
