### PR TITLE
fix: set AMPLIFY_NODE_VERSION=24.12.0 for E2E tests

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+AMPLIFY_NODE_VERSION=24.12.0
 # set exit on error to true
 set -e
 


### PR DESCRIPTION
## Problem

E2E tests on the `release-api-plugin-stable` branch are failing at a ~74% rate (67/91 tests) because the Node.js version is not pinned.

## Solution

Set `AMPLIFY_NODE_VERSION=24.12.0` in `shared-scripts.sh` to ensure consistent Node.js version across all E2E test runs.

## Evidence

4-way TLS regression test (Apr 10, 2026):
- **Run 3** (release-api-plugin-stable without fix): 24✅ / 67❌ (26% pass rate)
- **Run 4** (with AMPLIFY_NODE_VERSION=24.12.0): 56✅ / 5❌ with 30 still running (~92% pass rate)

The 5 remaining failures are unrelated migration tests, not Node version issues.

## Changes

Single line addition in `shared-scripts.sh` — sets the Node version before E2E test execution.

---

## E2E Test Comparison: `release-api-plugin-stable` vs `fix/set-node-version-stable`

### Context
The `release-api-plugin-stable` branch was broken because it inherited Node.js 24.x from the CodeBuild environment without pinning a specific version. This caused widespread test failures. This PR pins `AMPLIFY_NODE_VERSION=24.12.0` in `shared-scripts.sh` to stabilize the environment.

### Results (FINAL)

| Metric | Baseline (`release-api-plugin-stable`) | With Fix (`fix/set-node-version-stable`) |
|--------|---------------------------------------|----------------------------------------|
| Batch ID | `553c99ae-3a81-4056-9d78-d4fe096dcdd5` | `528e6f48-1eb4-4410-8dbe-bf892d037b3a` |
| ✅ Succeeded | 27 | 68 |
| ❌ Failed | 54 | 14 |
| Pass Rate | 33% | **83%** |
| Improvement | — | **74% fewer failures** |

### Remaining Failures With Fix (14 tests — all pre-existing)
These failures also occur on `main` branch and the `release-api-plugin-stable` baseline. They are **not caused by this change**:
- `predictions_migration` — pre-existing migration test flake
- `http_migration` — pre-existing migration test flake
- `schema_iterative_update_3` — pre-existing
- `custom_policies_container` — pre-existing
- `api_5` — pre-existing
- `api_6` — pre-existing
- `function_migration` — pre-existing migration test flake
- `schema_auth_10` — pre-existing
- `containers_api_1` — pre-existing
- `schema_model` — pre-existing
- `custom_query_mutation_extension` — pre-existing
- `api_2` — pre-existing
- `IndexWithClaimFieldAsSortKeyAuth` — pre-existing
- `cleanup_e2e_resources` — cleanup job, not a real test failure

### Verdict
Pinning `AMPLIFY_NODE_VERSION=24.12.0` **reduces failures from 54 to 14** (74% reduction) and **increases pass rate from 33% to 83%**. All remaining failures are pre-existing on `main` and unrelated to this change. The fix restores `release-api-plugin-stable` to a healthy state.
