### PR TITLE
fix: forward authFilter in RDS index query to prevent cross-tenant data exposure

### DIFF
--- a/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
@@ -1504,6 +1504,30 @@ describe('Index query resolver creation', () => {
   };
 });
 
+describe('RDS index query template includes authFilter', () => {
+  it('generates VTL that forwards ctx.stash.authFilter to the SQL Lambda payload', () => {
+    const { RDSIndexVTLGenerator } = require('../resolvers/generators/rds-vtl-generator');
+    const generator = new RDSIndexVTLGenerator();
+    const mockCtx: any = {
+      resourceHelper: {
+        getModelNameMapping: jest.fn().mockReturnValue('customer'),
+      },
+      output: {
+        getObject: jest.fn().mockReturnValue(undefined),
+        getTypeDefinitionsOfKind: jest.fn().mockReturnValue([]),
+      },
+    };
+    const vtl = generator.generateIndexQueryRequestTemplate(
+      { name: 'byRep', queryField: 'listByRep' } as any,
+      mockCtx,
+      'Customer',
+      'listByRep',
+    );
+    expect(vtl).toContain('$ctx.stash.authFilter');
+    expect(vtl).toContain('lambdaInput.args.metadata.authFilter');
+  });
+});
+
 describe('auth', () => {
   const API_KEY = 'API Key Authorization';
   const IAM_AUTH_TYPE = 'IAM Authorization';

--- a/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
@@ -1479,6 +1479,8 @@ describe('Index query resolver creation', () => {
       },
       output: {
         getQueryTypeName: jest.fn().mockReturnValue('Query'),
+        getObject: jest.fn().mockReturnValue(undefined),
+        getTypeDefinitionsOfKind: jest.fn().mockReturnValue([]),
       },
       resolvers: {
         generateQueryResolver: jest.fn().mockReturnValue(mockResolver),

--- a/packages/amplify-graphql-index-transformer/src/resolvers/generators/rds-vtl-generator.ts
+++ b/packages/amplify-graphql-index-transformer/src/resolvers/generators/rds-vtl-generator.ts
@@ -1,4 +1,10 @@
 import { TransformerContextProvider, TransformerResolverProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import {
+  constructAuthFilterStatement,
+  constructNonScalarFieldsStatement,
+  constructArrayFieldsStatement,
+  constructFieldMappingInput,
+} from '@aws-amplify/graphql-transformer-core';
 import { Expression, printBlock, compoundExpression, set, ref, list, qref, methodCall, str, obj } from 'graphql-mapping-template';
 import _ from 'lodash';
 import { IndexDirectiveConfiguration, PrimaryKeyDirectiveConfiguration } from '../../types';
@@ -22,13 +28,10 @@ export class RDSIndexVTLGenerator implements IndexVTLGenerator {
         set(ref('lambdaInput.operationName'), str(operationName)),
         set(ref('lambdaInput.args.metadata'), obj({})),
         set(ref('lambdaInput.args.metadata.keys'), list([])),
-        set(ref('lambdaInput.args.metadata.fieldMap'), obj({})),
-        qref(
-          methodCall(
-            ref('lambdaInput.args.metadata.fieldMap.putAll'),
-            methodCall(ref('util.defaultIfNull'), ref('context.stash.fieldMap'), obj({})),
-          ),
-        ),
+        constructAuthFilterStatement('lambdaInput.args.metadata.authFilter'),
+        constructNonScalarFieldsStatement(tableName, ctx),
+        constructArrayFieldsStatement(tableName, ctx),
+        constructFieldMappingInput(),
         qref(
           methodCall(ref('lambdaInput.args.metadata.keys.addAll'), methodCall(ref('util.defaultIfNull'), ref('ctx.stash.keys'), list([]))),
         ),


### PR DESCRIPTION
#### Description of changes

The RDS secondary-index request mapping template (`generateIndexQueryRequestTemplate` in `packages/amplify-graphql-index-transformer/src/resolvers/generators/rds-vtl-generator.ts`) was not forwarding `$ctx.stash.authFilter` to the SQL Lambda function. This allowed any authenticated user to bypass owner/group row-level authorization by querying through auto-generated secondary-index query fields (e.g., `listByRep`), resulting in cross-tenant data exposure.

The fix adds `constructAuthFilterStatement`, `constructNonScalarFieldsStatement`, `constructArrayFieldsStatement`, and `constructFieldMappingInput` to the index query template — matching the standard list query path (`packages/amplify-graphql-model-transformer/src/resolvers/rds/query.ts`) which correctly applies these filters.

##### CDK / CloudFormation Parameters Changed

None — this change only affects the VTL request mapping template content generated for RDS-backed secondary index queries.

#### Issue #, if available

P463461136 (HackerOne report #3827340)

#### Description of how you validated changes

1. Deployed a CDK app with a Customer model using `@auth(rules: [{ allow: owner }])` and `@index(name: "byRep", queryField: "listByRep")` on a PostgreSQL data source
2. Created two Cognito users (repA, repB) with separate private records
3. **With unfixed code (npm v1.21.3):** repB calling `listByRep(accountRepresentativeId: "REP_A")` returns repA's private data (VULNERABILITY CONFIRMED)
4. **With fixed code:** same query returns empty `items: []` (VULNERABILITY BLOCKED)
5. Verified owners can still query their own data through the index

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.