### PR TITLE
fix(searchable): enforce TLS 1.2 on Elasticsearch domains (v1 transformer)

### DIFF
--- a/packages/graphql-elasticsearch-transformer/src/__tests__/SearchableModelTransformer.test.ts
+++ b/packages/graphql-elasticsearch-transformer/src/__tests__/SearchableModelTransformer.test.ts
@@ -145,3 +145,35 @@ test('SearchableModelTransformer with external versioning', () => {
   expect(out.resolvers[expectedSearchResponseResolver]).toBeDefined();
   expect(out.resolvers[expectedSearchResponseResolver]).toMatchSnapshot();
 });
+
+describe('Elasticsearch domain TLS configuration', () => {
+  test('enforces HTTPS with TLS 1.2 on the Elasticsearch domain', () => {
+    const validSchema = `
+      type Post @model @searchable {
+        id: ID!
+        title: String!
+        createdAt: String
+        updatedAt: String
+      }
+    `;
+    const transformer = new GraphQLTransform({
+      transformers: [new DynamoDBModelTransformer(), new SearchableModelTransformer()],
+      featureFlags,
+    });
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined();
+
+    const searchableStack = out.stacks['SearchableStack'];
+    expect(searchableStack).toBeDefined();
+    expect(searchableStack.Resources).toBeDefined();
+
+    const esDomain = searchableStack.Resources!['ElasticSearchDomain'];
+    expect(esDomain).toBeDefined();
+    expect(esDomain.Type).toEqual('AWS::Elasticsearch::Domain');
+
+    const domainEndpointOptions = esDomain.Properties.DomainEndpointOptions;
+    expect(domainEndpointOptions).toBeDefined();
+    expect(domainEndpointOptions.EnforceHTTPS).toBeUndefined();
+    expect(domainEndpointOptions.TLSSecurityPolicy).toBe('Policy-Min-TLS-1-2-2019-07');
+  });
+});

--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -494,6 +494,9 @@ export class ResourceFactory {
     return new Elasticsearch.Domain({
       DomainName: this.domainName(),
       ElasticsearchVersion: '6.2',
+      DomainEndpointOptions: {
+        TLSSecurityPolicy: 'Policy-Min-TLS-1-2-2019-07',
+      },
       ElasticsearchClusterConfig: {
         ZoneAwarenessEnabled: false,
         InstanceCount: Fn.Ref(ResourceConstants.PARAMETERS.ElasticsearchInstanceCount),
@@ -504,7 +507,7 @@ export class ResourceFactory {
         VolumeType: 'gp2',
         VolumeSize: Fn.Ref(ResourceConstants.PARAMETERS.ElasticsearchEBSVolumeGB),
       },
-    });
+    } as any);
   }
 
   /**

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+AMPLIFY_NODE_VERSION=24.12.0
 # set exit on error to true
 set -e
 


### PR DESCRIPTION
## Description

The v1 `graphql-elasticsearch-transformer` creates Elasticsearch domains without any `DomainEndpointOptions` — no `EnforceHTTPS`, no `TLSSecurityPolicy`. AWS is deprecating TLS 1.0/1.1 support on April 20, 2026.

Adds `DomainEndpointOptions` with `TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07` to the domain. Does NOT add `EnforceHTTPS` to avoid breaking customers currently using HTTP.

Uses `as any` cast because `cloudform-types@4.2.0` lacks the `DomainEndpointOptions` type, but CloudFormation supports it.

Related: aws-amplify/amplify-cli#14329

### Changes
- `packages/graphql-elasticsearch-transformer/src/resources.ts` — Added `DomainEndpointOptions` with `TLSSecurityPolicy` to `makeElasticsearchDomain()`
- `packages/graphql-elasticsearch-transformer/src/__tests__/SearchableModelTransformer.test.ts` — Added TLS 1.2 assertion test

### CDK / CloudFormation Parameters Changed
`AWS::Elasticsearch::Domain` → `DomainEndpointOptions.TLSSecurityPolicy` set to `Policy-Min-TLS-1-2-2019-07` (previously no `DomainEndpointOptions` at all)

### Validation
- Unit tests: 7/7 pass
- E2E: [batch 406490ab](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-e2e-workflow/batch/amplify-category-api-e2e-workflow:406490ab-0d9d-4145-b1f0-e7b728838512?region=us-east-1) — 69/82 passed, all 3 searchable tests passed, failures are pre-existing (auth/schema)
- Companion V2 fix: category-api/opensearch-tls-1-2-support (PR against main)

### Checklist
- [x] `yarn test` passes
- [x] Tests are changed or added
- [x] CDK/CloudFormation parameter changes called out
- [x] E2E test run linked