### PR TITLE
fix(graphql-elasticsearch-transformer): enforce HTTPS so TLS 1.2 applies on v1 searchable

### DIFF
--- a/packages/graphql-elasticsearch-transformer/src/__tests__/SearchableModelTransformer.test.ts
+++ b/packages/graphql-elasticsearch-transformer/src/__tests__/SearchableModelTransformer.test.ts
@@ -173,7 +173,7 @@ describe('Elasticsearch domain TLS configuration', () => {
 
     const domainEndpointOptions = esDomain.Properties.DomainEndpointOptions;
     expect(domainEndpointOptions).toBeDefined();
-    expect(domainEndpointOptions.EnforceHTTPS).toBeUndefined();
+    expect(domainEndpointOptions.EnforceHTTPS).toBe(true);
     expect(domainEndpointOptions.TLSSecurityPolicy).toBe('Policy-Min-TLS-1-2-2019-07');
   });
 });

--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -495,6 +495,7 @@ export class ResourceFactory {
       DomainName: this.domainName(),
       ElasticsearchVersion: '6.2',
       DomainEndpointOptions: {
+        EnforceHTTPS: true,
         TLSSecurityPolicy: 'Policy-Min-TLS-1-2-2019-07',
       },
       ElasticsearchClusterConfig: {


### PR DESCRIPTION
## Description

#### TLS 1.2 gap on the v1 (Elasticsearch) searchable domain

PR #3456 set `DomainEndpointOptions.TLSSecurityPolicy` to `Policy-Min-TLS-1-2-2019-07` on the v1 Elasticsearch searchable domain but omitted `EnforceHTTPS`. On `AWS::Elasticsearch::Domain` the minimum TLS policy only governs the HTTPS endpoint, so without `EnforceHTTPS: true` the policy is never applied and the domain keeps reporting `Policy-Min-TLS-1-0-2019-07`. This is why amplify-cli e2e still saw a `Policy-Min-TLS-1-0` `CREATE_FAILED` for v1 searchable after #3456 merged.

The companion v2 (OpenSearch) fix in #3472 already pairs `enforceHttps: true` with `tlsSecurityPolicy: TLS_1_2`, so only the v1 path was left incomplete.

#### Fix

Add `EnforceHTTPS: true` to the v1 domain's `DomainEndpointOptions`, matching v2 behavior. The existing unit test (which incorrectly asserted `EnforceHTTPS` was undefined) is updated to assert `true`.

## Testing

`jest SearchableModelTransformer`: 7 passed, 7 snapshots passed, `resources.ts` at 100% coverage.

Split out from #3494 (PR-5 of the full split).
