### PR TITLE
chore: add a timeout on the entire CLI invocation

### DIFF
--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -55,6 +55,7 @@ export function initJSProjectWithProfile(cwd: string, settings?: Partial<typeof 
       env,
       disableCIDetection: s.disableCIDetection,
       noOutputTimeout: 10 * 60 * 1000,
+      totalDurationTimeout: 30 * 60 * 1000,
     })
       .wait('Do you want to continue with Amplify Gen 1?')
       .sendConfirmYes()


### PR DESCRIPTION
In ca-central-1 our canary is taking more than an hour to finih. It's not producing no output for 5 minutes because the "no output timeout" would have caught that.

Add another "total duration timeout", set to 30 minutes, to see what it's doing as it's timing out.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
