### PR TITLE
fix(graphql-searchable-transformer): enforce TLS 1.2 on OpenSearch domains (v2 transformer)

### DIFF
--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts
@@ -233,6 +233,7 @@ test('it generates expected resources', () => {
     ElasticsearchVersion: '7.10',
     DomainEndpointOptions: {
       EnforceHTTPS: true,
+      TLSSecurityPolicy: 'Policy-Min-TLS-1-2-2019-07',
     },
   });
   Template.fromJSON(searchableStack).hasResource('AWS::Elasticsearch::Domain', {
@@ -444,6 +445,29 @@ describe('nodeToNodeEncryption transformParameter', () => {
     Template.fromJSON(searchableStack).hasResourceProperties('AWS::Elasticsearch::Domain', {
       NodeToNodeEncryptionOptions: {
         Enabled: true,
+      },
+    });
+  });
+});
+
+describe('TLS security policy', () => {
+  const schema = /* GraphQL */ `
+    type Todo @model @searchable {
+      content: String!
+    }
+  `;
+
+  it('synthesizes w/ TLS 1.2 security policy on the OpenSearch domain', () => {
+    const out = testTransform({
+      schema,
+      transformers: [new ModelTransformer(), new SearchableModelTransformer()],
+    });
+    expect(out).toBeDefined();
+    const searchableStack = out.stacks.SearchableStack;
+    Template.fromJSON(searchableStack).hasResourceProperties('AWS::Elasticsearch::Domain', {
+      DomainEndpointOptions: {
+        EnforceHTTPS: true,
+        TLSSecurityPolicy: 'Policy-Min-TLS-1-2-2019-07',
       },
     });
   });

--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts
@@ -1,6 +1,6 @@
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { EbsDeviceVolumeType } from 'aws-cdk-lib/aws-ec2';
-import { CfnDomain, Domain, ElasticsearchVersion } from 'aws-cdk-lib/aws-elasticsearch';
+import { CfnDomain, Domain, ElasticsearchVersion, TLSSecurityPolicy } from 'aws-cdk-lib/aws-elasticsearch';
 import { IRole, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { CfnParameter, Fn, RemovalPolicy } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
@@ -20,6 +20,7 @@ export const createSearchableDomain = (
   const domain = new Domain(stack, OpenSearchDomainLogicalID, {
     version: { version: '7.10' } as ElasticsearchVersion,
     enforceHttps: true,
+    tlsSecurityPolicy: TLSSecurityPolicy.TLS_1_2,
     ebs: {
       enabled: true,
       volumeType: EbsDeviceVolumeType.GP2,


### PR DESCRIPTION
## Description

Sets `tlsSecurityPolicy` to `TLS_1_2` on OpenSearch domains created by the `@searchable` directive in the v2 transformer (`@aws-amplify/graphql-searchable-transformer`), ensuring Gen 1 LTS customers using the v2 transformer get TLS 1.2 enforcement.

This is the same fix as PR #3452 on main, implemented directly on the release branch.

## Changes

- **`packages/amplify-graphql-searchable-transformer/src/cdk/create-searchable-domain.ts`**: Added `TLSSecurityPolicy` import and set `tlsSecurityPolicy: TLSSecurityPolicy.TLS_1_2` in the Domain constructor
- **`packages/amplify-graphql-searchable-transformer/src/__tests__/amplify-graphql-searchable-transformer.test.ts`**: Updated existing assertion and added dedicated TLS 1.2 security policy test

## Testing

- 36/36 unit tests pass
- E2E batch running: `amplify-category-api-e2e-workflow:5f982b9d-679c-4a9a-abce-bf4efdb8ce84` (82 build groups, Gen 1 baseline)

## Related

- Replaces #3470 (closed due to CodeBuild branch resolution issue)
- Same fix as #3452 (main branch)
- V1 transformer fix: #3456 (already merged)