### PR TITLE
fix: restore e2e-tests version to 4.1.13 after accidental downgrade

### DIFF
--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-category-api-e2e-tests",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "E2e test suite",
   "repository": {
     "type": "git",


### PR DESCRIPTION
#### Description of changes

Restores `amplify-category-api-e2e-tests` package version from `4.1.12` back to `4.1.13`. The version was accidentally downgraded in #3441 (bddb2c84), which caused lerna to fail when it tried to bump and tag `4.1.13` again — the git tag `amplify-category-api-e2e-tests@4.1.13` already existed from the prior release.

##### CDK / CloudFormation Parameters Changed

None.

#### Issue #, if available

N/A — build failure caused by tag collision during `lerna version`.

#### Description of how you validated changes

Confirmed via `git tag -l "amplify-category-api-e2e-tests*"` that the `@4.1.13` tag already exists. Verified the parent commit of #3441 had version `4.1.13` and the commit itself downgraded it to `4.1.12`. Restoring to `4.1.13` means lerna will see no version change needed and skip re-tagging.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] ~~E2E test run linked~~ (not applicable — version-only change)
- [ ] ~~Tests are changed or added~~ (not applicable)
- [ ] ~~Relevant documentation is changed or added~~ (not applicable)
- [ ] ~~New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies~~ (not applicable)
- [ ] ~~Any CDK or CloudFormation parameter changes are called out explicitly~~ (not applicable)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
