### PR TITLE
fix: add _setupNodeVersion to _setupCDKTestsLinux and _setupE2ETestsLinux

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -252,12 +252,8 @@ function _setupE2ETestsLinux {
     echo "Setup E2E Tests Linux"
     loadCacheFromBuildJob
     loadCache verdaccio-cache $CODEBUILD_SRC_DIR/../verdaccio-cache
-    # Ignore engines while we're still on Node 18.x
-    yarn config set ignore-engines true
+    _setupNodeVersion $AMPLIFY_NODE_VERSION
     _installCLIFromLocalRegistry
-    # Rebuild native modules for current Node.js version
-    echo "Rebuilding native modules for Node.js $(node --version)"
-    npm rebuild
     _loadTestAccountCredentials
     _setShell
 }
@@ -266,6 +262,7 @@ function _setupCDKTestsLinux {
     echo "Setup E2E Tests Linux"
     loadCacheFromBuildJob
     loadCache verdaccio-cache $CODEBUILD_SRC_DIR/../verdaccio-cache
+    _setupNodeVersion $AMPLIFY_NODE_VERSION
     _installCLIFromLocalRegistry
     yarn package
     _loadTestAccountCredentials


### PR DESCRIPTION
The canary test functions _setupCDKTestsLinux and _setupE2ETestsLinux never called _setupNodeVersion, causing them to run on the Docker image's system Node 18.15.0 instead of the configured AMPLIFY_NODE_VERSION (24.12.0). This worked until lru-cache v11 was published to npm (~Apr 6 2026 00:00 UTC), which requires diagnostics_channel.tracingChannel() (Node 20.5+).

This PR adds the missing _setupNodeVersion $AMPLIFY_NODE_VERSION call to both functions in Gen1 as well

Companion PRs:
- #3461 (main)
- #3462 (release)