### PR TITLE
fix: centralize GSI accessor helper

### DIFF
--- a/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
+++ b/packages/amplify-graphql-conversation-transformer/src/transformer-steps/conversation-resolver-generator.ts
@@ -1,6 +1,11 @@
 import { conversation } from '@aws-amplify/ai-constructs';
 import { overrideIndexAtCfnLevel } from '@aws-amplify/graphql-index-transformer';
-import { getModelDataSourceNameForTypeName, getTable, TransformerResolver } from '@aws-amplify/graphql-transformer-core';
+import {
+  getModelDataSourceNameForTypeName,
+  getGlobalSecondaryIndexes,
+  getTable,
+  TransformerResolver,
+} from '@aws-amplify/graphql-transformer-core';
 import { DataSourceProvider, TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { BackendOutputEntry, BackendOutputStorageStrategy } from '@aws-amplify/plugin-types';
 import * as cdk from 'aws-cdk-lib';
@@ -331,10 +336,7 @@ export class ConversationResolverGenerator {
       writeCapacity: cdk.Fn.ref(ResourceConstants.PARAMETERS.DynamoDBModelTableWriteIOPS),
     });
 
-    // aws-cdk-lib 2.260 renamed the private `globalSecondaryIndexes` array on the DynamoDB L2 `Table` to
-    // `_globalSecondaryIndexes` (an `ArrayBox` exposing the same `find` surface and `{ indexName, keySchema }`
-    // element shape); Amplify's managed-table construct keeps the public `globalSecondaryIndexes` array.
-    const globalSecondaryIndexes = table['_globalSecondaryIndexes'] ?? table.globalSecondaryIndexes;
+    const globalSecondaryIndexes = getGlobalSecondaryIndexes(table);
     const gsi = globalSecondaryIndexes.find((g: any) => g.indexName === indexName);
 
     const newIndex = {

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -1,6 +1,6 @@
 import { attributeTypeFromType, overrideIndexAtCfnLevel } from '@aws-amplify/graphql-index-transformer';
 import { generateApplyDefaultsToInputTemplate } from '@aws-amplify/graphql-model-transformer';
-import { InvalidDirectiveError, MappingTemplate, getTable } from '@aws-amplify/graphql-transformer-core';
+import { InvalidDirectiveError, MappingTemplate, getGlobalSecondaryIndexes, getTable } from '@aws-amplify/graphql-transformer-core';
 import {
   TransformerContextProvider,
   TransformerPrepareStepContextProvider,
@@ -28,18 +28,6 @@ import { ModelResourceIDs, ResourceConstants, graphqlName, toCamelCase, toUpper 
 import { getSortKeyFields } from './schema';
 import { HasManyDirectiveConfiguration, HasOneDirectiveConfiguration } from './types';
 import { getConnectionAttributeName, getObjectPrimaryKey } from './utils';
-
-/**
- * Reads the list of global secondary indexes tracked on a DynamoDB L2 `Table` construct.
- *
- * `aws-cdk-lib` 2.260 renamed the (private) `globalSecondaryIndexes` array to `_globalSecondaryIndexes`
- * and now backs it with an `ArrayBox`, which still exposes the array-like `some`/`find`/`length` surface
- * and the same element shape (`{ indexName, keySchema }`). Amplify's own managed-table construct
- * (`AmplifyDynamoDBTable`) instead keeps its indexes on a public `globalSecondaryIndexes` array. Reading
- * `_globalSecondaryIndexes` first and falling back to `globalSecondaryIndexes` works for both table types
- * and preserves the duplicate-index-name detection rather than silently disabling it.
- */
-const getGlobalSecondaryIndexes = (table: any): any => table['_globalSecondaryIndexes'] ?? table.globalSecondaryIndexes;
 
 /**
  * Creates a GSI on the table of the `relatedType` based on the config's `references` / `referenceNodes`

--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -251,6 +251,9 @@ export const getFieldNameFor: (op: Operation, typeName: string) => string;
 export const getFilterInputName: (modelName: string) => string;
 
 // @public (undocumented)
+export const getGlobalSecondaryIndexes: (table: any) => any;
+
+// @public (undocumented)
 export const getImportedRDSTypeFromStrategyDbType: (dbType: ModelDataSourceStrategyDbType) => ImportedRDSType;
 
 // @public (undocumented)

--- a/packages/amplify-graphql-transformer-core/src/__tests__/utils/schema-utils.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/utils/schema-utils.test.ts
@@ -1,0 +1,43 @@
+import { Stack } from 'aws-cdk-lib';
+import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
+import { getGlobalSecondaryIndexes } from '../../utils/schema-utils';
+
+describe('getGlobalSecondaryIndexes', () => {
+  it('reads the indexes off a real DynamoDB L2 Table regardless of the installed aws-cdk-lib field name', () => {
+    const table = new Table(new Stack(), 'TestTable', {
+      partitionKey: { name: 'id', type: AttributeType.STRING },
+    });
+    table.addGlobalSecondaryIndex({
+      indexName: 'byName',
+      partitionKey: { name: 'name', type: AttributeType.STRING },
+    });
+
+    const indexes = getGlobalSecondaryIndexes(table);
+
+    expect(indexes).toBeDefined();
+    expect(indexes.find((gsi: any) => gsi.indexName === 'byName')).toBeDefined();
+  });
+
+  it('returns the private _globalSecondaryIndexes ArrayBox when present', () => {
+    const indexes = [{ indexName: 'byName', keySchema: [{ attributeName: 'name', keyType: 'HASH' }] }];
+
+    expect(getGlobalSecondaryIndexes({ _globalSecondaryIndexes: indexes })).toBe(indexes);
+  });
+
+  it('falls back to the public globalSecondaryIndexes array (Amplify managed table)', () => {
+    const indexes = [{ indexName: 'byOwner', keySchema: [{ attributeName: 'owner', keyType: 'HASH' }] }];
+
+    expect(getGlobalSecondaryIndexes({ globalSecondaryIndexes: indexes })).toBe(indexes);
+  });
+
+  it('prefers _globalSecondaryIndexes when both fields are populated', () => {
+    const renamed = [{ indexName: 'renamed' }];
+    const legacy = [{ indexName: 'legacy' }];
+
+    expect(getGlobalSecondaryIndexes({ _globalSecondaryIndexes: renamed, globalSecondaryIndexes: legacy })).toBe(renamed);
+  });
+
+  it('returns undefined when neither field is present', () => {
+    expect(getGlobalSecondaryIndexes({})).toBeUndefined();
+  });
+});

--- a/packages/amplify-graphql-transformer-core/src/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/index.ts
@@ -39,6 +39,7 @@ export {
   getDefaultStrategyNameForDbType,
   getField,
   getFilterInputName,
+  getGlobalSecondaryIndexes,
   getImportedRDSTypeFromStrategyDbType,
   getKeySchema,
   getModelDataSourceNameForTypeName,

--- a/packages/amplify-graphql-transformer-core/src/utils/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/index.ts
@@ -9,7 +9,7 @@ export {
 export { DirectiveWrapper, GetArgumentsOptions, generateGetArgumentsInput } from './directive-wrapper';
 export { collectDirectives, collectDirectivesByTypeNames } from './type-map-utils';
 export { stripDirectives } from './strip-directives';
-export { getTable, getKeySchema, getSortKeyFieldNames, getStrategyDbTypeFromTypeNode } from './schema-utils';
+export { getTable, getKeySchema, getGlobalSecondaryIndexes, getSortKeyFieldNames, getStrategyDbTypeFromTypeNode } from './schema-utils';
 export { DEFAULT_SCHEMA_DEFINITION } from './defaultSchema';
 export {
   constructArrayFieldsStatement,

--- a/packages/amplify-graphql-transformer-core/src/utils/schema-utils.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/schema-utils.ts
@@ -7,14 +7,25 @@ import { ModelResourceIDs, getBaseType } from 'graphql-transformer-common';
 import { getModelDataSourceStrategy } from './model-datasource-strategy-utils';
 
 /**
+ * Reads the list of global secondary indexes tracked on a DynamoDB L2 `Table` construct.
+ *
+ * aws-cdk-lib 2.260 renamed the private `globalSecondaryIndexes` array on the DynamoDB L2 `Table` to
+ * `_globalSecondaryIndexes` (now an `ArrayBox` exposing the same `find`/`some`/`length` surface and the
+ * same `{ indexName, keySchema }` element shape); Amplify's managed-table construct keeps the public
+ * `globalSecondaryIndexes` array. This reads whichever exists (covers standard `Table` + Amplify managed
+ * table). Centralized so a future CDK rename is a one-line fix.
+ */
+export const getGlobalSecondaryIndexes = (table: any): any => table['_globalSecondaryIndexes'] ?? table.globalSecondaryIndexes;
+
+/**
  * getKeySchema
  */
 export const getKeySchema = (table: any, indexName?: string): any => {
-  // aws-cdk-lib 2.260 renamed the private `globalSecondaryIndexes`/`localSecondaryIndexes` arrays on the
-  // DynamoDB L2 `Table` to `_globalSecondaryIndexes`/`_localSecondaryIndexes` (now `ArrayBox`es exposing the
-  // same `find` surface and element shape). Amplify's managed-table construct keeps the public array names.
-  // Read the renamed fields first, falling back to the public ones so both table types resolve correctly.
-  const globalSecondaryIndexes = table['_globalSecondaryIndexes'] ?? table.globalSecondaryIndexes;
+  // aws-cdk-lib 2.260 renamed the private `localSecondaryIndexes` array on the DynamoDB L2 `Table` to
+  // `_localSecondaryIndexes` (now an `ArrayBox` exposing the same `find` surface and element shape).
+  // Amplify's managed-table construct keeps the public array name. Read the renamed field first, falling
+  // back to the public one so both table types resolve correctly.
+  const globalSecondaryIndexes = getGlobalSecondaryIndexes(table);
   const localSecondaryIndexes = table['_localSecondaryIndexes'] ?? table.localSecondaryIndexes;
   return (
     (


### PR DESCRIPTION
## What

Centralizes the dual-path DynamoDB GSI accessor introduced in #3505 into a **single shared helper** and points all three consumers at it.

`aws-cdk-lib` 2.252/2.260 renamed the DynamoDB L2 `Table` internal `globalSecondaryIndexes` array to `_globalSecondaryIndexes` (now an `ArrayBox`). #3505 landed the fallback expression `table['_globalSecondaryIndexes'] ?? table.globalSecondaryIndexes`, but the identical accessor ended up duplicated in 3 packages.

New export in `@aws-amplify/graphql-transformer-core` (`src/utils/schema-utils.ts`):

```ts
export const getGlobalSecondaryIndexes = (table: any): any =>
  table['_globalSecondaryIndexes'] ?? table.globalSecondaryIndexes;
```

## Why

Per sarayev's review suggestion (idea B) on #3505: dedupe the 3× accessor so a future CDK rename is a one-line fix in one place instead of a hunt across packages.

## Updated call sites (all 3)

- `packages/amplify-graphql-relational-transformer/src/resolvers.ts` — removed the local `getGlobalSecondaryIndexes` in favor of the shared one; `.some(gsi => gsi.indexName === …)` logic unchanged.
- `packages/amplify-graphql-transformer-core/src/utils/schema-utils.ts` — `getKeySchema` now calls the shared helper for the GSI array (LSI accessor left inline, out of scope).
- `packages/amplify-graphql-conversation-transformer/.../conversation-resolver-generator.ts` — inline accessor replaced with the shared helper; `.find(…).keySchema` logic unchanged.

All three already depend on `@aws-amplify/graphql-transformer-core`, so no new/circular dependency is introduced.

## No behavior change

This is a **pure refactor + dedupe**. The dual-path semantics are byte-for-byte identical — notably it does **not** add `?? []` or otherwise harden the accessor (that hardening is a separate decision). Return type kept as `any` to match exactly what the call sites rely on (`.find(...).keySchema` without a null-guard).

It also does **not** remove the private-field dependency: a truly private-free accessor would require a managed-vs-standard-table branch, which is deliberately out of scope here.

## Testing

- **Direct unit tests added for the accessor** (`src/__tests__/utils/schema-utils.test.ts`), per review feedback: real `aws-cdk-lib` L2 `Table` with a GSI (version-agnostic), `_globalSecondaryIndexes`-only (ArrayBox path), public `globalSecondaryIndexes`-only (Amplify managed table), both-present precedence, and neither-present → `undefined`.
- `graphql-transformer-core` unit tests: **97 passed / 14 suites** (incl. the 5 new accessor tests)
- `graphql-relational-transformer` unit tests: **194 passed**
- `graphql-conversation-transformer` unit tests: **25 passed**
- All 3 packages compile (`tsc`), prettier applied, `API.md` regenerated (only the new export added).

Split out of #3517 so the accessor dedupe lands independently of the `addCfnResourceDependency` deprecation shim. Follow-up to #3505.

