### PR TITLE
fix: make release workflows use node 20

### DIFF
--- a/codebuild_specs/deploy.yml
+++ b/codebuild_specs/deploy.yml
@@ -5,4 +5,5 @@ env:
 phases:
   build:
     commands:
+      - source ./shared-scripts.sh && _setupNodeVersion 20
       - source ./shared-scripts.sh && _deploy

--- a/codebuild_specs/install_linux.yml
+++ b/codebuild_specs/install_linux.yml
@@ -4,6 +4,7 @@ env:
 phases:
   build:
     commands:
+      - source ./shared-scripts.sh && _setupNodeVersion 20
       - source ./shared-scripts.sh && _installLinux
 artifacts:
   files:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Missed node 20 update on publish step of release workflow.

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
