### PR TITLE
fix: exclude broken regions from E2E tests (Gen 1)

### DIFF
--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -544,7 +544,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/searchable-migration.test.ts
-          CLI_REGION: eu-north-1
+          CLI_REGION: ap-southeast-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry

--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -105,7 +105,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/schema-iterative-update-3.test.ts|src/__tests__/api_8.test.ts|src/__tests__/transformer-migrations/auth-migration.test.ts|src/__tests__/schema-iterative-update-locking.test.ts
-          CLI_REGION: sa-east-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -116,7 +116,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/schema-iterative-update-1.test.ts|src/__tests__/graphql-v2/lambda-conflict-handler.test.ts|src/__tests__/graphql-v2/index-with-stack-mappings.test.ts|src/__tests__/schema-iterative-update-2.test.ts
-          CLI_REGION: ap-east-1
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -137,18 +137,18 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/api_5.test.ts|src/__tests__/schema-function-1.test.ts|src/__tests__/api_3.test.ts|src/__tests__/generate_ts_data_schema.test.ts
-          CLI_REGION: me-south-1
+          CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        api_canary_ap_southeast_1_api_override_ddb_table_name_resolvers_sync_query_datastore
+        api_canary_eu_north_1_api_override_ddb_table_name_resolvers_sync_query_datastore
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TEST_SUITE: >-
             src/__tests__/api_canary.test.ts|src/__tests__/api-override-ddb-table-name.test.ts|src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: eu-north-1
       depend-on:
         - publish_to_local_registry
     - identifier: api_6_api_lambda_auth_api_9
@@ -158,7 +158,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/api_6.test.ts|src/__tests__/graphql-v2/api_lambda_auth.test.ts|src/__tests__/api_9.test.ts
-          CLI_REGION: eu-west-3
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: api_10
@@ -232,7 +232,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-10.test.ts
-          CLI_REGION: me-south-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_1
@@ -241,7 +241,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-1.test.ts
-          CLI_REGION: sa-east-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_13
@@ -250,7 +250,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-13.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_12
@@ -259,7 +259,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-12.test.ts
-          CLI_REGION: us-west-1
+          CLI_REGION: ap-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_3
@@ -268,7 +268,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-3.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_15
@@ -277,7 +277,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-15.test.ts
-          CLI_REGION: ap-east-1
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_iterative_rollback_1
@@ -286,7 +286,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-rollback-1.test.ts
-          CLI_REGION: ap-northeast-2
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: api_key_migration4
@@ -295,7 +295,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/migration/api.key.migration4.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: eu-north-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -305,7 +305,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-key.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_iterative_rollback_2
@@ -314,7 +314,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-rollback-2.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_8
@@ -323,7 +323,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-8.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: eu-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_4
@@ -332,7 +332,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-4.test.ts
-          CLI_REGION: eu-north-1
+          CLI_REGION: eu-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: containers_api_1
@@ -350,7 +350,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-11.test.ts
-          CLI_REGION: eu-west-1
+          CLI_REGION: eu-west-3
       depend-on:
         - publish_to_local_registry
     - identifier: api_key_migration2
@@ -359,7 +359,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/migration/api.key.migration2.test.ts
-          CLI_REGION: us-west-1
+          CLI_REGION: ap-northeast-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -369,7 +369,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/migration/api.key.migration1.test.ts
-          CLI_REGION: eu-west-3
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_model
@@ -378,7 +378,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-model.test.ts
-          CLI_REGION: me-south-1
+          CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: api_11
@@ -387,7 +387,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/api_11.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: ap-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: custom_query_mutation_extension
@@ -396,7 +396,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/custom-query-mutation-extension.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: apigw
@@ -405,7 +405,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/apigw.test.ts
-          CLI_REGION: us-west-1
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_9
@@ -414,7 +414,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-9.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_7
@@ -423,7 +423,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-7.test.ts
-          CLI_REGION: ap-east-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_14
@@ -432,7 +432,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-14.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: containers_api_2
@@ -450,7 +450,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/api_1.test.ts
-          CLI_REGION: ap-south-1
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_5
@@ -459,7 +459,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-5.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: eu-north-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_searchable
@@ -478,7 +478,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_datastore
@@ -487,7 +487,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts
-          CLI_REGION: us-west-1
+          CLI_REGION: ap-northeast-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -497,7 +497,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-connection.test.ts
-          CLI_REGION: eu-south-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_6
@@ -506,7 +506,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/schema-auth-6.test.ts
-          CLI_REGION: eu-west-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_had_node_to_node
@@ -516,7 +516,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-had-node-to-node.test.ts
-          CLI_REGION: ap-northeast-2
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_no_node_to_node
@@ -526,7 +526,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-no-node-to-node.test.ts
-          CLI_REGION: ap-south-1
+          CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: api_2
@@ -535,7 +535,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/api_2.test.ts
-          CLI_REGION: me-south-1
+          CLI_REGION: ap-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_migration
@@ -544,7 +544,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/searchable-migration.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: eu-north-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -655,7 +655,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/IndexWithClaimFieldAsSortKeyAuth.e2e.test.ts|src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts|src/__tests__/RelationalWithAuthV2.e2e.test.ts|src/__tests__/MapsToTransformer.e2e.test.ts
-          CLI_REGION: me-south-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -666,7 +666,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/MultiAuthV2TransformerWithFF.e2e.test.ts|src/__tests__/IndexTransformer.e2e.test.ts|src/__tests__/AuthV2Transformer.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT1B.test.ts
-          CLI_REGION: sa-east-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -677,7 +677,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/AuthV2ExhaustiveT1A.test.ts|src/__tests__/IndexWithAutoQueryField.e2e.test.ts|src/__tests__/AuthV2TransformerWithFF.e2e.test.ts|src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -688,7 +688,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/RelationalTransformers.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT2A.test.ts|src/__tests__/AuthV2ExhaustiveT1C.test.ts|src/__tests__/AuthV2ExhaustiveT1D.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -699,7 +699,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/AuthV2ExhaustiveT2B.test.ts|src/__tests__/AuthV2ExhaustiveT2D.test.ts|src/__tests__/AuthV2ExhaustiveT2C.test.ts|src/__tests__/RelationalWithAuthV2Redacted.e2e.test.ts
-          CLI_REGION: us-west-1
+          CLI_REGION: ap-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -710,7 +710,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/RelationalWithAuthV2NonRedacted.e2e.test.ts|src/__tests__/AuthV2TransformerIAM.test.ts|src/__tests__/AuthV2ExhaustiveT3D.test.ts|src/__tests__/AuthV2ExhaustiveT3C.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -721,7 +721,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/AuthV2ExhaustiveT3B.test.ts|src/__tests__/AuthV2ExhaustiveT3A.test.ts|src/__tests__/SearchableModelTransformerV2.e2e.test.ts|src/__tests__/SearchableWithAuthTests.e2e.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -732,7 +732,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/SearchableModelTransformer.e2e.test.ts|src/__tests__/SearchableWithAuthV2WithFF.e2e.test.ts|src/__tests__/SearchableWithAuthV2.e2e.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: FunctionTransformerTestsV2

--- a/packages/amplify-e2e-core/src/configure/index.ts
+++ b/packages/amplify-e2e-core/src/configure/index.ts
@@ -38,8 +38,6 @@ export const amplifyRegions = [
   'ap-southeast-2',
   'ap-south-1',
   'ca-central-1',
-  'me-south-1',
-  'sa-east-1',
 ];
 
 const configurationOptions = ['Project information', 'AWS Profile setting', 'Advanced: Container-based deployments'];

--- a/scripts/e2e-test-regions.json
+++ b/scripts/e2e-test-regions.json
@@ -12,8 +12,6 @@
   { "name": "eu-west-1", "optIn": false, "cognitoSupported": true, "betaLayerDeployed": true },
   { "name": "eu-west-2", "optIn": false, "cognitoSupported": true, "betaLayerDeployed": true },
   { "name": "eu-west-3", "optIn": false, "cognitoSupported": true, "betaLayerDeployed": true },
-  { "name": "me-south-1", "optIn": true, "cognitoSupported": true, "betaLayerDeployed": false },
-  { "name": "sa-east-1", "optIn": false, "cognitoSupported": true, "betaLayerDeployed": true },
   { "name": "us-east-1", "optIn": false, "cognitoSupported": true, "betaLayerDeployed": true },
   { "name": "us-east-2", "optIn": false, "cognitoSupported": true, "betaLayerDeployed": true },
   { "name": "us-west-1", "optIn": false, "cognitoSupported": true, "betaLayerDeployed": true },

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -178,7 +178,10 @@ const RUN_IN_COGNITO_REGIONS: (string | RegExp)[] = [
   /src\/__tests__\/AuthV2ExhaustiveT3C.test.ts/,
 ];
 
-const RUN_IN_V1_TRANSFORMER_REGIONS = ['src/__tests__/schema-searchable.test.ts'];
+const RUN_IN_V1_TRANSFORMER_REGIONS = [
+  'src/__tests__/schema-searchable.test.ts',
+  'src/__tests__/transformer-migrations/searchable-migration.test.ts',
+];
 
 const DEBUG_FLAG = '--debug';
 


### PR DESCRIPTION
Excludes me-south-1 (BAH) and sa-east-1 from E2E test region assignments on the release branch.

These regions have infrastructure issues causing consistent failures:
- **me-south-1 (BAH)** — broken RDS infrastructure
- **sa-east-1** — consistent test failures

Note: me-central-1 (DXB) was not present in the release branch region pool, so no change needed.

## Changes
- Removed me-south-1 and sa-east-1 from `scripts/e2e-test-regions.json`
- Regenerated `codebuild_specs/e2e_workflow.yml` (tests redistributed to remaining regions via round-robin)

## Testing
- E2E tests to be triggered and compared against baseline batch `ff2330a8-186c-4dca-a677-424287ffe523`