### PR TITLE
fix(amplify-e2e-tests): handle InvalidClientTokenId in getAmplifyApps opt-in region cleanup

### DIFF
--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -180,7 +180,7 @@ const getAmplifyApps = async (account: AWSAccountInfo, region: string): Promise<
   try {
     amplifyApps = await amplifyClient.send(new ListAppsCommand({ maxResults: 50 })); // keeping it to 50 as max supported is 50
   } catch (e) {
-    if (e?.name === 'UnrecognizedClientException') {
+    if (e?.name === 'UnrecognizedClientException' || e?.name === 'InvalidClientTokenId') {
       // Do not fail the cleanup and continue
       console.log(`Listing apps for account ${account.accountId}-${region} failed with error with code ${e?.name}. Skipping.`);
       return result;


### PR DESCRIPTION
## Description

Opt-in regions (`ap-east-1`, `eu-south-1`) are not enabled on the e2e test accounts. When `getAmplifyApps` calls the Amplify client in those regions, it throws `InvalidClientTokenId`, which currently propagates out of the cleanup script → `process.exit(1)` → fails the `cleanup_e2e_resources` shard.

This mirrors the existing guard in `getStacks()` by also skipping on `InvalidClientTokenId` (in addition to the existing `UnrecognizedClientException`), logging and continuing rather than failing.

This is a backport of the fix already on `main` (#3304) to the `release-api-plugin-stable` branch.

## Scope
- e2e-cleanup only, not customer-facing
- Exactly one file, one logical change