### PR TITLE
fix(searchable): enforce TLS 1.2 on OpenSearch domains (v2 transformer)

### DIFF
--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
@@ -233,6 +233,7 @@ test('it generates expected resources', () => {
     ElasticsearchVersion: '7.10',
     DomainEndpointOptions: {
       EnforceHTTPS: true,
+      TLSSecurityPolicy: 'Policy-Min-TLS-1-2-2019-07',
     },
   });
   Template.fromJSON(searchableStack).hasResource('AWS::Elasticsearch::Domain', {
@@ -444,6 +445,29 @@ describe('nodeToNodeEncryption transformParameter', () => {
     Template.fromJSON(searchableStack).hasResourceProperties('AWS::Elasticsearch::Domain', {
       NodeToNodeEncryptionOptions: {
         Enabled: true,
+      },
+    });
+  });
+});
+
+describe('TLS security policy', () => {
+  const schema = /* GraphQL */ `
+    type Todo @model @searchable {
+      content: String!
+    }
+  `;
+
+  it('synthesizes w/ TLS 1.2 security policy on the OpenSearch domain', () => {
+    const out = testTransform({
+      schema,
+      transformers: [new ModelTransformer(), new SearchableModelTransformer()],
+    });
+    expect(out).toBeDefined();
+    const searchableStack = out.stacks.SearchableStack;
+    Template.fromJSON(searchableStack).hasResourceProperties('AWS::Elasticsearch::Domain', {
+      DomainEndpointOptions: {
+        EnforceHTTPS: true,
+        TLSSecurityPolicy: 'Policy-Min-TLS-1-2-2019-07',
       },
     });
   });

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
@@ -1,6 +1,6 @@
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { EbsDeviceVolumeType } from 'aws-cdk-lib/aws-ec2';
-import { CfnDomain, Domain, ElasticsearchVersion } from 'aws-cdk-lib/aws-elasticsearch';
+import { CfnDomain, Domain, ElasticsearchVersion, TLSSecurityPolicy } from 'aws-cdk-lib/aws-elasticsearch';
 import { IRole, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { CfnParameter, Fn, RemovalPolicy } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
@@ -20,6 +20,7 @@ export const createSearchableDomain = (
   const domain = new Domain(stack, OpenSearchDomainLogicalID, {
     version: { version: '7.10' } as ElasticsearchVersion,
     enforceHttps: true,
+    tlsSecurityPolicy: TLSSecurityPolicy.TLS_1_2,
     ebs: {
       enabled: true,
       volumeType: EbsDeviceVolumeType.GP2,


### PR DESCRIPTION
Cherry-pick of #3452 to release branch.

This adds TLS 1.2 enforcement to the v2 searchable transformer for Gen 1 LTS customers.

## Changes
- Sets tlsSecurityPolicy: TLSSecurityPolicy.TLS_1_2 on OpenSearch domains created by the @searchable directive (v2 transformer)
- Backport of the fix already merged to main via PR #3452

## Testing
- Unit tests passing
- E2E tests to be triggered separately