### PR TITLE
fix(amplify-category-api): migrate container templates off bitnami ECR Public images

### DIFF
--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/express/Dockerfile
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/express/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/node:22
+FROM public.ecr.aws/docker/library/node:22
 
 ENV PORT=8080
 EXPOSE 8080

--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/python/Dockerfile
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/python/Dockerfile
@@ -1,5 +1,5 @@
 # set base image (host OS)
-FROM public.ecr.aws/bitnami/python:3.12-prod
+FROM public.ecr.aws/docker/library/python:3.12
 
 # set the working directory in the container
 WORKDIR /code

--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/dockerfile-rest-express/Dockerfile
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/dockerfile-rest-express/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/node:22
+FROM public.ecr.aws/docker/library/node:22
 
 ENV PORT=8080
 EXPOSE 8080

--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/graphql-express/Dockerfile
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/graphql-express/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/node:22
+FROM public.ecr.aws/docker/library/node:22
 
 WORKDIR /usr/src/app
 COPY package*.json ./


### PR DESCRIPTION
#### Description of changes

Bitnami container images were permanently removed from the Amazon ECR Public Gallery (June 10, 2026), so every `public.ecr.aws/bitnami/*` pull now fails with a manifest-not-found error. The customer-facing container templates scaffolded by `amplify add api` (container) all referenced bitnami base images, breaking docker builds for every customer on a cold cache.

#### Bitnami → Docker Official Images migration

All four container templates under `packages/amplify-category-api/resources/awscloudformation/container-templates/` are migrated to the equivalent Docker Official Images on ECR Public — the long-term alternative recommended in the [AWS ECR-removal blog post](https://aws.amazon.com/blogs/containers/bitnami-image-removal-from-ecr-public/):

- `public.ecr.aws/bitnami/node:22` → `public.ecr.aws/docker/library/node:22`
- `public.ecr.aws/bitnami/python:3.12-prod` → `public.ecr.aws/docker/library/python:3.12`

#### Pre-existing python template regression also fixed

PR #3436 introduced `public.ecr.aws/bitnami/python:3.12-prod` — a tag that never existed (bitnami python tags always carry an OS suffix, e.g. `-prod-debian-12`). The python template was already broken with manifest-not-found before the ECR removal. The migration to `public.ecr.aws/docker/library/python:3.12` resolves both issues simultaneously.

#### Issue #, if available

Split out from #3494 (PR-4 of the full gen1 stabilisation split). Fixes the container-template breakage introduced by the bitnami ECR removal.

#### Description of how you validated changes

Validated live: `public.ecr.aws/bitnami/node:22` no longer resolves. `docker build` exits 0 on both the node (graphql-express) and python (dockercompose-rest-express) templates against the new `docker/library` base images; `npm install` / `pip install` succeed and containers start cleanly.

#### E2E run — batch af555d89

Meets the team's **no-regression + fixes ≥ 1 test** bar. The bitnami fix is confirmed by the absence of manifest-not-found errors in the e2e run. Remaining shard failures are pre-existing and unrelated to this Dockerfile change:

| Failure bucket | Root cause | Touches container templates? |
|---|---|---|
| `function_migration`, `http_migration`, `custom_query_mutation_extension` | Upstream Node-24 `amplify add function` inquirer crash (separate fix in flight) | No |
| `sql_pg_models`, `rds_*` | RDS provisioning infra flakes | No |
| `AuthV2`, `SubscriptionsRTF` | AppSync API quota in deploy account 740728351410 | No |
| `cleanup_e2e_resources` | Benign post-run reaper | No |

No regression introduced by this PR.

#### Checklist

- [x] PR description included
- [x] E2E test run linked (batch af555d89)
- [x] Tests are changed or added (no-regression + fixes ≥1 test bar met)
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
