### PR TITLE
fix(graphql-generation-transformer): grant InvokeModel on inference profile and underlying models

### DIFF
--- a/packages/amplify-graphql-generation-transformer/src/__tests__/__snapshots__/amplify-graphql-generation-transformer.test.ts.snap
+++ b/packages/amplify-graphql-generation-transformer/src/__tests__/__snapshots__/amplify-graphql-generation-transformer.test.ts.snap
@@ -148,6 +148,62 @@ function createUserAgent(request) {
 }
 `;
 
+exports[`generation route bedrock InvokeModel IAM resources cross-region inference profile id grants the profile ARN and wildcard-region foundation-model ARN 1`] = `
+[
+  {
+    "Fn::Join": [
+      "",
+      [
+        "arn:",
+        {
+          "Ref": "AWS::Partition",
+        },
+        ":bedrock:",
+        {
+          "Ref": "AWS::Region",
+        },
+        ":",
+        {
+          "Ref": "AWS::AccountId",
+        },
+        ":inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+      ],
+    ],
+  },
+  {
+    "Fn::Join": [
+      "",
+      [
+        "arn:",
+        {
+          "Ref": "AWS::Partition",
+        },
+        ":bedrock:*::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
+      ],
+    ],
+  },
+]
+`;
+
+exports[`generation route bedrock InvokeModel IAM resources plain foundation-model id grants the foundation-model ARN only 1`] = `
+{
+  "Fn::Join": [
+    "",
+    [
+      "arn:",
+      {
+        "Ref": "AWS::Partition",
+      },
+      ":bedrock:",
+      {
+        "Ref": "AWS::Region",
+      },
+      "::foundation-model/anthropic.claude-3-haiku-20240307-v1:0",
+    ],
+  ],
+}
+`;
+
 exports[`generation route custom query 1`] = `
 {
   "Fn::Join": [

--- a/packages/amplify-graphql-generation-transformer/src/__tests__/amplify-graphql-generation-transformer.test.ts
+++ b/packages/amplify-graphql-generation-transformer/src/__tests__/amplify-graphql-generation-transformer.test.ts
@@ -326,6 +326,55 @@ describe('generation route invalid inference configuration', () => {
 });
 // });
 
+describe('generation route bedrock InvokeModel IAM resources', () => {
+  const generationRoute = (aiModel: string): string => `
+    type Query {
+        generate(description: String!): String
+        @generation(
+          aiModel: "${aiModel}",
+          systemPrompt: "Make a string based on the description."
+        )
+    }
+  `;
+
+  const getBedrockInvokeResources = (out: DeploymentResources, fieldName: string): unknown => {
+    const stackName = `GenerationBedrockDataSource${fieldName}Stack`;
+    const stack = out.stacks[stackName];
+    expect(stack).toBeDefined();
+
+    const role = Object.values(stack.Resources ?? {}).find(
+      (resource: any) => resource.Type === 'AWS::IAM::Role' && resource.Properties?.Policies,
+    ) as any;
+    expect(role).toBeDefined();
+
+    const statement = role.Properties.Policies[0].PolicyDocument.Statement.find(
+      (s: any) => Array.isArray(s.Action) ? s.Action.includes('bedrock:InvokeModel') : s.Action === 'bedrock:InvokeModel',
+    );
+    expect(statement).toBeDefined();
+    return statement.Resource;
+  };
+
+  test('plain foundation-model id grants the foundation-model ARN only', () => {
+    const out = transform(generationRoute('anthropic.claude-3-haiku-20240307-v1:0'));
+    const resources = getBedrockInvokeResources(out, 'Generate');
+    const serialized = JSON.stringify(resources);
+
+    expect(serialized).toContain('foundation-model/anthropic.claude-3-haiku-20240307-v1:0');
+    expect(serialized).not.toContain('inference-profile');
+    expect(resources).toMatchSnapshot();
+  });
+
+  test('cross-region inference profile id grants the profile ARN and wildcard-region foundation-model ARN', () => {
+    const out = transform(generationRoute('us.anthropic.claude-haiku-4-5-20251001-v1:0'));
+    const resources = getBedrockInvokeResources(out, 'Generate');
+    const serialized = JSON.stringify(resources);
+
+    expect(serialized).toContain('inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0');
+    expect(serialized).toContain('foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0');
+    expect(resources).toMatchSnapshot();
+  });
+});
+
 const getResolverResource = (queryName: string, resources?: Record<string, any>): Record<string, any> => {
   const resolverName = `Query${queryName}Resolver`;
   return resources?.[resolverName];

--- a/packages/amplify-graphql-generation-transformer/src/grapqhl-generation-transformer.ts
+++ b/packages/amplify-graphql-generation-transformer/src/grapqhl-generation-transformer.ts
@@ -207,12 +207,45 @@ export class GenerationTransformer extends TransformerPluginBase {
             new iam.PolicyStatement({
               effect: iam.Effect.ALLOW,
               actions: ['bedrock:InvokeModel'],
-              resources: [`arn:${cdk.Stack.of(dataSourceScope).partition}:bedrock:${region}::foundation-model/${bedrockModelId}`],
+              resources: this.bedrockInvokeModelResources(dataSourceScope, region, bedrockModelId),
             }),
           ],
         }),
       },
     });
+  }
+
+  /**
+   * Builds the list of resource ARNs that `bedrock:InvokeModel` is granted on for a given model id.
+   *
+   * For a plain foundation-model id (e.g. `anthropic.claude-3-haiku-20240307-v1:0`) this is the
+   * single regional foundation-model ARN, preserving the original behavior.
+   *
+   * For a cross-region inference profile id (prefixed with `us.`, `eu.`, or `apac.`) invoking the
+   * profile requires `bedrock:InvokeModel` on BOTH the inference-profile ARN AND the underlying
+   * regional foundation-model ARNs the profile routes to. The underlying model id is the profile id
+   * with the region prefix stripped, and the foundation-model ARN is granted with a wildcard region
+   * so it covers every region the profile may dispatch to. Without this, customers using a
+   * cross-region profile with `@generation` hit runtime AccessDenied.
+   *
+   * @param {Construct} scope - The construct scope used to resolve account/partition tokens.
+   * @param {string} region - The AWS region for the Bedrock service.
+   * @param {string} bedrockModelId - The foundation-model id or cross-region inference profile id.
+   * @returns {string[]} The resource ARNs to grant `bedrock:InvokeModel` on.
+   */
+  private bedrockInvokeModelResources(scope: Construct, region: string, bedrockModelId: string): string[] {
+    const { partition, account } = cdk.Stack.of(scope);
+    const inferenceProfileMatch = bedrockModelId.match(/^(us|eu|apac)\.(.+)$/);
+
+    if (inferenceProfileMatch) {
+      const foundationModelId = inferenceProfileMatch[2];
+      return [
+        `arn:${partition}:bedrock:${region}:${account}:inference-profile/${bedrockModelId}`,
+        `arn:${partition}:bedrock:*::foundation-model/${foundationModelId}`,
+      ];
+    }
+
+    return [`arn:${partition}:bedrock:${region}::foundation-model/${bedrockModelId}`];
   }
 
   private bedrockDataSourceName(fieldName: string): string {


### PR DESCRIPTION
#### Description of changes

The `@generation` transformer creates an AppSync→Bedrock IAM role that grants `bedrock:InvokeModel`. Previously the role scoped the action to a single regional foundation-model ARN:

```
arn:<partition>:bedrock:<region>::foundation-model/<modelId>
```

For a **cross-region inference profile** model id (prefixed `us.`, `eu.`, or `apac.` — e.g. `us.anthropic.claude-haiku-4-5-20251001-v1:0`) that ARN is incorrect. Invoking an inference profile requires `bedrock:InvokeModel` on the **inference-profile ARN** *and* on the **underlying regional foundation-model ARNs** the profile routes to. Because the transformer only granted the (malformed) foundation-model ARN, customers using a cross-region profile id with `@generation` hit runtime **AccessDenied**.

(The `@conversation` path is unaffected — it invokes Bedrock through `@aws-amplify/ai-constructs`.)

##### Fix

When the model id matches `/^(us|eu|apac)\./`, the role now grants `bedrock:InvokeModel` on both:

- the inference-profile ARN: `arn:<partition>:bedrock:<region>:<account>:inference-profile/<modelId>`
- the underlying foundation-model ARN with a wildcard region: `arn:<partition>:bedrock:*::foundation-model/<foundationModelId>`, where `<foundationModelId>` is the profile id with the region prefix stripped. A wildcard region is used because a cross-region profile may dispatch to any of several regions.

Plain foundation-model ids keep the existing single-ARN behavior. All ARNs are built from CDK `partition`/`region`/`account` tokens — nothing is hardcoded.

##### Tests

Added unit/snapshot tests in the generation transformer package proving:
- a plain FM id grants only the foundation-model ARN (unchanged behavior), and
- an inference-profile id grants both the profile ARN and the wildcard-region foundation-model ARN.

These tests are offline (no AWS). Full suite: **16 passed, 16 total** (`jest`).

##### CDK / CloudFormation Parameters Changed

None. Only the resource list of an existing inline IAM policy statement changes.

#### Issue #, if available

N/A

#### Description of how you validated changes

- `jest` (offline) — 16 passed, 16 total, including 2 new tests + 2 new snapshots.
- `tsc --noEmit` — passes (exit 0).

#### Checklist

- [x] PR description included
- [x] `yarn test` passes (generation transformer package: 16/16)
- [ ] E2E test run linked
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (no docs file exists for this package)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
