### PR TITLE
fix(ci): replace direct push with PR creation in postpublish:release

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "link-win": "node ./scripts/link-bin.js node_modules/amplify-cli-internal/bin/amplify amplify-dev",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "package": "lerna run package",
-    "postpublish:release": "git fetch . release:main && git push origin main",
+    "postpublish:release": "echo \"Creating PR to sync release \u2192 main\" && gh pr create --head release --base main --title \"chore: merge release to main [ci skip]\" --body \"Automated post-release sync of version bump commits. Use Create a merge commit (fast-forward).\" || echo \"PR already exists or could not be created \u2014 manual sync required.\"",
     "prettier-check": "yarn prettier --check .",
     "prettier-write": "yarn prettier --write .",
     "production-install": "yarn --frozen-lockfile --cache-folder ~/.cache/yarn",


### PR DESCRIPTION
## Problem

The `postpublish:release` script runs `git push origin main` after publishing to npm. This always fails because `main` has branch protection requiring 2 status checks. The deploy step of the release workflow fails every time, triggering retries that publish additional empty version bumps.

## Fix

Replace the direct push with `gh pr create` to open a PR from `release` → `main`. This PR can then be admin-merged as a fast-forward.

### Before
```
"postpublish:release": "git fetch . release:main && git push origin main"
```

### After
```
"postpublish:release": "gh pr create --head release --base main --title 'chore: merge release to main [ci skip]' ..."
```

## Note

The CodeBuild environment needs `gh` CLI available and authenticated. If `gh` is not available in the build image, this will gracefully fail with a message instructing manual sync. The release itself (npm publish) is not affected — this only impacts the post-publish repo sync step.

## Context

This has been silently failing since branch protection was added to `main`. Previous releases required manual PR creation (e.g., #3507) to sync version bumps back to `main`.