### PR TITLE
Revert "chore(release): Publish [ci skip]"

### DIFF
--- a/packages/amplify-category-api/CHANGELOG.md
+++ b/packages/amplify-category-api/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.15.3](https://github.com/aws-amplify/amplify-category-api/compare/@aws-amplify/amplify-category-api@5.15.2...@aws-amplify/amplify-category-api@5.15.3) (2025-12-11)
-
-**Note:** Version bump only for package @aws-amplify/amplify-category-api
-
 ## [5.15.2](https://github.com/aws-amplify/amplify-category-api/compare/@aws-amplify/amplify-category-api@5.15.1...@aws-amplify/amplify-category-api@5.15.2) (2025-11-19)
 
 **Note:** Version bump only for package @aws-amplify/amplify-category-api

--- a/packages/amplify-category-api/package.json
+++ b/packages/amplify-category-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/amplify-category-api",
-  "version": "5.15.3",
+  "version": "5.15.2",
   "description": "Amplify CLI API Category Plugin",
   "repository": {
     "type": "git",
@@ -29,9 +29,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@aws-amplify/graphql-auth-transformer": "3.6.15",
+    "@aws-amplify/graphql-auth-transformer": "3.6.14",
     "@aws-amplify/graphql-schema-generator": "^0.9.4",
-    "@aws-amplify/graphql-transformer": "1.8.4",
+    "@aws-amplify/graphql-transformer": "1.8.3",
     "@aws-amplify/graphql-transformer-core": "2.11.3",
     "@aws-amplify/graphql-transformer-interfaces": "3.12.1",
     "@aws-amplify/graphql-transformer-migrator": "2.2.34",
@@ -49,10 +49,10 @@
     "cloudform-types": "^4.2.0",
     "fs-extra": "^8.1.0",
     "graphql": "^15.5.0",
-    "graphql-auth-transformer": "7.2.89",
+    "graphql-auth-transformer": "7.2.88",
     "graphql-connection-transformer": "5.2.85",
     "graphql-dynamodb-transformer": "7.2.85",
-    "graphql-elasticsearch-transformer": "5.2.88",
+    "graphql-elasticsearch-transformer": "5.2.87",
     "graphql-function-transformer": "3.3.76",
     "graphql-http-transformer": "5.2.85",
     "graphql-key-transformer": "3.2.85",

--- a/packages/amplify-graphql-auth-transformer/CHANGELOG.md
+++ b/packages/amplify-graphql-auth-transformer/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.6.15](https://github.com/aws-amplify/amplify-category-api/compare/@aws-amplify/graphql-auth-transformer@3.6.14...@aws-amplify/graphql-auth-transformer@3.6.15) (2025-12-11)
-
-**Note:** Version bump only for package @aws-amplify/graphql-auth-transformer
-
 ## [3.6.14](https://github.com/aws-amplify/amplify-category-api/compare/@aws-amplify/graphql-auth-transformer@3.6.13...@aws-amplify/graphql-auth-transformer@3.6.14) (2025-11-19)
 
 **Note:** Version bump only for package @aws-amplify/graphql-auth-transformer

--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/graphql-auth-transformer",
-  "version": "3.6.15",
+  "version": "3.6.14",
   "description": "Amplify GraphQL @auth transformer",
   "repository": {
     "type": "git",
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@aws-amplify/graphql-function-transformer": "2.1.34",
     "@aws-amplify/graphql-index-transformer": "2.4.18",
-    "@aws-amplify/graphql-searchable-transformer": "2.7.19",
+    "@aws-amplify/graphql-searchable-transformer": "2.7.18",
     "@aws-amplify/graphql-sql-transformer": "^0.3.9",
     "@aws-amplify/graphql-transformer-test-utils": "0.6.9",
     "@types/node": "^18.18.0"

--- a/packages/amplify-graphql-migration-tests/CHANGELOG.md
+++ b/packages/amplify-graphql-migration-tests/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [2.4.48](https://github.com/aws-amplify/amplify-category-api/compare/amplify-category-api-graphql-migration-tests@2.4.47...amplify-category-api-graphql-migration-tests@2.4.48) (2025-12-11)
-
-**Note:** Version bump only for package amplify-category-api-graphql-migration-tests
-
 ## [2.4.47](https://github.com/aws-amplify/amplify-category-api/compare/amplify-category-api-graphql-migration-tests@2.4.46...amplify-category-api-graphql-migration-tests@2.4.47) (2025-11-19)
 
 **Note:** Version bump only for package amplify-category-api-graphql-migration-tests

--- a/packages/amplify-graphql-migration-tests/package.json
+++ b/packages/amplify-graphql-migration-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-category-api-graphql-migration-tests",
-  "version": "2.4.48",
+  "version": "2.4.47",
   "description": "Tests migration from v1 to v2 of the Amplify GraphQL transformer",
   "main": "lib/index.js",
   "private": true,
@@ -56,7 +56,7 @@
     ]
   },
   "devDependencies": {
-    "@aws-amplify/graphql-auth-transformer": "3.6.15",
+    "@aws-amplify/graphql-auth-transformer": "3.6.14",
     "@aws-amplify/graphql-default-value-transformer": "2.3.22",
     "@aws-amplify/graphql-function-transformer": "2.1.34",
     "@aws-amplify/graphql-http-transformer": "2.1.34",
@@ -70,7 +70,7 @@
     "@aws-cdk/cloudformation-diff": "~2.80.0",
     "aws-cdk-lib": "~2.187.0",
     "fs-extra": "^8.1.0",
-    "graphql-auth-transformer": "7.2.89",
+    "graphql-auth-transformer": "7.2.88",
     "graphql-connection-transformer": "5.2.85",
     "graphql-dynamodb-transformer": "7.2.85",
     "graphql-http-transformer": "5.2.85",

--- a/packages/amplify-graphql-name-mapping-transformer/CHANGELOG.md
+++ b/packages/amplify-graphql-name-mapping-transformer/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.5.3](https://github.com/aws-amplify/amplify-category-api/compare/@aws-amplify/graphql-maps-to-transformer@3.5.2...@aws-amplify/graphql-maps-to-transformer@3.5.3) (2025-12-11)
-
-**Note:** Version bump only for package @aws-amplify/graphql-maps-to-transformer
-
 ## [3.5.2](https://github.com/aws-amplify/amplify-category-api/compare/@aws-amplify/graphql-maps-to-transformer@3.5.1...@aws-amplify/graphql-maps-to-transformer@3.5.2) (2025-11-19)
 
 **Note:** Version bump only for package @aws-amplify/graphql-maps-to-transformer

--- a/packages/amplify-graphql-name-mapping-transformer/package.json
+++ b/packages/amplify-graphql-name-mapping-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/graphql-maps-to-transformer",
-  "version": "3.5.3",
+  "version": "3.5.2",
   "description": "Amplify GraphQL @mapsTo transformer",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "@aws-amplify/graphql-index-transformer": "2.4.18",
     "@aws-amplify/graphql-model-transformer": "2.14.2",
     "@aws-amplify/graphql-relational-transformer": "2.5.20",
-    "@aws-amplify/graphql-searchable-transformer": "2.7.19",
+    "@aws-amplify/graphql-searchable-transformer": "2.7.18",
     "@aws-amplify/graphql-transformer-test-utils": "0.6.9",
     "graphql": "^15.5.0"
   },

--- a/packages/amplify-graphql-searchable-transformer/CHANGELOG.md
+++ b/packages/amplify-graphql-searchable-transformer/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [2.7.19](https://github.com/aws-amplify/amplify-category-api/compare/@aws-amplify/graphql-searchable-transformer@2.7.18...@aws-amplify/graphql-searchable-transformer@2.7.19) (2025-12-11)
-
-### Bug Fixes
-
-- gen 1 update python to 3.12 for searchable lambda ([#3373](https://github.com/aws-amplify/amplify-category-api/issues/3373)) ([81581dc](https://github.com/aws-amplify/amplify-category-api/commit/81581dc8e3a770eddb13ab7a250c24e6f8f97262))
-
 ## [2.7.18](https://github.com/aws-amplify/amplify-category-api/compare/@aws-amplify/graphql-searchable-transformer@2.7.17...@aws-amplify/graphql-searchable-transformer@2.7.18) (2025-11-19)
 
 ### Bug Fixes

--- a/packages/amplify-graphql-searchable-transformer/package.json
+++ b/packages/amplify-graphql-searchable-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/graphql-searchable-transformer",
-  "version": "2.7.19",
+  "version": "2.7.18",
   "description": "Amplfy GraphQL @searchable transformer",
   "repository": {
     "type": "git",

--- a/packages/amplify-graphql-transformer/CHANGELOG.md
+++ b/packages/amplify-graphql-transformer/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.8.4](https://github.com/aws-amplify/amplify-category-api/compare/@aws-amplify/graphql-transformer@1.8.3...@aws-amplify/graphql-transformer@1.8.4) (2025-12-11)
-
-**Note:** Version bump only for package @aws-amplify/graphql-transformer
-
 ## [1.8.3](https://github.com/aws-amplify/amplify-category-api/compare/@aws-amplify/graphql-transformer@1.8.2...@aws-amplify/graphql-transformer@1.8.3) (2025-11-19)
 
 **Note:** Version bump only for package @aws-amplify/graphql-transformer

--- a/packages/amplify-graphql-transformer/package.json
+++ b/packages/amplify-graphql-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/graphql-transformer",
-  "version": "1.8.4",
+  "version": "1.8.3",
   "description": "Amplify GraphQL Transformer Root Package",
   "repository": {
     "type": "git",
@@ -28,16 +28,16 @@
     "access": "public"
   },
   "dependencies": {
-    "@aws-amplify/graphql-auth-transformer": "3.6.15",
+    "@aws-amplify/graphql-auth-transformer": "3.6.14",
     "@aws-amplify/graphql-default-value-transformer": "2.3.22",
     "@aws-amplify/graphql-function-transformer": "2.1.34",
     "@aws-amplify/graphql-http-transformer": "2.1.34",
     "@aws-amplify/graphql-index-transformer": "2.4.18",
-    "@aws-amplify/graphql-maps-to-transformer": "3.5.3",
+    "@aws-amplify/graphql-maps-to-transformer": "3.5.2",
     "@aws-amplify/graphql-model-transformer": "2.14.2",
     "@aws-amplify/graphql-predictions-transformer": "2.2.2",
     "@aws-amplify/graphql-relational-transformer": "2.5.20",
-    "@aws-amplify/graphql-searchable-transformer": "2.7.19",
+    "@aws-amplify/graphql-searchable-transformer": "2.7.18",
     "@aws-amplify/graphql-sql-transformer": "^0.3.9",
     "@aws-amplify/graphql-transformer-core": "2.11.3",
     "@aws-amplify/graphql-transformer-interfaces": "3.12.1"

--- a/packages/amplify-util-mock/CHANGELOG.md
+++ b/packages/amplify-util-mock/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [6.7.4](https://github.com/aws-amplify/amplify-category-api/compare/amplify-category-api-util-mock@6.7.3...amplify-category-api-util-mock@6.7.4) (2025-12-11)
-
-**Note:** Version bump only for package amplify-category-api-util-mock
-
 ## [6.7.3](https://github.com/aws-amplify/amplify-category-api/compare/amplify-category-api-util-mock@6.7.2...amplify-category-api-util-mock@6.7.3) (2025-11-19)
 
 **Note:** Version bump only for package amplify-category-api-util-mock

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-category-api-util-mock",
-  "version": "6.7.4",
+  "version": "6.7.3",
   "description": "Amplify CLI plugin providing local testing",
   "repository": {
     "type": "git",
@@ -33,7 +33,7 @@
     "@aws-amplify/amplify-appsync-simulator": "^2.16.17",
     "@aws-amplify/amplify-category-function": "^5.7.18",
     "@aws-amplify/amplify-provider-awscloudformation": "^8.11.16",
-    "@aws-amplify/graphql-transformer": "1.8.4",
+    "@aws-amplify/graphql-transformer": "1.8.3",
     "@aws-amplify/graphql-transformer-core": "2.11.3",
     "@aws-amplify/graphql-transformer-interfaces": "3.12.1",
     "@aws-amplify/graphql-transformer-test-utils": "0.6.9",
@@ -58,13 +58,13 @@
     "@aws-amplify/amplify-environment-parameters": "^1.9.14"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-auth-transformer": "3.6.15",
+    "@aws-amplify/graphql-auth-transformer": "3.6.14",
     "@aws-amplify/graphql-function-transformer": "2.1.34",
     "@aws-amplify/graphql-index-transformer": "2.4.18",
-    "@aws-amplify/graphql-maps-to-transformer": "3.5.3",
+    "@aws-amplify/graphql-maps-to-transformer": "3.5.2",
     "@aws-amplify/graphql-model-transformer": "2.14.2",
     "@aws-amplify/graphql-relational-transformer": "2.5.20",
-    "@aws-amplify/graphql-searchable-transformer": "2.7.19",
+    "@aws-amplify/graphql-searchable-transformer": "2.7.18",
     "@aws-amplify/graphql-transformer-core": "2.11.2",
     "@aws-amplify/graphql-transformer-interfaces": "3.12.1",
     "@aws-amplify/graphql-transformer-test-utils": "0.6.8",
@@ -78,7 +78,7 @@
     "aws-appsync": "^4.1.9",
     "aws-sdk-client-mock": "^4.1.0",
     "axios": "^1.6.0",
-    "graphql-auth-transformer": "7.2.89",
+    "graphql-auth-transformer": "7.2.88",
     "graphql-connection-transformer": "5.2.85",
     "graphql-dynamodb-transformer": "7.2.85",
     "graphql-function-transformer": "3.3.76",

--- a/packages/graphql-auth-transformer/CHANGELOG.md
+++ b/packages/graphql-auth-transformer/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.2.89](https://github.com/aws-amplify/amplify-category-api/compare/graphql-auth-transformer@7.2.88...graphql-auth-transformer@7.2.89) (2025-12-11)
-
-**Note:** Version bump only for package graphql-auth-transformer
-
 ## [7.2.88](https://github.com/aws-amplify/amplify-category-api/compare/graphql-auth-transformer@7.2.87...graphql-auth-transformer@7.2.88) (2025-11-19)
 
 **Note:** Version bump only for package graphql-auth-transformer

--- a/packages/graphql-auth-transformer/package.json
+++ b/packages/graphql-auth-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-auth-transformer",
-  "version": "7.2.89",
+  "version": "7.2.88",
   "description": "Implements the @auth directive for the appsync model transform.",
   "repository": {
     "type": "git",
@@ -33,7 +33,7 @@
   "devDependencies": {
     "cloudform-types": "^4.2.0",
     "graphql-dynamodb-transformer": "7.2.85",
-    "graphql-elasticsearch-transformer": "5.2.88",
+    "graphql-elasticsearch-transformer": "5.2.87",
     "graphql-function-transformer": "3.3.76",
     "lodash": "^4.17.21",
     "rimraf": "^3.0.0"

--- a/packages/graphql-elasticsearch-transformer/CHANGELOG.md
+++ b/packages/graphql-elasticsearch-transformer/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.2.88](https://github.com/aws-amplify/amplify-category-api/compare/graphql-elasticsearch-transformer@5.2.87...graphql-elasticsearch-transformer@5.2.88) (2025-12-11)
-
-### Bug Fixes
-
-- gen 1 update python to 3.12 for searchable lambda ([#3373](https://github.com/aws-amplify/amplify-category-api/issues/3373)) ([81581dc](https://github.com/aws-amplify/amplify-category-api/commit/81581dc8e3a770eddb13ab7a250c24e6f8f97262))
-
 ## [5.2.87](https://github.com/aws-amplify/amplify-category-api/compare/graphql-elasticsearch-transformer@5.2.86...graphql-elasticsearch-transformer@5.2.87) (2025-11-19)
 
 **Note:** Version bump only for package graphql-elasticsearch-transformer

--- a/packages/graphql-elasticsearch-transformer/package.json
+++ b/packages/graphql-elasticsearch-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-elasticsearch-transformer",
-  "version": "5.2.88",
+  "version": "5.2.87",
   "description": "An AppSync model transform that creates an ElasticSearch index with the queries to match.",
   "repository": {
     "type": "git",

--- a/packages/graphql-transformers-e2e-tests/CHANGELOG.md
+++ b/packages/graphql-transformers-e2e-tests/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [8.9.3](https://github.com/aws-amplify/amplify-category-api/compare/amplify-category-api-graphql-transformers-e2e-tests@8.9.2...amplify-category-api-graphql-transformers-e2e-tests@8.9.3) (2025-12-11)
-
-**Note:** Version bump only for package amplify-category-api-graphql-transformers-e2e-tests
-
 ## [8.9.2](https://github.com/aws-amplify/amplify-category-api/compare/amplify-category-api-graphql-transformers-e2e-tests@8.9.1...amplify-category-api-graphql-transformers-e2e-tests@8.9.2) (2025-11-19)
 
 ### Bug Fixes

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-category-api-graphql-transformers-e2e-tests",
-  "version": "8.9.3",
+  "version": "8.9.2",
   "description": "End to end functional tests for appsync supported transformers ",
   "private": true,
   "repository": {
@@ -22,7 +22,7 @@
     "build-tests": "yarn tsc --build tsconfig.tests.json"
   },
   "dependencies": {
-    "@aws-amplify/graphql-auth-transformer": "3.6.15",
+    "@aws-amplify/graphql-auth-transformer": "3.6.14",
     "@aws-amplify/graphql-relational-transformer": "2.5.20",
     "axios": "^1.6.0",
     "cloudform-types": "^4.2.0",
@@ -35,7 +35,7 @@
     "@aws-amplify/core": "^6.0.0",
     "@aws-amplify/graphql-default-value-transformer": "2.3.22",
     "@aws-amplify/graphql-index-transformer": "2.4.18",
-    "@aws-amplify/graphql-maps-to-transformer": "3.5.3",
+    "@aws-amplify/graphql-maps-to-transformer": "3.5.2",
     "@aws-amplify/graphql-model-transformer": "2.14.2",
     "@aws-amplify/graphql-transformer-core": "2.11.3",
     "@aws-amplify/graphql-transformer-interfaces": "3.12.1",
@@ -51,10 +51,10 @@
     "aws-appsync": "^4.1.1",
     "execa": "^5.1.1",
     "fs-extra": "^8.1.0",
-    "graphql-auth-transformer": "7.2.89",
+    "graphql-auth-transformer": "7.2.88",
     "graphql-connection-transformer": "5.2.85",
     "graphql-dynamodb-transformer": "7.2.85",
-    "graphql-elasticsearch-transformer": "5.2.88",
+    "graphql-elasticsearch-transformer": "5.2.87",
     "graphql-function-transformer": "3.3.76",
     "graphql-http-transformer": "5.2.85",
     "graphql-key-transformer": "3.2.85",


### PR DESCRIPTION
This reverts commit 09cf54608c52b9609fec43f41434f04a9cb9a0f8.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
