### PR TITLE
fix(graphql-model-transformer): stop pinning DynamoDB table waiter execution name to CFN RequestId

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/__tests__/amplify-table-manager-execution-already-exists.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/amplify-table-manager-execution-already-exists.test.ts
@@ -1,0 +1,186 @@
+import { StartExecutionInput } from '@aws-sdk/client-sfn';
+import * as ddbTableManagerLambda from '../resources/amplify-dynamodb-table/amplify-table-manager-lambda/amplify-table-manager-handler';
+import * as outbound from '../resources/amplify-dynamodb-table/amplify-table-manager-lambda/outbound';
+
+jest.spyOn(ddbTableManagerLambda, 'getLambdaTags').mockReturnValue(Promise.resolve([]));
+
+const mockDescribeTable = jest.fn();
+const mockDescribeContinuousBackups = jest.fn();
+const mockUpdateContinuousBackups = jest.fn();
+const mockSend = jest.fn();
+
+jest.mock('@aws-sdk/client-dynamodb', () => {
+  return {
+    ...jest.requireActual('@aws-sdk/client-dynamodb'),
+    DynamoDB: jest.fn().mockImplementation(() => ({
+      describeTable: (input: any) => mockDescribeTable(input),
+      describeContinuousBackups: (input: any) => mockDescribeContinuousBackups(input),
+      updateContinuousBackups: (input: any) => mockUpdateContinuousBackups(input),
+      send: (input: any) => mockSend(input),
+    })),
+  };
+});
+
+const TABLE_ARN = 'arn:aws:dynamodb:us-east-1:123456789100:table/mockTable';
+const CFN_REQUEST_ID = 'a1b2c3d4-1111-2222-3333-444455556666';
+
+/**
+ * Minimal stand-in for the Step Functions StandardState machine name-uniqueness window.
+ * The real service keeps execution names unique for ~90 days on STANDARD state machines and
+ * rejects a duplicate name with `ExecutionAlreadyExists`.
+ */
+class FakeStepFunctions {
+  private readonly startedExecutionNames = new Set<string>();
+
+  startExecution = async (req: StartExecutionInput): Promise<{ executionArn: string; startDate: Date }> => {
+    const name = req.name;
+    if (name !== undefined) {
+      if (this.startedExecutionNames.has(name)) {
+        const error: Error & { name: string; code?: string } = new Error(
+          `Execution Already Exists: 'arn:aws:states:us-east-1:123456789100:execution:waiter:${name}'`,
+        );
+        error.name = 'ExecutionAlreadyExists';
+        error.code = 'ExecutionAlreadyExists';
+        throw error;
+      }
+      this.startedExecutionNames.add(name);
+    }
+    return {
+      executionArn: `arn:aws:states:us-east-1:123456789100:execution:waiter:${name ?? `auto-${this.startedExecutionNames.size}`}`,
+      startDate: new Date(),
+    };
+  };
+}
+
+const pitrUpdateEvent = (): AWSLambda.CloudFormationCustomResourceEvent =>
+  ({
+    RequestType: 'Update',
+    ServiceToken: 'arn:aws:lambda:us-east-1:123456789100:function:TableManagerCustomProviderframeworkonEvent',
+    ResponseURL: 'https://cloudformation-custom-resource-response.example.com/mock',
+    StackId: 'mockStackId',
+    RequestId: CFN_REQUEST_ID,
+    LogicalResourceId: 'ResourceTable',
+    ResourceType: 'Custom::AmplifyDynamoDBTable',
+    PhysicalResourceId: 'mockTable',
+    ResourceProperties: {
+      ServiceToken: 'arn:aws:lambda:us-east-1:123456789100:function:TableManagerCustomProviderframeworkonEvent',
+      tableName: 'mockTable',
+      attributeDefinitions: [{ attributeName: 'pk', attributeType: 'S' }],
+      keySchema: [{ attributeName: 'pk', keyType: 'HASH' }],
+      billingMode: 'PAY_PER_REQUEST',
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+    },
+    OldResourceProperties: {
+      ServiceToken: 'arn:aws:lambda:us-east-1:123456789100:function:TableManagerCustomProviderframeworkonEvent',
+      tableName: 'mockTable',
+      attributeDefinitions: [{ attributeName: 'pk', attributeType: 'S' }],
+      keySchema: [{ attributeName: 'pk', keyType: 'HASH' }],
+      billingMode: 'PAY_PER_REQUEST',
+    },
+  } as unknown as AWSLambda.CloudFormationCustomResourceEvent);
+
+const lambdaContext = {
+  invokedFunctionArn: 'arn:aws:lambda:us-east-1:123456789100:function:TableManagerCustomProviderframeworkonEvent',
+};
+
+describe('waiter state machine execution naming (P489859831 / #1047)', () => {
+  let fakeSfn: FakeStepFunctions;
+  let startExecutionSpy: jest.Mock;
+  let cfnResponses: any[];
+  const originalStartExecution = outbound.startExecution;
+  const originalHttpRequest = outbound.httpRequest;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.WAITER_STATE_MACHINE_ARN = 'arn:aws:states:us-east-1:123456789100:stateMachine:waiter';
+
+    fakeSfn = new FakeStepFunctions();
+    startExecutionSpy = jest.fn((req: StartExecutionInput) => fakeSfn.startExecution(req));
+    (outbound as any).startExecution = startExecutionSpy;
+
+    cfnResponses = [];
+    (outbound as any).httpRequest = jest.fn(async (_options: any, body: string) => {
+      cfnResponses.push(JSON.parse(body));
+    });
+
+    mockDescribeTable.mockResolvedValue({
+      Table: {
+        TableName: 'mockTable',
+        TableArn: TABLE_ARN,
+        TableStatus: 'ACTIVE',
+        KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }],
+        AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
+        BillingModeSummary: { BillingMode: 'PAY_PER_REQUEST' },
+      },
+    });
+    mockDescribeContinuousBackups.mockResolvedValue({
+      ContinuousBackupsDescription: {
+        ContinuousBackupsStatus: 'ENABLED',
+        PointInTimeRecoveryDescription: { PointInTimeRecoveryStatus: 'DISABLED' },
+      },
+    });
+    mockUpdateContinuousBackups.mockResolvedValue({
+      ContinuousBackupsDescription: {
+        ContinuousBackupsStatus: 'ENABLED',
+        PointInTimeRecoveryDescription: { PointInTimeRecoveryStatus: 'ENABLED' },
+      },
+    });
+    mockSend.mockResolvedValue({ Tags: [] });
+  });
+
+  afterEach(() => {
+    (outbound as any).startExecution = originalStartExecution;
+    (outbound as any).httpRequest = originalHttpRequest;
+    delete process.env.WAITER_STATE_MACHINE_ARN;
+  });
+
+  it('a CloudFormation retry with the same RequestId no longer fails with ExecutionAlreadyExists', async () => {
+    await ddbTableManagerLambda.onEvent(pitrUpdateEvent(), lambdaContext);
+    await ddbTableManagerLambda.onEvent(pitrUpdateEvent(), lambdaContext);
+
+    expect(startExecutionSpy).toHaveBeenCalledTimes(2);
+
+    // The handler must not pin the execution name to the CFN RequestId, otherwise the second
+    // (retried) invocation lands inside the Step Functions name-uniqueness window.
+    expect(startExecutionSpy.mock.calls[0][0].name).toBeUndefined();
+    expect(startExecutionSpy.mock.calls[1][0].name).toBeUndefined();
+
+    // Both waiter executions started, so nothing was reported back to CloudFormation yet:
+    // completion is reported later by the waiter state machine, not by onEvent.
+    expect(cfnResponses).toHaveLength(0);
+    expect(cfnResponses.filter((response) => response.Status === 'FAILED')).toHaveLength(0);
+  });
+
+  it('still forwards the state machine arn and the full resource event as waiter input', async () => {
+    await ddbTableManagerLambda.onEvent(pitrUpdateEvent(), lambdaContext);
+
+    const waiter = startExecutionSpy.mock.calls[0][0];
+    expect(waiter.stateMachineArn).toEqual('arn:aws:states:us-east-1:123456789100:stateMachine:waiter');
+
+    const input = JSON.parse(waiter.input);
+    expect(input.RequestId).toEqual(CFN_REQUEST_ID);
+    expect(input.PhysicalResourceId).toEqual('mockTable');
+    expect(input.StackId).toEqual('mockStackId');
+  });
+
+  it('demonstrates why the name had to go: reusing an explicit name throws ExecutionAlreadyExists', async () => {
+    const waiter = {
+      stateMachineArn: process.env.WAITER_STATE_MACHINE_ARN!,
+      name: CFN_REQUEST_ID,
+      input: '{}',
+    };
+
+    await expect(outbound.startExecution(waiter)).resolves.toBeDefined();
+    await expect(outbound.startExecution(waiter)).rejects.toMatchObject({ name: 'ExecutionAlreadyExists' });
+  });
+
+  it('omitting `name` (upstream CDK provider-framework behaviour) lets the retry succeed', async () => {
+    const withoutName = {
+      stateMachineArn: process.env.WAITER_STATE_MACHINE_ARN!,
+      input: JSON.stringify({ RequestId: CFN_REQUEST_ID }),
+    };
+
+    await expect(outbound.startExecution(withoutName)).resolves.toBeDefined();
+    await expect(outbound.startExecution(withoutName)).resolves.toBeDefined();
+  });
+});

--- a/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-table-manager-lambda/amplify-table-manager-handler.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-table-manager-lambda/amplify-table-manager-handler.ts
@@ -100,13 +100,11 @@ async function onEventHandler(cfnRequest: AWSLambda.CloudFormationCustomResource
     // `isComplete` in predefined intervals.
     const waiter = {
       stateMachineArn: getEnv('WAITER_STATE_MACHINE_ARN'),
-      name: resourceEvent.RequestId,
       input: JSON.stringify(resourceEvent),
     };
 
     log('starting waiter', {
       stateMachineArn: waiter.stateMachineArn,
-      name: resourceEvent.RequestId,
     });
 
     await startExecution(waiter);


### PR DESCRIPTION
## Problem

Deploying an Amplify GraphQL API with many `@model` tables can intermittently fail with a `Custom::AmplifyDynamoDBTable` resource reporting:

```
Execution Already Exists: 'arn:aws:states:...:execution:...TableManagerCustomProviderwaiterStateMachine...'
```

The custom resource is marked `FAILED` and the stack rolls back. It is intermittent and shows up most often under **parallel multi-table deploys** — e.g. enabling point-in-time recovery (PITR) across many tables at once, where a large number of table-manager invocations run concurrently and CloudFormation is more likely to retry an in-flight request.

The trigger is a CloudFormation **retry** of the same request. CFN may re-invoke the `onEvent` handler with the **same `RequestId`**, and the handler used that `RequestId` as the Step Functions execution name. STANDARD state machines enforce execution-name uniqueness for ~90 days, so the duplicate name is rejected with `ExecutionAlreadyExists` and the retry fails the resource instead of harmlessly re-starting the waiter.

## Root cause

In `packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-table-manager-lambda/amplify-table-manager-handler.ts`, the waiter execution name was pinned to the CFN `RequestId`:

```ts
const waiter = {
  stateMachineArn: getEnv('WAITER_STATE_MACHINE_ARN'),
  name: resourceEvent.RequestId,   // <-- deterministic name collides on CFN retry
  input: JSON.stringify(resourceEvent),
};
```

## Fix

Delete the explicit `name` (and the matching field in the adjacent `log('starting waiter', ...)` call) so Step Functions **auto-generates a unique execution name**. A CFN retry then starts a fresh waiter execution instead of erroring.

This mirrors the upstream aws-cdk provider-framework fix in **aws/aws-cdk#35988** (commit `36ea606334f1a4590a61d19b0675300ee202f798`), which removed exactly these two lines from `framework.ts`, shipped in `aws-cdk-lib >= 2.233.0`.

> [!IMPORTANT]
> Amplify **forked** the CDK provider framework into this package (#2490), so bumping `aws-cdk-lib` alone does **not** deliver the upstream fix to Amplify users. The fork needs this change applied directly — which is what this PR does.

Behaviour is otherwise unchanged: the full `resourceEvent` is still passed as the waiter `input`, and `isComplete` polling is keyed off that payload, not off the execution name.

## Testing

Target suite `packages/amplify-graphql-model-transformer/src/__tests__/amplify-table-manager-execution-already-exists.test.ts` — **4/4 pass**. It uses a fake Step Functions that faithfully models the real name-uniqueness constraint:

```
PASS src/__tests__/amplify-table-manager-execution-already-exists.test.ts
  waiter state machine execution naming (P489859831 / #1047)
    ✓ a CloudFormation retry with the same RequestId no longer fails with ExecutionAlreadyExists
    ✓ still forwards the state machine arn and the full resource event as waiter input
    ✓ demonstrates why the name had to go: reusing an explicit name throws ExecutionAlreadyExists
    ✓ omitting `name` (upstream CDK provider-framework behaviour) lets the retry succeed
Tests: 4 passed, 4 total
```

The regression test is **load-bearing** — with the handler change stashed, it fails:

```
=== WITHOUT FIX ===
  ✕ a CloudFormation retry with the same RequestId no longer fails with ExecutionAlreadyExists
Tests: 1 failed, 3 passed, 4 total
```

Broader related suites are green:

```
PASS src/__tests__/import-table.test.ts
PASS src/__tests__/amplify-dynamodb-table-construct.test.ts
PASS src/__tests__/amplify-table-manager-lambda.test.ts
Tests: 74 passed, 74 total   Snapshots: 46 passed, 46 total
```

### Pre-existing failures — NOT caused by this PR

Both reproduce identically on pristine `main` with this change stashed; please don't attribute them to this PR:

1. `amplify-dynamodb-table-generator.test.ts` fails to compile: `TS2305: Module '@aws-amplify/graphql-transformer-core' has no exported member 'addCfnResourceDependency'`.
2. `npx tsc --noEmit` reports 3 errors, all in files untouched here — `dynamo-model-resource-generator.ts` (same `addCfnResourceDependency`) and `rds-model-resource-generator.ts` (×2, `minimizeRdsVpcEndpoints`).

## Links

Fixes #1047
Refs SIM P489859831
Upstream: aws/aws-cdk#35988
