### PR TITLE
chore: remove unused CFN parameters from top-level stack

### DIFF
--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-cfnParameters.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-cfnParameters.ts
@@ -7,8 +7,6 @@ export const createParametersStack = (scope: Construct): Map<string, CfnParamete
   const {
     OpenSearchAccessIAMRoleName,
     OpenSearchStreamingLambdaHandlerName,
-    OpenSearchStreamingLambdaRuntime,
-    OpenSearchStreamingFunctionName,
     OpenSearchStreamBatchSize,
     OpenSearchStreamMaximumBatchingWindowInSeconds,
     OpenSearchStreamingIAMRoleName,
@@ -32,25 +30,6 @@ export const createParametersStack = (scope: Construct): Map<string, CfnParamete
       new CfnParameter(scope, OpenSearchStreamingLambdaHandlerName, {
         description: 'The name of the lambda handler.',
         default: 'python_streaming_function.lambda_handler',
-      }),
-    ],
-
-    [
-      OpenSearchStreamingLambdaRuntime,
-      new CfnParameter(scope, OpenSearchStreamingLambdaRuntime, {
-        // eslint-disable-next-line no-multi-str
-        description:
-          'The lambda runtime \
-                (https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime)',
-        default: 'python3.6',
-      }),
-    ],
-
-    [
-      OpenSearchStreamingFunctionName,
-      new CfnParameter(scope, OpenSearchStreamingFunctionName, {
-        description: 'The name of the streaming lambda function.',
-        default: 'DdbToEsFn',
       }),
     ],
 


### PR DESCRIPTION
These top-level parameters probably used to be passed to the OpenSearch nested stack at some point, but are not anymore. Remove the top-level parameters as well.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
