### PR TITLE
fix: add _setupNodeVersion to CDK and E2E test setup functions

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -334,8 +334,7 @@ function _setupE2ETestsLinux {
     echo "Setup E2E Tests Linux"
     loadCacheFromBuildJob
     loadCache verdaccio-cache $CODEBUILD_SRC_DIR/../verdaccio-cache
-    # Ignore engines while we're still on Node 18.x
-    yarn config set ignore-engines true
+    _setupNodeVersion $AMPLIFY_NODE_VERSION
     _installCLIFromLocalRegistry
     _loadTestAccountCredentials
     _setShell
@@ -345,6 +344,7 @@ function _setupCDKTestsLinux {
     echo "Setup E2E Tests Linux"
     loadCacheFromBuildJob
     loadCache verdaccio-cache $CODEBUILD_SRC_DIR/../verdaccio-cache
+    _setupNodeVersion $AMPLIFY_NODE_VERSION
     _installCLIFromLocalRegistry
     yarn package
     _loadTestAccountCredentials


### PR DESCRIPTION
## Problem

Data Canary alarms are failling because the CDK canary test steps run on Node.js v18.15.0 instead of the configured v24.12.0.

### Root Cause

`_setupCDKTestsLinux` and `_setupE2ETestsLinux` in `shared-scripts.sh` load the `.nvm` cache from S3 via `loadCacheFromBuildJob` but never call `_setupNodeVersion $AMPLIFY_NODE_VERSION` to activate NVM. This means the test phases fall back to the Docker image's system Node (v18.15.0).

When `lru-cache` v11+ was published to npm. This version uses `diagnostics_channel.tracingChannel()`, which only exists in Node.js >= 20.5.0. Since the test phases were running Node 18, every canary test crashes with:

```
TypeError: (0 , R.tracingChannel) is not a function
```

Every other function in `shared-scripts.sh` correctly calls `_setupNodeVersion`:

Only `_setupCDKTestsLinux` and `_setupE2ETestsLinux` were missing it.

### Testing
The `build_linux` phase already uses `_setupNodeVersion` successfully with Node 24.12.0 — this change makes the test phases consistent with it.