### PR TITLE
chore: reduce no-output timeout for `amplify push` in integ tests

### DIFF
--- a/packages/amplify-e2e-core/src/init/amplifyPush.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPush.ts
@@ -17,7 +17,7 @@
 
 import { getCLIPath, nspawn as spawn } from '..';
 
-const pushTimeoutMS = 1000 * 60 * 75; // 75 minutes;
+const pushTimeoutMS = 1000 * 60 * 10; // 10 minutes. This is just a no output timeout.
 
 /**
  * Data structure defined for Layer Push


### PR DESCRIPTION
In `ca-central-1`, the API Canary test is timing out after 1 hour.

The timeout after which the integ test call to `amplify push` aborts if it doesn't see any output from the process (to indicate the `amplify` command hangs) was set to 75 minutes. Reduce the timeout to 10 minutes to see the output of the CLI process, so that we can diagnose why it's hanging.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
