### PR TITLE
feat: support RDS IAM authentication for SQL data sources

### DIFF
--- a/packages/amplify-graphql-api-construct/src/model-datasource-strategy-types.ts
+++ b/packages/amplify-graphql-api-construct/src/model-datasource-strategy-types.ts
@@ -62,6 +62,18 @@ export interface ImportedAmplifyDynamoDbModelDataSourceStrategy {
 }
 
 /**
+ * Authentication strategy for RDS IAM database authentication.
+ */
+export interface SqlModelDataSourceRdsIamAuthenticationConfig {
+  readonly strategy: 'rdsIam';
+}
+
+/**
+ * The authentication configuration for an SQL data source. Currently only RDS IAM database authentication is supported.
+ */
+export type SqlModelDataSourceAuthentication = SqlModelDataSourceRdsIamAuthenticationConfig;
+
+/**
  * A strategy that creates a Lambda to connect to a pre-existing SQL table to resolve model data.
  */
 export interface SQLLambdaModelDataSourceStrategy {
@@ -96,6 +108,13 @@ export interface SQLLambdaModelDataSourceStrategy {
    * The configuration for the provisioned concurrency of the Lambda.
    */
   readonly sqlLambdaProvisionedConcurrencyConfig?: ProvisionedConcurrencyConfig;
+
+  /**
+   * The authentication configuration for the SQL data source. When set to RDS IAM authentication, the Lambda will generate an IAM
+   * authentication token at runtime instead of using a static password. This is required for Aurora PostgreSQL Express configurations
+   * that use RDS IAM database authentication.
+   */
+  readonly authentication?: SqlModelDataSourceAuthentication;
 }
 
 /**

--- a/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
+++ b/packages/amplify-graphql-model-transformer/rds-lambda/handler.ts
@@ -1,5 +1,6 @@
 import { SSMClient, GetParameterCommand, GetParameterCommandOutput } from '@aws-sdk/client-ssm';
 import { GetSecretValueCommand, SecretsManagerClient, GetSecretValueCommandOutput } from '@aws-sdk/client-secrets-manager';
+import { Signer } from '@aws-sdk/rds-signer';
 // @ts-ignore
 import { DBAdapter, DBConfig, getDBAdapter } from 'rds-query-processor';
 
@@ -16,6 +17,7 @@ const WAIT_COMPLETE = 'WAIT_COMPLETE';
 enum CredentialStorageMethod {
   SSM = 'SSM',
   SECRETS_MANAGER = 'SECRETS_MANAGER',
+  RDS_IAM_AUTH = 'RDS_IAM_AUTH',
 }
 
 export const run = async (event: any): Promise<any> => {
@@ -27,7 +29,7 @@ export const run = async (event: any): Promise<any> => {
   try {
     return await adapter.executeRequest(event, debugMode);
   } catch (e) {
-    if (isRetryableError(e)) {
+    if (isRetryableError(e as Error)) {
       return await retryWithRefreshedCredentials(event, debugMode)
     }
     throw e;
@@ -179,7 +181,22 @@ const retrieveSsmValueFromEnvPaths = async (path: string): Promise<string> => {
   }
 };
 
-const getDBConfig = async (): DBConfig => {
+const generateRdsIamAuthToken = async (hostname: string, port: number, username: string): Promise<string> => {
+  const region = process.env.AWS_REGION;
+  const signer = new Signer({ hostname, port, region, username });
+  return signer.getAuthToken();
+};
+
+const parseConnectionUri = (uri: string): { hostname: string; port: number; username: string; database: string } => {
+  const url = new URL(uri);
+  const hostname = url.hostname;
+  const port = url.port ? parseInt(url.port, 10) : 5432;
+  const username = url.username ? decodeURIComponent(url.username) : '';
+  const database = url.pathname.replace(/^\//, '');
+  return { hostname, port, username, database };
+};
+
+const getDBConfig = async (): Promise<DBConfig> => {
   const config: DBConfig = {};
 
   const sslCertificate = await getCustomSslCert();
@@ -219,6 +236,29 @@ const getDBConfig = async (): DBConfig => {
     const secrets = await getSecretManagerValue(process.env.secretArn);
     config.username = secrets.username;
     config.password = secrets.password;
+  } else if (credentialStorageMethod === CredentialStorageMethod.RDS_IAM_AUTH) {
+    if (!ssmClient) {
+      createSSMClient();
+    }
+
+    config.engine = getDBEngine();
+
+    const jsonConnectionString = process.env.connectionString;
+    if (jsonConnectionString) {
+      const uri = await retrieveSsmValueFromEnvPaths(jsonConnectionString);
+      const { hostname, port, username, database } = parseConnectionUri(uri);
+      config.host = hostname;
+      config.port = port;
+      config.username = username;
+      config.database = database;
+    } else {
+      config.host = await getSSMValue(process.env.host);
+      config.port = Number.parseInt(await getSSMValue(process.env.port)) || 5432;
+      config.username = await getSSMValue(process.env.username);
+      config.database = await getSSMValue(process.env.database);
+    }
+
+    config.password = await generateRdsIamAuthToken(config.host!, config.port!, config.username!);
   } else {
     throw new Error('Unable to determine credentials storage method (SSM or SECRETS_MANAGER).');
   }

--- a/packages/amplify-graphql-model-transformer/rds-lambda/package.json
+++ b/packages/amplify-graphql-model-transformer/rds-lambda/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "3.462.0",
     "@aws-sdk/client-ssm": "3.624.0",
+    "@aws-sdk/rds-signer": "3.624.0",
     "babel-jest": "^29.1.2",
     "bestzip": "^2.1.5",
     "jest": "^29.1.2",

--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/amplify-sql-resource-generator.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/amplify-sql-resource-generator.test.ts.snap
@@ -1,5 +1,71 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ModelTransformer with SQL data sources: RDS IAM authentication should assign rds-db:connect and SSM permissions when using connection URI with rdsIam auth 1`] = `
+Object {
+  "Statement": Array [
+    Object {
+      "Action": Array [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:logs:*:*:*",
+    },
+    Object {
+      "Action": Array [
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:ssm:*:*:parameter/test/connectionUri",
+    },
+    Object {
+      "Action": "rds-db:connect",
+      "Effect": "Allow",
+      "Resource": "*",
+    },
+  ],
+  "Version": "2012-10-17",
+}
+`;
+
+exports[`ModelTransformer with SQL data sources: RDS IAM authentication should assign rds-db:connect and SSM permissions when using individual SSM params with rdsIam auth 1`] = `
+Object {
+  "Statement": Array [
+    Object {
+      "Action": Array [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:logs:*:*:*",
+    },
+    Object {
+      "Action": Array [
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+      ],
+      "Effect": "Allow",
+      "Resource": Array [
+        "arn:aws:ssm:*:*:parameter/test/username",
+        "arn:aws:ssm:*:*:parameter/test/password",
+        "arn:aws:ssm:*:*:parameter/test/hostname",
+        "arn:aws:ssm:*:*:parameter/test/databaseName",
+        "arn:aws:ssm:*:*:parameter/test/port",
+      ],
+    },
+    Object {
+      "Action": "rds-db:connect",
+      "Effect": "Allow",
+      "Resource": "*",
+    },
+  ],
+  "Version": "2012-10-17",
+}
+`;
+
 exports[`ModelTransformer with SQL data sources: should accept multiple connection uris as input 1`] = `
 Object {
   "Statement": Array [

--- a/packages/amplify-graphql-model-transformer/src/__tests__/amplify-sql-resource-generator.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/amplify-sql-resource-generator.test.ts
@@ -1,6 +1,7 @@
 import { testTransform } from '@aws-amplify/graphql-transformer-test-utils';
 import {
   MYSQL_DB_TYPE,
+  POSTGRES_DB_TYPE,
   constructDataSourceStrategies,
   getResourceNamesForStrategy,
   validateModelSchema,
@@ -366,6 +367,168 @@ describe('ModelTransformer with SQL data sources:', () => {
     expect(tags.length).toEqual(1);
     expect(tags[0].Key).toEqual('amplify:function-type');
     expect(tags[0].Value).toEqual('sql-data-source');
+  });
+
+  describe('RDS IAM authentication', () => {
+    const postgresStrategyBase: SQLLambdaModelDataSourceStrategy = {
+      name: 'postgresStrategy',
+      dbType: POSTGRES_DB_TYPE,
+      dbConnectionConfig: {
+        connectionUriSsmPath: '/test/connectionUri',
+      },
+    };
+
+    const getPolicy = (out: ReturnType<typeof testTransform>, strategy: SQLLambdaModelDataSourceStrategy) => {
+      const resourceNames = getResourceNamesForStrategy(strategy);
+      const sqlApiStack = out.stacks[resourceNames.sqlStack];
+      const [, policy] =
+        Object.entries(sqlApiStack.Resources!).find(([resourceName]) =>
+          resourceName.startsWith(resourceNames.sqlLambdaExecutionRolePolicy),
+        ) || [];
+      return { sqlApiStack, policy };
+    };
+
+    const getSqlLambdaEnvVars = (out: ReturnType<typeof testTransform>, strategy: SQLLambdaModelDataSourceStrategy) => {
+      const resourceNames = getResourceNamesForStrategy(strategy);
+      const sqlApiStack = out.stacks[resourceNames.sqlStack];
+      const [, sqlLambda] =
+        Object.entries(sqlApiStack.Resources!).find(([resourceName]) => resourceName.startsWith(resourceNames.sqlLambdaFunction)) || [];
+      return sqlLambda?.Properties?.Environment?.Variables;
+    };
+
+    it('should assign rds-db:connect and SSM permissions when using connection URI with rdsIam auth', () => {
+      const strategy: SQLLambdaModelDataSourceStrategy = {
+        ...postgresStrategyBase,
+        authentication: { strategy: 'rdsIam' },
+      };
+      const out = testTransform({
+        schema: validSchema,
+        transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+        dataSourceStrategies: constructDataSourceStrategies(validSchema, strategy),
+      });
+
+      const { policy } = getPolicy(out, strategy);
+      expect(policy).toBeDefined();
+      const { PolicyDocument } = policy.Properties;
+
+      // CloudWatch + SSM + rds-db:connect = 3 statements
+      expect(PolicyDocument.Statement.length).toEqual(3);
+
+      const ssmStatements = PolicyDocument.Statement.filter(
+        (statement: any) => JSON.stringify(statement.Action) === JSON.stringify(['ssm:GetParameter', 'ssm:GetParameters']),
+      );
+      expect(ssmStatements.length).toEqual(1);
+      expect(ssmStatements[0].Resource).toEqual('arn:aws:ssm:*:*:parameter/test/connectionUri');
+
+      const rdsIamStatements = PolicyDocument.Statement.filter((statement: any) => statement.Action === 'rds-db:connect');
+      expect(rdsIamStatements.length).toEqual(1);
+      expect(rdsIamStatements[0].Resource).toEqual('*');
+
+      const secretsManagerStatements = PolicyDocument.Statement.filter(
+        (statement: any) => statement.Action === 'secretsmanager:GetSecretValue',
+      );
+      expect(secretsManagerStatements.length).toEqual(0);
+
+      expect(PolicyDocument).toMatchSnapshot();
+    });
+
+    it('should set CREDENTIAL_STORAGE_METHOD to RDS_IAM_AUTH and pass connection string env var when using connection URI', () => {
+      const strategy: SQLLambdaModelDataSourceStrategy = {
+        ...postgresStrategyBase,
+        authentication: { strategy: 'rdsIam' },
+      };
+      const out = testTransform({
+        schema: validSchema,
+        transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+        dataSourceStrategies: constructDataSourceStrategies(validSchema, strategy),
+      });
+
+      const envVars = getSqlLambdaEnvVars(out, strategy);
+      expect(envVars).toBeDefined();
+      expect(envVars.CREDENTIAL_STORAGE_METHOD).toEqual('RDS_IAM_AUTH');
+      expect(envVars.connectionString).toBeDefined();
+      expect(envVars.SSM_ENDPOINT).toBeDefined();
+      expect(envVars.username).toBeUndefined();
+      expect(envVars.password).toBeUndefined();
+    });
+
+    it('should assign rds-db:connect and SSM permissions when using individual SSM params with rdsIam auth', () => {
+      const strategy: SQLLambdaModelDataSourceStrategy = {
+        ...postgresStrategyBase,
+        dbConnectionConfig: {
+          hostnameSsmPath: '/test/hostname',
+          portSsmPath: '/test/port',
+          usernameSsmPath: '/test/username',
+          passwordSsmPath: '/test/password',
+          databaseNameSsmPath: '/test/databaseName',
+        },
+        authentication: { strategy: 'rdsIam' },
+      };
+      const out = testTransform({
+        schema: validSchema,
+        transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+        dataSourceStrategies: constructDataSourceStrategies(validSchema, strategy),
+      });
+
+      const { policy } = getPolicy(out, strategy);
+      expect(policy).toBeDefined();
+      const { PolicyDocument } = policy.Properties;
+
+      // CloudWatch + SSM (5 paths) + rds-db:connect = 3 statements
+      expect(PolicyDocument.Statement.length).toEqual(3);
+
+      const rdsIamStatements = PolicyDocument.Statement.filter((statement: any) => statement.Action === 'rds-db:connect');
+      expect(rdsIamStatements.length).toEqual(1);
+      expect(rdsIamStatements[0].Resource).toEqual('*');
+
+      expect(PolicyDocument).toMatchSnapshot();
+    });
+
+    it('should set CREDENTIAL_STORAGE_METHOD to RDS_IAM_AUTH and pass host/port/username/database env vars without password when using individual SSM params', () => {
+      const strategy: SQLLambdaModelDataSourceStrategy = {
+        ...postgresStrategyBase,
+        dbConnectionConfig: {
+          hostnameSsmPath: '/test/hostname',
+          portSsmPath: '/test/port',
+          usernameSsmPath: '/test/username',
+          passwordSsmPath: '/test/password',
+          databaseNameSsmPath: '/test/databaseName',
+        },
+        authentication: { strategy: 'rdsIam' },
+      };
+      const out = testTransform({
+        schema: validSchema,
+        transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+        dataSourceStrategies: constructDataSourceStrategies(validSchema, strategy),
+      });
+
+      const envVars = getSqlLambdaEnvVars(out, strategy);
+      expect(envVars).toBeDefined();
+      expect(envVars.CREDENTIAL_STORAGE_METHOD).toEqual('RDS_IAM_AUTH');
+      expect(envVars.host).toEqual('/test/hostname');
+      expect(envVars.port).toEqual('/test/port');
+      expect(envVars.username).toEqual('/test/username');
+      expect(envVars.database).toEqual('/test/databaseName');
+      expect(envVars.password).toBeUndefined();
+    });
+
+    it('should not assign rds-db:connect permission when authentication is not configured', () => {
+      const out = testTransform({
+        schema: validSchema,
+        transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+        dataSourceStrategies: constructDataSourceStrategies(validSchema, postgresStrategyBase),
+      });
+
+      const { policy } = getPolicy(out, postgresStrategyBase);
+      expect(policy).toBeDefined();
+      const { PolicyDocument } = policy.Properties;
+
+      const rdsIamStatements = PolicyDocument.Statement.filter((statement: any) => statement.Action === 'rds-db:connect');
+      expect(rdsIamStatements.length).toEqual(0);
+
+      const envVars = getSqlLambdaEnvVars(out, postgresStrategyBase);
+      expect(envVars.CREDENTIAL_STORAGE_METHOD).toEqual('SSM');
+    });
   });
 
   it('should add a description to the SQL function', async () => {

--- a/packages/amplify-graphql-model-transformer/src/__tests__/rds-lambda.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/rds-lambda.test.ts
@@ -8,7 +8,29 @@ const ssmMockReturnValues: Record<string, string> = {
   '/amplify/shared/amplify-test/SQL_CONNECTION_STRING': 'mysql://SHARED:password@localhost:3306/database',
   '/amplify/sandbox/user-sandbox-hash/CUSTOM_SSL_CERT': 'SANDBOX SSL CERT',
   '/amplify/shared/amplify-test/CUSTOM_SSL_CERT': 'SHARED SSL CERT',
+  '/amplify/sandbox/user-sandbox-hash/PG_CONNECTION_STRING':
+    'postgres://pguser@my-cluster.cluster-xxxx.us-east-1.rds.amazonaws.com:5432/mydb',
+  '/amplify/sandbox/user-sandbox-hash/PG_HOST': 'my-cluster.cluster-xxxx.us-east-1.rds.amazonaws.com',
+  '/amplify/sandbox/user-sandbox-hash/PG_PORT': '5432',
+  '/amplify/sandbox/user-sandbox-hash/PG_USER': 'pguser',
+  '/amplify/sandbox/user-sandbox-hash/PG_DATABASE': 'mydb',
 };
+
+const MOCK_IAM_TOKEN = 'mock-iam-auth-token';
+
+// Mock @aws-sdk/rds-signer (virtual: true because the package lives in rds-lambda/node_modules, not this package)
+jest.mock(
+  '@aws-sdk/rds-signer',
+  () => {
+    return {
+      __esModule: true,
+      Signer: jest.fn().mockImplementation(() => ({
+        getAuthToken: jest.fn().mockResolvedValue(MOCK_IAM_TOKEN),
+      })),
+    };
+  },
+  { virtual: true },
+);
 
 // Mock client-ssm
 jest.mock('@aws-sdk/client-ssm', () => {
@@ -180,5 +202,50 @@ describe('rds-lambda', () => {
     const payload = getEventPayload();
     process.env.SSL_CERT_SSM_PATH = 'NON-EXISTENT';
     await expect(run(payload)).rejects.toThrow('Unable to get the custom SSL certificate. Check the logs for more details.');
+  });
+
+  describe('RDS IAM authentication', () => {
+    beforeEach(() => {
+      process.env.CREDENTIAL_STORAGE_METHOD = 'RDS_IAM_AUTH';
+      process.env.engine = 'POSTGRES';
+      delete process.env.connectionString;
+    });
+
+    it('generates an IAM auth token from a connection string URI stored in SSM', async () => {
+      process.env.connectionString = '"/amplify/sandbox/user-sandbox-hash/PG_CONNECTION_STRING"';
+      const payload = getEventPayload();
+
+      const result = await run(payload);
+      expect(result).toBeDefined();
+      expect(result._config).toEqual({
+        engine: 'POSTGRES',
+        host: 'my-cluster.cluster-xxxx.us-east-1.rds.amazonaws.com',
+        port: 5432,
+        username: 'pguser',
+        database: 'mydb',
+        password: MOCK_IAM_TOKEN,
+      });
+      expect(result._event).toEqual(payload);
+    });
+
+    it('generates an IAM auth token from individual SSM parameters', async () => {
+      process.env.host = '/amplify/sandbox/user-sandbox-hash/PG_HOST';
+      process.env.port = '/amplify/sandbox/user-sandbox-hash/PG_PORT';
+      process.env.username = '/amplify/sandbox/user-sandbox-hash/PG_USER';
+      process.env.database = '/amplify/sandbox/user-sandbox-hash/PG_DATABASE';
+      const payload = getEventPayload();
+
+      const result = await run(payload);
+      expect(result).toBeDefined();
+      expect(result._config).toEqual({
+        engine: 'POSTGRES',
+        host: 'my-cluster.cluster-xxxx.us-east-1.rds.amazonaws.com',
+        port: 5432,
+        username: 'pguser',
+        database: 'mydb',
+        password: MOCK_IAM_TOKEN,
+      });
+      expect(result._event).toEqual(payload);
+    });
   });
 });

--- a/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
+++ b/packages/amplify-graphql-model-transformer/src/resolvers/rds/resolver.ts
@@ -36,6 +36,7 @@ import {
   VpcConfig,
   ProvisionedConcurrencyConfig,
   SqlModelDataSourceDbConnectionConfig,
+  SqlModelDataSourceAuthentication,
   isSqlModelDataSourceSsmDbConnectionConfig,
   isSqlModelDataSourceSecretsManagerDbConnectionConfig,
   isSqlModelDataSourceSsmDbConnectionStringConfig,
@@ -59,6 +60,7 @@ export type OPERATIONS = 'CREATE' | 'UPDATE' | 'DELETE' | 'GET' | 'LIST' | 'SYNC
 export enum CredentialStorageMethod {
   SSM = 'SSM',
   SECRETS_MANAGER = 'SECRETS_MANAGER',
+  RDS_IAM_AUTH = 'RDS_IAM_AUTH',
 }
 
 const OPERATION_KEY = '__operation';
@@ -150,6 +152,11 @@ export const createRdsLambda = (
     }
     lambdaEnvironment.SECRETS_MANAGER_ENDPOINT = secretsManagerEndpoint;
     lambdaEnvironment.CREDENTIAL_STORAGE_METHOD = CredentialStorageMethod.SECRETS_MANAGER;
+  } else if (credentialStorageMethod === CredentialStorageMethod.RDS_IAM_AUTH) {
+    lambdaEnvironment.CREDENTIAL_STORAGE_METHOD = CredentialStorageMethod.RDS_IAM_AUTH;
+    if (!lambdaEnvironment.SSM_ENDPOINT) {
+      lambdaEnvironment.SSM_ENDPOINT = getSsmEndpoint(scope, resourceNames, sqlLambdaVpcConfig);
+    }
   } else {
     throw new Error('Unable to determine if SSM or Secrets Manager should be used for credentials.');
   }
@@ -386,6 +393,7 @@ export const createRdsLambdaRole = (
   secretEntry: SqlModelDataSourceDbConnectionConfig,
   resourceNames: SQLLambdaResourceNames,
   sslCertSsmPath?: string | string[],
+  authentication?: SqlModelDataSourceAuthentication,
 ): IRole => {
   const role = new Role(scope, resourceNames.sqlLambdaExecutionRole, {
     assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
@@ -453,6 +461,16 @@ export const createRdsLambdaRole = (
           actions: ['ssm:GetParameter', 'ssm:GetParameters'],
           effect: Effect.ALLOW,
           resources: ssmPaths.map((ssmPath) => `arn:aws:ssm:*:*:parameter${ssmPath}`),
+        }),
+      );
+    }
+
+    if (authentication?.strategy === 'rdsIam') {
+      policyStatements.push(
+        new PolicyStatement({
+          actions: ['rds-db:connect'],
+          effect: Effect.ALLOW,
+          resources: ['*'],
         }),
       );
     }

--- a/packages/amplify-graphql-model-transformer/src/resources/rds-model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/rds-model-resource-generator.ts
@@ -113,19 +113,34 @@ export class RdsModelResourceGenerator extends ModelResourceGenerator {
 
     const layerVersionArn = resolveLayerVersion(lambdaScope, context, resourceNames);
 
+    const authentication = strategy.authentication;
+
     const role = createRdsLambdaRole(
       context.resourceHelper.generateIAMRoleName(resourceNames.sqlLambdaExecutionRole),
       lambdaRoleScope,
       dbConnectionConfig,
       resourceNames,
       sslCertSsmPath,
+      authentication,
     );
 
     const environment: { [key: string]: string } = {
       engine,
     };
     let credentialStorageMethod;
-    if (isSqlModelDataSourceSsmDbConnectionConfig(secretEntry)) {
+    if (authentication?.strategy === 'rdsIam') {
+      if (isSqlModelDataSourceSsmDbConnectionStringConfig(secretEntry)) {
+        environment.connectionString = JSON.stringify(secretEntry.connectionUriSsmPath);
+      } else if (isSqlModelDataSourceSsmDbConnectionConfig(secretEntry)) {
+        environment.host = secretEntry.hostnameSsmPath;
+        environment.port = secretEntry.portSsmPath;
+        environment.username = secretEntry.usernameSsmPath;
+        environment.database = secretEntry.databaseNameSsmPath;
+      } else {
+        throw new Error('RDS IAM authentication is only supported with SSM-based connection configurations.');
+      }
+      credentialStorageMethod = CredentialStorageMethod.RDS_IAM_AUTH;
+    } else if (isSqlModelDataSourceSsmDbConnectionConfig(secretEntry)) {
       environment.CREDENTIAL_STORAGE_METHOD = 'SSM';
       environment.username = secretEntry.usernameSsmPath;
       environment.password = secretEntry.passwordSsmPath;

--- a/packages/amplify-graphql-schema-generator/src/__tests__/vpc-helper.test.ts
+++ b/packages/amplify-graphql-schema-generator/src/__tests__/vpc-helper.test.ts
@@ -112,6 +112,28 @@ describe('detect VPC settings', () => {
 
     expect(result).toBeUndefined();
   });
+
+  it('should return undefined without checking DB instances when cluster is found but has no DBSubnetGroup (e.g. Aurora PostgreSQL Express)', async () => {
+    rdsClientSendSpy
+      .mockResolvedValueOnce(emptyProxyResponse as never)
+      .mockResolvedValueOnce(clusterWithoutSubnetGroupResponse as never)
+      .mockRejectedValue('Should not check DB instances for a cluster without VPC config' as never);
+
+    const result = await getHostVpc('mock-rds-cluster-no-vpc.cluster-abc123.us-west-2.rds.amazonaws.com', 'us-west-2');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined without checking DB instances when cluster is found but has no VPC security groups', async () => {
+    rdsClientSendSpy
+      .mockResolvedValueOnce(emptyProxyResponse as never)
+      .mockResolvedValueOnce(clusterWithoutSecurityGroupsResponse as never)
+      .mockRejectedValue('Should not check DB instances for a cluster without VPC config' as never);
+
+    const result = await getHostVpc('mock-rds-cluster-no-sg.cluster-abc123.us-west-2.rds.amazonaws.com', 'us-west-2');
+
+    expect(result).toBeUndefined();
+  });
 });
 
 const instanceResponse: DescribeDBInstancesCommandOutput = {
@@ -319,6 +341,28 @@ const describeDbSubnetGroupsResponse: DescribeDBSubnetGroupsCommandOutput = {
       ],
       DBSubnetGroupArn: 'arn:aws:rds:us-west-2:123456789012:subgrp:default-vpc-abc123',
       SupportedNetworkTypes: ['IPV4'],
+    },
+  ],
+};
+
+const clusterWithoutSubnetGroupResponse: DescribeDBClustersCommandOutput = {
+  $metadata: {},
+  DBClusters: [
+    {
+      ...clusterResponse.DBClusters[0],
+      Endpoint: 'mock-rds-cluster-no-vpc.cluster-abc123.us-west-2.rds.amazonaws.com',
+      DBSubnetGroup: undefined,
+    },
+  ],
+};
+
+const clusterWithoutSecurityGroupsResponse: DescribeDBClustersCommandOutput = {
+  $metadata: {},
+  DBClusters: [
+    {
+      ...clusterResponse.DBClusters[0],
+      Endpoint: 'mock-rds-cluster-no-sg.cluster-abc123.us-west-2.rds.amazonaws.com',
+      VpcSecurityGroups: [],
     },
   ],
 };

--- a/packages/amplify-graphql-schema-generator/src/utils/vpc-helper-cluster.ts
+++ b/packages/amplify-graphql-schema-generator/src/utils/vpc-helper-cluster.ts
@@ -9,8 +9,20 @@ import { VpcConfig, SubnetAvailabilityZone } from '@aws-amplify/graphql-transfor
 import { DB_ENGINES } from './supported-db-engines';
 import { filterSubnetAvailabilityZones } from './filter-subnet-availability-zones';
 
-// When region is not provided, it will use the region configured in the AWS profile.
-export const checkHostInDBClusters = async (hostname: string, region?: string): Promise<VpcConfig | undefined> => {
+/**
+ * The result of searching for a hostname in DB Clusters.
+ * - `undefined` means no matching cluster was found; the caller should continue searching elsewhere.
+ * - `{ vpcConfig: VpcConfig }` means the cluster was found with VPC configuration.
+ * - `{ vpcConfig: undefined }` means the cluster was found but has no VPC configuration
+ *   (e.g. Aurora PostgreSQL Express), so no VPC setup is needed.
+ */
+export type ClusterVpcResult = { vpcConfig: VpcConfig | undefined } | undefined;
+
+/**
+ * Searches for the hostname in DB Clusters. See {@link ClusterVpcResult} for return value semantics.
+ * When region is not provided, it will use the region configured in the AWS profile.
+ */
+export const checkHostInDBClusters = async (hostname: string, region?: string): Promise<ClusterVpcResult> => {
   const client = new RDSClient({ region });
   const params: DescribeDBClustersCommandInput = {
     Filters: [
@@ -33,13 +45,19 @@ export const checkHostInDBClusters = async (hostname: string, region?: string): 
     return undefined;
   }
 
+  if (!cluster.DBSubnetGroup || !cluster.VpcSecurityGroups?.length) {
+    return { vpcConfig: undefined };
+  }
+
   const { subnetAvailabilityZoneConfig, vpcId } = await getSubnetAvailabilityZonesFromSubnetGroup(cluster.DBSubnetGroup, region);
 
   const securityGroupIds = cluster.VpcSecurityGroups.map((securityGroup) => securityGroup.VpcSecurityGroupId);
   return {
-    vpcId,
-    subnetAvailabilityZoneConfig,
-    securityGroupIds,
+    vpcConfig: {
+      vpcId,
+      subnetAvailabilityZoneConfig,
+      securityGroupIds,
+    },
   };
 };
 const getSubnetAvailabilityZonesFromSubnetGroup = async (

--- a/packages/amplify-graphql-schema-generator/src/utils/vpc-helper.ts
+++ b/packages/amplify-graphql-schema-generator/src/utils/vpc-helper.ts
@@ -59,8 +59,10 @@ export const getHostVpc = async (hostname: string, region?: string): Promise<Vpc
 
   const clusterResult = await checkHostInDBClusters(hostname, region);
   if (clusterResult) {
-    console.warn(warning('cluster'));
-    return clusterResult;
+    if (clusterResult.vpcConfig) {
+      console.warn(warning('cluster'));
+    }
+    return clusterResult.vpcConfig;
   }
 
   const instanceResult = await checkHostInDBInstances(hostname, region);

--- a/packages/amplify-graphql-transformer-interfaces/src/model-datasource/types.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/model-datasource/types.ts
@@ -53,6 +53,18 @@ export interface ImportedAmplifyDynamoDbModelDataSourceStrategy {
 }
 
 /**
+ * Authentication strategy for RDS IAM database authentication.
+ */
+export interface SqlModelDataSourceRdsIamAuthenticationConfig {
+  readonly strategy: 'rdsIam';
+}
+
+/**
+ * The authentication configuration for an SQL data source. Currently only RDS IAM database authentication is supported.
+ */
+export type SqlModelDataSourceAuthentication = SqlModelDataSourceRdsIamAuthenticationConfig;
+
+/**
  * A strategy that creates a Lambda to connect to a pre-existing SQL table to resolve model data.
  *
  * Note: The implementation type is different from the interface type: the interface type contains the custom SQL statements that are
@@ -84,6 +96,13 @@ export interface SQLLambdaModelDataSourceStrategy extends ModelDataSourceStrateg
    * The configuration for the provisioned concurrency of the Lambda.
    */
   readonly sqlLambdaProvisionedConcurrencyConfig?: ProvisionedConcurrencyConfig;
+
+  /**
+   * The authentication configuration for the SQL data source. When set to RDS IAM authentication, the Lambda will generate an IAM
+   * authentication token at runtime instead of using a static password. This is required for Aurora PostgreSQL Express configurations
+   * that use RDS IAM database authentication.
+   */
+  readonly authentication?: SqlModelDataSourceAuthentication;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -6812,6 +6812,16 @@
     "@smithy/types" "^4.3.1"
     tslib "^2.6.2"
 
+"@aws-sdk/eventstream-handler-node@^3.821.0":
+  version "3.972.14"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.14.tgz#672027de0df8fa5c1ec4223c42c9d1b428265c13"
+  integrity sha512-m4X56gxG76/CKfxNVbOFuYwnAZcHgS6HOH8lgp15HoGHIAVTcZfZrXvcYzJFOMLEJgVn+JHBu6EiNV+xSNXXFg==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/eventstream-codec" "^4.2.14"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/eventstream-marshaller@3.6.1":
   version "3.6.1"
   resolved "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.6.1.tgz#6abfbdf3639249d1a77686cbcae5d8e47bcba989"
@@ -7180,6 +7190,16 @@
     "@aws-sdk/types" "3.821.0"
     "@smithy/protocol-http" "^5.1.2"
     "@smithy/types" "^4.3.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-eventstream@^3.821.0":
+  version "3.972.10"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.10.tgz#e16003a47e5fd8168f2c5db74b97fecf319206da"
+  integrity sha512-QUqLs7Af1II9X4fCRAu+EGHG3KHyOp4RkuLhRKoA3NuFlh6TL8i+zXBl8w2LUxqm44B/Kom45hgSlwA1SpTsXQ==
+  dependencies:
+    "@aws-sdk/types" "^3.973.8"
+    "@smithy/protocol-http" "^5.3.14"
+    "@smithy/types" "^4.14.1"
     tslib "^2.6.2"
 
 "@aws-sdk/middleware-expect-continue@3.6.1":
@@ -8941,6 +8961,14 @@
     "@smithy/types" "^4.14.0"
     tslib "^2.6.2"
 
+"@aws-sdk/types@^3.973.8":
+  version "3.973.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.973.8.tgz#7352cb74a5f8bae1218eee63e714cf94302911c5"
+  integrity sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==
+  dependencies:
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/url-parser-native@3.6.1":
   version "3.6.1"
   resolved "https://registry.npmjs.org/@aws-sdk/url-parser-native/-/url-parser-native-3.6.1.tgz#a5e787f98aafa777e73007f9490df334ef3389a2"
@@ -10503,7 +10531,7 @@
 
 "@isaacs/fs-minipass@^4.0.0":
   version "4.0.1"
-  resolved "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
+  resolved "https://registry.yarnpkg.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
   integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
   dependencies:
     minipass "^7.0.4"
@@ -11561,7 +11589,7 @@
 
 "@npmcli/agent@^3.0.0":
   version "3.0.0"
-  resolved "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz#1685b1fbd4a1b7bb4f930cbb68ce801edfe7aa44"
+  resolved "https://registry.yarnpkg.com/@npmcli/agent/-/agent-3.0.0.tgz#1685b1fbd4a1b7bb4f930cbb68ce801edfe7aa44"
   integrity sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==
   dependencies:
     agent-base "^7.1.0"
@@ -11627,7 +11655,7 @@
 
 "@npmcli/fs@^4.0.0":
   version "4.0.0"
-  resolved "https://registry.npmjs.org/@npmcli/fs/-/fs-4.0.0.tgz#a1eb1aeddefd2a4a347eca0fab30bc62c0e1c0f2"
+  resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-4.0.0.tgz#a1eb1aeddefd2a4a347eca0fab30bc62c0e1c0f2"
   integrity sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==
   dependencies:
     semver "^7.3.5"
@@ -12417,6 +12445,15 @@
     "@smithy/uuid" "^1.1.1"
     tslib "^2.6.2"
 
+"@smithy/core@^3.24.1":
+  version "3.24.1"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.24.1.tgz#f1aa4d9b19555c8a75f0bfcbb836b0a190097e6b"
+  integrity sha512-3mT7o4qQyUWttYnVK3A0Z/u3Xha3E81tXn32Tz6vjZiUXhBrkEivpw1hBYfh84iFF9CSzkBU9Y1DJ3Q6RQ231g==
+  dependencies:
+    "@aws-crypto/crc32" "5.2.0"
+    "@smithy/types" "^4.14.1"
+    tslib "^2.6.2"
+
 "@smithy/core@^3.3.3":
   version "3.3.3"
   resolved "https://registry.npmjs.org/@smithy/core/-/core-3.3.3.tgz#d87db94ff18e059bca791b63fdb9ab94565d8b17"
@@ -12571,6 +12608,14 @@
     "@aws-crypto/crc32" "5.2.0"
     "@smithy/types" "^4.14.0"
     "@smithy/util-hex-encoding" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/eventstream-codec@^4.2.14":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-codec/-/eventstream-codec-4.3.1.tgz#8b3290880aa145d4854367c0591c59dcdec7cd98"
+  integrity sha512-yS8AiJM3Kf7LR+lZyUilUyjdJGksAqxfSC3C9k3d1OCrAvWjpMlsJ+rW9cIslZJM4AtWh2UAqgZUWTtMeMdtDQ==
+  dependencies:
+    "@smithy/core" "^3.24.1"
     tslib "^2.6.2"
 
 "@smithy/eventstream-codec@^4.2.7":
@@ -13813,6 +13858,14 @@
     "@smithy/types" "^4.14.0"
     tslib "^2.6.2"
 
+"@smithy/protocol-http@^5.3.14":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@smithy/protocol-http/-/protocol-http-5.4.1.tgz#7acf497f56b95fa13bb89d8e230175ab1bb16ca0"
+  integrity sha512-8irPNCQgYxcSFp1aGcnDNFkTwSA+xPUaFq9V/v1+JXWu8sKr5b3cFmg2kBTkjkvypDmGeNffuNu0x5iqw1NoAw==
+  dependencies:
+    "@smithy/core" "^3.24.1"
+    tslib "^2.6.2"
+
 "@smithy/protocol-http@^5.3.6", "@smithy/protocol-http@^5.3.7":
   version "5.3.7"
   resolved "https://registry.yarnpkg.com/@smithy/protocol-http/-/protocol-http-5.3.7.tgz#2a58a1dfdb7cc90a8c79f081b5b6cf96d888891a"
@@ -14307,6 +14360,13 @@
   version "4.14.0"
   resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.14.0.tgz#72fb6fd315f2eff7d4878142db2d1db4ef94f9bc"
   integrity sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/types@^4.14.1":
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.14.1.tgz#aba92b4cdb406f2a2b062e82f1e3728d809a7c23"
+  integrity sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==
   dependencies:
     tslib "^2.6.2"
 
@@ -15788,9 +15848,9 @@
     tslib "^1.9.3"
 
 "@xmldom/xmldom@^0.8.8", "@xmldom/xmldom@^0.9.8", "@xmldom/xmldom@^0.9.9":
-  version "0.9.9"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.9.9.tgz#665b1cf4e5962d248bb4d032b5e020626f634503"
-  integrity sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==
+  version "0.9.10"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.9.10.tgz#a0ad5a26fe8aa996310870726e1704977f769dee"
+  integrity sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==
 
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
@@ -15836,7 +15896,7 @@ abbrev@1:
 
 abbrev@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz#8ac8b3b5024d31464fe2a5feeea9f4536bf44025"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-3.0.1.tgz#8ac8b3b5024d31464fe2a5feeea9f4536bf44025"
   integrity sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==
 
 abort-controller@^3.0.0:
@@ -16561,9 +16621,9 @@ aws-cdk-lib@2.224.0, aws-cdk-lib@~2.129.0, aws-cdk-lib@~2.177.0:
     yaml "1.10.2"
 
 aws-sdk@2.518.0, aws-sdk@^2.1141.0, aws-sdk@^2.1464.0:
-  version "2.1692.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1692.0.tgz#9dac5f7bfcc5ab45825cc8591b12753aa7d2902c"
-  integrity sha512-x511uiJ/57FIsbgUe5csJ13k3uzu25uWQE+XqfBis/sB0SFoiElJWXRkgEAUh0U6n40eT3ay5Ue4oPkRMu1LYw==
+  version "2.1693.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1693.0.tgz#fda38671af3dc5fa8117e9aa09cf6ce37e34010e"
+  integrity sha512-cJmb8xEnVLT+R6fBS5sn/EFJiX7tUnDaPtOPZ1vFbOJtd0fnZn/Ky2XGgsvvoeliWeH7mL3TWSX5zXXGSQV6gQ==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -16582,12 +16642,13 @@ axe-core@^4.10.0:
   integrity sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==
 
 axios@0.26.0, axios@^0.21.1, axios@^1.0.0, axios@^1.13.5, axios@^1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
-  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.1.tgz#517e29291d19d6e8cf919ff264f4fe157261ba12"
+  integrity sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==
   dependencies:
-    follow-redirects "^1.15.11"
+    follow-redirects "^1.16.0"
     form-data "^4.0.5"
+    https-proxy-agent "^5.0.1"
     proxy-from-env "^2.1.0"
 
 axobject-query@^4.1.0:
@@ -16703,14 +16764,14 @@ bare-events@^2.2.0:
   integrity sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==
 
 bare-events@^2.5.4, bare-events@^2.7.0:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/bare-events/-/bare-events-2.8.2.tgz#7b3e10bd8e1fc80daf38bb516921678f566ab89f"
-  integrity sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/bare-events/-/bare-events-2.8.3.tgz#ed26c87a24ece41c69dd4d2d0891c2c04a949e13"
+  integrity sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==
 
-bare-fs@^4.0.1:
-  version "4.5.4"
-  resolved "https://registry.yarnpkg.com/bare-fs/-/bare-fs-4.5.4.tgz#15d6c23eadefbdba48219c501a140ffc167469cf"
-  integrity sha512-POK4oplfA7P7gqvetNmCs4CNtm9fNsx+IAh7jH7GgU0OJdge2rso0R20TNWVq6VoWcCvsTdlNDaleLHGaKx8CA==
+bare-fs@^4.0.1, bare-fs@^4.5.5:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/bare-fs/-/bare-fs-4.7.1.tgz#6e81f784761102867c13f0823aa48c942d160f00"
+  integrity sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==
   dependencies:
     bare-events "^2.5.4"
     bare-path "^3.0.0"
@@ -16719,9 +16780,9 @@ bare-fs@^4.0.1:
     fast-fifo "^1.3.2"
 
 bare-os@^3.0.1:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/bare-os/-/bare-os-3.6.2.tgz#b3c4f5ad5e322c0fd0f3c29fc97d19009e2796e5"
-  integrity sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/bare-os/-/bare-os-3.9.1.tgz#660228ca7ffc47a72e96b6047cdd9d8342994e2f"
+  integrity sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==
 
 bare-path@^3.0.0:
   version "3.0.0"
@@ -16731,17 +16792,17 @@ bare-path@^3.0.0:
     bare-os "^3.0.1"
 
 bare-stream@^2.6.4:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/bare-stream/-/bare-stream-2.8.0.tgz#3ac6141a65d097fd2bf6e472c848c5d800d47df9"
-  integrity sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/bare-stream/-/bare-stream-2.13.1.tgz#acfd787a2983f5feb182ffe4c37ecc2c55b6ec85"
+  integrity sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==
   dependencies:
-    streamx "^2.21.0"
+    streamx "^2.25.0"
     teex "^1.0.1"
 
 bare-url@^2.2.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/bare-url/-/bare-url-2.3.2.tgz#4aef382efa662b2180a6fe4ca07a71b39bdf7ca3"
-  integrity sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/bare-url/-/bare-url-2.4.3.tgz#99aedf87519225669f15ecc0b910db11cad46930"
+  integrity sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==
   dependencies:
     bare-path "^3.0.0"
 
@@ -16756,9 +16817,9 @@ base64-js@^1.0.2, base64-js@^1.3.1, base64-js@^1.5.1:
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 basic-ftp@^5.0.2, basic-ftp@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.2.2.tgz#4cb2422deddf432896bdb3c9b8f13b944ad4842c"
-  integrity sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.3.1.tgz#3148ee9af43c0522514a4f973fecb1d3cbb6d71e"
+  integrity sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==
 
 before-after-hook@^2.2.0:
   version "2.2.3"
@@ -17021,7 +17082,7 @@ cacache@^17.0.0:
 
 cacache@^19.0.1:
   version "19.0.1"
-  resolved "https://registry.npmjs.org/cacache/-/cacache-19.0.1.tgz#3370cc28a758434c85c2585008bd5bdcff17d6cd"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-19.0.1.tgz#3370cc28a758434c85c2585008bd5bdcff17d6cd"
   integrity sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==
   dependencies:
     "@npmcli/fs" "^4.0.0"
@@ -17204,7 +17265,7 @@ chownr@^2.0.0:
 
 chownr@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
   integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
 
 ci-info@^2.0.0:
@@ -19040,7 +19101,7 @@ fb-watchman@^2.0.0:
 
 fdir@^6.5.0:
   version "6.5.0"
-  resolved "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
 fecha@^4.2.0:
@@ -19171,10 +19232,10 @@ fn.name@1.x.x:
   resolved "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.15.11:
-  version "1.15.11"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
-  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"
@@ -19902,9 +19963,9 @@ http2-wrapper@^2.1.10:
     quick-lru "^5.1.1"
     resolve-alpn "^1.2.0"
 
-https-proxy-agent@^5.0.0:
+https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
   dependencies:
     agent-base "6"
@@ -20606,9 +20667,9 @@ isexe@^2.0.0:
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
 isexe@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz#4a407e2bd78ddfb14bea0c27c6f7072dde775f0d"
-  integrity sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-3.1.5.tgz#42e368f68d5e10dadfee4fda7b550bc2d8892dc9"
+  integrity sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==
 
 isobject@^3.0.1:
   version "3.0.1"
@@ -21834,7 +21895,7 @@ make-fetch-happen@^11.0.0, make-fetch-happen@^11.0.1, make-fetch-happen@^11.1.1:
 
 make-fetch-happen@^14.0.3:
   version "14.0.3"
-  resolved "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz#d74c3ecb0028f08ab604011e0bc6baed483fcdcd"
+  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz#d74c3ecb0028f08ab604011e0bc6baed483fcdcd"
   integrity sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==
   dependencies:
     "@npmcli/agent" "^3.0.0"
@@ -22022,7 +22083,7 @@ minipass-collect@^1.0.2:
 
 minipass-collect@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz#1621bc77e12258a12c60d34e2276ec5c20680863"
+  resolved "https://registry.yarnpkg.com/minipass-collect/-/minipass-collect-2.0.1.tgz#1621bc77e12258a12c60d34e2276ec5c20680863"
   integrity sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==
   dependencies:
     minipass "^7.0.3"
@@ -22051,7 +22112,7 @@ minipass-fetch@^3.0.0:
 
 minipass-fetch@^4.0.0:
   version "4.0.1"
-  resolved "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-4.0.1.tgz#f2d717d5a418ad0b1a7274f9b913515d3e78f9e5"
+  resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-4.0.1.tgz#f2d717d5a418ad0b1a7274f9b913515d3e78f9e5"
   integrity sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==
   dependencies:
     minipass "^7.0.3"
@@ -22101,10 +22162,15 @@ minipass@^5.0.0:
   resolved "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
   integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.2, minipass@^7.0.3, minipass@^7.0.4, minipass@^7.1.2:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.3, minipass@^7.1.2:
   version "7.1.2"
   resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
+
+minipass@^7.0.2, minipass@^7.0.4:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
 minizlib@^2.1.2:
   version "2.1.2"
@@ -22116,7 +22182,7 @@ minizlib@^2.1.2:
 
 minizlib@^3.0.1, minizlib@^3.1.0:
   version "3.1.0"
-  resolved "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz#6ad76c3a8f10227c9b51d1c9ac8e30b27f5a251c"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-3.1.0.tgz#6ad76c3a8f10227c9b51d1c9ac8e30b27f5a251c"
   integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
   dependencies:
     minipass "^7.1.2"
@@ -22268,7 +22334,7 @@ negotiator@^0.6.3:
 
 negotiator@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
   integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
 
 neo-async@^2.6.2:
@@ -22319,7 +22385,7 @@ node-gyp-build@^4.3.0:
 
 node-gyp@^11.0.0, node-gyp@^9.0.0:
   version "11.5.0"
-  resolved "https://registry.npmjs.org/node-gyp/-/node-gyp-11.5.0.tgz#82661b5f40647a7361efe918e3cea76d297fcc56"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-11.5.0.tgz#82661b5f40647a7361efe918e3cea76d297fcc56"
   integrity sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==
   dependencies:
     env-paths "^2.2.0"
@@ -22367,7 +22433,7 @@ nopt@^5.0.0:
 
 nopt@^8.0.0:
   version "8.1.0"
-  resolved "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz#b11d38caf0f8643ce885818518064127f602eae3"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-8.1.0.tgz#b11d38caf0f8643ce885818518064127f602eae3"
   integrity sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==
   dependencies:
     abbrev "^3.0.0"
@@ -22962,7 +23028,7 @@ p-map@^4.0.0:
 
 p-map@^7.0.2:
   version "7.0.4"
-  resolved "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz#b81814255f542e252d5729dca4d66e5ec14935b8"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-7.0.4.tgz#b81814255f542e252d5729dca4d66e5ec14935b8"
   integrity sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==
 
 p-pipe@^3.1.0:
@@ -23317,6 +23383,11 @@ picomatch@^4, picomatch@^4.0.3:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
+picomatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
+
 pidtree@^0.6.0:
   version "0.6.0"
   resolved "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz#90ad7b6d42d5841e69e0a2419ef38f8883aa057c"
@@ -23492,7 +23563,7 @@ proc-log@^3.0.0:
 
 proc-log@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz#e6c93cf37aef33f835c53485f314f50ea906a9d8"
+  resolved "https://registry.yarnpkg.com/proc-log/-/proc-log-5.0.0.tgz#e6c93cf37aef33f835c53485f314f50ea906a9d8"
   integrity sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==
 
 process-nextick-args@~2.0.0:
@@ -23655,9 +23726,9 @@ q@^1.5.1:
   integrity sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==
 
 qs@6.13.0, qs@^6.12.3, qs@^6.15.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.0.tgz#db8fd5d1b1d2d6b5b33adaf87429805f1909e7b3"
-  integrity sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"
 
@@ -24663,7 +24734,7 @@ ssri@^10.0.0:
 
 ssri@^12.0.0:
   version "12.0.0"
-  resolved "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz#bcb4258417c702472f8191981d3c8a771fee6832"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-12.0.0.tgz#bcb4258417c702472f8191981d3c8a771fee6832"
   integrity sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==
   dependencies:
     minipass "^7.0.3"
@@ -24740,10 +24811,10 @@ streamroller@^3.1.5:
     debug "^4.3.4"
     fs-extra "^8.1.0"
 
-streamx@^2.12.5, streamx@^2.21.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.23.0.tgz#7d0f3d00d4a6c5de5728aecd6422b4008d66fd0b"
-  integrity sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==
+streamx@^2.12.5, streamx@^2.25.0:
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.25.0.tgz#cc967e99390fda8b918b1eeaf3bc437637c8c7af"
+  integrity sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==
   dependencies:
     events-universal "^1.0.0"
     fast-fifo "^1.3.2"
@@ -25055,9 +25126,9 @@ table@^6, table@^6.9.0:
     strip-ansi "^6.0.1"
 
 tar-fs@^2.0.0, tar-fs@^2.1.1, tar-fs@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.1.1.tgz#4f164e59fb60f103d472360731e8c6bb4a7fe9ef"
-  integrity sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.1.2.tgz#114b012f54796f31e62f3e57792820a80b83ae6e"
+  integrity sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==
   dependencies:
     pump "^3.0.0"
     tar-stream "^3.1.5"
@@ -25076,7 +25147,7 @@ tar-stream@^2.2.0, tar-stream@~2.2.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar-stream@^3.0.0, tar-stream@^3.1.5:
+tar-stream@^3.0.0:
   version "3.1.7"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-3.1.7.tgz#24b3fb5eabada19fe7338ed6d26e5f7c482e792b"
   integrity sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==
@@ -25085,10 +25156,20 @@ tar-stream@^3.0.0, tar-stream@^3.1.5:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
+tar-stream@^3.1.5:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-3.2.0.tgz#0d0064d9b67ea3c9f5abde155e35faab0df37591"
+  integrity sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==
+  dependencies:
+    b4a "^1.6.4"
+    bare-fs "^4.5.5"
+    fast-fifo "^1.2.0"
+    streamx "^2.15.0"
+
 tar@^6.1.0, tar@^6.1.11, tar@^7.4.3, tar@^7.5.11:
-  version "7.5.11"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.11.tgz#1250fae45d98806b36d703b30973fa8e0a6d8868"
-  integrity sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==
+  version "7.5.15"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.15.tgz#afe6d1316cddf614a566e3813e42fe01aed46fee"
+  integrity sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"
@@ -25186,12 +25267,12 @@ tildify@2.0.0:
   integrity sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==
 
 tinyglobby@^0.2.12:
-  version "0.2.15"
-  resolved "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
-  integrity sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.16.tgz#1c3b7eb953fce42b226bc5a1ee06428281aff3d6"
+  integrity sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==
   dependencies:
     fdir "^6.5.0"
-    picomatch "^4.0.3"
+    picomatch "^4.0.4"
 
 tmp@^0.0.33, tmp@^0.2.5, tmp@~0.2.1:
   version "0.2.5"
@@ -25571,7 +25652,7 @@ unique-filename@^3.0.0:
 
 unique-filename@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.npmjs.org/unique-filename/-/unique-filename-4.0.0.tgz#a06534d370e7c977a939cd1d11f7f0ab8f1fed13"
+  resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-4.0.0.tgz#a06534d370e7c977a939cd1d11f7f0ab8f1fed13"
   integrity sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==
   dependencies:
     unique-slug "^5.0.0"
@@ -25592,7 +25673,7 @@ unique-slug@^4.0.0:
 
 unique-slug@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.npmjs.org/unique-slug/-/unique-slug-5.0.0.tgz#ca72af03ad0dbab4dad8aa683f633878b1accda8"
+  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-5.0.0.tgz#ca72af03ad0dbab4dad8aa683f633878b1accda8"
   integrity sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==
   dependencies:
     imurmurhash "^0.1.4"
@@ -25928,7 +26009,7 @@ which@^3.0.0:
 
 which@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.npmjs.org/which/-/which-5.0.0.tgz#d93f2d93f79834d4363c7d0c23e00d07c466c8d6"
+  resolved "https://registry.yarnpkg.com/which/-/which-5.0.0.tgz#d93f2d93f79834d4363c7d0c23e00d07c466c8d6"
   integrity sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==
   dependencies:
     isexe "^3.1.1"
@@ -26182,7 +26263,7 @@ yallist@^4.0.0:
 
 yallist@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
   integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yaml@1.10.2, yaml@^1, yaml@^1.10.0:


### PR DESCRIPTION
#### Description of changes

This PR adds support for Aurora PostgreSQL Express / RDS IAM database authentication in SQL Lambda data sources.

When `authentication.strategy` is set to `rdsIam` in `SQLLambdaModelDataSourceStrategy`, the generated infrastructure:

- Generates an IAM authentication token at runtime using `@aws-sdk/rds-signer` instead of reading a static password from SSM
- Sets `CREDENTIAL_STORAGE_METHOD` to `RDS_IAM_AUTH` in the Lambda environment
- Grants `rds-db:connect` permission to the SQL Lambda execution role
- Supports both connection URI (`connectionUriSsmPath`) and individual SSM parameter configs (without requiring a `passwordSsmPath`)
- Allows the Lambda to run without VPC configuration when no `vpcConfiguration` is provided (required for Aurora PostgreSQL Express)
- Preserves existing password-based behavior when no `authentication` config is provided

**Usage example:**

```typescript
const strategy: SQLLambdaModelDataSourceStrategy = {
  name: 'myDatabase',
  dbType: 'POSTGRES',
  dbConnectionConfig: {
    // Passwordless URI stored in SSM: postgres://username@host:5432/dbname
    connectionUriSsmPath: '/myapp/db/connection-uri',
  },
  authentication: {
    strategy: 'rdsIam',
  },
  // vpcConfiguration is not required for Aurora PostgreSQL Express
};
```

This PR also fixes a bug in `checkHostInDBClusters` where Aurora clusters without VPC configuration (no `DBSubnetGroup` or empty `VpcSecurityGroups`) caused an error or fell through incorrectly to DB instance search. The return type is now `ClusterVpcResult` (`{ vpcConfig: VpcConfig | undefined } | undefined`) to distinguish "cluster found without VPC" from "cluster not found".

##### CDK / CloudFormation Parameters Changed

- Added `rds-db:connect` IAM policy statement to the SQL Lambda execution role when `authentication.strategy === 'rdsIam'`
  - Resource: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMdbauth.IAMPolicy.html

#### Issue #, if available

Closes #3485

#### Description of how you validated changes

- Added unit tests in `amplify-sql-resource-generator.test.ts` covering:
  - `rds-db:connect` permission is granted when using `rdsIam` authentication with connection URI
  - `CREDENTIAL_STORAGE_METHOD=RDS_IAM_AUTH` is set in Lambda environment variables
  - `rdsIam` with individual SSM parameters (host/port/username/database, no password)
  - `rds-db:connect` is NOT granted when no authentication config is provided (backward compatibility)
- Added unit tests in `rds-lambda.test.ts` covering:
  - IAM auth token generated from connection URI parsed from SSM
  - IAM auth token generated from individual SSM parameters
- Added unit tests in `vpc-helper.test.ts` covering:
  - Clusters without `DBSubnetGroup` return `undefined` without falling through to instance search
  - Clusters without VPC security groups return `undefined` without falling through to instance search

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.