### PR TITLE
chore: add `ap-east-1` region to possible e2e test regions

### DIFF
--- a/packages/amplify-e2e-core/src/configure/index.ts
+++ b/packages/amplify-e2e-core/src/configure/index.ts
@@ -31,6 +31,7 @@ export const amplifyRegions = [
   'ap-southeast-1',
   'ap-southeast-2',
   'ap-south-1',
+  'ap-east-1',
   'ca-central-1',
   'me-south-1',
   'sa-east-1',


### PR DESCRIPTION
This caused canaries to default to us-east-1, potentially interfering with other tests.

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
