### PR TITLE
fix: align filter input type name casing for index and relational query fields

### DIFF
--- a/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
@@ -329,6 +329,39 @@ test('@index with multiple sort keys adds a query field and GSI correctly', () =
   expect(queryField.arguments[5].type.name.value).toEqual('String');
 });
 
+test('@index query field filter input type name is PascalCased for a lowercase-first model name (issue #3267)', () => {
+  const inputSchema = `
+    type userPrivateSyncItem @model {
+      id: ID!
+      dataType: String! @index(name: "byDataType", queryField: "userPrivateSyncItemsByDataType")
+    }`;
+  const out = testTransform({
+    schema: inputSchema,
+    transformers: [new ModelTransformer(), new IndexTransformer()],
+  });
+  const schema = parse(out.schema);
+
+  validateModelSchema(schema);
+
+  const expectedFilterName = 'ModelUserPrivateSyncItemFilterInput';
+  const queryType = schema.definitions.find((def: any) => def.name && def.name.value === 'Query') as any;
+
+  const listField = queryType.fields.find((f: any) => f.name && f.name.value === 'listUserPrivateSyncItems');
+  const listFilterArg = listField.arguments.find((a: any) => a.name.value === 'filter');
+  expect(listFilterArg.type.name.value).toEqual(expectedFilterName);
+
+  const queryField = queryType.fields.find((f: any) => f.name && f.name.value === 'userPrivateSyncItemsByDataType');
+  const gsiFilterArg = queryField.arguments.find((a: any) => a.name.value === 'filter');
+  // Before the fix this was 'ModeluserPrivateSyncItemFilterInput', mismatching the client-sent variable type.
+  expect(gsiFilterArg.type.name.value).toEqual(expectedFilterName);
+
+  const filterInputNames = schema.definitions
+    .filter((def: any) => def.kind === 'InputObjectTypeDefinition' && /PrivateSyncItemFilterInput$/.test(def.name.value))
+    .map((def: any) => def.name.value);
+  expect(filterInputNames).toContain(expectedFilterName);
+  expect(filterInputNames).not.toContain('ModeluserPrivateSyncItemFilterInput');
+});
+
 test('@index with a single sort key adds a query field and GSI correctly', () => {
   const inputSchema = `
     type Test @model {

--- a/packages/amplify-graphql-index-transformer/src/schema.ts
+++ b/packages/amplify-graphql-index-transformer/src/schema.ts
@@ -32,7 +32,7 @@ import {
   withNamedNodeNamed,
   wrapNonNull,
 } from 'graphql-transformer-common';
-import { InvalidDirectiveError } from '@aws-amplify/graphql-transformer-core';
+import { getFilterInputName, InvalidDirectiveError } from '@aws-amplify/graphql-transformer-core';
 import { IndexDirectiveConfiguration, PrimaryKeyDirectiveConfiguration } from './types';
 import { lookupResolverName } from './utils';
 
@@ -350,8 +350,18 @@ export function ensureQueryField(config: IndexDirectiveConfiguration, ctx: Trans
   }
 
   const queryFieldObj = makeConnectionField(queryField, object.name.value, args, directives);
+  // makeConnectionField derives the `filter` arg type from the raw model name; the model
+  // transformer and generated client use the PascalCased getFilterInputName. Align to it so
+  // models whose names don't start with an uppercase letter don't get a mismatched type name.
+  const filterInputName = getFilterInputName(object.name.value);
+  const queryFieldWithFilter: FieldDefinitionNode = {
+    ...queryFieldObj,
+    arguments: queryFieldObj.arguments!.map((arg) =>
+      arg.name.value === 'filter' ? { ...arg, type: makeNamedType(filterInputName) } : arg,
+    ),
+  };
 
-  ctx.output.addQueryFields([queryFieldObj]);
+  ctx.output.addQueryFields([queryFieldWithFilter]);
   ensureModelSortDirectionEnum(ctx);
   generateFilterInputs(config, ctx);
   generateModelXConnectionType(config, ctx);
@@ -406,7 +416,7 @@ function generateFilterInputs(config: IndexDirectiveConfiguration, ctx: Transfor
 function makeModelXFilterInputObject(config: IndexDirectiveConfiguration, ctx: TransformerContextProvider): InputObjectTypeDefinitionNode {
   const supportsConditions = true;
   const { object } = config;
-  const name = ModelResourceIDs.ModelFilterInputTypeName(object.name.value);
+  const name = getFilterInputName(object.name.value);
   const fields = object
     .fields!.filter((field: FieldDefinitionNode) => {
       const fieldType = ctx.output.getType(getBaseType(field.type));

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-many-transformer.test.ts
@@ -289,6 +289,39 @@ test('has many query case', () => {
   expect((relatedField.type as any).name.value).toEqual('ModelTest1Connection');
 });
 
+test('@hasMany connection filter input type name is PascalCased for a lowercase-first related model name (issue #3267)', () => {
+  const inputSchema = `
+    type Blog @model {
+      id: ID!
+      email: String!
+      otherParts: [otherPart] @hasMany(fields: ["id", "email"])
+    }
+
+    type otherPart @model {
+      id: ID! @primaryKey(sortKeyFields: ["email"])
+      friendID: ID!
+      email: String!
+    }`;
+  const out = testTransform({
+    schema: inputSchema,
+    transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new HasManyTransformer()],
+  });
+  const schema = parse(out.schema);
+  validateModelSchema(schema);
+
+  const blogType = schema.definitions.find((def: any) => def.name && def.name.value === 'Blog') as any;
+  const connectionField = blogType.fields.find((f: any) => f.name.value === 'otherParts');
+  const filterArg = connectionField.arguments.find((a: any) => a.name.value === 'filter');
+  // Before the fix this was 'ModelotherPartFilterInput', mismatching the client-sent variable type.
+  expect(filterArg.type.name.value).toEqual('ModelOtherPartFilterInput');
+
+  const filterInputNames = schema.definitions
+    .filter((def: any) => def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION && /OtherPartFilterInput$/i.test(def.name.value))
+    .map((def: any) => def.name.value);
+  expect(filterInputNames).toContain('ModelOtherPartFilterInput');
+  expect(filterInputNames).not.toContain('ModelotherPartFilterInput');
+});
+
 test('bidirectional has many query case', () => {
   const inputSchema = `
     type Post @model {

--- a/packages/amplify-graphql-relational-transformer/src/schema.ts
+++ b/packages/amplify-graphql-relational-transformer/src/schema.ts
@@ -33,7 +33,7 @@ import {
   toUpper,
   wrapNonNull,
 } from 'graphql-transformer-common';
-import { getSortKeyFieldNames, getSubscriptionFilterInputName } from '@aws-amplify/graphql-transformer-core';
+import { getFilterInputName, getSortKeyFieldNames, getSubscriptionFilterInputName } from '@aws-amplify/graphql-transformer-core';
 import { WritableDraft } from 'immer/dist/types/types-external';
 import {
   BelongsToDirectiveConfiguration,
@@ -451,7 +451,7 @@ const getFilterConnectionInputFieldsWithConnectionField = (
 const makeModelConnectionField = (config: HasManyDirectiveConfiguration): FieldDefinitionNode => {
   const { field, fields, indexName, relatedType, relatedTypeIndex } = config;
   const args = [
-    makeInputValueDefinition('filter', makeNamedType(ModelResourceIDs.ModelFilterInputTypeName(relatedType.name.value))),
+    makeInputValueDefinition('filter', makeNamedType(getFilterInputName(relatedType.name.value))),
     makeInputValueDefinition('sortDirection', makeNamedType('ModelSortDirection')),
     makeInputValueDefinition('limit', makeNamedType('Int')),
     makeInputValueDefinition('nextToken', makeNamedType('String')),
@@ -493,7 +493,7 @@ const makeModelXFilterInputObject = (
   ctx: TransformerContextProvider,
 ): InputObjectTypeDefinitionNode => {
   const { relatedType } = config;
-  const name = ModelResourceIDs.ModelFilterInputTypeName(relatedType.name.value);
+  const name = getFilterInputName(relatedType.name.value);
   const fields = relatedType
     .fields!.filter((field: FieldDefinitionNode) => {
       const fieldType = ctx.output.getType(getBaseType(field.type));


### PR DESCRIPTION
#### Description of changes

Amplify Data models whose GraphQL type name does not begin with an uppercase letter (e.g. a model declared as `userPrivateSyncItem`) produce a schema whose secondary-index (`@index` `queryField`) and `@hasMany` connection query fields declare a `filter` argument type that the generated client never sends. At runtime AppSync rejects the query with:

```
Validation error of type VariableTypeMismatch: Variable type 'ModelUserPrivateSyncItemFilterInput'
doesn't match expected type 'ModeluserPrivateSyncItemFilterInput' @ 'userPrivateSyncItemsByDataType'
```

**Root cause:** two helpers name the `Model<name>FilterInput` type with different casing rules:

- The **model transformer** (regular `list` query) uses `getFilterInputName` → `toPascalCase(['Model', name, 'FilterInput'])`, which capitalizes the model name → `ModelUserPrivateSyncItemFilterInput`.
- The **index transformer** (GSI query field) and the **relational transformer** (`@hasMany` connection field) used `ModelResourceIDs.ModelFilterInputTypeName(name)`, which is a raw `` `Model${name}FilterInput` `` with no capitalization → `ModeluserPrivateSyncItemFilterInput`.

The generated client (`@aws-amplify/data-schema`) PascalCases the model name, matching the model transformer. So for a lowercase-first model name the base `list` filter type matches the client, but the GSI / `@hasMany` filter type does not — hence the mismatch on those fields only.

**Fix:** align the index and relational transformers to the same `getFilterInputName` helper the model transformer uses, so the filter input type name is generated consistently.

- `packages/amplify-graphql-index-transformer/src/schema.ts`
  - `makeModelXFilterInputObject` now creates the filter input type via `getFilterInputName(object.name.value)`.
  - `ensureQueryField` aligns the GSI query field's `filter` argument type to the same name.
- `packages/amplify-graphql-relational-transformer/src/schema.ts`
  - `makeModelConnectionField` and `makeModelXFilterInputObject` now use `getFilterInputName(relatedType.name.value)`.

For model names that already start with an uppercase letter, `getFilterInputName` returns a string identical to the previous `ModelResourceIDs.ModelFilterInputTypeName` output, so there is no change for the common case (confirmed by unchanged snapshots). The shared `ModelResourceIDs.ModelFilterInputTypeName` helper is intentionally left untouched, since it is used by other code paths; only the two affected transformers are changed.

##### CDK / CloudFormation Parameters Changed

None. This only changes a generated GraphQL type name (and only for model names that do not begin with an uppercase letter).

#### Issue #, if available

Fixes aws-amplify/amplify-backend#3267

#### Description of how you validated changes

- Added regression unit tests using a lowercase-first model name:
  - `amplify-graphql-index-transformer.test.ts` — asserts the GSI query field and the `list` query field both reference `ModelUserPrivateSyncItemFilterInput`, and no `ModeluserPrivateSyncItemFilterInput` type is emitted.
  - `amplify-graphql-has-many-transformer.test.ts` — asserts the `@hasMany` connection field's `filter` arg is `ModelOtherPartFilterInput` (related model `otherPart`), and no lowercase variant is emitted.
- `yarn build` + `yarn test` on both affected packages:
  - index transformer: 94/94 tests, 30/30 snapshots pass (no snapshot churn).
  - relational transformer: 195/195 tests, 126/126 snapshots pass (no snapshot churn).
- Ran `eslint` on the four changed files: no new lint findings introduced by this change. Pre-existing lint issues in these files (jsdoc, `no-shadow`, `max-depth`, function length, etc.) are unrelated to this fix and left as-is per the repo's iterative-lint policy.
- Not validated against a live AppSync deployment; verification is at the transformer/schema level.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes (for the two affected packages)
- [ ] E2E test run linked
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced) — n/a
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies — n/a
- [x] Any CDK or CloudFormation parameter changes are called out explicitly (none)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
