### PR TITLE
chore: make cloud-pr use the branch name (gen1) (#3350)

### DIFF
--- a/scripts/cloud-pr.sh
+++ b/scripts/cloud-pr.sh
@@ -3,8 +3,7 @@
 scriptDir=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
 source $scriptDir/.env set
 
-printf 'What is your PR number ? '
-read PR_NUMBER
+CURR_BRANCH=$(git branch --show-current)
 
 if [[ -n $USE_FIDO_KEY ]] ; then
   mwinit -s -f
@@ -18,7 +17,7 @@ RESULT=$(aws codebuild start-build-batch \
 --region us-east-1 \
 --project-name amplify-category-api-pr-workflow \
 --build-timeout-in-minutes-override 180 \
---source-version "pr/$PR_NUMBER" \
+--source-version "$CURR_BRANCH" \
 --debug-session-enabled \
 --git-clone-depth-override=1000 \
 --environment-variables-override name=AMPLIFY_CI_MANUAL_PR_BUILD,value=true,type=PLAINTEXT \


### PR DESCRIPTION
`yarn cloud-pr` currently asks you for the PR number, which is annoying if you need to run it a lot because you need to input the PR number over and over again.

Instead, it can work exactly the same as `yarn cloud-e2e`: using the current branch name instead. That way you can submit it unattended.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
