### PR TITLE
fix: stagger e2e batch fan-out into waves to avoid CodeBuild batch-orchestration fault

### DIFF
--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -532,7 +532,8 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-multi-auth-1.test.ts
           CLI_REGION: sa-east-1
       depend-on:
-        - publish_to_local_registry
+        - >-
+          custom_transformers_invalid_input_arguments_schema_data_access_patterns_schema_predictions_function_10
     - identifier: rds_mysql_model_v2
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -542,7 +543,8 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-model-v2.test.ts
           CLI_REGION: us-east-1
       depend-on:
-        - publish_to_local_registry
+        - >-
+          api_7_schema_function_2_global_sandbox_lambda_conflict_handler_index_with_stack_mappings
     - identifier: rds_mysql_field_auth_userpool_static_dynamic
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -552,7 +554,8 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-userpool-static-dynamic.test.ts
           CLI_REGION: us-east-2
       depend-on:
-        - publish_to_local_registry
+        - >-
+          api_5_schema_function_1_generate_ts_data_schema_resolvers_sync_query_datastore
     - identifier: rds_mysql_field_auth_userpool_iam
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -562,7 +565,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-userpool-iam.test.ts
           CLI_REGION: us-west-1
       depend-on:
-        - publish_to_local_registry
+        - api_6_api_lambda_auth
     - identifier: rds_mysql_field_auth_lambda
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -572,7 +575,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-lambda.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - publish_to_local_registry
+        - rds_v2
     - identifier: rds_mysql_field_auth_identityPool
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -582,7 +585,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-identityPool.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
-        - publish_to_local_registry
+        - schema_iterative_update_5
     - identifier: rds_mysql_field_auth_iam
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -592,7 +595,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-iam.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
-        - publish_to_local_registry
+        - schema_auth_2
     - identifier: rds_mysql_field_auth_apikey
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -602,7 +605,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-apikey.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - publish_to_local_registry
+        - schema_auth_10
     - identifier: rds_mysql_custom_claims_refersto_auth
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -612,7 +615,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-custom-claims-refersto-auth.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - publish_to_local_registry
+        - schema_auth_1
     - identifier: rds_mysql_auth_iam
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -622,7 +625,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-auth-iam.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
-        - publish_to_local_registry
+        - schema_auth_13
     - identifier: rds_mysql_auth_iam_apikey_lambda_subscription
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -632,7 +635,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
-        - publish_to_local_registry
+        - schema_auth_12
     - identifier: rds_mysql_auth_apikey_lambda
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -642,7 +645,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-auth-apikey-lambda.test.ts
           CLI_REGION: ca-central-1
       depend-on:
-        - publish_to_local_registry
+        - schema_auth_3
     - identifier: schema_auth_9
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -652,7 +655,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-9.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
-        - publish_to_local_registry
+        - schema_auth_15
     - identifier: schema_auth_7
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -662,7 +665,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-7.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
-        - publish_to_local_registry
+        - schema_auth_8
     - identifier: schema_auth_14
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -672,7 +675,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-14.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - publish_to_local_registry
+        - schema_auth_4
     - identifier: schema_auth_5
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -682,7 +685,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-5.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - publish_to_local_registry
+        - schema_auth_11
     - identifier: schema_searchable
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -693,7 +696,7 @@ batch:
           CLI_REGION: ap-southeast-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - publish_to_local_registry
+        - sql_generate_unauth
     - identifier: searchable_datastore
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -704,7 +707,7 @@ batch:
           CLI_REGION: us-east-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - publish_to_local_registry
+        - schema_model
     - identifier: schema_auth_6
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -714,7 +717,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-6.test.ts
           CLI_REGION: eu-central-1
       depend-on:
-        - publish_to_local_registry
+        - rds_v2_test_utils
     - identifier: searchable_previous_deployment_had_node_to_node
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -725,7 +728,7 @@ batch:
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-had-node-to-node.test.ts
           CLI_REGION: us-west-1
       depend-on:
-        - publish_to_local_registry
+        - rds_relational_directives
     - identifier: searchable_previous_deployment_no_node_to_node
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -736,7 +739,7 @@ batch:
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-no-node-to-node.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_v2_generate_schema
     - identifier: utils_log_config_gsi_projection_type_ddb_iam_access_data_construct
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -747,7 +750,7 @@ batch:
             src/__tests__/utils.test.ts|src/__tests__/log-config.test.ts|src/__tests__/gsi-projection-type.test.ts|src/__tests__/ddb-iam-access.test.ts|src/__tests__/data-construct.test.ts
           CLI_REGION: eu-west-3
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_userpool_auth
     - identifier: >-
         custom_logic_amplify_table_5_add_resources_validate_transformer_evaluate_mapping_template_validate_transformer_e2e
       buildspec: codebuild_specs/run_cdk_tests.yml
@@ -759,7 +762,7 @@ batch:
             src/__tests__/custom-logic.test.ts|src/__tests__/amplify-table-5.test.ts|src/__tests__/add-resources.test.ts|src/__tests__/validate-transformer/validate-transformer-evaluate-mapping-template.test.ts|src/__tests__/validate-transformer/validate-transformer-e2e.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_userpool_auth_fields
     - identifier: >-
         references_migration_migration_validation_many_to_many_migration_base_migration
       buildspec: codebuild_specs/run_cdk_tests.yml
@@ -771,7 +774,7 @@ batch:
             src/__tests__/migration/references-migration.test.ts|src/__tests__/migration/migration-validation.test.ts|src/__tests__/migration/many-to-many-migration.test.ts|src/__tests__/migration/base-migration.test.ts
           CLI_REGION: eu-south-1
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_relational_directives
     - identifier: sql_pg_userpool_auth
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -781,7 +784,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-pg-userpool-auth.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_refers_to
     - identifier: sql_pg_oidc_auth
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -791,7 +794,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-pg-oidc-auth.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_refers_to_fields
     - identifier: sql_pg_models
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -801,7 +804,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-pg-models.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_oidc_auth_fields
     - identifier: sql_pg_canary
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -812,7 +815,7 @@ batch:
           CLI_REGION: us-east-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_model_v2
     - identifier: sql_pg_auto_increment
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -822,7 +825,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-pg-auto-increment.test.ts
           CLI_REGION: ca-central-1
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_import
     - identifier: sql_pg_array_objects
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -832,7 +835,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-pg-array-objects.test.ts
           CLI_REGION: eu-central-1
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_field_auth_userpool_static_dynamic
     - identifier: sql_mysql_oidc_auth
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -842,7 +845,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-mysql-oidc-auth.test.ts
           CLI_REGION: eu-north-1
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_field_auth_userpool_iam
     - identifier: sql_mysql_canary
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -852,7 +855,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: eu-west-1
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_field_auth_lambda
     - identifier: sql_models_2
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -862,7 +865,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-models-2.test.ts
           CLI_REGION: eu-west-2
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_field_auth_identityPool
     - identifier: sql_models_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -872,7 +875,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-models-1.test.ts
           CLI_REGION: eu-west-3
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_field_auth_iam
     - identifier: sql_iam_access
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -882,7 +885,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-iam-access.test.ts
           CLI_REGION: sa-east-1
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_field_auth_apikey
     - identifier: default_ddb_canary
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -892,7 +895,7 @@ batch:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: eu-west-3
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_custom_claims_refersto_auth
     - identifier: custom_query_mutation_extension
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -902,7 +905,7 @@ batch:
           TEST_SUITE: src/__tests__/custom-query-mutation-extension.test.ts
           CLI_REGION: us-east-1
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_auth_iam
     - identifier: base_cdk_ap_east_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -912,7 +915,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: ap-east-1
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_auth_iam_apikey_lambda_subscription
     - identifier: base_cdk_ap_northeast_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -922,7 +925,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_auth_apikey_lambda
     - identifier: base_cdk_ap_northeast_2
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -932,7 +935,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
-        - publish_to_local_registry
+        - rds_pg_array_objects
     - identifier: base_cdk_ap_northeast_3
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -942,7 +945,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_v2_generate_schema
     - identifier: base_cdk_ap_south_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -952,7 +955,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_userpool_auth
     - identifier: base_cdk_ap_southeast_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -962,7 +965,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_userpool_auth_fields
     - identifier: base_cdk_ap_southeast_2
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -972,7 +975,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_refers_to
     - identifier: base_cdk_ca_central_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -982,7 +985,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: ca-central-1
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_refers_to_fields
     - identifier: base_cdk_eu_central_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -992,7 +995,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: eu-central-1
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_oidc_auth_fields
     - identifier: base_cdk_eu_north_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1002,7 +1005,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: eu-north-1
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_multi_auth_1
     - identifier: base_cdk_eu_south_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1012,7 +1015,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: eu-south-1
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_model_v2
     - identifier: base_cdk_eu_west_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1022,7 +1025,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: eu-west-1
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_field_auth_userpool_static_dynamic
     - identifier: base_cdk_eu_west_2
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1032,7 +1035,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: eu-west-2
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_field_auth_userpool_iam
     - identifier: base_cdk_eu_west_3
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1042,7 +1045,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: eu-west-3
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_field_auth_lambda
     - identifier: base_cdk_sa_east_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1052,7 +1055,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: sa-east-1
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_field_auth_identityPool
     - identifier: base_cdk_us_east_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1062,7 +1065,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: us-east-1
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_field_auth_iam
     - identifier: base_cdk_us_east_2
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1072,7 +1075,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: us-east-2
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_field_auth_apikey
     - identifier: base_cdk_us_west_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1082,7 +1085,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: us-west-1
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_custom_claims_refersto_auth
     - identifier: base_cdk_us_west_2
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1092,7 +1095,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_auth_iam
     - identifier: amplify_table_4
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1102,7 +1105,7 @@ batch:
           TEST_SUITE: src/__tests__/amplify-table-4.test.ts
           CLI_REGION: us-east-2
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_auth_iam_apikey_lambda_subscription
     - identifier: amplify_table_3
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1112,7 +1115,7 @@ batch:
           TEST_SUITE: src/__tests__/amplify-table-3.test.ts
           CLI_REGION: us-west-1
       depend-on:
-        - publish_to_local_registry
+        - rds_mysql_auth_apikey_lambda
     - identifier: amplify_table_2
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1122,7 +1125,7 @@ batch:
           TEST_SUITE: src/__tests__/amplify-table-2.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - publish_to_local_registry
+        - schema_auth_9
     - identifier: amplify_table_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1132,7 +1135,7 @@ batch:
           TEST_SUITE: src/__tests__/amplify-table-1.test.ts
           CLI_REGION: ap-east-1
       depend-on:
-        - publish_to_local_registry
+        - schema_auth_7
     - identifier: amplify_ddb_canary
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1142,7 +1145,7 @@ batch:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
-        - publish_to_local_registry
+        - schema_auth_14
     - identifier: all_auth_modes
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1152,7 +1155,7 @@ batch:
           TEST_SUITE: src/__tests__/all-auth-modes.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
-        - publish_to_local_registry
+        - schema_auth_5
     - identifier: admin_role
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1162,7 +1165,7 @@ batch:
           TEST_SUITE: src/__tests__/admin-role.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - publish_to_local_registry
+        - schema_searchable
     - identifier: sql_custom_ssl
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1172,7 +1175,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-custom-ssl/sql-custom-ssl.test.ts
           CLI_REGION: eu-west-1
       depend-on:
-        - publish_to_local_registry
+        - searchable_datastore
     - identifier: restricted_field_auth_gen2
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1183,7 +1186,7 @@ batch:
             src/__tests__/restricted-field-auth/restricted-field-auth-gen2.test.ts
           CLI_REGION: eu-west-2
       depend-on:
-        - publish_to_local_registry
+        - schema_auth_6
     - identifier: restricted_field_auth_gen1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1194,7 +1197,7 @@ batch:
             src/__tests__/restricted-field-auth/restricted-field-auth-gen1.test.ts
           CLI_REGION: eu-south-1
       depend-on:
-        - publish_to_local_registry
+        - searchable_previous_deployment_had_node_to_node
     - identifier: restricted_field_auth_gen2_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1205,7 +1208,7 @@ batch:
             src/__tests__/restricted-field-auth/subscriptions-off/restricted-field-auth-gen2-subscriptions-off.test.ts
           CLI_REGION: sa-east-1
       depend-on:
-        - publish_to_local_registry
+        - searchable_previous_deployment_no_node_to_node
     - identifier: restricted_field_auth_gen1_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1216,7 +1219,7 @@ batch:
             src/__tests__/restricted-field-auth/subscriptions-off/restricted-field-auth-gen1-subscriptions-off.test.ts
           CLI_REGION: eu-west-2
       depend-on:
-        - publish_to_local_registry
+        - utils_log_config_gsi_projection_type_ddb_iam_access_data_construct
     - identifier: references_sqlprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1227,7 +1230,8 @@ batch:
             src/__tests__/relationships/references/references-sqlprimary-sqlrelated.test.ts
           CLI_REGION: us-east-2
       depend-on:
-        - publish_to_local_registry
+        - >-
+          custom_logic_amplify_table_5_add_resources_validate_transformer_evaluate_mapping_template_validate_transformer_e2e
     - identifier: references_sqlprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1238,7 +1242,8 @@ batch:
             src/__tests__/relationships/references/references-sqlprimary-ddbrelated.test.ts
           CLI_REGION: us-west-1
       depend-on:
-        - publish_to_local_registry
+        - >-
+          references_migration_migration_validation_many_to_many_migration_base_migration
     - identifier: references_ddbprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1249,7 +1254,7 @@ batch:
             src/__tests__/relationships/references/references-ddbprimary-sqlrelated.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - publish_to_local_registry
+        - sql_pg_userpool_auth
     - identifier: references_ddbprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1260,7 +1265,7 @@ batch:
             src/__tests__/relationships/references/references-ddbprimary-ddbrelated.test.ts
           CLI_REGION: eu-west-3
       depend-on:
-        - publish_to_local_registry
+        - sql_pg_oidc_auth
     - identifier: recursive_relationships_sql
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1271,7 +1276,7 @@ batch:
             src/__tests__/relationships/recursive/recursive-relationships-sql.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
-        - publish_to_local_registry
+        - sql_pg_models
     - identifier: recursive_relationships_ddb
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1282,7 +1287,7 @@ batch:
             src/__tests__/relationships/recursive/recursive-relationships-ddb.test.ts
           CLI_REGION: us-east-1
       depend-on:
-        - publish_to_local_registry
+        - sql_pg_canary
     - identifier: uuid_pk_sqlprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1293,7 +1298,7 @@ batch:
             src/__tests__/relationships/postgres-uuid-pk/uuid-pk-sqlprimary-sqlrelated.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - publish_to_local_registry
+        - sql_pg_auto_increment
     - identifier: uuid_pk_sqlprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1304,7 +1309,7 @@ batch:
             src/__tests__/relationships/postgres-uuid-pk/uuid-pk-sqlprimary-ddbrelated.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
-        - publish_to_local_registry
+        - sql_pg_array_objects
     - identifier: uuid_pk_ddbprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1315,7 +1320,7 @@ batch:
             src/__tests__/relationships/postgres-uuid-pk/uuid-pk-ddbprimary-sqlrelated.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
-        - publish_to_local_registry
+        - sql_mysql_oidc_auth
     - identifier: multi_relationship_sqlprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1326,7 +1331,7 @@ batch:
             src/__tests__/relationships/multi-relationship/multi-relationship-sqlprimary-sqlrelated.test.ts
           CLI_REGION: ca-central-1
       depend-on:
-        - publish_to_local_registry
+        - sql_mysql_canary
     - identifier: multi_relationship_sqlprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1337,7 +1342,7 @@ batch:
             src/__tests__/relationships/multi-relationship/multi-relationship-sqlprimary-ddbrelated.test.ts
           CLI_REGION: eu-central-1
       depend-on:
-        - publish_to_local_registry
+        - sql_models_2
     - identifier: multi_relationship_ddbprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1348,7 +1353,7 @@ batch:
             src/__tests__/relationships/multi-relationship/multi-relationship-ddbprimary-sqlrelated.test.ts
           CLI_REGION: eu-north-1
       depend-on:
-        - publish_to_local_registry
+        - sql_models_1
     - identifier: multi_relationship_ddbprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1359,7 +1364,7 @@ batch:
             src/__tests__/relationships/multi-relationship/multi-relationship-ddbprimary-ddbrelated.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - publish_to_local_registry
+        - sql_iam_access
     - identifier: relationships_gen1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1369,7 +1374,7 @@ batch:
           TEST_SUITE: src/__tests__/relationships/gen1/relationships-gen1.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - publish_to_local_registry
+        - default_ddb_canary
     - identifier: assoc_field_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1380,7 +1385,7 @@ batch:
             src/__tests__/owner-auth/subscriptions-off/assoc-field-subscriptions-off.test.ts
           CLI_REGION: eu-north-1
       depend-on:
-        - publish_to_local_registry
+        - custom_query_mutation_extension
     - identifier: bind_sql_ids
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1390,7 +1395,7 @@ batch:
           TEST_SUITE: src/__tests__/owner-auth/bind-sql-ids/bind-sql-ids.test.ts
           CLI_REGION: sa-east-1
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_ap_east_1
     - identifier: assoc_field_sqlprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1401,7 +1406,7 @@ batch:
             src/__tests__/owner-auth/assoc-field/assoc-field-sqlprimary-sqlrelated.test.ts
           CLI_REGION: us-east-1
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_ap_northeast_1
     - identifier: assoc_field_sqlprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1412,7 +1417,7 @@ batch:
             src/__tests__/owner-auth/assoc-field/assoc-field-sqlprimary-ddbrelated.test.ts
           CLI_REGION: us-east-2
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_ap_northeast_2
     - identifier: assoc_field_ddbprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1423,7 +1428,7 @@ batch:
             src/__tests__/owner-auth/assoc-field/assoc-field-ddbprimary-sqlrelated.test.ts
           CLI_REGION: us-west-1
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_ap_northeast_3
     - identifier: assoc_field_ddbprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1434,7 +1439,7 @@ batch:
             src/__tests__/owner-auth/assoc-field/assoc-field-ddbprimary-ddbrelated.test.ts
           CLI_REGION: sa-east-1
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_ap_south_1
     - identifier: static_group_auth_sqlprimary_sqlrelated_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1445,7 +1450,7 @@ batch:
             src/__tests__/group-auth/subscriptions-off/static-group-auth/static-group-auth-sqlprimary-sqlrelated-subscriptions-off.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_ap_southeast_1
     - identifier: static_group_auth_sqlprimary_ddbrelated_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1456,7 +1461,7 @@ batch:
             src/__tests__/group-auth/subscriptions-off/static-group-auth/static-group-auth-sqlprimary-ddbrelated-subscriptions-off.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_ap_southeast_2
     - identifier: static_group_auth_ddbprimary_sqlrelated_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1467,7 +1472,7 @@ batch:
             src/__tests__/group-auth/subscriptions-off/static-group-auth/static-group-auth-ddbprimary-sqlrelated-subscriptions-off.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_ca_central_1
     - identifier: static_group_auth_ddbprimary_ddbrelated_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1478,7 +1483,7 @@ batch:
             src/__tests__/group-auth/subscriptions-off/static-group-auth/static-group-auth-ddbprimary-ddbrelated-subscriptions-off.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_eu_central_1
     - identifier: dynamic_group_auth_sqlprimary_sqlrelated_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1489,7 +1494,7 @@ batch:
             src/__tests__/group-auth/subscriptions-off/dynamic-group-auth/dynamic-group-auth-sqlprimary-sqlrelated-subscriptions-off.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_eu_north_1
     - identifier: dynamic_group_auth_sqlprimary_ddbrelated_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1500,7 +1505,7 @@ batch:
             src/__tests__/group-auth/subscriptions-off/dynamic-group-auth/dynamic-group-auth-sqlprimary-ddbrelated-subscriptions-off.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_eu_south_1
     - identifier: dynamic_group_auth_ddbprimary_sqlrelated_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1511,7 +1516,7 @@ batch:
             src/__tests__/group-auth/subscriptions-off/dynamic-group-auth/dynamic-group-auth-ddbprimary-sqlrelated-subscriptions-off.test.ts
           CLI_REGION: ca-central-1
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_eu_west_1
     - identifier: dynamic_group_auth_ddbprimary_ddbrelated_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1522,7 +1527,7 @@ batch:
             src/__tests__/group-auth/subscriptions-off/dynamic-group-auth/dynamic-group-auth-ddbprimary-ddbrelated-subscriptions-off.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_eu_west_2
     - identifier: static_group_auth_sqlprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1533,7 +1538,7 @@ batch:
             src/__tests__/group-auth/static-group-auth/static-group-auth-sqlprimary-sqlrelated.test.ts
           CLI_REGION: eu-north-1
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_eu_west_3
     - identifier: static_group_auth_sqlprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1544,7 +1549,7 @@ batch:
             src/__tests__/group-auth/static-group-auth/static-group-auth-sqlprimary-ddbrelated.test.ts
           CLI_REGION: eu-west-1
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_sa_east_1
     - identifier: static_group_auth_ddbprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1555,7 +1560,7 @@ batch:
             src/__tests__/group-auth/static-group-auth/static-group-auth-ddbprimary-sqlrelated.test.ts
           CLI_REGION: eu-west-2
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_us_east_1
     - identifier: static_group_auth_ddbprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1566,7 +1571,7 @@ batch:
             src/__tests__/group-auth/static-group-auth/static-group-auth-ddbprimary-ddbrelated.test.ts
           CLI_REGION: eu-central-1
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_us_east_2
     - identifier: dynamic_group_auth_sqlprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1577,7 +1582,7 @@ batch:
             src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-sqlprimary-sqlrelated.test.ts
           CLI_REGION: sa-east-1
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_us_west_1
     - identifier: dynamic_group_auth_sqlprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1588,7 +1593,7 @@ batch:
             src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-sqlprimary-ddbrelated.test.ts
           CLI_REGION: us-east-1
       depend-on:
-        - publish_to_local_registry
+        - base_cdk_us_west_2
     - identifier: dynamic_group_auth_ddbprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1599,7 +1604,7 @@ batch:
             src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-ddbprimary-sqlrelated.test.ts
           CLI_REGION: us-east-2
       depend-on:
-        - publish_to_local_registry
+        - amplify_table_4
     - identifier: dynamic_group_auth_ddbprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1610,7 +1615,7 @@ batch:
             src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-ddbprimary-ddbrelated.test.ts
           CLI_REGION: eu-west-2
       depend-on:
-        - publish_to_local_registry
+        - amplify_table_3
     - identifier: generation
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1621,7 +1626,7 @@ batch:
           CLI_REGION: us-west-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - publish_to_local_registry
+        - amplify_table_2
     - identifier: single_gsi_single_record
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1632,7 +1637,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-single-record.test.ts
           CLI_REGION: eu-north-1
       depend-on:
-        - publish_to_local_registry
+        - amplify_table_1
     - identifier: single_gsi_empty_table
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1643,7 +1648,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-empty-table.test.ts
           CLI_REGION: eu-south-1
       depend-on:
-        - publish_to_local_registry
+        - amplify_ddb_canary
     - identifier: single_gsi_1k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1654,7 +1659,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-1k-records.test.ts
           CLI_REGION: eu-west-1
       depend-on:
-        - publish_to_local_registry
+        - all_auth_modes
     - identifier: single_gsi_10k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1665,7 +1670,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-10k-records.test.ts
           CLI_REGION: eu-west-2
       depend-on:
-        - publish_to_local_registry
+        - admin_role
     - identifier: replace_2_gsis_update_attr_single_record
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1676,7 +1681,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-single-record.test.ts
           CLI_REGION: eu-west-3
       depend-on:
-        - publish_to_local_registry
+        - sql_custom_ssl
     - identifier: replace_2_gsis_update_attr_empty_table
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1687,7 +1692,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-empty-table.test.ts
           CLI_REGION: sa-east-1
       depend-on:
-        - publish_to_local_registry
+        - restricted_field_auth_gen2
     - identifier: replace_2_gsis_update_attr_1k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1698,7 +1703,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-1k-records.test.ts
           CLI_REGION: us-east-1
       depend-on:
-        - publish_to_local_registry
+        - restricted_field_auth_gen1
     - identifier: replace_2_gsis_update_attr_10k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1709,7 +1714,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-10k-records.test.ts
           CLI_REGION: us-east-2
       depend-on:
-        - publish_to_local_registry
+        - restricted_field_auth_gen2_subscriptions_off
     - identifier: replace_2_gsis_single_record
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1720,7 +1725,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-single-record.test.ts
           CLI_REGION: us-west-1
       depend-on:
-        - publish_to_local_registry
+        - restricted_field_auth_gen1_subscriptions_off
     - identifier: replace_2_gsis_empty_table
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1731,7 +1736,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-empty-table.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - publish_to_local_registry
+        - references_sqlprimary_sqlrelated
     - identifier: replace_2_gsis_1k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1742,7 +1747,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-1k-records.test.ts
           CLI_REGION: ap-east-1
       depend-on:
-        - publish_to_local_registry
+        - references_sqlprimary_ddbrelated
     - identifier: replace_2_gsis_10k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1753,7 +1758,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-10k-records.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
-        - publish_to_local_registry
+        - references_ddbprimary_sqlrelated
     - identifier: 3_gsis_single_record
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1764,7 +1769,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-single-record.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
-        - publish_to_local_registry
+        - references_ddbprimary_ddbrelated
     - identifier: 3_gsis_empty_table
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1775,7 +1780,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-empty-table.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - publish_to_local_registry
+        - recursive_relationships_sql
     - identifier: 3_gsis_1k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1786,7 +1791,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-1k-records.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - publish_to_local_registry
+        - recursive_relationships_ddb
     - identifier: 3_gsis_10k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1797,7 +1802,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-10k-records.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
-        - publish_to_local_registry
+        - uuid_pk_sqlprimary_sqlrelated
     - identifier: single_gsi_100k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1807,7 +1812,7 @@ batch:
           TEST_SUITE: src/__tests__/deploy-velocity/single-gsi-100k-records.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
-        - publish_to_local_registry
+        - uuid_pk_sqlprimary_ddbrelated
     - identifier: replace_2_gsis_update_attr_100k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1818,7 +1823,7 @@ batch:
             src/__tests__/deploy-velocity/replace-2-gsis-update-attr-100k-records.test.ts
           CLI_REGION: ca-central-1
       depend-on:
-        - publish_to_local_registry
+        - uuid_pk_ddbprimary_sqlrelated
     - identifier: replace_2_gsis_100k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1828,7 +1833,7 @@ batch:
           TEST_SUITE: src/__tests__/deploy-velocity/replace-2-gsis-100k-records.test.ts
           CLI_REGION: eu-central-1
       depend-on:
-        - publish_to_local_registry
+        - multi_relationship_sqlprimary_sqlrelated
     - identifier: 3_gsis_100k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1838,7 +1843,7 @@ batch:
           TEST_SUITE: src/__tests__/deploy-velocity/3-gsis-100k-records.test.ts
           CLI_REGION: eu-north-1
       depend-on:
-        - publish_to_local_registry
+        - multi_relationship_sqlprimary_ddbrelated
     - identifier: conversation
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1849,7 +1854,7 @@ batch:
           CLI_REGION: us-west-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - publish_to_local_registry
+        - multi_relationship_ddbprimary_sqlrelated
     - identifier: >-
         NonModelAuthV2Function_TransformerOptionsV2_DefaultValueTransformer_PerFieldAuthV2TransformerWithFF_PerFieldAuthV2Transformer
       buildspec: codebuild_specs/graphql_e2e_tests.yml
@@ -1861,7 +1866,7 @@ batch:
             src/__tests__/NonModelAuthV2Function.e2e.test.ts|src/__tests__/TransformerOptionsV2.e2e.test.ts|src/__tests__/DefaultValueTransformer.e2e.test.ts|src/__tests__/PerFieldAuthV2TransformerWithFF.e2e.test.ts|src/__tests__/PerFieldAuthV2Transformer.e2e.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - publish_to_local_registry
+        - multi_relationship_ddbprimary_ddbrelated
     - identifier: >-
         BelongsToTransformerV2_RelationalWithAuthV2WithFF_IndexWithAuthV2_IndexWithAuthV2WithFF_SubscriptionsWithAuthV2WithFF
       buildspec: codebuild_specs/graphql_e2e_tests.yml
@@ -1873,7 +1878,7 @@ batch:
             src/__tests__/BelongsToTransformerV2.e2e.test.ts|src/__tests__/RelationalWithAuthV2WithFF.e2e.test.ts|src/__tests__/IndexWithAuthV2.e2e.test.ts|src/__tests__/IndexWithAuthV2WithFF.e2e.test.ts|src/__tests__/SubscriptionsWithAuthV2WithFF.e2e.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
-        - publish_to_local_registry
+        - relationships_gen1
     - identifier: >-
         MultiAuthV2Transformer_ModelTransformer_SubscriptionsWithAuthV2_RelationalWithAuthV2_MapsToTransformer
       buildspec: codebuild_specs/graphql_e2e_tests.yml
@@ -1885,7 +1890,7 @@ batch:
             src/__tests__/MultiAuthV2Transformer.e2e.test.ts|src/__tests__/ModelTransformer.e2e.test.ts|src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts|src/__tests__/RelationalWithAuthV2.e2e.test.ts|src/__tests__/MapsToTransformer.e2e.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
-        - publish_to_local_registry
+        - assoc_field_subscriptions_off
     - identifier: >-
         MultiAuthV2TransformerWithFF_AuthV2Transformer_AuthV2ExhaustiveT1B_AuthV2ExhaustiveT1A_AuthV2TransformerWithFF
       buildspec: codebuild_specs/graphql_e2e_tests.yml
@@ -1897,7 +1902,7 @@ batch:
             src/__tests__/MultiAuthV2TransformerWithFF.e2e.test.ts|src/__tests__/AuthV2Transformer.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT1B.test.ts|src/__tests__/AuthV2ExhaustiveT1A.test.ts|src/__tests__/AuthV2TransformerWithFF.e2e.test.ts
           CLI_REGION: ca-central-1
       depend-on:
-        - publish_to_local_registry
+        - bind_sql_ids
     - identifier: >-
         SubscriptionsRuntimeFiltering_AuthV2ExhaustiveT2A_AuthV2ExhaustiveT1C_AuthV2ExhaustiveT1D_AuthV2ExhaustiveT2B
       buildspec: codebuild_specs/graphql_e2e_tests.yml
@@ -1909,7 +1914,7 @@ batch:
             src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT2A.test.ts|src/__tests__/AuthV2ExhaustiveT1C.test.ts|src/__tests__/AuthV2ExhaustiveT1D.test.ts|src/__tests__/AuthV2ExhaustiveT2B.test.ts
           CLI_REGION: eu-central-1
       depend-on:
-        - publish_to_local_registry
+        - assoc_field_sqlprimary_sqlrelated
     - identifier: >-
         AuthV2ExhaustiveT2D_AuthV2ExhaustiveT2C_RelationalWithAuthV2Redacted_RelationalWithAuthV2NonRedacted_AuthV2TransformerIAM
       buildspec: codebuild_specs/graphql_e2e_tests.yml
@@ -1921,7 +1926,7 @@ batch:
             src/__tests__/AuthV2ExhaustiveT2D.test.ts|src/__tests__/AuthV2ExhaustiveT2C.test.ts|src/__tests__/RelationalWithAuthV2Redacted.e2e.test.ts|src/__tests__/RelationalWithAuthV2NonRedacted.e2e.test.ts|src/__tests__/AuthV2TransformerIAM.test.ts
           CLI_REGION: eu-north-1
       depend-on:
-        - publish_to_local_registry
+        - assoc_field_sqlprimary_ddbrelated
     - identifier: >-
         AuthV2ExhaustiveT3D_AuthV2ExhaustiveT3C_AuthV2ExhaustiveT3B_AuthV2ExhaustiveT3A_SearchableModelTransformerV2
       buildspec: codebuild_specs/graphql_e2e_tests.yml
@@ -1933,7 +1938,7 @@ batch:
             src/__tests__/AuthV2ExhaustiveT3D.test.ts|src/__tests__/AuthV2ExhaustiveT3C.test.ts|src/__tests__/AuthV2ExhaustiveT3B.test.ts|src/__tests__/AuthV2ExhaustiveT3A.test.ts|src/__tests__/SearchableModelTransformerV2.e2e.test.ts
           CLI_REGION: eu-west-2
       depend-on:
-        - publish_to_local_registry
+        - assoc_field_ddbprimary_sqlrelated
     - identifier: SearchableWithAuthV2WithFF_SearchableWithAuthV2
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
@@ -1944,7 +1949,7 @@ batch:
             src/__tests__/SearchableWithAuthV2WithFF.e2e.test.ts|src/__tests__/SearchableWithAuthV2.e2e.test.ts
           CLI_REGION: eu-west-3
       depend-on:
-        - publish_to_local_registry
+        - assoc_field_ddbprimary_ddbrelated
     - identifier: PredictionsTransformerV2Tests
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
@@ -1954,7 +1959,7 @@ batch:
           TEST_SUITE: src/__tests__/PredictionsTransformerV2Tests.e2e.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
-        - publish_to_local_registry
+        - static_group_auth_sqlprimary_sqlrelated_subscriptions_off
     - identifier: FunctionTransformerTestsV2
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
@@ -1965,7 +1970,7 @@ batch:
           CLI_REGION: ap-south-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - publish_to_local_registry
+        - static_group_auth_sqlprimary_ddbrelated_subscriptions_off
     - identifier: HttpTransformerV2
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
@@ -1975,7 +1980,7 @@ batch:
           TEST_SUITE: src/__tests__/HttpTransformerV2.e2e.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - publish_to_local_registry
+        - static_group_auth_ddbprimary_sqlrelated_subscriptions_off
     - identifier: cleanup_e2e_resources
       buildspec: codebuild_specs/cleanup_e2e_resources.yml
       env:
@@ -1983,5 +1988,56 @@ batch:
         variables:
           JSII_DEPRECATED: quiet
       depend-on:
+        - static_group_auth_ddbprimary_ddbrelated_subscriptions_off
+        - dynamic_group_auth_sqlprimary_sqlrelated_subscriptions_off
+        - dynamic_group_auth_sqlprimary_ddbrelated_subscriptions_off
+        - dynamic_group_auth_ddbprimary_sqlrelated_subscriptions_off
+        - dynamic_group_auth_ddbprimary_ddbrelated_subscriptions_off
+        - static_group_auth_sqlprimary_sqlrelated
+        - static_group_auth_sqlprimary_ddbrelated
+        - static_group_auth_ddbprimary_sqlrelated
+        - static_group_auth_ddbprimary_ddbrelated
+        - dynamic_group_auth_sqlprimary_sqlrelated
+        - dynamic_group_auth_sqlprimary_ddbrelated
+        - dynamic_group_auth_ddbprimary_sqlrelated
+        - dynamic_group_auth_ddbprimary_ddbrelated
+        - generation
+        - single_gsi_single_record
+        - single_gsi_empty_table
+        - single_gsi_1k_records
+        - single_gsi_10k_records
+        - replace_2_gsis_update_attr_single_record
+        - replace_2_gsis_update_attr_empty_table
+        - replace_2_gsis_update_attr_1k_records
+        - replace_2_gsis_update_attr_10k_records
+        - replace_2_gsis_single_record
+        - replace_2_gsis_empty_table
+        - replace_2_gsis_1k_records
+        - replace_2_gsis_10k_records
+        - 3_gsis_single_record
+        - 3_gsis_empty_table
+        - 3_gsis_1k_records
+        - 3_gsis_10k_records
+        - single_gsi_100k_records
+        - replace_2_gsis_update_attr_100k_records
+        - replace_2_gsis_100k_records
+        - 3_gsis_100k_records
+        - conversation
         - >-
-          custom_transformers_invalid_input_arguments_schema_data_access_patterns_schema_predictions_function_10
+          NonModelAuthV2Function_TransformerOptionsV2_DefaultValueTransformer_PerFieldAuthV2TransformerWithFF_PerFieldAuthV2Transformer
+        - >-
+          BelongsToTransformerV2_RelationalWithAuthV2WithFF_IndexWithAuthV2_IndexWithAuthV2WithFF_SubscriptionsWithAuthV2WithFF
+        - >-
+          MultiAuthV2Transformer_ModelTransformer_SubscriptionsWithAuthV2_RelationalWithAuthV2_MapsToTransformer
+        - >-
+          MultiAuthV2TransformerWithFF_AuthV2Transformer_AuthV2ExhaustiveT1B_AuthV2ExhaustiveT1A_AuthV2TransformerWithFF
+        - >-
+          SubscriptionsRuntimeFiltering_AuthV2ExhaustiveT2A_AuthV2ExhaustiveT1C_AuthV2ExhaustiveT1D_AuthV2ExhaustiveT2B
+        - >-
+          AuthV2ExhaustiveT2D_AuthV2ExhaustiveT2C_RelationalWithAuthV2Redacted_RelationalWithAuthV2NonRedacted_AuthV2TransformerIAM
+        - >-
+          AuthV2ExhaustiveT3D_AuthV2ExhaustiveT3C_AuthV2ExhaustiveT3B_AuthV2ExhaustiveT3A_SearchableModelTransformerV2
+        - SearchableWithAuthV2WithFF_SearchableWithAuthV2
+        - PredictionsTransformerV2Tests
+        - FunctionTransformerTestsV2
+        - HttpTransformerV2

--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -532,8 +532,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-multi-auth-1.test.ts
           CLI_REGION: sa-east-1
       depend-on:
-        - >-
-          custom_transformers_invalid_input_arguments_schema_data_access_patterns_schema_predictions_function_10
+        - publish_to_local_registry
     - identifier: rds_mysql_model_v2
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -543,8 +542,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-model-v2.test.ts
           CLI_REGION: us-east-1
       depend-on:
-        - >-
-          api_7_schema_function_2_global_sandbox_lambda_conflict_handler_index_with_stack_mappings
+        - publish_to_local_registry
     - identifier: rds_mysql_field_auth_userpool_static_dynamic
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -554,8 +552,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-userpool-static-dynamic.test.ts
           CLI_REGION: us-east-2
       depend-on:
-        - >-
-          api_5_schema_function_1_generate_ts_data_schema_resolvers_sync_query_datastore
+        - publish_to_local_registry
     - identifier: rds_mysql_field_auth_userpool_iam
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -565,7 +562,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-userpool-iam.test.ts
           CLI_REGION: us-west-1
       depend-on:
-        - api_6_api_lambda_auth
+        - publish_to_local_registry
     - identifier: rds_mysql_field_auth_lambda
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -575,7 +572,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-lambda.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - rds_v2
+        - publish_to_local_registry
     - identifier: rds_mysql_field_auth_identityPool
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -585,7 +582,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-identityPool.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
-        - schema_iterative_update_5
+        - publish_to_local_registry
     - identifier: rds_mysql_field_auth_iam
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -595,7 +592,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-iam.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
-        - schema_auth_2
+        - publish_to_local_registry
     - identifier: rds_mysql_field_auth_apikey
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -605,7 +602,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-field-auth-apikey.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - schema_auth_10
+        - publish_to_local_registry
     - identifier: rds_mysql_custom_claims_refersto_auth
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -615,7 +612,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-custom-claims-refersto-auth.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - schema_auth_1
+        - publish_to_local_registry
     - identifier: rds_mysql_auth_iam
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -625,7 +622,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-auth-iam.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
-        - schema_auth_13
+        - publish_to_local_registry
     - identifier: rds_mysql_auth_iam_apikey_lambda_subscription
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -635,7 +632,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-auth-iam-apikey-lambda-subscription.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
-        - schema_auth_12
+        - publish_to_local_registry
     - identifier: rds_mysql_auth_apikey_lambda
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -645,7 +642,7 @@ batch:
           TEST_SUITE: src/__tests__/rds-mysql-auth-apikey-lambda.test.ts
           CLI_REGION: ca-central-1
       depend-on:
-        - schema_auth_3
+        - publish_to_local_registry
     - identifier: schema_auth_9
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -655,7 +652,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-9.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
-        - schema_auth_15
+        - publish_to_local_registry
     - identifier: schema_auth_7
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -665,7 +662,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-7.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
-        - schema_auth_8
+        - publish_to_local_registry
     - identifier: schema_auth_14
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -675,7 +672,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-14.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - schema_auth_4
+        - publish_to_local_registry
     - identifier: schema_auth_5
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -685,7 +682,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-5.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - schema_auth_11
+        - publish_to_local_registry
     - identifier: schema_searchable
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -696,7 +693,7 @@ batch:
           CLI_REGION: ap-southeast-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - sql_generate_unauth
+        - publish_to_local_registry
     - identifier: searchable_datastore
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -707,7 +704,7 @@ batch:
           CLI_REGION: us-east-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - schema_model
+        - publish_to_local_registry
     - identifier: schema_auth_6
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -717,7 +714,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-6.test.ts
           CLI_REGION: eu-central-1
       depend-on:
-        - rds_v2_test_utils
+        - publish_to_local_registry
     - identifier: searchable_previous_deployment_had_node_to_node
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -728,7 +725,7 @@ batch:
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-had-node-to-node.test.ts
           CLI_REGION: us-west-1
       depend-on:
-        - rds_relational_directives
+        - publish_to_local_registry
     - identifier: searchable_previous_deployment_no_node_to_node
       buildspec: codebuild_specs/run_e2e_tests.yml
       env:
@@ -739,7 +736,7 @@ batch:
             src/__tests__/graphql-v2/searchable-node-to-node-encryption/searchable-previous-deployment-no-node-to-node.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - rds_pg_v2_generate_schema
+        - publish_to_local_registry
     - identifier: utils_log_config_gsi_projection_type_ddb_iam_access_data_construct
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -750,7 +747,7 @@ batch:
             src/__tests__/utils.test.ts|src/__tests__/log-config.test.ts|src/__tests__/gsi-projection-type.test.ts|src/__tests__/ddb-iam-access.test.ts|src/__tests__/data-construct.test.ts
           CLI_REGION: eu-west-3
       depend-on:
-        - rds_pg_userpool_auth
+        - publish_to_local_registry
     - identifier: >-
         custom_logic_amplify_table_5_add_resources_validate_transformer_evaluate_mapping_template_validate_transformer_e2e
       buildspec: codebuild_specs/run_cdk_tests.yml
@@ -762,7 +759,7 @@ batch:
             src/__tests__/custom-logic.test.ts|src/__tests__/amplify-table-5.test.ts|src/__tests__/add-resources.test.ts|src/__tests__/validate-transformer/validate-transformer-evaluate-mapping-template.test.ts|src/__tests__/validate-transformer/validate-transformer-e2e.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - rds_pg_userpool_auth_fields
+        - publish_to_local_registry
     - identifier: >-
         references_migration_migration_validation_many_to_many_migration_base_migration
       buildspec: codebuild_specs/run_cdk_tests.yml
@@ -774,7 +771,7 @@ batch:
             src/__tests__/migration/references-migration.test.ts|src/__tests__/migration/migration-validation.test.ts|src/__tests__/migration/many-to-many-migration.test.ts|src/__tests__/migration/base-migration.test.ts
           CLI_REGION: eu-south-1
       depend-on:
-        - rds_pg_relational_directives
+        - publish_to_local_registry
     - identifier: sql_pg_userpool_auth
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -784,7 +781,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-pg-userpool-auth.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - rds_pg_refers_to
+        - publish_to_local_registry
     - identifier: sql_pg_oidc_auth
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -794,7 +791,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-pg-oidc-auth.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - rds_pg_refers_to_fields
+        - publish_to_local_registry
     - identifier: sql_pg_models
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -804,7 +801,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-pg-models.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
-        - rds_pg_oidc_auth_fields
+        - publish_to_local_registry
     - identifier: sql_pg_canary
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -815,7 +812,7 @@ batch:
           CLI_REGION: us-east-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - rds_pg_model_v2
+        - publish_to_local_registry
     - identifier: sql_pg_auto_increment
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -825,7 +822,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-pg-auto-increment.test.ts
           CLI_REGION: ca-central-1
       depend-on:
-        - rds_pg_import
+        - publish_to_local_registry
     - identifier: sql_pg_array_objects
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -835,7 +832,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-pg-array-objects.test.ts
           CLI_REGION: eu-central-1
       depend-on:
-        - rds_pg_field_auth_userpool_static_dynamic
+        - publish_to_local_registry
     - identifier: sql_mysql_oidc_auth
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -845,7 +842,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-mysql-oidc-auth.test.ts
           CLI_REGION: eu-north-1
       depend-on:
-        - rds_pg_field_auth_userpool_iam
+        - publish_to_local_registry
     - identifier: sql_mysql_canary
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -855,7 +852,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-mysql-canary.test.ts
           CLI_REGION: eu-west-1
       depend-on:
-        - rds_pg_field_auth_lambda
+        - publish_to_local_registry
     - identifier: sql_models_2
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -865,7 +862,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-models-2.test.ts
           CLI_REGION: eu-west-2
       depend-on:
-        - rds_pg_field_auth_identityPool
+        - publish_to_local_registry
     - identifier: sql_models_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -875,7 +872,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-models-1.test.ts
           CLI_REGION: eu-west-3
       depend-on:
-        - rds_pg_field_auth_iam
+        - publish_to_local_registry
     - identifier: sql_iam_access
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -885,7 +882,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-iam-access.test.ts
           CLI_REGION: sa-east-1
       depend-on:
-        - rds_pg_field_auth_apikey
+        - publish_to_local_registry
     - identifier: default_ddb_canary
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -895,7 +892,7 @@ batch:
           TEST_SUITE: src/__tests__/default-ddb-canary.test.ts
           CLI_REGION: eu-west-3
       depend-on:
-        - rds_pg_custom_claims_refersto_auth
+        - publish_to_local_registry
     - identifier: custom_query_mutation_extension
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -905,7 +902,7 @@ batch:
           TEST_SUITE: src/__tests__/custom-query-mutation-extension.test.ts
           CLI_REGION: us-east-1
       depend-on:
-        - rds_pg_auth_iam
+        - publish_to_local_registry
     - identifier: base_cdk_ap_east_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -915,7 +912,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: ap-east-1
       depend-on:
-        - rds_pg_auth_iam_apikey_lambda_subscription
+        - publish_to_local_registry
     - identifier: base_cdk_ap_northeast_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -925,7 +922,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
-        - rds_pg_auth_apikey_lambda
+        - publish_to_local_registry
     - identifier: base_cdk_ap_northeast_2
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -935,7 +932,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
-        - rds_pg_array_objects
+        - publish_to_local_registry
     - identifier: base_cdk_ap_northeast_3
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -945,7 +942,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - rds_mysql_v2_generate_schema
+        - publish_to_local_registry
     - identifier: base_cdk_ap_south_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -955,7 +952,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - rds_mysql_userpool_auth
+        - publish_to_local_registry
     - identifier: base_cdk_ap_southeast_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -965,7 +962,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
-        - rds_mysql_userpool_auth_fields
+        - publish_to_local_registry
     - identifier: base_cdk_ap_southeast_2
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -975,7 +972,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
-        - rds_mysql_refers_to
+        - publish_to_local_registry
     - identifier: base_cdk_ca_central_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -985,7 +982,8 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: ca-central-1
       depend-on:
-        - rds_mysql_refers_to_fields
+        - >-
+          custom_transformers_invalid_input_arguments_schema_data_access_patterns_schema_predictions_function_10
     - identifier: base_cdk_eu_central_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -995,7 +993,8 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: eu-central-1
       depend-on:
-        - rds_mysql_oidc_auth_fields
+        - >-
+          api_7_schema_function_2_global_sandbox_lambda_conflict_handler_index_with_stack_mappings
     - identifier: base_cdk_eu_north_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1005,7 +1004,8 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: eu-north-1
       depend-on:
-        - rds_mysql_multi_auth_1
+        - >-
+          api_5_schema_function_1_generate_ts_data_schema_resolvers_sync_query_datastore
     - identifier: base_cdk_eu_south_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1015,7 +1015,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: eu-south-1
       depend-on:
-        - rds_mysql_model_v2
+        - api_6_api_lambda_auth
     - identifier: base_cdk_eu_west_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1025,7 +1025,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: eu-west-1
       depend-on:
-        - rds_mysql_field_auth_userpool_static_dynamic
+        - rds_v2
     - identifier: base_cdk_eu_west_2
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1035,7 +1035,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: eu-west-2
       depend-on:
-        - rds_mysql_field_auth_userpool_iam
+        - schema_iterative_update_5
     - identifier: base_cdk_eu_west_3
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1045,7 +1045,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: eu-west-3
       depend-on:
-        - rds_mysql_field_auth_lambda
+        - schema_auth_2
     - identifier: base_cdk_sa_east_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1055,7 +1055,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: sa-east-1
       depend-on:
-        - rds_mysql_field_auth_identityPool
+        - schema_auth_10
     - identifier: base_cdk_us_east_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1065,7 +1065,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: us-east-1
       depend-on:
-        - rds_mysql_field_auth_iam
+        - schema_auth_1
     - identifier: base_cdk_us_east_2
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1075,7 +1075,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: us-east-2
       depend-on:
-        - rds_mysql_field_auth_apikey
+        - schema_auth_13
     - identifier: base_cdk_us_west_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1085,7 +1085,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: us-west-1
       depend-on:
-        - rds_mysql_custom_claims_refersto_auth
+        - schema_auth_12
     - identifier: base_cdk_us_west_2
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1095,7 +1095,7 @@ batch:
           TEST_SUITE: src/__tests__/base-cdk.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - rds_mysql_auth_iam
+        - schema_auth_3
     - identifier: amplify_table_4
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1105,7 +1105,7 @@ batch:
           TEST_SUITE: src/__tests__/amplify-table-4.test.ts
           CLI_REGION: us-east-2
       depend-on:
-        - rds_mysql_auth_iam_apikey_lambda_subscription
+        - schema_auth_15
     - identifier: amplify_table_3
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1115,7 +1115,7 @@ batch:
           TEST_SUITE: src/__tests__/amplify-table-3.test.ts
           CLI_REGION: us-west-1
       depend-on:
-        - rds_mysql_auth_apikey_lambda
+        - schema_auth_8
     - identifier: amplify_table_2
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1125,7 +1125,7 @@ batch:
           TEST_SUITE: src/__tests__/amplify-table-2.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - schema_auth_9
+        - schema_auth_4
     - identifier: amplify_table_1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1135,7 +1135,7 @@ batch:
           TEST_SUITE: src/__tests__/amplify-table-1.test.ts
           CLI_REGION: ap-east-1
       depend-on:
-        - schema_auth_7
+        - schema_auth_11
     - identifier: amplify_ddb_canary
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1145,7 +1145,7 @@ batch:
           TEST_SUITE: src/__tests__/amplify-ddb-canary.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
-        - schema_auth_14
+        - sql_generate_unauth
     - identifier: all_auth_modes
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1155,7 +1155,7 @@ batch:
           TEST_SUITE: src/__tests__/all-auth-modes.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
-        - schema_auth_5
+        - schema_model
     - identifier: admin_role
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1165,7 +1165,7 @@ batch:
           TEST_SUITE: src/__tests__/admin-role.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - schema_searchable
+        - rds_v2_test_utils
     - identifier: sql_custom_ssl
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1175,7 +1175,7 @@ batch:
           TEST_SUITE: src/__tests__/sql-custom-ssl/sql-custom-ssl.test.ts
           CLI_REGION: eu-west-1
       depend-on:
-        - searchable_datastore
+        - rds_relational_directives
     - identifier: restricted_field_auth_gen2
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1186,7 +1186,7 @@ batch:
             src/__tests__/restricted-field-auth/restricted-field-auth-gen2.test.ts
           CLI_REGION: eu-west-2
       depend-on:
-        - schema_auth_6
+        - rds_pg_v2_generate_schema
     - identifier: restricted_field_auth_gen1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1197,7 +1197,7 @@ batch:
             src/__tests__/restricted-field-auth/restricted-field-auth-gen1.test.ts
           CLI_REGION: eu-south-1
       depend-on:
-        - searchable_previous_deployment_had_node_to_node
+        - rds_pg_userpool_auth
     - identifier: restricted_field_auth_gen2_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1208,7 +1208,7 @@ batch:
             src/__tests__/restricted-field-auth/subscriptions-off/restricted-field-auth-gen2-subscriptions-off.test.ts
           CLI_REGION: sa-east-1
       depend-on:
-        - searchable_previous_deployment_no_node_to_node
+        - rds_pg_userpool_auth_fields
     - identifier: restricted_field_auth_gen1_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1219,7 +1219,7 @@ batch:
             src/__tests__/restricted-field-auth/subscriptions-off/restricted-field-auth-gen1-subscriptions-off.test.ts
           CLI_REGION: eu-west-2
       depend-on:
-        - utils_log_config_gsi_projection_type_ddb_iam_access_data_construct
+        - rds_pg_relational_directives
     - identifier: references_sqlprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1230,8 +1230,7 @@ batch:
             src/__tests__/relationships/references/references-sqlprimary-sqlrelated.test.ts
           CLI_REGION: us-east-2
       depend-on:
-        - >-
-          custom_logic_amplify_table_5_add_resources_validate_transformer_evaluate_mapping_template_validate_transformer_e2e
+        - rds_pg_refers_to
     - identifier: references_sqlprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1242,8 +1241,7 @@ batch:
             src/__tests__/relationships/references/references-sqlprimary-ddbrelated.test.ts
           CLI_REGION: us-west-1
       depend-on:
-        - >-
-          references_migration_migration_validation_many_to_many_migration_base_migration
+        - rds_pg_refers_to_fields
     - identifier: references_ddbprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1254,7 +1252,7 @@ batch:
             src/__tests__/relationships/references/references-ddbprimary-sqlrelated.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - sql_pg_userpool_auth
+        - rds_pg_oidc_auth_fields
     - identifier: references_ddbprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1265,7 +1263,7 @@ batch:
             src/__tests__/relationships/references/references-ddbprimary-ddbrelated.test.ts
           CLI_REGION: eu-west-3
       depend-on:
-        - sql_pg_oidc_auth
+        - rds_pg_model_v2
     - identifier: recursive_relationships_sql
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1276,7 +1274,7 @@ batch:
             src/__tests__/relationships/recursive/recursive-relationships-sql.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
-        - sql_pg_models
+        - rds_pg_import
     - identifier: recursive_relationships_ddb
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1287,7 +1285,7 @@ batch:
             src/__tests__/relationships/recursive/recursive-relationships-ddb.test.ts
           CLI_REGION: us-east-1
       depend-on:
-        - sql_pg_canary
+        - rds_pg_field_auth_userpool_static_dynamic
     - identifier: uuid_pk_sqlprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1298,7 +1296,7 @@ batch:
             src/__tests__/relationships/postgres-uuid-pk/uuid-pk-sqlprimary-sqlrelated.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - sql_pg_auto_increment
+        - rds_pg_field_auth_userpool_iam
     - identifier: uuid_pk_sqlprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1309,7 +1307,7 @@ batch:
             src/__tests__/relationships/postgres-uuid-pk/uuid-pk-sqlprimary-ddbrelated.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
-        - sql_pg_array_objects
+        - rds_pg_field_auth_lambda
     - identifier: uuid_pk_ddbprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1320,7 +1318,7 @@ batch:
             src/__tests__/relationships/postgres-uuid-pk/uuid-pk-ddbprimary-sqlrelated.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
-        - sql_mysql_oidc_auth
+        - rds_pg_field_auth_identityPool
     - identifier: multi_relationship_sqlprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1331,7 +1329,7 @@ batch:
             src/__tests__/relationships/multi-relationship/multi-relationship-sqlprimary-sqlrelated.test.ts
           CLI_REGION: ca-central-1
       depend-on:
-        - sql_mysql_canary
+        - rds_pg_field_auth_iam
     - identifier: multi_relationship_sqlprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1342,7 +1340,7 @@ batch:
             src/__tests__/relationships/multi-relationship/multi-relationship-sqlprimary-ddbrelated.test.ts
           CLI_REGION: eu-central-1
       depend-on:
-        - sql_models_2
+        - rds_pg_field_auth_apikey
     - identifier: multi_relationship_ddbprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1353,7 +1351,7 @@ batch:
             src/__tests__/relationships/multi-relationship/multi-relationship-ddbprimary-sqlrelated.test.ts
           CLI_REGION: eu-north-1
       depend-on:
-        - sql_models_1
+        - rds_pg_custom_claims_refersto_auth
     - identifier: multi_relationship_ddbprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1364,7 +1362,7 @@ batch:
             src/__tests__/relationships/multi-relationship/multi-relationship-ddbprimary-ddbrelated.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - sql_iam_access
+        - rds_pg_auth_iam
     - identifier: relationships_gen1
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1374,7 +1372,7 @@ batch:
           TEST_SUITE: src/__tests__/relationships/gen1/relationships-gen1.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - default_ddb_canary
+        - rds_pg_auth_iam_apikey_lambda_subscription
     - identifier: assoc_field_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1385,7 +1383,7 @@ batch:
             src/__tests__/owner-auth/subscriptions-off/assoc-field-subscriptions-off.test.ts
           CLI_REGION: eu-north-1
       depend-on:
-        - custom_query_mutation_extension
+        - rds_pg_auth_apikey_lambda
     - identifier: bind_sql_ids
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1395,7 +1393,7 @@ batch:
           TEST_SUITE: src/__tests__/owner-auth/bind-sql-ids/bind-sql-ids.test.ts
           CLI_REGION: sa-east-1
       depend-on:
-        - base_cdk_ap_east_1
+        - rds_pg_array_objects
     - identifier: assoc_field_sqlprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1406,7 +1404,7 @@ batch:
             src/__tests__/owner-auth/assoc-field/assoc-field-sqlprimary-sqlrelated.test.ts
           CLI_REGION: us-east-1
       depend-on:
-        - base_cdk_ap_northeast_1
+        - rds_mysql_v2_generate_schema
     - identifier: assoc_field_sqlprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1417,7 +1415,7 @@ batch:
             src/__tests__/owner-auth/assoc-field/assoc-field-sqlprimary-ddbrelated.test.ts
           CLI_REGION: us-east-2
       depend-on:
-        - base_cdk_ap_northeast_2
+        - rds_mysql_userpool_auth
     - identifier: assoc_field_ddbprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1428,7 +1426,7 @@ batch:
             src/__tests__/owner-auth/assoc-field/assoc-field-ddbprimary-sqlrelated.test.ts
           CLI_REGION: us-west-1
       depend-on:
-        - base_cdk_ap_northeast_3
+        - rds_mysql_userpool_auth_fields
     - identifier: assoc_field_ddbprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1439,7 +1437,7 @@ batch:
             src/__tests__/owner-auth/assoc-field/assoc-field-ddbprimary-ddbrelated.test.ts
           CLI_REGION: sa-east-1
       depend-on:
-        - base_cdk_ap_south_1
+        - rds_mysql_refers_to
     - identifier: static_group_auth_sqlprimary_sqlrelated_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1450,7 +1448,7 @@ batch:
             src/__tests__/group-auth/subscriptions-off/static-group-auth/static-group-auth-sqlprimary-sqlrelated-subscriptions-off.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
-        - base_cdk_ap_southeast_1
+        - rds_mysql_refers_to_fields
     - identifier: static_group_auth_sqlprimary_ddbrelated_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1461,7 +1459,7 @@ batch:
             src/__tests__/group-auth/subscriptions-off/static-group-auth/static-group-auth-sqlprimary-ddbrelated-subscriptions-off.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
-        - base_cdk_ap_southeast_2
+        - rds_mysql_oidc_auth_fields
     - identifier: static_group_auth_ddbprimary_sqlrelated_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1472,7 +1470,7 @@ batch:
             src/__tests__/group-auth/subscriptions-off/static-group-auth/static-group-auth-ddbprimary-sqlrelated-subscriptions-off.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - base_cdk_ca_central_1
+        - rds_mysql_multi_auth_1
     - identifier: static_group_auth_ddbprimary_ddbrelated_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1483,7 +1481,7 @@ batch:
             src/__tests__/group-auth/subscriptions-off/static-group-auth/static-group-auth-ddbprimary-ddbrelated-subscriptions-off.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - base_cdk_eu_central_1
+        - rds_mysql_model_v2
     - identifier: dynamic_group_auth_sqlprimary_sqlrelated_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1494,7 +1492,7 @@ batch:
             src/__tests__/group-auth/subscriptions-off/dynamic-group-auth/dynamic-group-auth-sqlprimary-sqlrelated-subscriptions-off.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
-        - base_cdk_eu_north_1
+        - rds_mysql_field_auth_userpool_static_dynamic
     - identifier: dynamic_group_auth_sqlprimary_ddbrelated_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1505,7 +1503,7 @@ batch:
             src/__tests__/group-auth/subscriptions-off/dynamic-group-auth/dynamic-group-auth-sqlprimary-ddbrelated-subscriptions-off.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
-        - base_cdk_eu_south_1
+        - rds_mysql_field_auth_userpool_iam
     - identifier: dynamic_group_auth_ddbprimary_sqlrelated_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1516,7 +1514,7 @@ batch:
             src/__tests__/group-auth/subscriptions-off/dynamic-group-auth/dynamic-group-auth-ddbprimary-sqlrelated-subscriptions-off.test.ts
           CLI_REGION: ca-central-1
       depend-on:
-        - base_cdk_eu_west_1
+        - rds_mysql_field_auth_lambda
     - identifier: dynamic_group_auth_ddbprimary_ddbrelated_subscriptions_off
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1527,7 +1525,7 @@ batch:
             src/__tests__/group-auth/subscriptions-off/dynamic-group-auth/dynamic-group-auth-ddbprimary-ddbrelated-subscriptions-off.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - base_cdk_eu_west_2
+        - rds_mysql_field_auth_identityPool
     - identifier: static_group_auth_sqlprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1538,7 +1536,7 @@ batch:
             src/__tests__/group-auth/static-group-auth/static-group-auth-sqlprimary-sqlrelated.test.ts
           CLI_REGION: eu-north-1
       depend-on:
-        - base_cdk_eu_west_3
+        - rds_mysql_field_auth_iam
     - identifier: static_group_auth_sqlprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1549,7 +1547,7 @@ batch:
             src/__tests__/group-auth/static-group-auth/static-group-auth-sqlprimary-ddbrelated.test.ts
           CLI_REGION: eu-west-1
       depend-on:
-        - base_cdk_sa_east_1
+        - rds_mysql_field_auth_apikey
     - identifier: static_group_auth_ddbprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1560,7 +1558,7 @@ batch:
             src/__tests__/group-auth/static-group-auth/static-group-auth-ddbprimary-sqlrelated.test.ts
           CLI_REGION: eu-west-2
       depend-on:
-        - base_cdk_us_east_1
+        - rds_mysql_custom_claims_refersto_auth
     - identifier: static_group_auth_ddbprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1571,7 +1569,7 @@ batch:
             src/__tests__/group-auth/static-group-auth/static-group-auth-ddbprimary-ddbrelated.test.ts
           CLI_REGION: eu-central-1
       depend-on:
-        - base_cdk_us_east_2
+        - rds_mysql_auth_iam
     - identifier: dynamic_group_auth_sqlprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1582,7 +1580,7 @@ batch:
             src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-sqlprimary-sqlrelated.test.ts
           CLI_REGION: sa-east-1
       depend-on:
-        - base_cdk_us_west_1
+        - rds_mysql_auth_iam_apikey_lambda_subscription
     - identifier: dynamic_group_auth_sqlprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1593,7 +1591,7 @@ batch:
             src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-sqlprimary-ddbrelated.test.ts
           CLI_REGION: us-east-1
       depend-on:
-        - base_cdk_us_west_2
+        - rds_mysql_auth_apikey_lambda
     - identifier: dynamic_group_auth_ddbprimary_sqlrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1604,7 +1602,7 @@ batch:
             src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-ddbprimary-sqlrelated.test.ts
           CLI_REGION: us-east-2
       depend-on:
-        - amplify_table_4
+        - schema_auth_9
     - identifier: dynamic_group_auth_ddbprimary_ddbrelated
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1615,7 +1613,7 @@ batch:
             src/__tests__/group-auth/dynamic-group-auth/dynamic-group-auth-ddbprimary-ddbrelated.test.ts
           CLI_REGION: eu-west-2
       depend-on:
-        - amplify_table_3
+        - schema_auth_7
     - identifier: generation
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1626,7 +1624,7 @@ batch:
           CLI_REGION: us-west-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - amplify_table_2
+        - schema_auth_14
     - identifier: single_gsi_single_record
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1637,7 +1635,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-single-record.test.ts
           CLI_REGION: eu-north-1
       depend-on:
-        - amplify_table_1
+        - schema_auth_5
     - identifier: single_gsi_empty_table
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1648,7 +1646,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-empty-table.test.ts
           CLI_REGION: eu-south-1
       depend-on:
-        - amplify_ddb_canary
+        - schema_searchable
     - identifier: single_gsi_1k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1659,7 +1657,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-1k-records.test.ts
           CLI_REGION: eu-west-1
       depend-on:
-        - all_auth_modes
+        - searchable_datastore
     - identifier: single_gsi_10k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1670,7 +1668,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/single-gsi-10k-records.test.ts
           CLI_REGION: eu-west-2
       depend-on:
-        - admin_role
+        - schema_auth_6
     - identifier: replace_2_gsis_update_attr_single_record
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1681,7 +1679,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-single-record.test.ts
           CLI_REGION: eu-west-3
       depend-on:
-        - sql_custom_ssl
+        - searchable_previous_deployment_had_node_to_node
     - identifier: replace_2_gsis_update_attr_empty_table
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1692,7 +1690,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-empty-table.test.ts
           CLI_REGION: sa-east-1
       depend-on:
-        - restricted_field_auth_gen2
+        - searchable_previous_deployment_no_node_to_node
     - identifier: replace_2_gsis_update_attr_1k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1703,7 +1701,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-1k-records.test.ts
           CLI_REGION: us-east-1
       depend-on:
-        - restricted_field_auth_gen1
+        - utils_log_config_gsi_projection_type_ddb_iam_access_data_construct
     - identifier: replace_2_gsis_update_attr_10k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1714,7 +1712,8 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-update-attr-10k-records.test.ts
           CLI_REGION: us-east-2
       depend-on:
-        - restricted_field_auth_gen2_subscriptions_off
+        - >-
+          custom_logic_amplify_table_5_add_resources_validate_transformer_evaluate_mapping_template_validate_transformer_e2e
     - identifier: replace_2_gsis_single_record
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1725,7 +1724,8 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-single-record.test.ts
           CLI_REGION: us-west-1
       depend-on:
-        - restricted_field_auth_gen1_subscriptions_off
+        - >-
+          references_migration_migration_validation_many_to_many_migration_base_migration
     - identifier: replace_2_gsis_empty_table
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1736,7 +1736,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-empty-table.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - references_sqlprimary_sqlrelated
+        - sql_pg_userpool_auth
     - identifier: replace_2_gsis_1k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1747,7 +1747,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-1k-records.test.ts
           CLI_REGION: ap-east-1
       depend-on:
-        - references_sqlprimary_ddbrelated
+        - sql_pg_oidc_auth
     - identifier: replace_2_gsis_10k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1758,7 +1758,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/replace-2-gsis-10k-records.test.ts
           CLI_REGION: ap-northeast-1
       depend-on:
-        - references_ddbprimary_sqlrelated
+        - sql_pg_models
     - identifier: 3_gsis_single_record
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1769,7 +1769,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-single-record.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
-        - references_ddbprimary_ddbrelated
+        - sql_pg_canary
     - identifier: 3_gsis_empty_table
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1780,7 +1780,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-empty-table.test.ts
           CLI_REGION: ap-northeast-3
       depend-on:
-        - recursive_relationships_sql
+        - sql_pg_auto_increment
     - identifier: 3_gsis_1k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1791,7 +1791,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-1k-records.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - recursive_relationships_ddb
+        - sql_pg_array_objects
     - identifier: 3_gsis_10k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1802,7 +1802,7 @@ batch:
             src/__tests__/deploy-velocity-temporarily-disabled/3-gsis-10k-records.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
-        - uuid_pk_sqlprimary_sqlrelated
+        - sql_mysql_oidc_auth
     - identifier: single_gsi_100k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1812,7 +1812,7 @@ batch:
           TEST_SUITE: src/__tests__/deploy-velocity/single-gsi-100k-records.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
-        - uuid_pk_sqlprimary_ddbrelated
+        - sql_mysql_canary
     - identifier: replace_2_gsis_update_attr_100k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1823,7 +1823,7 @@ batch:
             src/__tests__/deploy-velocity/replace-2-gsis-update-attr-100k-records.test.ts
           CLI_REGION: ca-central-1
       depend-on:
-        - uuid_pk_ddbprimary_sqlrelated
+        - sql_models_2
     - identifier: replace_2_gsis_100k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1833,7 +1833,7 @@ batch:
           TEST_SUITE: src/__tests__/deploy-velocity/replace-2-gsis-100k-records.test.ts
           CLI_REGION: eu-central-1
       depend-on:
-        - multi_relationship_sqlprimary_sqlrelated
+        - sql_models_1
     - identifier: 3_gsis_100k_records
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1843,7 +1843,7 @@ batch:
           TEST_SUITE: src/__tests__/deploy-velocity/3-gsis-100k-records.test.ts
           CLI_REGION: eu-north-1
       depend-on:
-        - multi_relationship_sqlprimary_ddbrelated
+        - sql_iam_access
     - identifier: conversation
       buildspec: codebuild_specs/run_cdk_tests.yml
       env:
@@ -1854,7 +1854,7 @@ batch:
           CLI_REGION: us-west-2
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - multi_relationship_ddbprimary_sqlrelated
+        - default_ddb_canary
     - identifier: >-
         NonModelAuthV2Function_TransformerOptionsV2_DefaultValueTransformer_PerFieldAuthV2TransformerWithFF_PerFieldAuthV2Transformer
       buildspec: codebuild_specs/graphql_e2e_tests.yml
@@ -1866,7 +1866,7 @@ batch:
             src/__tests__/NonModelAuthV2Function.e2e.test.ts|src/__tests__/TransformerOptionsV2.e2e.test.ts|src/__tests__/DefaultValueTransformer.e2e.test.ts|src/__tests__/PerFieldAuthV2TransformerWithFF.e2e.test.ts|src/__tests__/PerFieldAuthV2Transformer.e2e.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - multi_relationship_ddbprimary_ddbrelated
+        - custom_query_mutation_extension
     - identifier: >-
         BelongsToTransformerV2_RelationalWithAuthV2WithFF_IndexWithAuthV2_IndexWithAuthV2WithFF_SubscriptionsWithAuthV2WithFF
       buildspec: codebuild_specs/graphql_e2e_tests.yml
@@ -1878,7 +1878,7 @@ batch:
             src/__tests__/BelongsToTransformerV2.e2e.test.ts|src/__tests__/RelationalWithAuthV2WithFF.e2e.test.ts|src/__tests__/IndexWithAuthV2.e2e.test.ts|src/__tests__/IndexWithAuthV2WithFF.e2e.test.ts|src/__tests__/SubscriptionsWithAuthV2WithFF.e2e.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
-        - relationships_gen1
+        - base_cdk_ap_east_1
     - identifier: >-
         MultiAuthV2Transformer_ModelTransformer_SubscriptionsWithAuthV2_RelationalWithAuthV2_MapsToTransformer
       buildspec: codebuild_specs/graphql_e2e_tests.yml
@@ -1890,7 +1890,7 @@ batch:
             src/__tests__/MultiAuthV2Transformer.e2e.test.ts|src/__tests__/ModelTransformer.e2e.test.ts|src/__tests__/SubscriptionsWithAuthV2.e2e.test.ts|src/__tests__/RelationalWithAuthV2.e2e.test.ts|src/__tests__/MapsToTransformer.e2e.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
-        - assoc_field_subscriptions_off
+        - base_cdk_ap_northeast_1
     - identifier: >-
         MultiAuthV2TransformerWithFF_AuthV2Transformer_AuthV2ExhaustiveT1B_AuthV2ExhaustiveT1A_AuthV2TransformerWithFF
       buildspec: codebuild_specs/graphql_e2e_tests.yml
@@ -1902,7 +1902,7 @@ batch:
             src/__tests__/MultiAuthV2TransformerWithFF.e2e.test.ts|src/__tests__/AuthV2Transformer.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT1B.test.ts|src/__tests__/AuthV2ExhaustiveT1A.test.ts|src/__tests__/AuthV2TransformerWithFF.e2e.test.ts
           CLI_REGION: ca-central-1
       depend-on:
-        - bind_sql_ids
+        - base_cdk_ap_northeast_2
     - identifier: >-
         SubscriptionsRuntimeFiltering_AuthV2ExhaustiveT2A_AuthV2ExhaustiveT1C_AuthV2ExhaustiveT1D_AuthV2ExhaustiveT2B
       buildspec: codebuild_specs/graphql_e2e_tests.yml
@@ -1914,7 +1914,7 @@ batch:
             src/__tests__/SubscriptionsRuntimeFiltering.e2e.test.ts|src/__tests__/AuthV2ExhaustiveT2A.test.ts|src/__tests__/AuthV2ExhaustiveT1C.test.ts|src/__tests__/AuthV2ExhaustiveT1D.test.ts|src/__tests__/AuthV2ExhaustiveT2B.test.ts
           CLI_REGION: eu-central-1
       depend-on:
-        - assoc_field_sqlprimary_sqlrelated
+        - base_cdk_ap_northeast_3
     - identifier: >-
         AuthV2ExhaustiveT2D_AuthV2ExhaustiveT2C_RelationalWithAuthV2Redacted_RelationalWithAuthV2NonRedacted_AuthV2TransformerIAM
       buildspec: codebuild_specs/graphql_e2e_tests.yml
@@ -1926,7 +1926,7 @@ batch:
             src/__tests__/AuthV2ExhaustiveT2D.test.ts|src/__tests__/AuthV2ExhaustiveT2C.test.ts|src/__tests__/RelationalWithAuthV2Redacted.e2e.test.ts|src/__tests__/RelationalWithAuthV2NonRedacted.e2e.test.ts|src/__tests__/AuthV2TransformerIAM.test.ts
           CLI_REGION: eu-north-1
       depend-on:
-        - assoc_field_sqlprimary_ddbrelated
+        - base_cdk_ap_south_1
     - identifier: >-
         AuthV2ExhaustiveT3D_AuthV2ExhaustiveT3C_AuthV2ExhaustiveT3B_AuthV2ExhaustiveT3A_SearchableModelTransformerV2
       buildspec: codebuild_specs/graphql_e2e_tests.yml
@@ -1938,7 +1938,7 @@ batch:
             src/__tests__/AuthV2ExhaustiveT3D.test.ts|src/__tests__/AuthV2ExhaustiveT3C.test.ts|src/__tests__/AuthV2ExhaustiveT3B.test.ts|src/__tests__/AuthV2ExhaustiveT3A.test.ts|src/__tests__/SearchableModelTransformerV2.e2e.test.ts
           CLI_REGION: eu-west-2
       depend-on:
-        - assoc_field_ddbprimary_sqlrelated
+        - base_cdk_ap_southeast_1
     - identifier: SearchableWithAuthV2WithFF_SearchableWithAuthV2
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
@@ -1949,7 +1949,7 @@ batch:
             src/__tests__/SearchableWithAuthV2WithFF.e2e.test.ts|src/__tests__/SearchableWithAuthV2.e2e.test.ts
           CLI_REGION: eu-west-3
       depend-on:
-        - assoc_field_ddbprimary_ddbrelated
+        - base_cdk_ap_southeast_2
     - identifier: PredictionsTransformerV2Tests
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
@@ -1959,7 +1959,7 @@ batch:
           TEST_SUITE: src/__tests__/PredictionsTransformerV2Tests.e2e.test.ts
           CLI_REGION: ap-northeast-2
       depend-on:
-        - static_group_auth_sqlprimary_sqlrelated_subscriptions_off
+        - base_cdk_ca_central_1
     - identifier: FunctionTransformerTestsV2
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
@@ -1970,7 +1970,7 @@ batch:
           CLI_REGION: ap-south-1
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - static_group_auth_sqlprimary_ddbrelated_subscriptions_off
+        - base_cdk_eu_central_1
     - identifier: HttpTransformerV2
       buildspec: codebuild_specs/graphql_e2e_tests.yml
       env:
@@ -1980,7 +1980,7 @@ batch:
           TEST_SUITE: src/__tests__/HttpTransformerV2.e2e.test.ts
           CLI_REGION: ap-south-1
       depend-on:
-        - static_group_auth_ddbprimary_sqlrelated_subscriptions_off
+        - base_cdk_eu_north_1
     - identifier: cleanup_e2e_resources
       buildspec: codebuild_specs/cleanup_e2e_resources.yml
       env:
@@ -1988,6 +1988,50 @@ batch:
         variables:
           JSII_DEPRECATED: quiet
       depend-on:
+        - base_cdk_eu_south_1
+        - base_cdk_eu_west_1
+        - base_cdk_eu_west_2
+        - base_cdk_eu_west_3
+        - base_cdk_sa_east_1
+        - base_cdk_us_east_1
+        - base_cdk_us_east_2
+        - base_cdk_us_west_1
+        - base_cdk_us_west_2
+        - amplify_table_4
+        - amplify_table_3
+        - amplify_table_2
+        - amplify_table_1
+        - amplify_ddb_canary
+        - all_auth_modes
+        - admin_role
+        - sql_custom_ssl
+        - restricted_field_auth_gen2
+        - restricted_field_auth_gen1
+        - restricted_field_auth_gen2_subscriptions_off
+        - restricted_field_auth_gen1_subscriptions_off
+        - references_sqlprimary_sqlrelated
+        - references_sqlprimary_ddbrelated
+        - references_ddbprimary_sqlrelated
+        - references_ddbprimary_ddbrelated
+        - recursive_relationships_sql
+        - recursive_relationships_ddb
+        - uuid_pk_sqlprimary_sqlrelated
+        - uuid_pk_sqlprimary_ddbrelated
+        - uuid_pk_ddbprimary_sqlrelated
+        - multi_relationship_sqlprimary_sqlrelated
+        - multi_relationship_sqlprimary_ddbrelated
+        - multi_relationship_ddbprimary_sqlrelated
+        - multi_relationship_ddbprimary_ddbrelated
+        - relationships_gen1
+        - assoc_field_subscriptions_off
+        - bind_sql_ids
+        - assoc_field_sqlprimary_sqlrelated
+        - assoc_field_sqlprimary_ddbrelated
+        - assoc_field_ddbprimary_sqlrelated
+        - assoc_field_ddbprimary_ddbrelated
+        - static_group_auth_sqlprimary_sqlrelated_subscriptions_off
+        - static_group_auth_sqlprimary_ddbrelated_subscriptions_off
+        - static_group_auth_ddbprimary_sqlrelated_subscriptions_off
         - static_group_auth_ddbprimary_ddbrelated_subscriptions_off
         - dynamic_group_auth_sqlprimary_sqlrelated_subscriptions_off
         - dynamic_group_auth_sqlprimary_ddbrelated_subscriptions_off

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -210,6 +210,16 @@ const EXCLUDE_TEST_IDS: string[] = [];
 
 const MAX_WORKERS = 5;
 
+// Number of e2e jobs released per "wave" when staggering the batch fan-out.
+//
+// CodeBuild's batch orchestrator FAULTs ("Internal Service Error") when a single
+// dependency (publish_to_local_registry) completes and releases the entire e2e
+// fan-out (~184 jobs) in one simultaneous burst. To stay well under that
+// threshold we partition the generated jobs into sequential waves of at most
+// WAVE_SIZE jobs each (see applyFanOutWaves). ~184 jobs / 46 => 4 waves, so no
+// single completion event ever releases more than ~46 jobs at once.
+const WAVE_SIZE = 46;
+
 // eslint-disable-next-line import/namespace
 const loadConfigBase = (): ConfigBase => yaml.load(fs.readFileSync(CODEBUILD_CONFIG_BASE_PATH, 'utf8')) as ConfigBase;
 
@@ -400,6 +410,44 @@ const filterCandidateRegions = (test: string, candidateRegions: string[], useBet
   return resolvedRegions;
 };
 
+/**
+ * Staggers the generated e2e jobs into sequential "waves" to avoid overwhelming
+ * CodeBuild's batch orchestrator with a single large fan-out.
+ *
+ * Every generated job originally depends only on `publish_to_local_registry`, so
+ * when that build completes the orchestrator tries to release all ~184 jobs at
+ * once, which deterministically triggers an "Internal Service Error" FAULT.
+ *
+ * Instead, we chain each job to the job WAVE_SIZE positions earlier:
+ *   - jobs in wave 0 (index < WAVE_SIZE) depend on `publish_to_local_registry`
+ *   - every later job (index i) depends on the job at index (i - WAVE_SIZE)
+ *
+ * Because each dependency edge points to a strictly smaller index, the graph is
+ * acyclic. With `fast-fail: false`, a dependent job is released once its single
+ * predecessor completes (regardless of pass/fail), so this only staggers the
+ * release timing — it does not change which tests run or their isolation. The
+ * most jobs released by any single completion event is therefore WAVE_SIZE
+ * (when `publish_to_local_registry` finishes), instead of the full ~184.
+ *
+ * Tradeoff: waves serialize, adding some wall-clock latency, but the orchestrator
+ * never sees the >150-job single-wave burst that caused the fault.
+ *
+ * Returns the identifiers of the "leaf" jobs (those nothing else depends on, i.e.
+ * the last WAVE_SIZE jobs) so downstream jobs (e.g. cleanup) can wait for the
+ * entire fan-out to finish.
+ */
+const applyFanOutWaves = (builds: BatchBuildJob[]): string[] => {
+  builds.forEach((build, index) => {
+    build['depend-on'] = index < WAVE_SIZE ? ['publish_to_local_registry'] : [builds[index - WAVE_SIZE].identifier];
+  });
+
+  // A job at index i is a leaf when no later job chains off it, i.e. when
+  // (i + WAVE_SIZE) >= builds.length. That is exactly the final WAVE_SIZE jobs.
+  // Every earlier job is an ancestor of one of these leaves, so waiting on the
+  // leaves transitively waits for the whole fan-out.
+  return builds.slice(Math.max(0, builds.length - WAVE_SIZE)).map((build) => build.identifier);
+};
+
 const main = (): void => {
   const useBetaLayer = process.argv[2] === 'beta';
   const filteredTests = process.argv.slice(3);
@@ -467,6 +515,11 @@ const main = (): void => {
     builds = builds.filter((build) => !EXCLUDE_TEST_IDS.includes(build.identifier));
   }
 
+  // Stagger the e2e fan-out into waves so the batch orchestrator is never asked
+  // to release the entire fan-out at once. Returns the leaf job identifiers so
+  // cleanup can wait for every test job to finish.
+  const leafJobIdentifiers = applyFanOutWaves(builds);
+
   const cleanupResources: BatchBuildJob = {
     identifier: 'cleanup_e2e_resources',
     buildspec: 'codebuild_specs/cleanup_e2e_resources.yml',
@@ -476,7 +529,7 @@ const main = (): void => {
         ...DEFAULT_VARIABLES,
       },
     },
-    'depend-on': builds.length > 0 ? [builds[0].identifier] : 'publish_to_local_registry',
+    'depend-on': builds.length > 0 ? leafJobIdentifiers : 'publish_to_local_registry',
   };
 
   console.log(`Total number of splitted jobs: ${builds.length}`);

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -216,9 +216,14 @@ const MAX_WORKERS = 5;
 // dependency (publish_to_local_registry) completes and releases the entire e2e
 // fan-out (~184 jobs) in one simultaneous burst. To stay well under that
 // threshold we partition the generated jobs into sequential waves of at most
-// WAVE_SIZE jobs each (see applyFanOutWaves). ~184 jobs / 46 => 4 waves, so no
-// single completion event ever releases more than ~46 jobs at once.
-const WAVE_SIZE = 46;
+// WAVE_SIZE jobs each (see applyFanOutWaves). ~184 jobs / 90 => 2 waves, so no
+// single completion event ever releases more than ~90 jobs at once.
+//
+// CodeBuild concurrency quotas (Medium=1200, Large=500) far exceed the fan-out,
+// so concurrency is not the constraint. WAVE_SIZE is sized to the largest wave
+// that still avoids the batch-orchestration FAULT (184 faults, 46 works); 90
+// uses 2 waves to cut the wall-clock latency from serializing into 4 waves.
+const WAVE_SIZE = 90;
 
 // eslint-disable-next-line import/namespace
 const loadConfigBase = (): ConfigBase => yaml.load(fs.readFileSync(CODEBUILD_CONFIG_BASE_PATH, 'utf8')) as ConfigBase;


### PR DESCRIPTION
## Problem
The `amplify-category-api-e2e-workflow` CodeBuild batch deterministically FAULTs with `Internal Service Error` ("CodeBuild is experiencing issues") at the `IN_PROGRESS` batch-orchestration phase, ~22s after `publish_to_local_registry` completes. All downstream test groups are force-STOPPED. This has blocked e2e since ~May 22, 2026.

## Root cause
The generated batch build-graph fans out into ~184 test jobs that **all depend solely on `publish_to_local_registry`**, so they are released in a single simultaneous wave. CodeBuild's batch orchestrator faults on that burst.

This is **not** a concurrency/quota issue (every sampled build had QUEUED=0s and provisioned immediately; `maximumBuildsAllowed=300 > 184`) and **not** caused by test growth (the fan-out has been ~180-193 since Nov 2024, and was higher — 205-229 — in 2024 with no faults). Evidence points to a CodeBuild service-side change ~May 21-22, 2026 that reduced batch-orchestration tolerance: the identical 193-group batch ran healthy on May 19 and faulted on May 22 with no repo change. The pr-workflow (only ~11 groups) is unaffected.

## Fix
Stagger the fan-out into sequential waves in `scripts/split-e2e-tests.ts` so the orchestrator never sees a single >~50-job release burst:
- New constant `WAVE_SIZE = 46`.
- Wave 0 (first 46 jobs) depends on `publish_to_local_registry`; each later job `i` depends on job `i - WAVE_SIZE` (strictly-decreasing index → acyclic; max single-event release width = WAVE_SIZE).
- `cleanup_e2e_resources` now depends on the final wave's leaf jobs so it still runs after all tests.
- Regenerated `codebuild_specs/e2e_workflow.yml`.

**No test logic, test isolation, or job count changes** — only `depend-on` edges. Total jobs unchanged (192); max simultaneous release width 174 → 46.

## Verification
Triggered an e2e batch on this branch (`amplify-category-api-e2e-workflow:a6fe9799-...`): after `publish_to_local_registry` succeeded, wave 1 released ~46-49 jobs and the batch stayed `IN_PROGRESS` with **no FAULT** — clearing the +22s death window that killed every prior unstaggered batch, and holding healthy through the run.

## Tradeoff
Waves serialize, adding some wall-clock latency — an accepted tradeoff to eliminate the deterministic orchestration FAULT.

## Note
The underlying trigger is a CodeBuild service-side regression (~May 22, 2026); this change is a defensive workaround that makes the batch resilient to the lower orchestration ceiling. Worth a CodeBuild support ticket separately.