### PR TITLE
fix(cleanup): preserve Gen1 seed apps from e2e resource reaper

### DIFF
--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -136,6 +136,16 @@ const BUCKET_TEST_REGEX = /test/;
 const IAM_TEST_REGEX =
   /!RotateE2eAwsToken-e2eTestContextRole|-integtest$|^amplify-|^eu-|^us-|^ap-|^auth-exhaustive-tests|rds-schema-inspector-integtest|^amplify_e2e_tests_lambda|^JsonMockStack-jsonMockApi|^SubscriptionAuth|^cdkamplifytable[0-9]*-|^MutationConditionTest-|^SearchableAuth|^SubscriptionRTFTests-|^NonModelAuthV2FunctionTransformerTests-|^MultiAuthV2Transformer|^FunctionTransformerTests|-integtest-/;
 const RDS_TEST_REGEX = /integtest/;
+/**
+ * Seed apps provisioned to satisfy the Gen1 new-customer restriction.
+ * amplify-provider-awscloudformation enforces that an account must have at least one
+ * Amplify app with a backend environment before `amplify init` is allowed (Gen1
+ * entered maintenance mode and blocks new customers). These seed apps are intentionally
+ * long-lived and MUST NOT be deleted by the cleanup workflow, or every canary that
+ * calls `amplify init` will fail with ProjectInitError.
+ * See: P457496122
+ */
+const GEN1_SEED_APP_NAME_PREFIX = 'DoNotDelete';
 const STALE_DURATION_MS = 6 * 60 * 60 * 1000; // 6 hours in milliseconds
 
 const staleHorizonDate = new Date(Date.now() - STALE_DURATION_MS);
@@ -163,6 +173,10 @@ const testStackStalenessFilter = (resource: Stack): boolean => {
 };
 
 const testAppStalenessFilter = (resource: App): boolean => {
+  // Never delete Gen1 seed apps — they satisfy the Gen1 new-customer restriction so
+  // canaries can run `amplify init`. Deleting them causes ProjectInitError on every run.
+  const isSeedApp = resource.name?.startsWith(GEN1_SEED_APP_NAME_PREFIX);
+  if (isSeedApp) return false;
   const isStaleResource = before(resource.createTime, staleHorizonDate);
   return !!isStaleResource;
 };


### PR DESCRIPTION
The cleanup workflow's testAppStalenessFilter deletes ALL Amplify apps older than 6 hours with no name-based exclusion. This causes it to delete the 'DoNotDeleteAppToBypassGen1Deprecation' seed apps that the canary accounts depend on.

Root cause of P457496122 and related Amplify Data canary failures: amplify-provider-awscloudformation (>=8.11.18, shipped in CLI 14.4.0) enforces a Gen1 new-customer restriction via enforceGen1NewCustomerRestriction(). It calls ListApps + ListBackendEnvironments; if the account has NO app with a backend environment it throws:
  ProjectInitError: 'AWS Amplify Gen 1 has entered maintenance mode
  and will no longer accept new customers'

The seed apps were provisioned 2026-05-05 to satisfy this check, but the cleanup workflow was deleting them on every run (6h TTL), causing every subsequent canary run to fail at `amplify init`.

Fix: add GEN1_SEED_APP_NAME_PREFIX = 'DoNotDelete' constant and an early-return guard in testAppStalenessFilter so any app whose name starts with 'DoNotDelete' is unconditionally excluded from deletion.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

##### CDK / CloudFormation Parameters Changed

<!--
Please list any changes to the CDK/CFN params, with a link to references https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html

e.g.

* Conditionally added support for `Code` based AppSync Functions: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-functionconfiguration.html#cfn-appsync-functionconfiguration-code
* Conditionally added support for `Code` based AppSync Resolvers: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-resolver.html#cfn-appsync-resolver-code
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
