### PR TITLE
fix: add sa-east-1 region back to E2E test pool

### DIFF
--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -89,7 +89,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=14848'
           TEST_SUITE: >-
             src/__tests__/api_5.test.ts|src/__tests__/schema-function-1.test.ts|src/__tests__/generate_ts_data_schema.test.ts|src/__tests__/resolvers.test.ts|src/__tests__/graphql-v2/sync_query_datastore.test.ts
-          CLI_REGION: ca-central-1
+          CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: api_6_api_lambda_auth
@@ -100,7 +100,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=14848'
           TEST_SUITE: >-
             src/__tests__/api_6.test.ts|src/__tests__/graphql-v2/api_lambda_auth.test.ts
-          CLI_REGION: eu-west-3
+          CLI_REGION: eu-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_v2
@@ -210,7 +210,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/schema-auth-4.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: sa-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_11
@@ -220,7 +220,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/schema-auth-11.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: sql_generate_unauth
@@ -230,7 +230,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/sql-generate-unauth.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_model
@@ -240,7 +240,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/schema-model.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_v2_test_utils
@@ -250,7 +250,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-v2-test-utils.test.ts
-          CLI_REGION: ap-northeast-3
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_relational_directives
@@ -260,7 +260,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-relational-directives.test.ts
-          CLI_REGION: ap-south-1
+          CLI_REGION: ap-northeast-3
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_v2_generate_schema
@@ -270,7 +270,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-v2-generate-schema.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_userpool_auth
@@ -280,7 +280,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-userpool-auth.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_userpool_auth_fields
@@ -290,7 +290,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-userpool-auth-fields.test.ts
-          CLI_REGION: ca-central-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_relational_directives
@@ -300,7 +300,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-relational-directives.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_refers_to
@@ -310,7 +310,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-refers-to.test.ts
-          CLI_REGION: eu-north-1
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_refers_to_fields
@@ -320,7 +320,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-refers-to-fields.test.ts
-          CLI_REGION: eu-west-1
+          CLI_REGION: eu-north-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_oidc_auth_fields
@@ -330,7 +330,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-oidc-auth-fields.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: eu-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_model_v2
@@ -340,7 +340,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-model-v2.test.ts
-          CLI_REGION: eu-west-3
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_import
@@ -350,7 +350,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-import.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: eu-west-3
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_field_auth_userpool_static_dynamic
@@ -360,7 +360,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-field-auth-userpool-static-dynamic.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: sa-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_field_auth_userpool_iam
@@ -370,7 +370,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-field-auth-userpool-iam.test.ts
-          CLI_REGION: us-west-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_field_auth_lambda
@@ -380,7 +380,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-field-auth-lambda.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_field_auth_identityPool
@@ -390,7 +390,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-field-auth-identityPool.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_field_auth_iam
@@ -400,7 +400,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-field-auth-iam.test.ts
-          CLI_REGION: ap-northeast-2
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_field_auth_apikey
@@ -410,7 +410,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-field-auth-apikey.test.ts
-          CLI_REGION: ap-northeast-3
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_custom_claims_refersto_auth
@@ -420,7 +420,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-custom-claims-refersto-auth.test.ts
-          CLI_REGION: ap-south-1
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_auth_iam
@@ -430,7 +430,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-auth-iam.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-northeast-3
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_auth_iam_apikey_lambda_subscription
@@ -440,7 +440,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-auth-iam-apikey-lambda-subscription.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_auth_apikey_lambda
@@ -450,7 +450,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-auth-apikey-lambda.test.ts
-          CLI_REGION: ca-central-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_pg_array_objects
@@ -460,7 +460,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-pg-array-objects.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_v2_generate_schema
@@ -470,7 +470,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-v2-generate-schema.test.ts
-          CLI_REGION: eu-north-1
+          CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_userpool_auth
@@ -480,7 +480,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-userpool-auth.test.ts
-          CLI_REGION: eu-west-1
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_userpool_auth_fields
@@ -490,7 +490,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-userpool-auth-fields.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: eu-north-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_refers_to
@@ -500,7 +500,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-refers-to.test.ts
-          CLI_REGION: eu-west-3
+          CLI_REGION: eu-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_refers_to_fields
@@ -510,7 +510,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-refers-to-fields.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_oidc_auth_fields
@@ -520,7 +520,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-oidc-auth-fields.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: eu-west-3
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_multi_auth_1
@@ -530,7 +530,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-multi-auth-1.test.ts
-          CLI_REGION: us-west-1
+          CLI_REGION: sa-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_model_v2
@@ -540,7 +540,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-model-v2.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_field_auth_userpool_static_dynamic
@@ -550,7 +550,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-userpool-static-dynamic.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_field_auth_userpool_iam
@@ -560,7 +560,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-userpool-iam.test.ts
-          CLI_REGION: ap-northeast-2
+          CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_field_auth_lambda
@@ -570,7 +570,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-lambda.test.ts
-          CLI_REGION: ap-northeast-3
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_field_auth_identityPool
@@ -580,7 +580,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-identityPool.test.ts
-          CLI_REGION: ap-south-1
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_field_auth_iam
@@ -590,7 +590,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-iam.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_field_auth_apikey
@@ -600,7 +600,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-apikey.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: ap-northeast-3
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_custom_claims_refersto_auth
@@ -610,7 +610,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-custom-claims-refersto-auth.test.ts
-          CLI_REGION: ca-central-1
+          CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_auth_iam
@@ -620,7 +620,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-auth-iam.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_auth_iam_apikey_lambda_subscription
@@ -630,7 +630,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts
-          CLI_REGION: eu-north-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: rds_mysql_auth_apikey_lambda
@@ -640,7 +640,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/rds-mysql-auth-apikey-lambda.test.ts
-          CLI_REGION: eu-west-1
+          CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_9
@@ -650,7 +650,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/schema-auth-9.test.ts
-          CLI_REGION: ap-south-1
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_7
@@ -660,7 +660,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/schema-auth-7.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_14
@@ -670,7 +670,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/schema-auth-14.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: ap-northeast-3
       depend-on:
         - publish_to_local_registry
     - identifier: schema_auth_5
@@ -680,7 +680,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/schema-auth-5.test.ts
-          CLI_REGION: ca-central-1
+          CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: schema_searchable
@@ -701,7 +701,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: us-east-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - publish_to_local_registry
@@ -712,7 +712,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/schema-auth-6.test.ts
-          CLI_REGION: eu-west-1
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: searchable_previous_deployment_had_node_to_node
@@ -734,7 +734,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-no-node-to-node.test.ts
-          CLI_REGION: ap-south-1
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: utils_log_config_gsi_projection_type_ddb_iam_access_data_construct
@@ -757,7 +757,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=14848'
           TEST_SUITE: >-
             src/__tests__/custom-logic.test.ts|src/__tests__/amplify-table-5.test.ts|src/__tests__/add-resources.test.ts|src/__tests__/validate-transformer/validate-transformer-evaluate-mapping-template.test.ts|src/__tests__/validate-transformer/validate-transformer-e2e.test.ts
-          CLI_REGION: ap-south-1
+          CLI_REGION: ap-northeast-3
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -769,7 +769,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=14848'
           TEST_SUITE: >-
             src/__tests__/migration/references-migration.test.ts|src/__tests__/migration/migration-validation.test.ts|src/__tests__/migration/many-to-many-migration.test.ts|src/__tests__/migration/base-migration.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: eu-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: sql_pg_userpool_auth
@@ -880,7 +880,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/sql-iam-access.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: sa-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: default_ddb_canary
@@ -900,7 +900,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/custom-query-mutation-extension.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: base_cdk_ap_east_1
@@ -1043,6 +1043,16 @@ batch:
           CLI_REGION: eu-west-3
       depend-on:
         - publish_to_local_registry
+    - identifier: base_cdk_sa_east_1
+      buildspec: codebuild_specs/run_cdk_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        variables:
+          NODE_OPTIONS: '--max-old-space-size=6656'
+          TEST_SUITE: src/__tests__/base-cdk.test.ts
+          CLI_REGION: sa-east-1
+      depend-on:
+        - publish_to_local_registry
     - identifier: base_cdk_us_east_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1090,7 +1100,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/amplify-table-4.test.ts
-          CLI_REGION: us-west-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: amplify_table_3
@@ -1100,7 +1110,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/amplify-table-3.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: amplify_table_2
@@ -1110,7 +1120,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/amplify-table-2.test.ts
-          CLI_REGION: ap-east-1
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: amplify_table_1
@@ -1120,7 +1130,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/amplify-table-1.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: amplify_ddb_canary
@@ -1130,7 +1140,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
-          CLI_REGION: ap-northeast-2
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: all_auth_modes
@@ -1140,7 +1150,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/all-auth-modes.test.ts
-          CLI_REGION: ap-northeast-3
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: admin_role
@@ -1150,7 +1160,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/admin-role.test.ts
-          CLI_REGION: ap-south-1
+          CLI_REGION: ap-northeast-3
       depend-on:
         - publish_to_local_registry
     - identifier: sql_custom_ssl
@@ -1160,7 +1170,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/sql-custom-ssl/sql-custom-ssl.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: eu-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: restricted_field_auth_gen2
@@ -1171,7 +1181,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/restricted-field-auth/restricted-field-auth-gen2.test.ts
-          CLI_REGION: eu-west-3
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: restricted_field_auth_gen1
@@ -1182,7 +1192,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/restricted-field-auth/restricted-field-auth-gen1.test.ts
-          CLI_REGION: eu-west-1
+          CLI_REGION: eu-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: restricted_field_auth_gen2_subscriptions_off
@@ -1193,7 +1203,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/restricted-field-auth/subscriptions-off/restricted-field-auth-gen2-subscriptions-off.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: sa-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: restricted_field_auth_gen1_subscriptions_off
@@ -1204,7 +1214,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/restricted-field-auth/subscriptions-off/restricted-field-auth-gen1-subscriptions-off.test.ts
-          CLI_REGION: eu-west-3
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: references_sqlprimary_sqlrelated
@@ -1215,7 +1225,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/relationships/references/references-sqlprimary-sqlrelated.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: references_sqlprimary_ddbrelated
@@ -1226,7 +1236,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/relationships/references/references-sqlprimary-ddbrelated.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: references_ddbprimary_sqlrelated
@@ -1237,7 +1247,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/relationships/references/references-ddbprimary-sqlrelated.test.ts
-          CLI_REGION: ap-northeast-2
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: references_ddbprimary_ddbrelated
@@ -1248,7 +1258,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/relationships/references/references-ddbprimary-ddbrelated.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: eu-west-3
       depend-on:
         - publish_to_local_registry
     - identifier: recursive_relationships_sql
@@ -1259,7 +1269,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/relationships/recursive/recursive-relationships-sql.test.ts
-          CLI_REGION: ap-south-1
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: recursive_relationships_ddb
@@ -1270,7 +1280,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/relationships/recursive/recursive-relationships-ddb.test.ts
-          CLI_REGION: us-west-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: uuid_pk_sqlprimary_sqlrelated
@@ -1281,7 +1291,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/relationships/postgres-uuid-pk/uuid-pk-sqlprimary-sqlrelated.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: uuid_pk_sqlprimary_ddbrelated
@@ -1292,7 +1302,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/relationships/postgres-uuid-pk/uuid-pk-sqlprimary-ddbrelated.test.ts
-          CLI_REGION: ca-central-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: uuid_pk_ddbprimary_sqlrelated
@@ -1303,7 +1313,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/relationships/postgres-uuid-pk/uuid-pk-ddbprimary-sqlrelated.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: multi_relationship_sqlprimary_sqlrelated
@@ -1314,7 +1324,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/relationships/multi-relationship/multi-relationship-sqlprimary-sqlrelated.test.ts
-          CLI_REGION: eu-north-1
+          CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: multi_relationship_sqlprimary_ddbrelated
@@ -1325,7 +1335,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/relationships/multi-relationship/multi-relationship-sqlprimary-ddbrelated.test.ts
-          CLI_REGION: eu-west-1
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: multi_relationship_ddbprimary_sqlrelated
@@ -1336,7 +1346,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/relationships/multi-relationship/multi-relationship-ddbprimary-sqlrelated.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: eu-north-1
       depend-on:
         - publish_to_local_registry
     - identifier: multi_relationship_ddbprimary_ddbrelated
@@ -1347,7 +1357,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/relationships/multi-relationship/multi-relationship-ddbprimary-ddbrelated.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-northeast-3
       depend-on:
         - publish_to_local_registry
     - identifier: relationships_gen1
@@ -1357,7 +1367,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/relationships/gen1/relationships-gen1.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: assoc_field_subscriptions_off
@@ -1368,7 +1378,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/owner-auth/subscriptions-off/assoc-field-subscriptions-off.test.ts
-          CLI_REGION: eu-west-1
+          CLI_REGION: eu-north-1
       depend-on:
         - publish_to_local_registry
     - identifier: bind_sql_ids
@@ -1378,7 +1388,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/owner-auth/bind-sql-ids/bind-sql-ids.test.ts
-          CLI_REGION: us-west-1
+          CLI_REGION: sa-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: assoc_field_sqlprimary_sqlrelated
@@ -1389,7 +1399,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/owner-auth/assoc-field/assoc-field-sqlprimary-sqlrelated.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: assoc_field_sqlprimary_ddbrelated
@@ -1400,7 +1410,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/owner-auth/assoc-field/assoc-field-sqlprimary-ddbrelated.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: assoc_field_ddbprimary_sqlrelated
@@ -1411,7 +1421,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/owner-auth/assoc-field/assoc-field-ddbprimary-sqlrelated.test.ts
-          CLI_REGION: ap-northeast-2
+          CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: assoc_field_ddbprimary_ddbrelated
@@ -1422,7 +1432,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/owner-auth/assoc-field/assoc-field-ddbprimary-ddbrelated.test.ts
-          CLI_REGION: us-west-1
+          CLI_REGION: sa-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: static_group_auth_sqlprimary_sqlrelated_subscriptions_off
@@ -1433,7 +1443,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/group-auth/subscriptions-off/static-group-auth/static-group-auth-sqlprimary-sqlrelated-subscriptions-off.test.ts
-          CLI_REGION: ap-south-1
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: static_group_auth_sqlprimary_ddbrelated_subscriptions_off
@@ -1444,7 +1454,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/group-auth/subscriptions-off/static-group-auth/static-group-auth-sqlprimary-ddbrelated-subscriptions-off.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: static_group_auth_ddbprimary_sqlrelated_subscriptions_off
@@ -1455,7 +1465,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/group-auth/subscriptions-off/static-group-auth/static-group-auth-ddbprimary-sqlrelated-subscriptions-off.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: ap-northeast-3
       depend-on:
         - publish_to_local_registry
     - identifier: static_group_auth_ddbprimary_ddbrelated_subscriptions_off
@@ -1466,7 +1476,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/group-auth/subscriptions-off/static-group-auth/static-group-auth-ddbprimary-ddbrelated-subscriptions-off.test.ts
-          CLI_REGION: ap-northeast-3
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: dynamic_group_auth_sqlprimary_sqlrelated_subscriptions_off
@@ -1477,7 +1487,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/group-auth/subscriptions-off/dynamic-group-auth/dynamic-group-auth-sqlprimary-sqlrelated-subscriptions-off.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: dynamic_group_auth_sqlprimary_ddbrelated_subscriptions_off
@@ -1488,7 +1498,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/group-auth/subscriptions-off/dynamic-group-auth/dynamic-group-auth-sqlprimary-ddbrelated-subscriptions-off.test.ts
-          CLI_REGION: eu-north-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: dynamic_group_auth_ddbprimary_sqlrelated_subscriptions_off
@@ -1499,7 +1509,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/group-auth/subscriptions-off/dynamic-group-auth/dynamic-group-auth-ddbprimary-sqlrelated-subscriptions-off.test.ts
-          CLI_REGION: eu-west-1
+          CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: dynamic_group_auth_ddbprimary_ddbrelated_subscriptions_off
@@ -1510,7 +1520,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/group-auth/subscriptions-off/dynamic-group-auth/dynamic-group-auth-ddbprimary-ddbrelated-subscriptions-off.test.ts
-          CLI_REGION: ca-central-1
+          CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: static_group_auth_sqlprimary_sqlrelated
@@ -1521,7 +1531,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/group-auth/static-group-auth/static-group-auth-sqlprimary-sqlrelated.test.ts
-          CLI_REGION: eu-west-3
+          CLI_REGION: eu-north-1
       depend-on:
         - publish_to_local_registry
     - identifier: static_group_auth_sqlprimary_ddbrelated
@@ -1532,7 +1542,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/group-auth/static-group-auth/static-group-auth-sqlprimary-ddbrelated.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: eu-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: static_group_auth_ddbprimary_sqlrelated
@@ -1543,7 +1553,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/group-auth/static-group-auth/static-group-auth-ddbprimary-sqlrelated.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: static_group_auth_ddbprimary_ddbrelated
@@ -1554,7 +1564,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/group-auth/static-group-auth/static-group-auth-ddbprimary-ddbrelated.test.ts
-          CLI_REGION: eu-west-1
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: dynamic_group_auth_sqlprimary_sqlrelated
@@ -1565,7 +1575,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-sqlprimary-sqlrelated.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: sa-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: dynamic_group_auth_sqlprimary_ddbrelated
@@ -1576,7 +1586,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-sqlprimary-ddbrelated.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: dynamic_group_auth_ddbprimary_sqlrelated
@@ -1587,7 +1597,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-ddbprimary-sqlrelated.test.ts
-          CLI_REGION: ap-northeast-2
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: dynamic_group_auth_ddbprimary_ddbrelated
@@ -1598,7 +1608,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-ddbprimary-ddbrelated.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: generation
@@ -1620,7 +1630,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-single-record.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: eu-north-1
       depend-on:
         - publish_to_local_registry
     - identifier: single_gsi_empty_table
@@ -1631,7 +1641,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-empty-table.test.ts
-          CLI_REGION: eu-west-3
+          CLI_REGION: eu-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: single_gsi_1k_records
@@ -1642,7 +1652,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-1k-records.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: eu-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: single_gsi_10k_records
@@ -1653,7 +1663,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-10k-records.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: eu-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: replace_2_gsis_update_attr_single_record
@@ -1664,7 +1674,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-single-record.test.ts
-          CLI_REGION: us-west-1
+          CLI_REGION: eu-west-3
       depend-on:
         - publish_to_local_registry
     - identifier: replace_2_gsis_update_attr_empty_table
@@ -1675,7 +1685,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-empty-table.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: sa-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: replace_2_gsis_update_attr_1k_records
@@ -1686,7 +1696,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-1k-records.test.ts
-          CLI_REGION: ap-east-1
+          CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: replace_2_gsis_update_attr_10k_records
@@ -1697,7 +1707,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-10k-records.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: us-east-2
       depend-on:
         - publish_to_local_registry
     - identifier: replace_2_gsis_single_record
@@ -1708,7 +1718,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-single-record.test.ts
-          CLI_REGION: ap-northeast-2
+          CLI_REGION: us-west-1
       depend-on:
         - publish_to_local_registry
     - identifier: replace_2_gsis_empty_table
@@ -1719,7 +1729,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-empty-table.test.ts
-          CLI_REGION: ap-northeast-3
+          CLI_REGION: us-west-2
       depend-on:
         - publish_to_local_registry
     - identifier: replace_2_gsis_1k_records
@@ -1730,7 +1740,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-1k-records.test.ts
-          CLI_REGION: ap-south-1
+          CLI_REGION: ap-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: replace_2_gsis_10k_records
@@ -1741,7 +1751,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-10k-records.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: 3_gsis_single_record
@@ -1752,7 +1762,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-single-record.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: 3_gsis_empty_table
@@ -1763,7 +1773,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-empty-table.test.ts
-          CLI_REGION: ca-central-1
+          CLI_REGION: ap-northeast-3
       depend-on:
         - publish_to_local_registry
     - identifier: 3_gsis_1k_records
@@ -1774,7 +1784,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-1k-records.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: 3_gsis_10k_records
@@ -1785,7 +1795,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-10k-records.test.ts
-          CLI_REGION: eu-north-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: single_gsi_100k_records
@@ -1795,7 +1805,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/deploy-velocity/single-gsi-100k-records.test.ts
-          CLI_REGION: eu-south-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: replace_2_gsis_update_attr_100k_records
@@ -1806,7 +1816,7 @@ batch:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: >-
             src/__tests__/deploy-velocity/replace-2-gsis-update-attr-100k-records.test.ts
-          CLI_REGION: eu-west-1
+          CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: replace_2_gsis_100k_records
@@ -1816,7 +1826,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/deploy-velocity/replace-2-gsis-100k-records.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: 3_gsis_100k_records
@@ -1826,7 +1836,7 @@ batch:
         variables:
           NODE_OPTIONS: '--max-old-space-size=6656'
           TEST_SUITE: src/__tests__/deploy-velocity/3-gsis-100k-records.test.ts
-          CLI_REGION: eu-west-3
+          CLI_REGION: eu-north-1
       depend-on:
         - publish_to_local_registry
     - identifier: conversation

--- a/packages/amplify-e2e-core/src/configure/index.ts
+++ b/packages/amplify-e2e-core/src/configure/index.ts
@@ -32,7 +32,6 @@ export const amplifyRegions = [
   'ap-southeast-2',
   'ap-south-1',
   'ca-central-1',
-  'me-south-1',
   'sa-east-1',
 ];
 

--- a/packages/amplify-e2e-core/src/configure/index.ts
+++ b/packages/amplify-e2e-core/src/configure/index.ts
@@ -32,6 +32,8 @@ export const amplifyRegions = [
   'ap-southeast-2',
   'ap-south-1',
   'ca-central-1',
+  'me-south-1',
+  'sa-east-1',
 ];
 
 const configurationOptions = ['Project information', 'AWS Profile setting', 'Advanced: Container-based deployments'];

--- a/scripts/e2e-test-regions.json
+++ b/scripts/e2e-test-regions.json
@@ -13,6 +13,7 @@
   { "name": "eu-west-1", "dataAPISupported": true, "optIn": false, "cognitoSupported": true, "betaLayerDeployed": true },
   { "name": "eu-west-2", "dataAPISupported": true, "optIn": false, "cognitoSupported": true, "betaLayerDeployed": true },
   { "name": "eu-west-3", "dataAPISupported": true, "optIn": false, "cognitoSupported": true, "betaLayerDeployed": true },
+  { "name": "sa-east-1", "dataAPISupported": false, "optIn": false, "cognitoSupported": true, "betaLayerDeployed": true },
   { "name": "us-east-1", "dataAPISupported": true, "optIn": false, "cognitoSupported": true, "betaLayerDeployed": true },
   { "name": "us-east-2", "dataAPISupported": true, "optIn": false, "cognitoSupported": true, "betaLayerDeployed": true },
   { "name": "us-west-1", "dataAPISupported": true, "optIn": false, "cognitoSupported": true, "betaLayerDeployed": true },


### PR DESCRIPTION
#### Description of changes

Re-adds `sa-east-1` (São Paulo) region to the E2E test pool.

##### CDK / CloudFormation Parameters Changed

None.

#### Issue #, if available

N/A

#### Description of how you validated changes

- E2E test run in progress (batch `e0e7fc3a-71e2-43aa-a40b-2dd944d5d768`)

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] E2E test run linked
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.