### PR TITLE
fix(amplify-table): populate per-GSI provisionedThroughput on billing-mode update to prevent null capacity UPDATE_FAILED

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/amplify-table-manager-lambda.test.ts.snap
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/__snapshots__/amplify-table-manager-lambda.test.ts.snap
@@ -398,8 +398,8 @@ Object {
       "Update": Object {
         "IndexName": "gsi1",
         "ProvisionedThroughput": Object {
-          "ReadCapacityUnits": 5,
-          "WriteCapacityUnits": 5,
+          "ReadCapacityUnits": 4,
+          "WriteCapacityUnits": 4,
         },
       },
     },

--- a/packages/amplify-graphql-model-transformer/src/__tests__/amplify-table-manager-lambda.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/amplify-table-manager-lambda.test.ts
@@ -1114,6 +1114,126 @@ describe('Custom Resource Lambda Tests', () => {
         nextUpdate = getNextAtomicUpdate(currentState, endState);
         expect(nextUpdate).toMatchSnapshot();
       });
+      describe('per-index provisioned throughput', () => {
+        const keySchemaFor = (attributeName: string) => [{ attributeName, keyType: 'HASH' }];
+        const currentGsi = (indexName: string, attributeName: string, throughput?: { read: number; write: number }) => ({
+          IndexName: indexName,
+          KeySchema: [{ AttributeName: attributeName, KeyType: 'HASH' as const }],
+          Projection: { ProjectionType: 'ALL' as const },
+          ...(throughput ? { ProvisionedThroughput: { ReadCapacityUnits: throughput.read, WriteCapacityUnits: throughput.write } } : {}),
+        });
+        const endStateGsi = (indexName: string, attributeName: string, throughput?: { read: number; write: number }) => ({
+          indexName,
+          keySchema: keySchemaFor(attributeName),
+          projection: { projectionType: 'ALL' },
+          ...(throughput ? { provisionedThroughput: { readCapacityUnits: throughput.read, writeCapacityUnits: throughput.write } } : {}),
+        });
+        const twoIndexAttributeDefinitions = [
+          { attributeName: 'pk', attributeType: 'S' },
+          { attributeName: 'sk', attributeType: 'S' },
+          { attributeName: 'name', attributeType: 'S' },
+          { attributeName: 'title', attributeType: 'S' },
+        ];
+
+        it('populates non-null capacity for every GSI when billingMode flips to PROVISIONED and only one GSI declares its own throughput', () => {
+          currentState = {
+            ...currentStateBase,
+            BillingModeSummary: { BillingMode: 'PAY_PER_REQUEST' },
+            GlobalSecondaryIndexes: [currentGsi('gsi1', 'name'), currentGsi('gsi2', 'title')],
+          };
+          endState = {
+            ...baseTableDef,
+            billingMode: 'PROVISIONED',
+            provisionedThroughput: { readCapacityUnits: 10, writeCapacityUnits: 10 },
+            attributeDefinitions: twoIndexAttributeDefinitions,
+            globalSecondaryIndexes: [endStateGsi('gsi1', 'name', { read: 3, write: 4 }), endStateGsi('gsi2', 'title')],
+          };
+
+          nextUpdate = getNextAtomicUpdate(currentState, endState);
+
+          const gsiUpdates = nextUpdate!.GlobalSecondaryIndexUpdates!;
+          expect(gsiUpdates).toHaveLength(2);
+          // gsi1 keeps its own declared throughput, gsi2 inherits the table-level default
+          expect(gsiUpdates[0].Update).toEqual({
+            IndexName: 'gsi1',
+            ProvisionedThroughput: { ReadCapacityUnits: 3, WriteCapacityUnits: 4 },
+          });
+          expect(gsiUpdates[1].Update).toEqual({
+            IndexName: 'gsi2',
+            ProvisionedThroughput: { ReadCapacityUnits: 10, WriteCapacityUnits: 10 },
+          });
+          gsiUpdates.forEach((gsiUpdate) => {
+            expect(gsiUpdate.Update!.ProvisionedThroughput!.ReadCapacityUnits).toEqual(expect.any(Number));
+            expect(gsiUpdate.Update!.ProvisionedThroughput!.WriteCapacityUnits).toEqual(expect.any(Number));
+          });
+        });
+
+        // Regression: the GSI Update action used to source capacity from the end-state index only, emitting
+        // undefined read/write capacity when the index inherited the table-level throughput. DynamoDB then
+        // rejected UpdateTable with "Value null at 'globalSecondaryIndexUpdates.1.member.update.provisionedThroughput.*'".
+        it('falls back to table-level throughput when an existing GSI does not declare its own throughput', () => {
+          currentState = {
+            ...currentStateBase,
+            BillingModeSummary: { BillingMode: 'PROVISIONED' },
+            ProvisionedThroughput: { ReadCapacityUnits: 10, WriteCapacityUnits: 10 },
+            GlobalSecondaryIndexes: [
+              currentGsi('gsi1', 'name', { read: 10, write: 10 }),
+              currentGsi('gsi2', 'title', { read: 5, write: 5 }),
+            ],
+          };
+          endState = {
+            ...baseTableDef,
+            billingMode: 'PROVISIONED',
+            provisionedThroughput: { readCapacityUnits: 10, writeCapacityUnits: 10 },
+            attributeDefinitions: twoIndexAttributeDefinitions,
+            globalSecondaryIndexes: [endStateGsi('gsi1', 'name'), endStateGsi('gsi2', 'title')],
+          };
+
+          nextUpdate = getNextAtomicUpdate(currentState, endState);
+
+          // gsi1 already matches the table-level default so only gsi2 needs an update, with real numbers
+          expect(nextUpdate!.GlobalSecondaryIndexUpdates).toEqual([
+            {
+              Update: {
+                IndexName: 'gsi2',
+                ProvisionedThroughput: { ReadCapacityUnits: 10, WriteCapacityUnits: 10 },
+              },
+            },
+          ]);
+        });
+
+        it('does not emit a GSI throughput update when no throughput can be resolved', () => {
+          currentState = {
+            ...currentStateBase,
+            BillingModeSummary: { BillingMode: 'PROVISIONED' },
+            GlobalSecondaryIndexes: [currentGsi('gsi1', 'name', { read: 5, write: 5 })],
+          };
+          endState = {
+            ...baseTableDef,
+            billingMode: 'PROVISIONED',
+            attributeDefinitions: twoIndexAttributeDefinitions,
+            globalSecondaryIndexes: [endStateGsi('gsi1', 'name')],
+          };
+
+          expect(getNextAtomicUpdate(currentState, endState)).toBeUndefined();
+        });
+
+        it('omits ProvisionedThroughput on GSI updates when the table is billed PAY_PER_REQUEST', () => {
+          currentState = {
+            ...currentStateBase,
+            BillingModeSummary: { BillingMode: 'PAY_PER_REQUEST' },
+            GlobalSecondaryIndexes: [currentGsi('gsi1', 'name', { read: 5, write: 5 })],
+          };
+          endState = {
+            ...baseTableDef,
+            billingMode: 'PAY_PER_REQUEST',
+            attributeDefinitions: twoIndexAttributeDefinitions,
+            globalSecondaryIndexes: [endStateGsi('gsi1', 'name', { read: 9, write: 9 })],
+          };
+
+          expect(getNextAtomicUpdate(currentState, endState)).toBeUndefined();
+        });
+      });
     });
   });
   describe('isTtlModified', () => {

--- a/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-table-manager-lambda/amplify-table-manager-handler.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-table-manager-lambda/amplify-table-manager-handler.ts
@@ -566,6 +566,36 @@ const defaultPhysicalResourceId = (req: AWSLambda.CloudFormationCustomResourceEv
 };
 
 /**
+ * Resolves the provisioned throughput that should be applied to a single global secondary index.
+ *
+ * Precedence is the index's own end-state throughput, falling back to the table-level end-state
+ * throughput when the index does not declare one.
+ *
+ * @param endState The input table state from user
+ * @param indexEndState The end state of the specific index, if it is present in the end state
+ * @returns the read/write capacity pair to apply, or undefined when the index must not carry a
+ * ProvisionedThroughput (table is billed PAY_PER_REQUEST, or neither source supplies a complete
+ * read/write capacity pair). DynamoDB rejects a partially populated ProvisionedThroughput, so a
+ * complete pair is the only valid non-undefined result.
+ */
+const resolveGsiProvisionedThroughput = (
+  endState: CustomDDB.Input,
+  indexEndState?: CustomDDB.GlobalSecondaryIndexProperty,
+): { readCapacityUnits: number; writeCapacityUnits: number } | undefined => {
+  if (endState.billingMode === 'PAY_PER_REQUEST') {
+    return undefined;
+  }
+  const candidate = indexEndState?.provisionedThroughput ?? endState.provisionedThroughput;
+  if (candidate?.readCapacityUnits === undefined || candidate?.writeCapacityUnits === undefined) {
+    return undefined;
+  }
+  return {
+    readCapacityUnits: candidate.readCapacityUnits,
+    writeCapacityUnits: candidate.writeCapacityUnits,
+  };
+};
+
+/**
  * You can only perform one of the following operations at once:
     - Modify the provisioned throughput settings of the table.
     - Remove a global secondary index from the table.
@@ -601,17 +631,25 @@ export const getNextAtomicUpdate = (currentState: TableDescription, endState: Cu
     // should be updated with the provisionedThroughput at the same time. Otherwise it will fail the parameter validation.
     // The table's throughput will be applied by default.
     if (isTableBillingModeModified && endState.billingMode === 'PROVISIONED') {
-      const indexToBeUpdated = currentStateGSIs.map((gsiToUpdate) => {
-        return {
+      const endStateGSIsByName = new Map((endState.globalSecondaryIndexes ?? []).map((gsi) => [gsi.indexName, gsi]));
+      const indexToBeUpdated = currentStateGSIs
+        .map((gsiToUpdate) => ({
+          indexName: gsiToUpdate.IndexName,
+          throughput: resolveGsiProvisionedThroughput(endState, endStateGSIsByName.get(gsiToUpdate.IndexName!)),
+        }))
+        .filter(
+          (gsi): gsi is { indexName: string | undefined; throughput: { readCapacityUnits: number; writeCapacityUnits: number } } =>
+            gsi.throughput !== undefined,
+        )
+        .map((gsi) => ({
           Update: {
-            IndexName: gsiToUpdate.IndexName,
+            IndexName: gsi.indexName,
             ProvisionedThroughput: {
-              ReadCapacityUnits: endState.provisionedThroughput?.readCapacityUnits,
-              WriteCapacityUnits: endState.provisionedThroughput?.writeCapacityUnits,
+              ReadCapacityUnits: gsi.throughput.readCapacityUnits,
+              WriteCapacityUnits: gsi.throughput.writeCapacityUnits,
             },
           },
-        };
-      });
+        }));
       updateInput = {
         ...updateInput,
         GlobalSecondaryIndexUpdates: indexToBeUpdated.length > 0 ? indexToBeUpdated : undefined,
@@ -674,14 +712,8 @@ const getNextGSIUpdate = (currentState: TableDescription, endState: CustomDDB.In
 
   const gsiToAdd = endStateGSIs.find(gsiRequiresCreationPredicate);
   if (gsiToAdd) {
-    let gsiProvisionThroughput: any = gsiToAdd.provisionedThroughput;
     // When table is billing at `PROVISIONED` and no throughput defined for gsi, the table's throughput will be used by default
-    if (endState.billingMode === 'PROVISIONED' && gsiToAdd.provisionedThroughput === undefined) {
-      gsiProvisionThroughput = {
-        readCapacityUnits: endState.provisionedThroughput?.readCapacityUnits,
-        writeCapacityUnits: endState.provisionedThroughput?.writeCapacityUnits,
-      };
-    }
+    const gsiProvisionThroughput: any = resolveGsiProvisionedThroughput(endState, gsiToAdd);
     const attributeNamesToInclude = gsiToAdd.keySchema.map((schema) => schema.attributeName);
     const gsiToAddAction = {
       IndexName: gsiToAdd.indexName,
@@ -704,26 +736,22 @@ const getNextGSIUpdate = (currentState: TableDescription, endState: CustomDDB.In
 
   // The major update is the index provisioned throughput
   const gsiRequiresUpdatePredicate = (endStateGSI: CustomDDB.GlobalSecondaryIndexProperty): boolean => {
-    if (
-      endState.provisionedThroughput &&
-      endState.provisionedThroughput.readCapacityUnits &&
-      endState.provisionedThroughput.writeCapacityUnits &&
-      currentStateGSINames.includes(endStateGSI.indexName)
-    ) {
-      const currentStateGSI = currentStateGSIs.find((gsi) => gsi.IndexName === endStateGSI.indexName);
-      if (currentStateGSI) {
-        if (
-          currentStateGSI.ProvisionedThroughput?.ReadCapacityUnits !== endStateGSI.provisionedThroughput?.readCapacityUnits ||
-          currentStateGSI.ProvisionedThroughput?.WriteCapacityUnits !== endStateGSI.provisionedThroughput?.writeCapacityUnits
-        ) {
-          return true;
-        }
-      }
+    const resolvedThroughput = resolveGsiProvisionedThroughput(endState, endStateGSI);
+    if (!resolvedThroughput || !currentStateGSINames.includes(endStateGSI.indexName)) {
+      return false;
     }
-    return false;
+    const currentStateGSI = currentStateGSIs.find((gsi) => gsi.IndexName === endStateGSI.indexName);
+    if (!currentStateGSI) {
+      return false;
+    }
+    return (
+      currentStateGSI.ProvisionedThroughput?.ReadCapacityUnits !== resolvedThroughput.readCapacityUnits ||
+      currentStateGSI.ProvisionedThroughput?.WriteCapacityUnits !== resolvedThroughput.writeCapacityUnits
+    );
   };
   const gsiToUpdate = endStateGSIs.find(gsiRequiresUpdatePredicate);
   if (gsiToUpdate) {
+    const resolvedThroughput = resolveGsiProvisionedThroughput(endState, gsiToUpdate)!;
     return {
       TableName: currentState.TableName!,
       GlobalSecondaryIndexUpdates: [
@@ -731,8 +759,8 @@ const getNextGSIUpdate = (currentState: TableDescription, endState: CustomDDB.In
           Update: {
             IndexName: gsiToUpdate.indexName,
             ProvisionedThroughput: {
-              ReadCapacityUnits: gsiToUpdate.provisionedThroughput?.readCapacityUnits!,
-              WriteCapacityUnits: gsiToUpdate.provisionedThroughput?.writeCapacityUnits!,
+              ReadCapacityUnits: resolvedThroughput.readCapacityUnits,
+              WriteCapacityUnits: resolvedThroughput.writeCapacityUnits,
             },
           },
         },


### PR DESCRIPTION
## Problem

All five `replace_2_gsis_update_attr_*` deploy-velocity CDK e2e groups (`empty_table`, `single_record`, `1k_records`, `10k_records`, `100k_records`) fail deterministically at deploy time. The `Custom::AmplifyDynamoDBTable` resource goes to `UPDATE_FAILED` with:

```
2 validation errors detected:
Value null at 'globalSecondaryIndexUpdates.1.member.update.provisionedThroughput.writeCapacityUnits'
  failed to satisfy constraint: Member must not be null;
Value null at 'globalSecondaryIndexUpdates.1.member.update.provisionedThroughput.readCapacityUnits'
  failed to satisfy constraint: Member must not be null
```

These tests replace two GSIs while flipping the table to `BillingMode.PROVISIONED` with a table-level throughput of 10/10 (`API_POST_PROCESSOR_SET_PROVISIONED_THROUGHPUT_TWO_GSIS`).

## Root cause

In `amplify-table-manager-handler.ts`, the GSI throughput-**update** path of `getNextGSIUpdate()` sourced capacity units *exclusively* from the end-state **index** definition:

```ts
ProvisionedThroughput: {
  ReadCapacityUnits: gsiToUpdate.provisionedThroughput?.readCapacityUnits!,
  WriteCapacityUnits: gsiToUpdate.provisionedThroughput?.writeCapacityUnits!,
},
```

In the managed-table construct, a GSI only carries its own `provisionedThroughput` when the construct-level billing mode is already `PROVISIONED` (`amplify-dynamodb-table-construct/index.ts` L143-149). In this scenario the indexes inherit the table-level throughput and therefore have **no** `provisionedThroughput` of their own, so both units evaluated to `undefined`. The non-null assertions (`!`) suppressed the type error, and because this return value is not passed through `parsePropertiesToDynamoDBInput` the `undefined` keys survived to the SDK call, where DynamoDB saw an empty `provisionedThroughput` object and reported both members as null.

`gsiRequiresUpdatePredicate` made the mirror-image mistake, comparing the **live** index capacity against the **index** end state:

```ts
currentStateGSI.ProvisionedThroughput?.ReadCapacityUnits !== endStateGSI.provisionedThroughput?.readCapacityUnits
```

That is `10 !== undefined` → always `true`, so the handler kept selecting an index that did not actually need an update, guaranteeing the malformed request was issued on every reconciliation pass.

Separately, the billing-mode-change branch of `getNextAtomicUpdate()` had the opposite gap: it mapped **every** current-state GSI to a table-level `endState.provisionedThroughput`, clobbering any per-index throughput a customer had configured (and emitting the same empty object whenever the table-level value was absent).

The GSI **creation** path already resolved this correctly — index value first, table-level as the default (previously L677-684). The update paths simply never adopted that logic.

## Fix

Extract the creation path's resolution into a single helper and apply it uniformly across all three paths:

```ts
const resolveGsiProvisionedThroughput = (endState, indexEndState) => {
  if (endState.billingMode === 'PAY_PER_REQUEST') return undefined;
  const candidate = indexEndState?.provisionedThroughput ?? endState.provisionedThroughput;
  if (candidate?.readCapacityUnits === undefined || candidate?.writeCapacityUnits === undefined) return undefined;
  return { readCapacityUnits: candidate.readCapacityUnits, writeCapacityUnits: candidate.writeCapacityUnits };
};
```

- **Per-index precedence with table-level fallback** — each index gets its own declared throughput, or the table-level default when it declares none.
- **All-or-nothing** — the helper returns `undefined` rather than a partially populated object, so a `ProvisionedThroughput` with null/absent capacity can never be serialized. Indexes with no resolvable throughput are filtered out of `GlobalSecondaryIndexUpdates` instead of emitting an invalid member.
- **Unsafe non-null assertions removed** (previously L729-735).
- **`PAY_PER_REQUEST` preserved** — returns `undefined`, so on-demand tables continue to omit the property entirely.
- **Correct predicate** — comparing against the *resolved* throughput means an index that already matches the table-level default is no longer selected for a spurious update.

Change is localized to `getNextAtomicUpdate` / `getNextGSIUpdate` plus the new helper. No public API surface is touched (this package has no `api-extractor.json`), so no `API.md` update is required.

## Why now

The defect has been latent since #1940. The affected e2e groups were green on `main` on Jul 10 (`758ab96`) and began failing deterministically from Jul 24 onward, while the handler code is byte-identical across that window. The trigger is therefore external — service-side `UpdateTable` validation tightening that stopped tolerating an empty `provisionedThroughput` on an `Update` action — rather than a repo change. This fix makes the handler correct regardless of the external trigger.

## Validation

- `npx tsc --build` on `amplify-graphql-model-transformer` — clean.
- Full package unit suite: **196/196 passing, 87 snapshots**.
- Four new unit tests in `amplify-table-manager-lambda.test.ts` under `Get billing mode update › per-index provisioned throughput`:
  - billing mode flips to `PROVISIONED` with two GSIs where only one declares its own throughput → asserts **both** `Update.ProvisionedThroughput` entries have non-null numeric read/write capacity (gsi1 keeps 3/4, gsi2 inherits 10/10).
  - regression case: an existing GSI with no declared throughput now falls back to the table-level value instead of emitting nulls — this reproduced the `UPDATE_FAILED` scenario and now passes.
  - no resolvable throughput → no GSI update emitted.
  - `PAY_PER_REQUEST` → `ProvisionedThroughput` omitted.
- One existing snapshot intentionally updated: a GSI declaring its own 4/4 throughput is no longer overwritten with the table-level 5/5 during a billing-mode change. This is the behavioral correction, not a regression.
- CodeBuild e2e (`e2e_workflow_cdk.yml`, which contains the `replace_2_gsis_update_attr_*` groups) plus `pr_workflow.yml` were triggered on this branch and have completed — see **CI status** below.

## CI status

**The groups this PR targets are PASSING.** ✅

- All five `replace_2_gsis_update_attr_*` groups (`empty_table`, `single_record`, `1k_records`, `10k_records`, `100k_records`) are **green** on the e2e CDK batch, with **zero recurrence** of the `provisionedThroughput` null-capacity `UPDATE_FAILED`.
- The related `3_gsis_*` set is **green** as well — no regression from the per-index throughput resolution change.
- The `pr_workflow` gate is **green**.

### The two remaining red e2e groups are unrelated to this PR

`custom_query_mutation_extension` and `admin_role` fail for a **different, pre-existing reason** that has nothing to do with this change:

- **Cause:** unpinned `cdk init` CLI toolchain drift in the e2e scaffolder. `initCDKProject()` pins `aws-cdk-lib` but ran `cdk init` with a floating CLI, and the upstream template changed its synth command from `npx ts-node --prefer-ts-exts` to `npx tsc && npx tsx`. That turns synth into a whole-project typecheck of every `.ts` copied into the scratch project — including lambda entry files that are only referenced by esbuild as path strings and never imported.
- **Symptom:** `TS7006` (`authorizer.ts:1:26`) and `TS2307` (`apiInvoker.ts:6:51`), both failing **before `cdk synth` runs**.
- **Scope:** affects `main` and **every** open PR, not just this one. Deterministic — reproduced 6/6 locally. Retrying will never clear it.
- **Being fixed separately in #3519** — https://github.com/aws-amplify/amplify-category-api/pull/3519

No file touched by this PR is involved in those two failures.

## Notes

Independent of #3517 (`addResourceDependency` deprecation) — branched off latest `main`, no shared files.
