### PR TITLE
fix: primary key response should contain all parts of custom claims

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/vtl-generator/ddb/resolvers/helpers.ts
+++ b/packages/amplify-graphql-auth-transformer/src/vtl-generator/ddb/resolvers/helpers.ts
@@ -355,31 +355,16 @@ export const getOwnerClaimReference = (ownerClaim: string, refName: string): str
 /**
  * Creates field resolver for owner
  */
+/**
+ * Creates field resolver for owner
+ */
 export const generateFieldResolverForOwner = (entity: string): string => {
   const expressions: Expression[] = [
     ifElse(
       methodCall(ref('util.isList'), ref(`ctx.source.${entity}`)),
-      compoundExpression([
-        set(ref('ownerEntitiesList'), list([])),
-        set(ref(entity), ref(`ctx.source.${entity}`)),
-        forEach(ref('entities'), ref(entity), [
-          set(ref('ownerEntities'), ref(`entities.split("${IDENTITY_CLAIM_DELIMITER}")`)),
-          set(ref('ownerEntitiesLastIdx'), raw('$ownerEntities.size() - 1')),
-          set(ref('ownerEntitiesLast'), ref('ownerEntities[$ownerEntitiesLastIdx]')),
-          qref(methodCall(ref('ownerEntitiesList.add'), ref('ownerEntitiesLast'))),
-        ]),
-        qref(methodCall(ref(`ctx.source.${entity}.put`), ref('ownerEntitiesList'))),
-        toJson(ref('ownerEntitiesList')),
-      ]),
-      compoundExpression([
-        set(ref('ownerEntities'), ref(`ctx.source.${entity}.split("${IDENTITY_CLAIM_DELIMITER}")`)),
-        set(ref('ownerEntitiesLastIdx'), raw('$ownerEntities.size() - 1')),
-        set(ref('ownerEntitiesLast'), ref('ownerEntities[$ownerEntitiesLastIdx]')),
-        qref(methodCall(ref('ctx.source.put'), str(entity), ref('ownerEntitiesLast'))),
-        toJson(ref(`ctx.source.${entity}`)),
-      ]),
+      toJson(ref(`ctx.source.${entity}`)),
+      toJson(ref(`ctx.source.${entity}`)),
     ),
   ];
-
   return printBlock('Parse owner field auth for Get')(compoundExpression(expressions));
 };

--- a/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/common.ts
+++ b/packages/amplify-graphql-auth-transformer/src/vtl-generator/rds/resolvers/common.ts
@@ -262,32 +262,17 @@ export const setDeniedFieldFlag = (operation: string, subscriptionsEnabled: bool
 /**
  * Creates field resolver for owner
  */
+/**
+ * Creates field resolver for owner
+ */
 export const generateFieldResolverForOwner = (entity: string): string => {
   const expressions: Expression[] = [
     ifElse(
       methodCall(ref('util.isList'), ref(`ctx.source.${entity}`)),
-      compoundExpression([
-        set(ref('ownerEntitiesList'), list([])),
-        set(ref(entity), ref(`ctx.source.${entity}`)),
-        forEach(ref('entities'), ref(entity), [
-          set(ref('ownerEntities'), ref(`entities.split("${IDENTITY_CLAIM_DELIMITER}")`)),
-          set(ref('ownerEntitiesLastIdx'), raw('$ownerEntities.size() - 1')),
-          set(ref('ownerEntitiesLast'), ref('ownerEntities[$ownerEntitiesLastIdx]')),
-          qref(methodCall(ref('ownerEntitiesList.add'), ref('ownerEntitiesLast'))),
-        ]),
-        qref(methodCall(ref(`ctx.source.${entity}.put`), ref('ownerEntitiesList'))),
-        toJson(ref('ownerEntitiesList')),
-      ]),
-      compoundExpression([
-        set(ref('ownerEntities'), ref(`ctx.source.${entity}.split("${IDENTITY_CLAIM_DELIMITER}")`)),
-        set(ref('ownerEntitiesLastIdx'), raw('$ownerEntities.size() - 1')),
-        set(ref('ownerEntitiesLast'), ref('ownerEntities[$ownerEntitiesLastIdx]')),
-        qref(methodCall(ref('ctx.source.put'), str(entity), ref('ownerEntitiesLast'))),
-        toJson(ref(`ctx.source.${entity}`)),
-      ]),
+      toJson(ref(`ctx.source.${entity}`)),
+      toJson(ref(`ctx.source.${entity}`)),
     ),
   ];
-
   return printBlock('Parse owner field auth for Get')(compoundExpression(expressions));
 };
 


### PR DESCRIPTION
#### Description of changes

When auth template process graphql responses, it should return all fields in custom claims 

##### CDK / CloudFormation Parameters Changed

#### Issue https://github.com/aws-amplify/amplify-backend/issues/2973

#### Description of how you validated changes

run build: `yarn build`

copied output to the project
`cp -r ../../amplify-category-api/packages/amplify-graphql-auth-transformer/lib/ node_modules/@aws-amplify/graphql-auth-transformer/lib/`

Deployed changes and observed grapqhl contains all parts of custom claims on get/list

```
{"message":["GraphQL raw response",{"data":{"tradeRequestPK":"roman@xxx::xxx-xxx-xxx-xxx-xxx", ... , "updatedAt":"2025-10-25T18:34:24.511Z"}}]
```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This probably requires a more though testing, or a more specialize test to isolate the regression and validate the fix. I also see `ownerEntitiesLast` stored in snapshot tests etc which I couldn't check or test.