### PR TITLE
fix(amplify-graphql-api-construct-tests): fail fast if cdk.json tsc-strip pattern stops matching

### DIFF
--- a/packages/amplify-graphql-api-construct-tests/src/commands.ts
+++ b/packages/amplify-graphql-api-construct-tests/src/commands.ts
@@ -91,6 +91,12 @@ const removeWholeProjectTypecheckFromSynth = (projectPath: string): void => {
   }
   const appWithoutTypecheck = cdkJson.app.replace(/^\s*npx\s+tsc\s*&&\s*/, '');
   if (appWithoutTypecheck === cdkJson.app) {
+    if (cdkJson.app.includes('tsc')) {
+      throw new Error(
+        `[initCDKProject] cdk.json synth command still contains 'tsc' but did not match the removal pattern (the CDK CLI template likely ` +
+          `changed): "${cdkJson.app}". Update this strip logic and/or CDK_CLI_VERSION (currently ${CDK_CLI_VERSION}).`,
+      );
+    }
     return;
   }
   cdkJson.app = appWithoutTypecheck;


### PR DESCRIPTION
## What

Adds a fail-fast guard to `removeWholeProjectTypecheckFromSynth` in `packages/amplify-graphql-api-construct-tests/src/commands.ts`. If the generated `cdk.json` `app` command still contains `tsc` but does **not** match the removal regex, we now throw with the actual command string instead of silently returning.

```ts
const appWithoutTypecheck = cdkJson.app.replace(/^\s*npx\s+tsc\s*&&\s*/, '');
if (appWithoutTypecheck === cdkJson.app) {
  if (cdkJson.app.includes('tsc')) {
    throw new Error(
      `[initCDKProject] cdk.json synth command still contains 'tsc' but did not match the removal pattern (the CDK CLI template likely ` +
        `changed): "${cdkJson.app}". Update this strip logic and/or CDK_CLI_VERSION (currently ${CDK_CLI_VERSION}).`,
    );
  }
  return;
}
```

## Why

This applies the outstanding review feedback on #3519 (sarayev's suggestion). The strip logic is coupled to the exact `app` string the CDK CLI template emits. If a future `CDK_CLI_VERSION` bump changes that template (e.g. a different `tsc` invocation form), the regex silently stops matching and the whole-project typecheck quietly comes back — reintroducing the slow/failing synth that the strip exists to avoid, with no signal about why.

Failing loudly at `initCDKProject` time, with the offending command echoed and the current `CDK_CLI_VERSION` named, turns a silent regression into an immediately actionable error.

The no-`tsc` case still returns normally, so projects whose template legitimately has no typecheck step are unaffected.

## Testing

- `packages/amplify-graphql-api-construct-tests` compiles clean (`tsc --build`).
- `prettier --check` passes on the changed file.

## Notes

Split out of #3517 so this test-harness guard lands independently of the `addCfnResourceDependency` deprecation shim.
