### PR TITLE
fix: add _setupNodeVersion to _setupCDKTestsLinux and _setupE2ETestsLinux

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -334,8 +334,7 @@ function _setupE2ETestsLinux {
     echo "Setup E2E Tests Linux"
     loadCacheFromBuildJob
     loadCache verdaccio-cache $CODEBUILD_SRC_DIR/../verdaccio-cache
-    # Ignore engines while we're still on Node 18.x
-    yarn config set ignore-engines true
+    _setupNodeVersion $AMPLIFY_NODE_VERSION
     _installCLIFromLocalRegistry
     _loadTestAccountCredentials
     _setShell
@@ -345,6 +344,7 @@ function _setupCDKTestsLinux {
     echo "Setup E2E Tests Linux"
     loadCacheFromBuildJob
     loadCache verdaccio-cache $CODEBUILD_SRC_DIR/../verdaccio-cache
+    _setupNodeVersion $AMPLIFY_NODE_VERSION
     _installCLIFromLocalRegistry
     yarn package
     _loadTestAccountCredentials


### PR DESCRIPTION
## Problem

The canary test functions `_setupCDKTestsLinux` and `_setupE2ETestsLinux` in `shared-scripts.sh` never called `_setupNodeVersion`, causing them to run on the Docker image's system Node 18.15.0 instead of the configured `AMPLIFY_NODE_VERSION` (24.12.0).

This worked until `lru-cache` v11 was published to npm (~Apr 6 2026 00:00 UTC), which requires `diagnostics_channel.tracingChannel()` (available from Node 20.5+). Since CodeBuild was still running Node 18.15.0 in these test steps, the canary builds broke.

**Result:** 83 CloudWatch alarms firing across Amplify Data Canary tests.

## Fix

Add the missing `_setupNodeVersion $AMPLIFY_NODE_VERSION` call to both functions, matching what every other test function in `shared-scripts.sh` already does.

- `_setupE2ETestsLinux`: replaced the stale `yarn config set ignore-engines true` workaround with `_setupNodeVersion`
- `_setupCDKTestsLinux`: added `_setupNodeVersion` after `loadCache` and before `_installCLIFromLocalRegistry`

## Notes

- Companion PR to main: #3461
- This PR targets `release` directly because canaries run from the `release` branch.