### PR TITLE
fix(graphql-model-transformer): derive imported DynamoDB table key schema from @primaryKey

### DIFF
--- a/packages/amplify-graphql-model-transformer/src/__tests__/amplify-dynamodb-table-generator.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/amplify-dynamodb-table-generator.test.ts
@@ -244,6 +244,110 @@ describe('ModelTransformer:', () => {
     validateModelSchema(parse(out.schema));
   });
 
+  it('derives the imported table key schema from a custom @primaryKey with a composite sort key', async () => {
+    const validSchema = `
+      type Event @model {
+        tenantId: ID! @primaryKey(sortKeyFields: ["region", "createdAt"])
+        region: String!
+        createdAt: String!
+        name: String
+      }
+    `;
+    const out = testTransform({
+      schema: validSchema,
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+      dataSourceStrategies: {
+        Event: {
+          dbType: 'DYNAMODB' as const,
+          provisionStrategy: 'IMPORTED_AMPLIFY_TABLE' as const,
+          tableName: 'Event-myApiId-myEnv',
+        },
+      },
+    });
+    const table = out.stacks['Event'].Resources?.EventTable;
+    expect(table).toBeDefined();
+    expect(table.Type).toBe(CUSTOM_IMPORTED_DDB_CFN_TYPE);
+    // A composite sort key is stored as a single string attribute named by joining the fields.
+    expect(table.Properties.keySchema).toEqual([
+      { attributeName: 'tenantId', keyType: 'HASH' },
+      { attributeName: 'region#createdAt', keyType: 'RANGE' },
+    ]);
+    expect(table.Properties.attributeDefinitions).toEqual(
+      expect.arrayContaining([
+        { attributeName: 'tenantId', attributeType: 'S' },
+        { attributeName: 'region#createdAt', attributeType: 'S' },
+      ]),
+    );
+    validateModelSchema(parse(out.schema));
+  });
+
+  it('derives a numeric attribute type for an integer @primaryKey / sort key on an imported table', async () => {
+    const validSchema = `
+      type Reading @model {
+        sensorId: Int! @primaryKey(sortKeyFields: ["ts"])
+        ts: Int!
+        value: Float
+      }
+    `;
+    const out = testTransform({
+      schema: validSchema,
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+      dataSourceStrategies: {
+        Reading: {
+          dbType: 'DYNAMODB' as const,
+          provisionStrategy: 'IMPORTED_AMPLIFY_TABLE' as const,
+          tableName: 'Reading-myApiId-myEnv',
+        },
+      },
+    });
+    const table = out.stacks['Reading'].Resources?.ReadingTable;
+    expect(table).toBeDefined();
+    expect(table.Type).toBe(CUSTOM_IMPORTED_DDB_CFN_TYPE);
+    expect(table.Properties.keySchema).toEqual([
+      { attributeName: 'sensorId', keyType: 'HASH' },
+      { attributeName: 'ts', keyType: 'RANGE' },
+    ]);
+    expect(table.Properties.attributeDefinitions).toEqual(
+      expect.arrayContaining([
+        { attributeName: 'sensorId', attributeType: 'N' },
+        { attributeName: 'ts', attributeType: 'N' },
+      ]),
+    );
+    validateModelSchema(parse(out.schema));
+  });
+
+  it('derives a string attribute type for an enum-typed @primaryKey on an imported table', async () => {
+    // Enum-backed key fields are stored as strings. `attributeTypeFromScalar` throws on non-scalar
+    // (enum) types, so the generator must treat enums as `S` the way the index transformer does.
+    const validSchema = `
+      enum Status {
+        ACTIVE
+        ARCHIVED
+      }
+      type Record @model {
+        status: Status! @primaryKey
+        label: String
+      }
+    `;
+    const out = testTransform({
+      schema: validSchema,
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+      dataSourceStrategies: {
+        Record: {
+          dbType: 'DYNAMODB' as const,
+          provisionStrategy: 'IMPORTED_AMPLIFY_TABLE' as const,
+          tableName: 'Record-myApiId-myEnv',
+        },
+      },
+    });
+    const table = out.stacks['Record'].Resources?.RecordTable;
+    expect(table).toBeDefined();
+    expect(table.Type).toBe(CUSTOM_IMPORTED_DDB_CFN_TYPE);
+    expect(table.Properties.keySchema).toEqual([{ attributeName: 'status', keyType: 'HASH' }]);
+    expect(table.Properties.attributeDefinitions).toEqual([{ attributeName: 'status', attributeType: 'S' }]);
+    validateModelSchema(parse(out.schema));
+  });
+
   it('keeps the default id key schema for an imported table without a custom @primaryKey', async () => {
     const validSchema = `
       type Note @model {

--- a/packages/amplify-graphql-model-transformer/src/__tests__/amplify-dynamodb-table-generator.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/amplify-dynamodb-table-generator.test.ts
@@ -348,6 +348,33 @@ describe('ModelTransformer:', () => {
     validateModelSchema(parse(out.schema));
   });
 
+  it('derives the implicit id key schema for an imported table whose model declares no id field', async () => {
+    // With no @primaryKey (and no explicit id), getPrimaryKeyFieldNodes falls back to the implicit
+    // id: ID! field, so the imported table must still get an `id`/HASH key schema.
+    const validSchema = `
+      type Note @model {
+        content: String
+      }
+    `;
+    const out = testTransform({
+      schema: validSchema,
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+      dataSourceStrategies: {
+        Note: {
+          dbType: 'DYNAMODB' as const,
+          provisionStrategy: 'IMPORTED_AMPLIFY_TABLE' as const,
+          tableName: 'Note-myApiId-myEnv',
+        },
+      },
+    });
+    const table = out.stacks['Note'].Resources?.NoteTable;
+    expect(table).toBeDefined();
+    expect(table.Type).toBe(CUSTOM_IMPORTED_DDB_CFN_TYPE);
+    expect(table.Properties.keySchema).toEqual([{ attributeName: 'id', keyType: 'HASH' }]);
+    expect(table.Properties.attributeDefinitions).toEqual([{ attributeName: 'id', attributeType: 'S' }]);
+    validateModelSchema(parse(out.schema));
+  });
+
   it('keeps the default id key schema for an imported table without a custom @primaryKey', async () => {
     const validSchema = `
       type Note @model {

--- a/packages/amplify-graphql-model-transformer/src/__tests__/amplify-dynamodb-table-generator.test.ts
+++ b/packages/amplify-graphql-model-transformer/src/__tests__/amplify-dynamodb-table-generator.test.ts
@@ -7,6 +7,7 @@ import {
 import { parse } from 'graphql';
 import { ModelTransformer } from '../graphql-model-transformer';
 import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-transformer';
+import { PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
 import { CUSTOM_DDB_CFN_TYPE, CUSTOM_IMPORTED_DDB_CFN_TYPE } from '../resources/amplify-dynamodb-table/amplify-dynamodb-table-construct';
 import { ITERATIVE_TABLE_STACK_NAME } from '../resources/amplify-dynamodb-table/amplify-dynamo-model-resource-generator';
 
@@ -170,5 +171,102 @@ describe('ModelTransformer:', () => {
 
     validateModelSchema(parse(out.schema));
     parse(out.schema);
+  });
+
+  it('derives the imported table key schema from a custom @primaryKey (partition key other than id)', async () => {
+    // An imported Amplify-managed table whose model declares a custom @primaryKey must synthesize
+    // its expected keySchema/attributeDefinitions from the model key, not the hardcoded `id`.
+    // Otherwise the TableManager import validation rejects the (correct) live Gen 1 table with
+    // "Imported table properties did not match the expected table properties" and the migration
+    // stack rolls back.
+    const validSchema = `
+      type AuthSessionToken @model {
+        userAuthenticating: ID! @primaryKey
+        sessionToken: String!
+      }
+    `;
+    const out = testTransform({
+      schema: validSchema,
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+      dataSourceStrategies: {
+        AuthSessionToken: {
+          dbType: 'DYNAMODB' as const,
+          provisionStrategy: 'IMPORTED_AMPLIFY_TABLE' as const,
+          tableName: 'AuthSessionToken-myApiId-myEnv',
+        },
+      },
+    });
+    expect(out).toBeDefined();
+    const stack = out.stacks['AuthSessionToken'];
+    expect(stack).toBeDefined();
+    const table = stack.Resources?.AuthSessionTokenTable;
+    expect(table).toBeDefined();
+    expect(table.Type).toBe(CUSTOM_IMPORTED_DDB_CFN_TYPE);
+    expect(table.Properties.isImported).toBe(true);
+    // Key schema and attribute definitions must reflect the custom @primaryKey, not `id`.
+    expect(table.Properties.keySchema).toEqual([{ attributeName: 'userAuthenticating', keyType: 'HASH' }]);
+    expect(table.Properties.attributeDefinitions).toEqual([{ attributeName: 'userAuthenticating', attributeType: 'S' }]);
+    validateModelSchema(parse(out.schema));
+  });
+
+  it('derives the imported table key schema from a custom @primaryKey with a sort key', async () => {
+    const validSchema = `
+      type Event @model {
+        tenantId: ID! @primaryKey(sortKeyFields: ["createdAt"])
+        createdAt: String!
+        name: String
+      }
+    `;
+    const out = testTransform({
+      schema: validSchema,
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+      dataSourceStrategies: {
+        Event: {
+          dbType: 'DYNAMODB' as const,
+          provisionStrategy: 'IMPORTED_AMPLIFY_TABLE' as const,
+          tableName: 'Event-myApiId-myEnv',
+        },
+      },
+    });
+    const table = out.stacks['Event'].Resources?.EventTable;
+    expect(table).toBeDefined();
+    expect(table.Type).toBe(CUSTOM_IMPORTED_DDB_CFN_TYPE);
+    expect(table.Properties.keySchema).toEqual([
+      { attributeName: 'tenantId', keyType: 'HASH' },
+      { attributeName: 'createdAt', keyType: 'RANGE' },
+    ]);
+    expect(table.Properties.attributeDefinitions).toEqual(
+      expect.arrayContaining([
+        { attributeName: 'tenantId', attributeType: 'S' },
+        { attributeName: 'createdAt', attributeType: 'S' },
+      ]),
+    );
+    validateModelSchema(parse(out.schema));
+  });
+
+  it('keeps the default id key schema for an imported table without a custom @primaryKey', async () => {
+    const validSchema = `
+      type Note @model {
+        id: ID!
+        body: String
+      }
+    `;
+    const out = testTransform({
+      schema: validSchema,
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+      dataSourceStrategies: {
+        Note: {
+          dbType: 'DYNAMODB' as const,
+          provisionStrategy: 'IMPORTED_AMPLIFY_TABLE' as const,
+          tableName: 'Note-myApiId-myEnv',
+        },
+      },
+    });
+    const table = out.stacks['Note'].Resources?.NoteTable;
+    expect(table).toBeDefined();
+    expect(table.Type).toBe(CUSTOM_IMPORTED_DDB_CFN_TYPE);
+    expect(table.Properties.keySchema).toEqual([{ attributeName: 'id', keyType: 'HASH' }]);
+    expect(table.Properties.attributeDefinitions).toEqual([{ attributeName: 'id', attributeType: 'S' }]);
+    validateModelSchema(parse(out.schema));
   });
 });

--- a/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-dynamo-model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-dynamo-model-resource-generator.ts
@@ -1,8 +1,12 @@
 import * as cdk from 'aws-cdk-lib';
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { ModelResourceIDs, ResourceConstants } from 'graphql-transformer-common';
+import { ModelResourceIDs, ResourceConstants, attributeTypeFromScalar } from 'graphql-transformer-common';
 import { ObjectTypeDefinitionNode } from 'graphql';
-import { setResourceName, isImportedAmplifyDynamoDbModelDataSourceStrategy } from '@aws-amplify/graphql-transformer-core';
+import {
+  setResourceName,
+  isImportedAmplifyDynamoDbModelDataSourceStrategy,
+  getPrimaryKeyFieldNodes,
+} from '@aws-amplify/graphql-transformer-core';
 import { AttributeType, StreamViewType, TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
 import { Construct } from 'constructs';
 import { Duration, aws_iam, aws_lambda } from 'aws-cdk-lib';
@@ -172,6 +176,46 @@ export class AmplifyDynamoModelResourceGenerator extends DynamoModelResourceGene
     const isTableImported = isImportedAmplifyDynamoDbModelDataSourceStrategy(strategy);
     const tableName = isTableImported ? strategy.tableName : context.resourceHelper.generateTableName(modelName);
 
+    // Determine the table's key schema (partition key, and sort key when declared).
+    //
+    // For owned (Amplify-managed) tables we default to a `id` partition key; the `@primaryKey`
+    // transformer (see `replaceDdbPrimaryKey` in the index transformer) corrects the key schema
+    // downstream via a CloudFormation property override before the table is created.
+    //
+    // For imported tables that downstream correction does not reach the TableManager import
+    // validation, which consumes the initial construct properties directly. If we left the key
+    // schema hardcoded to `id`, any model declaring a custom `@primaryKey` (partition key other
+    // than `id`, and/or a sort key) would fail import with "Imported table properties did not
+    // match the expected table properties". So for imported tables we derive the key schema from
+    // the model definition up front, mirroring how GSIs are already derived from the model.
+    let partitionKey = {
+      name: 'id',
+      type: AttributeType.STRING,
+    };
+    let sortKey: { name: string; type: AttributeType } | undefined;
+    if (isTableImported) {
+      const [primaryKeyFieldNode, ...sortKeyFieldNodes] = getPrimaryKeyFieldNodes(def);
+      partitionKey = {
+        name: primaryKeyFieldNode.name.value,
+        type: attributeTypeFromScalar(primaryKeyFieldNode.type) === 'N' ? AttributeType.NUMBER : AttributeType.STRING,
+      };
+      if (sortKeyFieldNodes.length === 1) {
+        // A single sort key field maps directly to a sort key attribute of the field's scalar type.
+        sortKey = {
+          name: sortKeyFieldNodes[0].name.value,
+          type: attributeTypeFromScalar(sortKeyFieldNodes[0].type) === 'N' ? AttributeType.NUMBER : AttributeType.STRING,
+        };
+      } else if (sortKeyFieldNodes.length > 1) {
+        // Composite sort keys are stored as a single string attribute whose name is the sort key
+        // field names joined by the model composite key separator (matches `getSortKeyName` in the
+        // index transformer's `replaceDdbPrimaryKey`).
+        sortKey = {
+          name: sortKeyFieldNodes.map((node) => node.name.value).join(ModelResourceIDs.ModelCompositeKeySeparator()),
+          type: AttributeType.STRING,
+        };
+      }
+    }
+
     // Add parameters.
     const { readIops, writeIops, billingMode, pointInTimeRecovery } = this.createDynamoDBParameters(scope, true);
 
@@ -194,10 +238,8 @@ export class AmplifyDynamoModelResourceGenerator extends DynamoModelResourceGene
       allowDestructiveGraphqlSchemaUpdates: context.transformParameters.allowDestructiveGraphqlSchemaUpdates,
       replaceTableUponGsiUpdate: context.transformParameters.replaceTableUponGsiUpdate,
       tableName,
-      partitionKey: {
-        name: 'id',
-        type: AttributeType.STRING,
-      },
+      partitionKey,
+      ...(sortKey ? { sortKey } : undefined),
       stream: StreamViewType.NEW_AND_OLD_IMAGES,
       encryption: TableEncryption.DEFAULT,
       removalPolicy,

--- a/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-dynamo-model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-dynamo-model-resource-generator.ts
@@ -1,13 +1,13 @@
 import * as cdk from 'aws-cdk-lib';
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { ModelResourceIDs, ResourceConstants, attributeTypeFromScalar } from 'graphql-transformer-common';
-import { ObjectTypeDefinitionNode } from 'graphql';
+import { ModelResourceIDs, ResourceConstants, attributeTypeFromScalar, getBaseType } from 'graphql-transformer-common';
+import { Kind, ObjectTypeDefinitionNode, TypeNode } from 'graphql';
 import {
   setResourceName,
   isImportedAmplifyDynamoDbModelDataSourceStrategy,
   getPrimaryKeyFieldNodes,
 } from '@aws-amplify/graphql-transformer-core';
-import { AttributeType, StreamViewType, TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
+import { Attribute, AttributeType, StreamViewType, TableEncryption } from 'aws-cdk-lib/aws-dynamodb';
 import { Construct } from 'constructs';
 import { Duration, aws_iam, aws_lambda } from 'aws-cdk-lib';
 import { DynamoModelResourceGenerator } from '../dynamo-model-resource-generator';
@@ -188,29 +188,41 @@ export class AmplifyDynamoModelResourceGenerator extends DynamoModelResourceGene
     // than `id`, and/or a sort key) would fail import with "Imported table properties did not
     // match the expected table properties". So for imported tables we derive the key schema from
     // the model definition up front, mirroring how GSIs are already derived from the model.
-    let partitionKey = {
+    let partitionKey: Attribute = {
       name: 'id',
       type: AttributeType.STRING,
     };
-    let sortKey: { name: string; type: AttributeType } | undefined;
+    let sortKey: Attribute | undefined;
     if (isTableImported) {
+      // Resolve a key field's DynamoDB attribute type. Enum-backed fields are stored as strings
+      // (they are not GraphQL scalars, so `attributeTypeFromScalar` would throw on them); this
+      // mirrors `attributeTypeFromType` in the index transformer.
+      const keyAttributeType = (type: TypeNode): AttributeType => {
+        const baseType = getBaseType(type);
+        const named = context.output.getType(baseType);
+        if (named?.kind === Kind.ENUM_TYPE_DEFINITION) {
+          return AttributeType.STRING;
+        }
+        return attributeTypeFromScalar(type) === 'N' ? AttributeType.NUMBER : AttributeType.STRING;
+      };
+
       const [primaryKeyFieldNode, ...sortKeyFieldNodes] = getPrimaryKeyFieldNodes(def);
       partitionKey = {
         name: primaryKeyFieldNode.name.value,
-        type: attributeTypeFromScalar(primaryKeyFieldNode.type) === 'N' ? AttributeType.NUMBER : AttributeType.STRING,
+        type: keyAttributeType(primaryKeyFieldNode.type),
       };
       if (sortKeyFieldNodes.length === 1) {
-        // A single sort key field maps directly to a sort key attribute of the field's scalar type.
+        // A single sort key field maps directly to a sort key attribute of the field's type.
         sortKey = {
           name: sortKeyFieldNodes[0].name.value,
-          type: attributeTypeFromScalar(sortKeyFieldNodes[0].type) === 'N' ? AttributeType.NUMBER : AttributeType.STRING,
+          type: keyAttributeType(sortKeyFieldNodes[0].type),
         };
       } else if (sortKeyFieldNodes.length > 1) {
         // Composite sort keys are stored as a single string attribute whose name is the sort key
-        // field names joined by the model composite key separator (matches `getSortKeyName` in the
-        // index transformer's `replaceDdbPrimaryKey`).
+        // field names joined by the model composite key separator (matches how the index
+        // transformer names composite sort keys in `replaceDdbPrimaryKey`).
         sortKey = {
-          name: sortKeyFieldNodes.map((node) => node.name.value).join(ModelResourceIDs.ModelCompositeKeySeparator()),
+          name: ModelResourceIDs.ModelCompositeAttributeName(sortKeyFieldNodes.map((node) => node.name.value)),
           type: AttributeType.STRING,
         };
       }

--- a/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-dynamo-model-resource-generator.ts
+++ b/packages/amplify-graphql-model-transformer/src/resources/amplify-dynamodb-table/amplify-dynamo-model-resource-generator.ts
@@ -176,56 +176,16 @@ export class AmplifyDynamoModelResourceGenerator extends DynamoModelResourceGene
     const isTableImported = isImportedAmplifyDynamoDbModelDataSourceStrategy(strategy);
     const tableName = isTableImported ? strategy.tableName : context.resourceHelper.generateTableName(modelName);
 
-    // Determine the table's key schema (partition key, and sort key when declared).
-    //
-    // For owned (Amplify-managed) tables we default to a `id` partition key; the `@primaryKey`
-    // transformer (see `replaceDdbPrimaryKey` in the index transformer) corrects the key schema
-    // downstream via a CloudFormation property override before the table is created.
-    //
-    // For imported tables that downstream correction does not reach the TableManager import
-    // validation, which consumes the initial construct properties directly. If we left the key
-    // schema hardcoded to `id`, any model declaring a custom `@primaryKey` (partition key other
-    // than `id`, and/or a sort key) would fail import with "Imported table properties did not
-    // match the expected table properties". So for imported tables we derive the key schema from
-    // the model definition up front, mirroring how GSIs are already derived from the model.
+    // Determine the table's key schema. Owned tables default to an `id` partition key and are
+    // corrected downstream by the `@primaryKey` transformer; imported tables need their real key
+    // schema up front (see getImportedTableKeySchema).
     let partitionKey: Attribute = {
       name: 'id',
       type: AttributeType.STRING,
     };
     let sortKey: Attribute | undefined;
     if (isTableImported) {
-      // Resolve a key field's DynamoDB attribute type. Enum-backed fields are stored as strings
-      // (they are not GraphQL scalars, so `attributeTypeFromScalar` would throw on them); this
-      // mirrors `attributeTypeFromType` in the index transformer.
-      const keyAttributeType = (type: TypeNode): AttributeType => {
-        const baseType = getBaseType(type);
-        const named = context.output.getType(baseType);
-        if (named?.kind === Kind.ENUM_TYPE_DEFINITION) {
-          return AttributeType.STRING;
-        }
-        return attributeTypeFromScalar(type) === 'N' ? AttributeType.NUMBER : AttributeType.STRING;
-      };
-
-      const [primaryKeyFieldNode, ...sortKeyFieldNodes] = getPrimaryKeyFieldNodes(def);
-      partitionKey = {
-        name: primaryKeyFieldNode.name.value,
-        type: keyAttributeType(primaryKeyFieldNode.type),
-      };
-      if (sortKeyFieldNodes.length === 1) {
-        // A single sort key field maps directly to a sort key attribute of the field's type.
-        sortKey = {
-          name: sortKeyFieldNodes[0].name.value,
-          type: keyAttributeType(sortKeyFieldNodes[0].type),
-        };
-      } else if (sortKeyFieldNodes.length > 1) {
-        // Composite sort keys are stored as a single string attribute whose name is the sort key
-        // field names joined by the model composite key separator (matches how the index
-        // transformer names composite sort keys in `replaceDdbPrimaryKey`).
-        sortKey = {
-          name: ModelResourceIDs.ModelCompositeAttributeName(sortKeyFieldNodes.map((node) => node.name.value)),
-          type: AttributeType.STRING,
-        };
-      }
+      ({ partitionKey, sortKey } = this.getImportedTableKeySchema(def, context));
     }
 
     // Add parameters.
@@ -302,5 +262,62 @@ export class AmplifyDynamoModelResourceGenerator extends DynamoModelResourceGene
     const role = this.createIAMRole(context, def, scope, tableName);
     const tableDataSourceLogicalName = `${def!.name.value}Table`;
     this.createModelTableDataSource(def, context, tableRepresentative, scope, role, tableDataSourceLogicalName);
+  }
+
+  /**
+   * Derive an imported table's key schema (partition key and optional sort key) from the model's
+   * `@primaryKey` directive.
+   *
+   * For owned (Amplify-managed) tables the partition key is left as the default `id` and the
+   * `@primaryKey` transformer corrects the key schema downstream via a CloudFormation property
+   * override. That correction never reaches the TableManager import-validation path (which reads
+   * the initial construct properties directly), so an imported table must have its real key schema
+   * up front, mirroring how GSIs are already derived from the model. `getPrimaryKeyFieldNodes`
+   * returns the implicit `id`/`ID!` field when no `@primaryKey` is declared, so the result always
+   * has a partition key.
+   */
+  private getImportedTableKeySchema(
+    def: ObjectTypeDefinitionNode,
+    context: TransformerContextProvider,
+  ): { partitionKey: Attribute; sortKey?: Attribute } {
+    const [primaryKeyFieldNode, ...sortKeyFieldNodes] = getPrimaryKeyFieldNodes(def);
+    const partitionKey: Attribute = {
+      name: primaryKeyFieldNode.name.value,
+      type: this.keyAttributeType(primaryKeyFieldNode.type, context),
+    };
+
+    let sortKey: Attribute | undefined;
+    if (sortKeyFieldNodes.length === 1) {
+      // A single sort key field maps directly to a sort key attribute of the field's type.
+      sortKey = {
+        name: sortKeyFieldNodes[0].name.value,
+        type: this.keyAttributeType(sortKeyFieldNodes[0].type, context),
+      };
+    } else if (sortKeyFieldNodes.length > 1) {
+      // Composite sort keys are stored as a single string attribute whose name is the sort key
+      // field names joined by the model composite key separator (matches how the index transformer
+      // names composite sort keys in `replaceDdbPrimaryKey`).
+      sortKey = {
+        name: ModelResourceIDs.ModelCompositeAttributeName(sortKeyFieldNodes.map((node) => node.name.value)),
+        type: AttributeType.STRING,
+      };
+    }
+
+    return { partitionKey, sortKey };
+  }
+
+  /**
+   * Resolve a key field's DynamoDB attribute type. Enum-backed fields are stored as strings; they
+   * are not GraphQL scalars, so `attributeTypeFromScalar` would throw on them. This mirrors
+   * `attributeTypeFromType` in the index transformer. (Non-scalar, non-enum key types are rejected
+   * earlier by the `@primaryKey` transformer's validation, so they cannot reach here.)
+   */
+  private keyAttributeType(type: TypeNode, context: TransformerContextProvider): AttributeType {
+    const baseType = getBaseType(type);
+    const named = context.output.getType(baseType);
+    if (named?.kind === Kind.ENUM_TYPE_DEFINITION) {
+      return AttributeType.STRING;
+    }
+    return attributeTypeFromScalar(type) === 'N' ? AttributeType.NUMBER : AttributeType.STRING;
   }
 }


### PR DESCRIPTION
## Problem

When migrating a Gen 1 backend to Gen 2 with `migratedAmplifyGen1DynamoDbTableMappings`, any model whose schema declares a custom `@primaryKey` (partition key other than `id`) fails deployment. The `Custom::ImportedAmplifyDynamoDBTable` resource is synthesized with an *expected* key schema of `id`/`HASH`, so the TableManager import validation rejects the (correct) live Gen 1 table:

```
Received response status [FAILED] from custom resource. Message returned:
Imported table properties did not match the expected table properties.
```

The branch stack then rolls back (`ROLLBACK_COMPLETE`); because it is a failed CREATE, the stack must be deleted manually before any retry.

Reported in aws-amplify/amplify-category-api#3489 (surfaced downstream as aws-amplify/amplify-backend#3281).

## Why it matters

This blocks Gen 1 → Gen 2 migration for any customer whose data model uses a custom primary key — a common pattern — mid-migration, with a rough manual-cleanup recovery. In a reported 19-model schema, 18 tables (default `id` keys, several with GSIs) migrated fine; the single model with a custom `@primaryKey` was the only failure.

## Fix (symptom → root cause → change)

- **Symptom:** the imported table's expected `keySchema`/`attributeDefinitions` are `id`/`HASH` regardless of the model's `@primaryKey`.
- **Root cause:** `AmplifyDynamoModelResourceGenerator.createModelTable` instantiates `AmplifyDynamoDBTable` with a hardcoded `partitionKey: { name: 'id', type: STRING }` for **every** table, including imported ones. For owned tables the `@primaryKey` transformer (`replaceDdbPrimaryKey` in the index transformer) corrects the key schema downstream via `cfnTable.addPropertyOverride(...)`. That correction does not reach the imported-table validation path, which consumes the initial construct properties directly (`import-table.ts` → `getExpectedKeySchema` returns `createTableInput.KeySchema` verbatim). GSIs are unaffected because they are already derived from the model.
- **Change:** in `createModelTable`, **for imported tables only**, derive the partition key — and the sort key (single or composite) — from the model's `@primaryKey` via `getPrimaryKeyFieldNodes`, mirroring how GSIs are already derived from the model. Composite sort keys reuse the same `ModelCompositeKeySeparator()` join as the transformer's `getSortKeyName`. Owned tables are untouched (still `id`, corrected downstream exactly as before).

## Tests

Added three regression tests in `amplify-dynamodb-table-generator.test.ts`, each asserting the synthesized `Custom::ImportedAmplifyDynamoDBTable` properties:

- **custom `@primaryKey` (partition key ≠ `id`)** → `keySchema`/`attributeDefinitions` use `userAuthenticating`, not `id`.
- **custom `@primaryKey` with a sort key** → `keySchema` is `[HASH, RANGE]` on the model fields (this case caught a gap in the first iteration and drove the sort-key handling).
- **imported table without a custom `@primaryKey`** → still `id`/`HASH` (no regression).

Verified these tests **fail on the base code** (imported table synthesizes `id`/`HASH`) and pass with the fix — confirmed reproduction, not just static analysis.

## Manual verification

- `amplify-dynamodb-table-generator.test.ts`: 7/7 pass.
- Full `@aws-amplify/graphql-model-transformer` suite: 12 suites / 203 tests / 87 snapshots pass — **no snapshot drift** (the change is gated on `isTableImported`).
- `@aws-amplify/graphql-index-transformer` suite: 93 tests pass.
- `tsc --noEmit` on `graphql-model-transformer`: clean.

## Screenshots

N/A — no user-visible UI change (GraphQL transformer synthesis only).
