### PR TITLE
fix(graphql-transformer-core): silence CfnResource#addDependency deprecation warning on aws-cdk-lib >= 2.262.0

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/resources/dynamo-model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/dynamo-model-resource-generator.ts
@@ -2,7 +2,7 @@ import * as cdk from 'aws-cdk-lib';
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { ModelResourceIDs, ResourceConstants, SyncResourceIDs } from 'graphql-transformer-common';
 import { ObjectTypeDefinitionNode } from 'graphql';
-import { SyncUtils, setResourceName } from '@aws-amplify/graphql-transformer-core';
+import { SyncUtils, setResourceName, addCfnResourceDependency } from '@aws-amplify/graphql-transformer-core';
 import { AttributeType, CfnTable, ITable, StreamViewType, Table, TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
 import { CfnDataSource } from 'aws-cdk-lib/aws-appsync';
 import * as iam from 'aws-cdk-lib/aws-iam';
@@ -139,7 +139,7 @@ export class DynamoModelResourceGenerator extends ModelResourceGenerator {
     );
 
     const cfnDataSource = dataSource.node.defaultChild as CfnDataSource;
-    cfnDataSource.addDependency(role.node.defaultChild as CfnRole);
+    addCfnResourceDependency(cfnDataSource, role.node.defaultChild as CfnRole);
 
     if (context.isProjectUsingDataStore()) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/amplify-graphql-transformer-core/API.md
+++ b/packages/amplify-graphql-transformer-core/API.md
@@ -105,6 +105,9 @@ import { Visibility } from 'aws-cdk-lib/aws-appsync';
 import { VTLRuntimeTemplate } from '@aws-amplify/graphql-transformer-interfaces';
 
 // @public (undocumented)
+export const addCfnResourceDependency: (source: CfnResource, target: CfnResource) => void;
+
+// @public (undocumented)
 export const APICategory = "api";
 
 // @public (undocumented)

--- a/packages/amplify-graphql-transformer-core/src/__tests__/cfn-dependency.test.ts
+++ b/packages/amplify-graphql-transformer-core/src/__tests__/cfn-dependency.test.ts
@@ -1,0 +1,40 @@
+import { App, Stack, CfnResource } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { addCfnResourceDependency } from '../utils/cfn-dependency';
+
+const makePair = () => {
+  const stack = new Stack(new App(), 'TestStack');
+  const target = new CfnResource(stack, 'Target', { type: 'AWS::IAM::Role', properties: {} });
+  const source = new CfnResource(stack, 'Source', { type: 'AWS::AppSync::DataSource', properties: {} });
+  return { stack, source, target };
+};
+
+describe('addCfnResourceDependency', () => {
+  it('emits a CloudFormation DependsOn entry', () => {
+    const { stack, source, target } = makePair();
+    addCfnResourceDependency(source, target);
+    const resources = Template.fromStack(stack).toJSON().Resources;
+    expect(resources.Source.DependsOn).toEqual([stack.resolve(target.logicalId)]);
+  });
+
+  it('prefers addResourceDependency when the installed CDK exposes it', () => {
+    const { source, target } = makePair();
+    const spy = jest.fn();
+    (source as unknown as Record<string, unknown>).addResourceDependency = spy;
+    const legacy = jest.spyOn(source, 'addDependency');
+    addCfnResourceDependency(source, target);
+    expect(spy).toHaveBeenCalledWith(target);
+    expect(legacy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to addDependency on CDK versions without addResourceDependency', () => {
+    const { source, target } = makePair();
+    const capable = source as unknown as { addResourceDependency?: unknown };
+    const original = capable.addResourceDependency;
+    capable.addResourceDependency = undefined;
+    const legacy = jest.spyOn(source, 'addDependency');
+    addCfnResourceDependency(source, target);
+    expect(legacy).toHaveBeenCalledWith(target);
+    capable.addResourceDependency = original;
+  });
+});

--- a/packages/amplify-graphql-transformer-core/src/appsync-function.ts
+++ b/packages/amplify-graphql-transformer-core/src/appsync-function.ts
@@ -3,7 +3,7 @@ import { BackedDataSource, BaseDataSource, CfnFunctionConfiguration } from 'aws-
 import { Construct } from 'constructs';
 import { InlineTemplate } from './cdk-compat/template-asset';
 import { GraphQLApi } from './graphql-api';
-import { setResourceName } from './utils';
+import { addCfnResourceDependency, setResourceName } from './utils';
 import { getRuntimeSpecificFunctionProps } from './utils/function-runtime';
 
 export interface BaseFunctionConfigurationProps {
@@ -66,7 +66,7 @@ export class AppSyncFunctionConfiguration extends Construct {
     setResourceName(this.function, { name: id });
     props.api.addSchemaDependency(this.function);
     if (props.dataSource instanceof BackedDataSource) {
-      this.function.addDependency(props.dataSource?.ds);
+      addCfnResourceDependency(this.function, props.dataSource?.ds);
     }
     this.arn = this.function.attrFunctionArn;
     this.functionId = this.function.attrFunctionId;

--- a/packages/amplify-graphql-transformer-core/src/graphql-api.ts
+++ b/packages/amplify-graphql-transformer-core/src/graphql-api.ts
@@ -22,7 +22,7 @@ import { Construct } from 'constructs';
 import { LogRetention, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { TransformerSchema } from './cdk-compat/schema-asset';
 import { DefaultTransformHost } from './transform-host';
-import { setResourceName } from './utils';
+import { addCfnResourceDependency, setResourceName } from './utils';
 
 export interface GraphqlApiProps {
   /**
@@ -194,7 +194,7 @@ export class GraphQLApi extends GraphqlApiBase implements GraphQLAPIProvider {
         (mode: AuthorizationMode) => mode.authorizationType === AuthorizationType.API_KEY && mode.apiKeyConfig,
       )?.apiKeyConfig;
       this.apiKeyResource = this.createAPIKey(config);
-      this.apiKeyResource.addDependency(this.schemaResource);
+      addCfnResourceDependency(this.apiKeyResource, this.schemaResource);
       this.apiKey = this.apiKeyResource.attrApiKey;
     }
 
@@ -297,7 +297,7 @@ export class GraphQLApi extends GraphqlApiBase implements GraphQLAPIProvider {
   }
 
   public addSchemaDependency(construct: CfnResource): boolean {
-    construct.addDependency(this.schemaResource);
+    addCfnResourceDependency(construct, this.schemaResource);
     return true;
   }
 

--- a/packages/amplify-graphql-transformer-core/src/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/index.ts
@@ -74,6 +74,7 @@ export {
   isSqlStrategy,
   normalizeDbType,
   setResourceName,
+  addCfnResourceDependency,
   SQLLambdaResourceNames,
 } from './utils';
 export type { SetResourceNameProps } from './utils';

--- a/packages/amplify-graphql-transformer-core/src/utils/cfn-dependency.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/cfn-dependency.ts
@@ -1,0 +1,23 @@
+import { CfnResource } from 'aws-cdk-lib';
+
+type ResourceDependencyCapable = { addResourceDependency?: (target: CfnResource) => void };
+
+/**
+ * Declares that `source` depends on `target`, emitting a CloudFormation `DependsOn` entry.
+ *
+ * aws-cdk-lib >= 2.262.0 renamed `CfnResource#addDependency` to `addResourceDependency` and
+ * deprecated the old name (jsii emits a runtime deprecation warning). Older versions do not
+ * expose `addResourceDependency` at all. Feature-detecting at runtime keeps this library
+ * warning-free on new CDK while remaining compatible with older supported versions.
+ *
+ * @param source the resource that depends on `target`
+ * @param target the resource that must be created first
+ */
+export const addCfnResourceDependency = (source: CfnResource, target: CfnResource): void => {
+  const candidate = source as unknown as ResourceDependencyCapable;
+  if (typeof candidate.addResourceDependency === 'function') {
+    candidate.addResourceDependency(target);
+  } else {
+    source.addDependency(target);
+  }
+};

--- a/packages/amplify-graphql-transformer-core/src/utils/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/index.ts
@@ -20,6 +20,7 @@ export {
   getNonScalarFields,
   getParameterStoreSecretPath,
 } from './rds-util';
+export { addCfnResourceDependency } from './cfn-dependency';
 export const APICategory = 'api';
 export {
   setResourceName,


### PR DESCRIPTION
### Problem

On `aws-cdk-lib >= 2.262.0`, Amplify's transformer packages emit a jsii deprecation warning — once per resource dependency edge — during `synth`/deploy:

```
[WARNING] aws-cdk-lib.CfnResource#addDependency is deprecated. Use addResourceDependency instead. This API will be removed in the next major release.
```

[aws/aws-cdk#38314](https://github.com/aws/aws-cdk/pull/38314) (shipped in `aws-cdk-lib` 2.262.0) renamed the public `CfnResource#addDependency` method to `addResourceDependency` and marked the old name `@deprecated`. Amplify calls `addDependency` internally, so any consumer whose resolved `aws-cdk-lib` is `>= 2.262.0` sees the warning repeated many times — cosmetic (deploys succeed) but it drowns out genuine warnings.

### Why not a plain rename

This repo pins `aws-cdk-lib@2.260.0`, where `addResourceDependency` does **not** exist publicly (only an `@internal` `_addResourceDependency`) — a plain rename fails to compile (TS2551). Bumping the peer-dependency floor to `>= 2.262.0` would be a breaking change for consumers pinned below that. So this uses a version-tolerant runtime feature-detect instead.

### Fix

A small helper `addCfnResourceDependency(source, target)` in `packages/amplify-graphql-transformer-core/src/utils/cfn-dependency.ts` that calls `addResourceDependency` when it exists (CDK `>= 2.262.0`) and falls back to `addDependency` otherwise (CDK `<= 2.261.0`). Wired into the 4 `CfnResource` call sites. The unrelated construct-node `.node.addDependency` call is left untouched. The `as`-cast is contained entirely within the helper.

### Validation

- CDK 2.260.0 (pinned): compiles; `amplify-graphql-transformer-core` unit tests pass (incl. 3 dedicated `cfn-dependency.test.ts` cases); all snapshots unchanged (identical CloudFormation `DependsOn`).
- CDK 2.262.1: synth harness shows the deprecation warning count go 1 → 0, with byte-identical `DependsOn` output.

### Scope

This PR is scoped to the `addCfnResourceDependency` shim only. Two changes that previously rode along have been split out:
- `getGlobalSecondaryIndexes` accessor centralization → #3511
- `cdk init` tsc-strip fail-fast guard → #3520
