### PR TITLE
ci: pin e2e node.js to 20 so gen1 cli function-add works

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-AMPLIFY_NODE_VERSION=24.12.0
+# Gen1 CLI (cli-internal, maintenance mode, EOL 2027-05-01) is not compatible
+# with Node.js 24 in the `amplify add function` finalize path, which breaks the
+# function_migration and http_migration (schema-function-2) e2e suites. Pin the
+# e2e Node.js version to 20 to match the build/install/deploy stages
+# (_setupNodeVersion 20) and the version the Gen1 CLI supports.
+AMPLIFY_NODE_VERSION=20
 # set exit on error to true
 set -e
 


### PR DESCRIPTION
## Description

Pins the e2e Node.js version to 20 (from 24.12.0) so the Gen1 `amplify add function` finalize path works in CI.

This is the root-cause fix split out into its own focused PR — a single-line change to `shared-scripts.sh` plus an explanatory comment.

## E2E status / failures addressed

The `function_migration` and `http_migration` (schema-function-2) suites failed deterministically at `amplify add function`. CI installs Node.js 24 (`AMPLIFY_NODE_VERSION=24.12.0`, introduced in #3466), but the published Gen1 `@aws-amplify/cli-internal@14.5.1` (maintenance mode, EOL 2027-05-01) is incompatible with Node 24 in the add-function finalize path. Both failing suites funnel through `addFunction` (function-migration directly; schema-function-2 via `testSchema -> runFunctionTest -> addSimpleFunction`), which is why only these two fail.

Local reproduction against the published CLI: `amplify add function` SUCCEEDS on Node 18, 20, and 22, and FAILS only on Node 24 — confirming a version-specific incompatibility rather than a product or test-logic regression.

Fix pins `AMPLIFY_NODE_VERSION=20`, matching the build/install/deploy stages (`_setupNodeVersion 20`) and a Node version the Gen1 CLI supports.

## How did you test this change?

- `bash -n shared-scripts.sh` (syntax check passes)
- Local repro across Node 18/20/22/24 against published CLI (see above)

## Checklist

- [x] PR description included
- [x] Single-file change scoped to CI configuration
