### PR TITLE
chore: disable UserPool self-signup in a couple more tests

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/admin-role/app.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/admin-role/app.ts
@@ -49,7 +49,9 @@ new CfnOutput(stack, 'ApiInvokerFunctionName', {
   value: apiInvoker.functionName,
 });
 
-const userPool = new UserPool(stack, 'Userpool');
+const userPool = new UserPool(stack, 'Userpool', {
+  selfSignUpEnabled: false,
+});
 const userPoolClient = new UserPoolClient(stack, 'UserpoolClient', { userPool });
 const identityPool = new IdentityPool(stack, 'Identitypool', {
   authenticationProviders: {

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/all-auth-modes/app.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/all-auth-modes/app.ts
@@ -15,7 +15,9 @@ const stack = new Stack(app, packageJson.name.replace(/_/g, '-'), {
   env: { region: process.env.CLI_REGION || 'us-west-2' },
 });
 
-const userPool = new UserPool(stack, 'TestPool', {});
+const userPool = new UserPool(stack, 'TestPool', {
+  selfSignUpEnabled: false,
+});
 const identityPoolId = new CfnIdentityPool(stack, 'TestIdentityPool', { allowUnauthenticatedIdentities: true }).ref;
 const appsync = new ServicePrincipal('appsync.amazonaws.com');
 const authenticatedUserRole = new Role(stack, 'TestAuthRole', { assumedBy: appsync });

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/configurable-stack/app.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/configurable-stack/app.ts
@@ -52,6 +52,7 @@ interface StackConfig {
 const createUserPool = (prefix: string): { userPool: UserPool; userPoolClient: UserPoolClient } => {
   const userPool = new UserPool(stack, `${prefix}UserPool`, {
     deletionProtection: false,
+    selfSignUpEnabled: false,
   });
   userPool.applyRemovalPolicy(RemovalPolicy.DESTROY);
 

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/sql-configurable-stack/app.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/sql-configurable-stack/app.ts
@@ -169,7 +169,7 @@ const createUserPool = (prefix: string, triggers?: Record<string, string>): { us
       username: true,
       email: false,
     },
-    selfSignUpEnabled: true,
+    selfSignUpEnabled: false,
     autoVerify: { email: true },
     standardAttributes: {
       email: {


### PR DESCRIPTION
Here are a couple more places where Cognito UserPool self-signup looks to be enabled by default, which should be disabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
