### PR TITLE
fix(amplify-graphql-api-construct-tests): pin cdk init CLI and type e2e lambda scaffolds

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/admin-role/apiInvoker.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/admin-role/apiInvoker.ts
@@ -3,7 +3,24 @@ import { defaultProvider } from '@aws-sdk/credential-provider-node';
 import { SignatureV4 } from '@aws-sdk/signature-v4';
 import { HttpRequest } from '@aws-sdk/protocol-http';
 import { default as fetch, Request } from 'node-fetch';
-import type { GraphqlProxiedLambdaResponse } from '../../../lambda-request';
+
+/**
+ * Shape of the response this lambda returns to callers.
+ *
+ * Intentionally declared inline rather than imported from the test helpers: this file is bundled as a standalone lambda entry point and is
+ * copied into a scratch CDK project, so any relative import reaching outside its own directory cannot be resolved.
+ */
+export type GraphqlProxiedLambdaResponse<ResponseDataType> = {
+  statusCode: number;
+  body: {
+    errors: Array<{
+      status?: number;
+      message: string;
+      stack: string[];
+    }>;
+    data: ResponseDataType;
+  };
+};
 
 if (!process.env.GRAPHQL_URL) throw new Error('GRAPHQL_URL not found in environment variables');
 const graphqlEndpoint = new URL(process.env.GRAPHQL_URL);

--- a/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/custom-query-mutation-extension/authorizer.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/__tests__/backends/custom-query-mutation-extension/authorizer.ts
@@ -1,4 +1,8 @@
-exports.handler = async (event) => {
+type CustomAuthorizerEvent = {
+  authorizationToken?: string;
+};
+
+exports.handler = async (event: CustomAuthorizerEvent) => {
   const { authorizationToken } = event;
   const response = {
     isAuthorized: authorizationToken === 'custom-authorized',

--- a/packages/amplify-graphql-api-construct-tests/src/commands.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/commands.ts
@@ -65,6 +65,38 @@ const appendToCDKContext = (projectPath: string, additionalContext: Record<strin
   writeFileSync(cdkJsonPath, JSON.stringify(cdkJson, null, 2));
 };
 
+/**
+ * Pinned version of the `aws-cdk` CLI used to scaffold e2e test projects.
+ *
+ * The CLI must be pinned independently of `aws-cdk-lib`: the two have used separate version lines since CLI v2.1000.0, so there is no
+ * `aws-cdk` release matching a modern `aws-cdk-lib` version. Leaving the CLI floating means `cdk init` silently picks up upstream template
+ * changes, which has broken e2e groups before (the template switched the synth command from `ts-node` to `tsc && tsx`, turning synth into a
+ * whole-project typecheck).
+ */
+const CDK_CLI_VERSION = '2.1134.0';
+
+/**
+ * Removes the whole-project `tsc` typecheck from the generated `cdk.json` synth command.
+ *
+ * Backend templates are copied wholesale into the scratch project's `bin/` directory, and some of those files are lambda entry points that
+ * are only ever referenced by esbuild as a path string -- they are never imported by `app.ts`. A whole-project typecheck compiles them
+ * anyway, in a directory they were never written to resolve from, failing synth before it starts. Transpiling only the import graph (the
+ * historical behavior) keeps synth scoped to code the app actually loads.
+ */
+const removeWholeProjectTypecheckFromSynth = (projectPath: string): void => {
+  const cdkJsonPath = path.join(projectPath, 'cdk.json');
+  const cdkJson = JSON.parse(readFileSync(cdkJsonPath, 'utf-8'));
+  if (typeof cdkJson.app !== 'string') {
+    return;
+  }
+  const appWithoutTypecheck = cdkJson.app.replace(/^\s*npx\s+tsc\s*&&\s*/, '');
+  if (appWithoutTypecheck === cdkJson.app) {
+    return;
+  }
+  cdkJson.app = appWithoutTypecheck;
+  writeFileSync(cdkJsonPath, JSON.stringify(cdkJson, null, 2));
+};
+
 export type InitCDKProjectProps = {
   construct?: CdkConstruct;
   cdkContext?: Record<string, string>;
@@ -82,7 +114,7 @@ export type InitCDKProjectProps = {
 export const initCDKProject = async (cwd: string, templatePath: string, props?: InitCDKProjectProps): Promise<string> => {
   const { cdkVersion = '2.260.0', additionalDependencies = [] } = props ?? {};
 
-  await spawn(getNpxPath(), ['cdk', 'init', 'app', '--language', 'typescript'], {
+  await spawn(getNpxPath(), [`aws-cdk@${CDK_CLI_VERSION}`, 'init', 'app', '--language', 'typescript'], {
     cwd,
     stripColors: true,
     // npx cdk does not work on verdaccio
@@ -92,6 +124,8 @@ export const initCDKProject = async (cwd: string, templatePath: string, props?: 
   })
     .sendYes()
     .runAsync();
+
+  removeWholeProjectTypecheckFromSynth(cwd);
 
   if (props?.cdkContext) {
     appendToCDKContext(cwd, props.cdkContext);


### PR DESCRIPTION
### Problem

Two CDK e2e groups fail deterministically (6/6 locally reproduced), on `main` and on every open PR:

| group | file | error |
|---|---|---|
| `custom_query_mutation_extension` | `backends/custom-query-mutation-extension/authorizer.ts:1:26` | `TS7006` — Parameter `event` implicitly has an `any` type |
| `admin_role` | `backends/admin-role/apiInvoker.ts:6:51` | `TS2307` — Cannot find module `'../../../lambda-request'` |

Both fail **before `cdk synth` runs**, so no stack is ever deployed.

### Root cause: unpinned `cdk init` CLI toolchain drift

`initCDKProject()` in `packages/amplify-graphql-api-construct-tests/src/commands.ts` pins **`aws-cdk-lib`** (`2.260.0`) but ran `cdk init` with a **floating CLI**:

```ts
await spawn(getNpxPath(), ['cdk', 'init', 'app', '--language', 'typescript'], { ... })
```

The upstream TypeScript app template has since changed. Verified by running both CLIs into temp dirs:

|  | CLI `2.179.0` (old, working) | CLI `2.1134.0` (current) |
|---|---|---|
| `cdk.json` `app` | `npx ts-node --prefer-ts-exts bin/app.ts` | `npx tsc && npx tsx bin/app.ts` |
| `typescript` | `~5.6.3` | `~7.0.2` |
| `tsconfig` `include` | none | none |
| `strict` / `noImplicitAny` | on | on |

The critical change is the `npx tsc &&` prefix. `ts-node` only ever compiled the **import graph** reachable from `app.ts`. `npx tsc` with no `include` glob typechecks **every `.ts` file in the scratch project**.

That matters because `copyTemplateDirectory()` `copySync`s the whole backend directory **flat into `bin/`**. Several of those files are lambda *entry points* that are only ever referenced by esbuild as a **path string** — never imported:

```ts
const apiInvoker = new NodejsFunction(stack, 'ApiInvoker', {
  entry: path.join(__dirname, 'apiInvoker.ts'),   // <- string, not an import
```

So they are now typechecked from `bin/`, a directory they were never written to resolve from, and their relative import `'../../../lambda-request'` escapes the scratch project entirely.

This is **pre-existing on `main`** and unrelated to any product code.

### Fix

1. **Pin the `aws-cdk` CLI** (durable — stops the template drifting again).
   Note the CLI could *not* be pinned to `cdkVersion`: `aws-cdk` and `aws-cdk-lib` have used **separate version lines since CLI `v2.1000.0`**, so there is no `aws-cdk@2.260.0` (nor `aws-cdk@2.224.0`) to install — and `cdkVersion` is legitimately `'latest'` in some tests. It therefore gets its own `CDK_CLI_VERSION` constant.
2. **Drop the whole-project typecheck from the generated synth command**, restoring the historical `ts-node` semantics where synth only loads the app's import graph. The runtime invocation (`npx tsx bin/app.ts`) is unchanged — only the `npx tsc &&` gate is removed. This makes the scaffolder immune to *any* stray non-imported `.ts` in a backend, not just today's two.
3. **Fix the two scaffold files** so they are clean even under a full typecheck:
   - `authorizer.ts` — type the handler `event` param (behavior identical).
   - `apiInvoker.ts` — inline the self-contained `GraphqlProxiedLambdaResponse` type instead of importing it from outside the bundle. **All previously exported names remain exported**, so `admin-role.test.ts`'s `import type { CreateTodoHandlerEvent, CreateTodoResponseData }` still compiles.

### Validation

Faithful local repro of `initCDKProject()` (pinned `cdk init` → copy backend flat into `bin/` → rename `app.ts` → install `additionalDependencies`):

```
BEFORE (main)
  custom-query-mutation-extension  npx tsc exit=1
    bin/authorizer.ts(1,26): error TS7006: Parameter 'event' implicitly has an 'any' type.
  admin-role                       npx tsc exit=1
    bin/apiInvoker.ts(6,51): error TS2307: Cannot find module '../../../lambda-request'

AFTER (this branch)
  custom-query-mutation-extension  cdk.json app => npx tsx bin/<app>.ts
    zero errors in backend entry files
  admin-role                       npx tsc exit=0   (clean, whole project)
```

- `tsc --build tsconfig.tests.json` → exit `0`
- `prettier --check` on all 3 changed files → clean
- Commit passed the full husky pre-commit gate (e2e split reconciliation `PASS`, construct-dependency validation, license extraction)

Full e2e is CI's job — CodeBuild batches triggered on this branch.
