### PR TITLE
fix(graphql-auth-transformer): match admin roles on the assumed-role name segment of the caller ARN

### DIFF
--- a/.changeset/admin-role-arn-matching.md
+++ b/.changeset/admin-role-arn-matching.md
@@ -1,0 +1,10 @@
+---
+'@aws-amplify/graphql-auth-transformer': patch
+'@aws-amplify/amplify-category-api': patch
+---
+
+fix: match admin roles on the assumed-role name segment of the caller ARN
+
+Admin-role matching for IAM-authorized GraphQL APIs is now anchored to the caller's assumed-role name, so an admin role name that appears elsewhere in the caller ARN no longer grants admin access. As part of this, a function granted API access is matched by its Lambda execution role name rather than its function name.
+
+After upgrading, run `amplify push` to regenerate the resolvers; until then existing deployments keep their current behavior. A function whose execution role name cannot be resolved is not granted admin access and a warning naming it is printed — adding that role name to `adminRoleNames` in `custom-roles.json` restores access.

--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/utils.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/utils.test.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
-import { $TSContext, CloudformationProviderFacade, pathManager, JSONUtilities } from '@aws-amplify/amplify-cli-core';
+import { $TSContext, CloudformationProviderFacade, pathManager, JSONUtilities, readCFNTemplate } from '@aws-amplify/amplify-cli-core';
+import { printer } from '@aws-amplify/amplify-prompts';
 import { mergeUserConfigWithTransformOutput, writeDeploymentToDisk, getAdminRoles } from '../../graphql-transformer/utils';
 import { TransformerProjectConfig } from '../../graphql-transformer/cdk-compat/project-config';
 import { DeploymentResources } from '../../graphql-transformer/cdk-compat/deployment-resources';
@@ -10,8 +11,12 @@ jest.mock('@aws-amplify/amplify-cli-core');
 
 const fs_mock = fs as jest.Mocked<typeof fs>;
 const prePushCfnTemplateModifier_mock = jest.fn();
+const printerWarn_mock = jest.fn();
+const readCFNTemplate_mock = readCFNTemplate as unknown as jest.Mock;
+const JSONUtilities_mock = JSONUtilities as jest.Mocked<typeof JSONUtilities>;
 
 CloudformationProviderFacade.prePushCfnTemplateModifier = prePushCfnTemplateModifier_mock;
+printer.warn = printerWarn_mock;
 
 fs_mock.readdirSync.mockReturnValue([]);
 
@@ -333,6 +338,121 @@ describe('graphql transformer utils', () => {
       fs_mock.existsSync.mockReturnValueOnce(true);
       const adminRoles = await getAdminRoles(mockContext, 'test');
       expect(adminRoles).toEqual([testRole]);
+    });
+  });
+
+  describe('admin roles for functions granted api access', () => {
+    const FUNCTION_TEMPLATE_FILE = 'myFunc-cloudformation-template.json';
+    const EXECUTION_ROLE_NAME = 'myAppLambdaRoleabc123';
+
+    const buildFunctionTemplate = (roleName: string): any => ({
+      Conditions: { ShouldNotCreateEnvResources: { 'Fn::Equals': [{ Ref: 'env' }, 'NONE'] } },
+      Resources: {
+        LambdaExecutionRole: {
+          Type: 'AWS::IAM::Role',
+          Properties: {
+            RoleName: { 'Fn::If': ['ShouldNotCreateEnvResources', roleName, { 'Fn::Join': ['', [roleName, '-', { Ref: 'env' }]] }] },
+          },
+        },
+      },
+    });
+
+    const buildContext = (envName: string, output?: Record<string, string>): $TSContext =>
+      ({
+        amplify: {
+          getEnvInfo: () => ({ envName }),
+          getResourceStatus: () => ({
+            allResources: [{ resourceName: 'myFunc', dependsOn: [{ resourceName: 'test' }], output }],
+            resourcesToBeDeleted: [],
+          }),
+        },
+      } as unknown as $TSContext);
+
+    beforeEach(() => {
+      printerWarn_mock.mockClear();
+      readCFNTemplate_mock.mockReset();
+      fs_mock.existsSync.mockReset();
+      fs_mock.existsSync.mockImplementation((filePath) => String(filePath).endsWith(FUNCTION_TEMPLATE_FILE));
+    });
+
+    it('uses the execution role name published by the deployed function stack', async () => {
+      const context = buildContext('test', { LambdaExecutionRole: `${EXECUTION_ROLE_NAME}-test` });
+      const adminRoles = await getAdminRoles(context, 'test');
+      expect(adminRoles).toEqual([`${EXECUTION_ROLE_NAME}-test`]);
+      expect(readCFNTemplate_mock).not.toHaveBeenCalled();
+    });
+
+    it('resolves the execution role name from the local template when the function is not deployed yet', async () => {
+      readCFNTemplate_mock.mockReturnValueOnce({ cfnTemplate: buildFunctionTemplate(EXECUTION_ROLE_NAME), templateFormat: 'json' });
+      const adminRoles = await getAdminRoles(buildContext('test'), 'test');
+      expect(adminRoles).toEqual([`${EXECUTION_ROLE_NAME}-test`]);
+    });
+
+    it('resolves the unsuffixed execution role name when the env does not create env specific resources', async () => {
+      readCFNTemplate_mock.mockReturnValueOnce({ cfnTemplate: buildFunctionTemplate(EXECUTION_ROLE_NAME), templateFormat: 'json' });
+      const adminRoles = await getAdminRoles(buildContext('NONE'), 'test');
+      expect(adminRoles).toEqual([EXECUTION_ROLE_NAME]);
+    });
+
+    it('warns and grants no access when the execution role name cannot be resolved', async () => {
+      readCFNTemplate_mock.mockReturnValueOnce({ cfnTemplate: { Resources: {} }, templateFormat: 'json' });
+      const adminRoles = await getAdminRoles(buildContext('test'), 'test');
+      expect(adminRoles).toEqual([]);
+      expect(printerWarn_mock).toHaveBeenCalledWith(expect.stringContaining('myFunc'));
+    });
+
+    it('does not resolve a role name guarded by a condition other than the env condition', async () => {
+      const cfnTemplate = buildFunctionTemplate(EXECUTION_ROLE_NAME);
+      cfnTemplate.Resources.LambdaExecutionRole.Properties.RoleName['Fn::If'][0] = 'SomeOtherCondition';
+      readCFNTemplate_mock.mockReturnValueOnce({ cfnTemplate, templateFormat: 'json' });
+      const adminRoles = await getAdminRoles(buildContext('test'), 'test');
+      expect(adminRoles).toEqual([]);
+      expect(printerWarn_mock).toHaveBeenCalledWith(expect.stringContaining('myFunc'));
+    });
+
+    it('never grants admin access to the deployed function name, which appears only in the session name segment', async () => {
+      readCFNTemplate_mock.mockReturnValueOnce({ cfnTemplate: buildFunctionTemplate(EXECUTION_ROLE_NAME), templateFormat: 'json' });
+      const adminRoles = await getAdminRoles(buildContext('test'), 'test');
+      expect(adminRoles).not.toContain('myFunc-test');
+      expect(adminRoles).not.toContain('myFunc');
+    });
+  });
+
+  describe('validate admin role names from custom-roles.json', () => {
+    const mockContext = {
+      amplify: {
+        getEnvInfo: () => ({ envName: 'test' }),
+        getResourceStatus: () => ({ allResources: [], resourcesToBeDeleted: [] }),
+      },
+    } as unknown as $TSContext;
+
+    beforeEach(() => {
+      printerWarn_mock.mockClear();
+      fs_mock.existsSync.mockReset();
+      fs_mock.existsSync.mockImplementation((filePath) => String(filePath).endsWith('custom-roles.json'));
+    });
+
+    it('ignores an iam role arn, which never appears in a caller identity', async () => {
+      const iamRoleArn = 'arn:aws:iam::123456789012:role/MyAdminRole';
+      JSONUtilities_mock.readJson.mockReturnValueOnce({ adminRoleNames: [iamRoleArn, 'MyOtherRole'] });
+      const adminRoles = await getAdminRoles(mockContext, 'test');
+      expect(adminRoles).toEqual(['MyOtherRole']);
+      expect(printerWarn_mock).toHaveBeenCalledWith(expect.stringContaining(iamRoleArn));
+    });
+
+    it('reduces a fully qualified assumed-role arn to its role name segments', async () => {
+      JSONUtilities_mock.readJson.mockReturnValueOnce({ adminRoleNames: 'arn:aws:sts::123456789012:assumed-role/MyAdminRole/MySession' });
+      const adminRoles = await getAdminRoles(mockContext, 'test');
+      expect(adminRoles).toEqual(['MyAdminRole/MySession']);
+      expect(printerWarn_mock).not.toHaveBeenCalled();
+    });
+
+    it('substitutes every env placeholder in a custom role name', async () => {
+      // eslint-disable-next-line no-template-curly-in-string
+      JSONUtilities_mock.readJson.mockReturnValueOnce({ adminRoleNames: 'MyAdminRole-${env}-fallback-${env}' });
+      const adminRoles = await getAdminRoles(mockContext, 'test');
+      expect(adminRoles).toEqual(['MyAdminRole-test-fallback-test']);
+      expect(printerWarn_mock).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/amplify-category-api/src/graphql-transformer/utils.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/utils.ts
@@ -7,6 +7,7 @@ import {
   CloudformationProviderFacade,
   JSONUtilities,
   pathManager,
+  readCFNTemplate,
   stateManager,
 } from '@aws-amplify/amplify-cli-core';
 import { CloudFormation, Fn } from 'cloudform-types';
@@ -21,6 +22,12 @@ const CUSTOM_ROLES_FILE_NAME = 'custom-roles.json';
 const AMPLIFY_ADMIN_ROLE = '_Full-access/CognitoIdentityCredentials';
 const AMPLIFY_MANAGE_ROLE = '_Manage-only/CognitoIdentityCredentials';
 const PROVIDER_NAME = 'awscloudformation';
+const FUNCTION_CFN_TEMPLATE_SUFFIX = '-cloudformation-template.json';
+const LAMBDA_EXECUTION_ROLE_LOGICAL_ID = 'LambdaExecutionRole';
+const NO_ENV_RESOURCES_ENV_NAME = 'NONE';
+const SHOULD_NOT_CREATE_ENV_RESOURCES_CONDITION = 'ShouldNotCreateEnvResources';
+const ENV_PLACEHOLDER_PATTERN = /\$\{env\}/g;
+const STS_ASSUMED_ROLE_ARN_PATTERN = /^arn:[^:]*:sts::[^:]*:assumed-role\/(.+)$/;
 
 interface CustomRolesConfig {
   adminRoleNames?: Array<string> | string;
@@ -33,6 +40,91 @@ export const getIdentityPoolId = async (ctx: $TSContext): Promise<string | undef
   return authResource?.output?.IdentityPoolId;
 };
 
+/**
+ * Resolves the subset of CloudFormation intrinsics used by the function template's role name into a literal string, returning
+ * `undefined` for any shape that cannot be resolved without deploying.
+ */
+const resolveStaticCfnValue = (value: unknown, currentEnv: string): string | undefined => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+  const intrinsic = value as Record<string, unknown>;
+  if (Array.isArray(intrinsic['Fn::If'])) {
+    const [conditionName, whenTrue, whenFalse] = intrinsic['Fn::If'];
+    // `ShouldNotCreateEnvResources` is the only condition whose meaning is known here, `env === 'NONE'`; any other condition
+    // cannot be evaluated without deploying
+    if (conditionName !== SHOULD_NOT_CREATE_ENV_RESOURCES_CONDITION) {
+      return undefined;
+    }
+    return resolveStaticCfnValue(currentEnv === NO_ENV_RESOURCES_ENV_NAME ? whenTrue : whenFalse, currentEnv);
+  }
+  if (Array.isArray(intrinsic['Fn::Join'])) {
+    const [delimiter, parts] = intrinsic['Fn::Join'];
+    if (typeof delimiter !== 'string' || !Array.isArray(parts)) {
+      return undefined;
+    }
+    const resolvedParts = parts.map((part) => resolveStaticCfnValue(part, currentEnv));
+    return resolvedParts.some((part) => part === undefined) ? undefined : resolvedParts.join(delimiter);
+  }
+  if (intrinsic.Ref === 'env') {
+    return currentEnv;
+  }
+  return undefined;
+};
+
+/**
+ * Resolves the name of a function's Lambda execution role, preferring the deployed stack output and falling back to the role name
+ * declared in the local CloudFormation template so that a not-yet-deployed function resolves too.
+ */
+const getFunctionExecutionRoleName = (functionResource: any, currentEnv: string): string | undefined => {
+  const deployedRoleName = functionResource?.output?.[LAMBDA_EXECUTION_ROLE_LOGICAL_ID];
+  if (typeof deployedRoleName === 'string' && deployedRoleName.length > 0) {
+    return deployedRoleName;
+  }
+  const { resourceName } = functionResource;
+  const templatePath = path.join(
+    pathManager.getResourceDirectoryPath(undefined, AmplifyCategories.FUNCTION, resourceName),
+    `${resourceName}${FUNCTION_CFN_TEMPLATE_SUFFIX}`,
+  );
+  if (!fs.existsSync(templatePath)) {
+    return undefined;
+  }
+  try {
+    const { cfnTemplate } = readCFNTemplate(templatePath);
+    return resolveStaticCfnValue(cfnTemplate?.Resources?.[LAMBDA_EXECUTION_ROLE_LOGICAL_ID]?.Properties?.RoleName, currentEnv);
+  } catch (err) {
+    return undefined;
+  }
+};
+
+/**
+ * Normalizes a `custom-roles.json` entry into the role-name shape the generated resolvers compare against, returning `undefined`
+ * for a value that can never match a caller identity.
+ */
+const normalizeCustomAdminRoleName = (adminRoleName: string, customRoleFile: string): string | undefined => {
+  const assumedRoleArnMatch = STS_ASSUMED_ROLE_ARN_PATTERN.exec(adminRoleName);
+  if (assumedRoleArnMatch) {
+    return assumedRoleArnMatch[1];
+  }
+  if (adminRoleName.startsWith('arn:')) {
+    printer.warn(
+      `Ignoring "${adminRoleName}" in ${customRoleFile}: an IAM role arn never appears in the caller identity that admin access is ` +
+        'checked against, so it would silently grant nothing. Use the IAM role name instead.',
+    );
+    return undefined;
+  }
+  return adminRoleName;
+};
+
+/**
+ * Collects the IAM identities that are granted admin access to the API regardless of its auth rules.
+ *
+ * Every entry is role-name shaped, either a bare `<RoleName>` or a qualified `<RoleName>/<SessionName>`, because the generated
+ * resolvers match each entry against the `assumed-role/` segment of the caller arn. A fully qualified arn is never returned.
+ */
 export const getAdminRoles = async (ctx: $TSContext, apiResourceName: string | undefined): Promise<Array<string>> => {
   let currentEnv;
   const adminRoles = new Array<string>();
@@ -60,10 +152,23 @@ export const getAdminRoles = async (ctx: $TSContext, apiResourceName: string | u
   if (apiResourceName) {
     // lambda functions which have access to the api
     const { allResources, resourcesToBeDeleted } = await ctx.amplify.getResourceStatus('function');
-    const resources = pullAllBy(allResources, resourcesToBeDeleted, 'resourceName')
-      .filter((r: any) => r.dependsOn?.some((d: any) => d?.resourceName === apiResourceName))
-      .map((r: any) => `${r.resourceName}-${currentEnv}`);
-    adminRoles.push(...resources);
+    const functionResources = pullAllBy(allResources, resourcesToBeDeleted, 'resourceName').filter((r: any) =>
+      r.dependsOn?.some((d: any) => d?.resourceName === apiResourceName),
+    );
+    functionResources.forEach((functionResource: any) => {
+      // A function's deployed name only ever appears in the session segment of the caller arn, which the caller chooses freely, so
+      // the execution role name is the only part of a function's identity that can be trusted.
+      const executionRoleName = getFunctionExecutionRoleName(functionResource, currentEnv);
+      if (executionRoleName) {
+        adminRoles.push(executionRoleName);
+        return;
+      }
+      printer.warn(
+        `Unable to determine the Lambda execution role name of function "${functionResource.resourceName}", so it is not granted ` +
+          `admin access to the "${apiResourceName}" GraphQL API. Add its execution role name to "adminRoleNames" in ` +
+          `${CUSTOM_ROLES_FILE_NAME} to grant access.`,
+      );
+    });
 
     // check for custom iam admin roles
     const customRoleFile = path.join(
@@ -77,8 +182,9 @@ export const getAdminRoles = async (ctx: $TSContext, apiResourceName: string | u
           ? customRoleConfig.adminRoleNames
           : [customRoleConfig.adminRoleNames];
         const adminRoleNames = customAdminRoles
-          // eslint-disable-next-line no-template-curly-in-string
-          .map((r) => (r.includes('${env}') ? r.replace('${env}', currentEnv) : r));
+          .map((r) => r.replace(ENV_PLACEHOLDER_PATTERN, currentEnv))
+          .map((r) => normalizeCustomAdminRoleName(r, customRoleFile))
+          .filter((r): r is string => r !== undefined);
         adminRoles.push(...adminRoleNames);
       }
     }

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/amplify-admin-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/amplify-admin-auth.test.ts.snap
@@ -4,8 +4,9 @@ exports[`admin roles should be return the field name inside field resolvers 1`] 
 "## [Start] Field Authorization Steps. **
 #set( $isAuthorized = false )
 #if( $util.authType() == "IAM Authorization" )
+  #set( $userArnWithTrailingSlash = "\${ctx.identity.userArn}/" )
   #foreach( $adminRole in $ctx.stash.adminRoles )
-    #if( $ctx.identity.userArn.contains($adminRole) && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
+    #if( $userArnWithTrailingSlash.contains(":assumed-role/\${adminRole}/") && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
       #return($context.source.secretValue)
     #end
   #end
@@ -41,8 +42,9 @@ $util.qr($ctx.stash.put("hasAuth", true))
 #set( $isAuthorized = false )
 #set( $allowedFields = [] )
 #if( $util.authType() == "IAM Authorization" )
+  #set( $userArnWithTrailingSlash = "\${ctx.identity.userArn}/" )
   #foreach( $adminRole in $ctx.stash.adminRoles )
-    #if( $ctx.identity.userArn.contains($adminRole) && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
+    #if( $userArnWithTrailingSlash.contains(":assumed-role/\${adminRole}/") && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
       #return($util.toJson({}))
     #end
   #end
@@ -115,8 +117,9 @@ $util.qr($ctx.stash.put("hasAuth", true))
 #set( $isAuthorized = false )
 #set( $allowedFields = [] )
 #if( $util.authType() == "IAM Authorization" )
+  #set( $userArnWithTrailingSlash = "\${ctx.identity.userArn}/" )
   #foreach( $adminRole in $ctx.stash.adminRoles )
-    #if( $ctx.identity.userArn.contains($adminRole) && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
+    #if( $userArnWithTrailingSlash.contains(":assumed-role/\${adminRole}/") && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
       #return($util.toJson({}))
     #end
   #end
@@ -150,8 +153,9 @@ $util.qr($ctx.stash.put("hasAuth", true))
 #set( $nullAllowedFields = [] )
 #set( $deniedFields = {} )
 #if( $util.authType() == "IAM Authorization" )
+  #set( $userArnWithTrailingSlash = "\${ctx.identity.userArn}/" )
   #foreach( $adminRole in $ctx.stash.adminRoles )
-    #if( $ctx.identity.userArn.contains($adminRole) && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
+    #if( $userArnWithTrailingSlash.contains(":assumed-role/\${adminRole}/") && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
       #return($util.toJson({}))
     #end
   #end
@@ -185,8 +189,9 @@ exports[`simple model with AdminUI enabled should add IAM policy only for fields
 $util.qr($ctx.stash.put("hasAuth", true))
 #set( $isAuthorized = false )
 #if( $util.authType() == "IAM Authorization" )
+  #set( $userArnWithTrailingSlash = "\${ctx.identity.userArn}/" )
   #foreach( $adminRole in $ctx.stash.adminRoles )
-    #if( $ctx.identity.userArn.contains($adminRole) && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
+    #if( $userArnWithTrailingSlash.contains(":assumed-role/\${adminRole}/") && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
       #return($util.toJson({}))
     #end
   #end
@@ -209,8 +214,9 @@ $util.qr($ctx.stash.put("hasAuth", true))
 #set( $isAuthorized = false )
 #set( $allowedFields = [] )
 #if( $util.authType() == "IAM Authorization" )
+  #set( $userArnWithTrailingSlash = "\${ctx.identity.userArn}/" )
   #foreach( $adminRole in $ctx.stash.adminRoles )
-    #if( $ctx.identity.userArn.contains($adminRole) && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
+    #if( $userArnWithTrailingSlash.contains(":assumed-role/\${adminRole}/") && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
       #return($util.toJson({}))
     #end
   #end
@@ -244,8 +250,9 @@ $util.qr($ctx.stash.put("hasAuth", true))
 #set( $nullAllowedFields = [] )
 #set( $deniedFields = {} )
 #if( $util.authType() == "IAM Authorization" )
+  #set( $userArnWithTrailingSlash = "\${ctx.identity.userArn}/" )
   #foreach( $adminRole in $ctx.stash.adminRoles )
-    #if( $ctx.identity.userArn.contains($adminRole) && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
+    #if( $userArnWithTrailingSlash.contains(":assumed-role/\${adminRole}/") && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
       #return($util.toJson({}))
     #end
   #end
@@ -279,8 +286,9 @@ exports[`simple model with AdminUI enabled should add IAM policy only for fields
 $util.qr($ctx.stash.put("hasAuth", true))
 #set( $isAuthorized = false )
 #if( $util.authType() == "IAM Authorization" )
+  #set( $userArnWithTrailingSlash = "\${ctx.identity.userArn}/" )
   #foreach( $adminRole in $ctx.stash.adminRoles )
-    #if( $ctx.identity.userArn.contains($adminRole) && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
+    #if( $userArnWithTrailingSlash.contains(":assumed-role/\${adminRole}/") && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
       #return($util.toJson({}))
     #end
   #end

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/multi-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/multi-auth.test.ts.snap
@@ -7,8 +7,9 @@ $util.qr($ctx.stash.put("hasAuth", true))
 #set( $isAuthorized = false )
 #set( $allowedFields = [] )
 #if( $util.authType() == "IAM Authorization" )
+  #set( $userArnWithTrailingSlash = "\${ctx.identity.userArn}/" )
   #foreach( $adminRole in $ctx.stash.adminRoles )
-    #if( $ctx.identity.userArn.contains($adminRole) && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
+    #if( $userArnWithTrailingSlash.contains(":assumed-role/\${adminRole}/") && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
       #return($util.toJson({}))
     #end
   #end
@@ -36,8 +37,9 @@ $util.qr($ctx.stash.put("hasAuth", true))
 #set( $isAuthorized = false )
 #set( $allowedFields = [] )
 #if( $util.authType() == "IAM Authorization" )
+  #set( $userArnWithTrailingSlash = "\${ctx.identity.userArn}/" )
   #foreach( $adminRole in $ctx.stash.adminRoles )
-    #if( $ctx.identity.userArn.contains($adminRole) && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
+    #if( $userArnWithTrailingSlash.contains(":assumed-role/\${adminRole}/") && $ctx.identity.userArn != $ctx.stash.authRole && $ctx.identity.userArn != $ctx.stash.unauthRole )
       #return($util.toJson({}))
     #end
   #end

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/amplify-admin-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/amplify-admin-auth.test.ts
@@ -462,3 +462,46 @@ test('admin roles should be return the field name inside field resolvers', () =>
   expectNoStashValueLike(out, 'Student', IDENTITY_POOL_ASSIGNMENT_PREFIX);
   expect(out.resolvers['Mutation.createStudent.auth.1.req.vtl']).toMatchSnapshot();
 });
+
+test('admin role check anchors each admin role on the caller assumed role name segment', () => {
+  const validSchema = `
+    type Post @model @auth(rules: [{ allow: private, provider: iam }]) {
+      id: ID!
+      title: String!
+    }`;
+  const out = testTransform({
+    schema: validSchema,
+    authConfig: {
+      defaultAuthentication: {
+        authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+      },
+      additionalAuthenticationProviders: [
+        {
+          authenticationType: 'AWS_IAM',
+        },
+      ],
+    },
+    synthParameters: {
+      adminRoles: ADMIN_UI_ROLES,
+    },
+    transformers: [new ModelTransformer(), new AuthTransformer()],
+  });
+  expect(out).toBeDefined();
+
+  const adminRoleCheckResolvers = Object.values(out.resolvers).filter((vtl) =>
+    vtl.includes('#foreach( $adminRole in $ctx.stash.adminRoles )'),
+  );
+  expect(adminRoleCheckResolvers.length).toBeGreaterThan(0);
+  adminRoleCheckResolvers.forEach((vtl) => {
+    // the `${...}` sequences are Velocity interpolations in the generated template, not JavaScript template placeholders
+    // eslint-disable-next-line no-template-curly-in-string
+    expect(vtl).toContain('#set( $userArnWithTrailingSlash = "${ctx.identity.userArn}/" )');
+    // eslint-disable-next-line no-template-curly-in-string
+    expect(vtl).toContain('$userArnWithTrailingSlash.contains(":assumed-role/${adminRole}/")');
+  });
+
+  // an unanchored search of the caller arn is the over-broad match this check exists to prevent
+  Object.values(out.resolvers).forEach((vtl) => {
+    expect(vtl).not.toContain('$ctx.identity.userArn.contains($adminRole)');
+  });
+});

--- a/packages/amplify-graphql-auth-transformer/src/vtl-generator/ddb/resolvers/helpers.ts
+++ b/packages/amplify-graphql-auth-transformer/src/vtl-generator/ddb/resolvers/helpers.ts
@@ -188,15 +188,25 @@ export const generateIAMAccessCheck = (enableIamAccess: boolean, expression: Exp
 
 /**
  * Creates iam admin role check helper
+ *
+ * Admin roles are role-name shaped needles (`<RoleName>` or `<RoleName>/<SessionName>`), so each needle is anchored between
+ * `:assumed-role/` and `/` within a slash-terminated copy of the caller arn. That anchoring is what the check's safety rests on: a
+ * role session name cannot contain `/` or `:`, so `:assumed-role/` appears exactly once in a real assumed-role arn and a
+ * caller-chosen session name can never produce a second one. Searching the raw caller arn for a bare needle instead matched any
+ * principal that assumed any role with `--role-session-name <adminRole>`, granting admin access more broadly than intended.
  */
 export const iamAdminRoleCheckExpression = (fieldName?: string, adminCheckExpression?: Expression): Expression => {
   const returnStatement = fieldName ? raw(`#return($context.source.${fieldName})`) : raw('#return($util.toJson({}))');
   const fullReturnExpression = adminCheckExpression ? compoundExpression([adminCheckExpression, returnStatement]) : returnStatement;
   return compoundExpression([
+    // the `${...}` sequences here are Velocity interpolations evaluated by AppSync, not JavaScript template placeholders
+    // eslint-disable-next-line no-template-curly-in-string
+    set(ref('userArnWithTrailingSlash'), str('${ctx.identity.userArn}/')),
     forEach(/* for */ ref('adminRole'), /* in */ ref('ctx.stash.adminRoles'), [
       iff(
         and([
-          methodCall(ref('ctx.identity.userArn.contains'), ref('adminRole')),
+          // eslint-disable-next-line no-template-curly-in-string
+          methodCall(ref('userArnWithTrailingSlash.contains'), str(':assumed-role/${adminRole}/')),
           notEquals(ref('ctx.identity.userArn'), ref('ctx.stash.authRole')),
           notEquals(ref('ctx.identity.userArn'), ref('ctx.stash.unauthRole')),
         ]),

--- a/packages/amplify-util-mock/src/__tests__/velocity/admin-auth.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/velocity/admin-auth.test.ts
@@ -94,6 +94,102 @@ describe('admin roles query checks', () => {
   });
 });
 
+describe('admin role identity matching', () => {
+  const ADMIN_ROLE_NAME = 'myappLambdaRoleaf16b2c3-dev';
+  const ADMIN_UI_ROLE = 'us-fake-1_uuid_Full-access/CognitoIdentityCredentials';
+  const validSchema = `
+    type Student @model @auth(rules: [{ allow: groups, groups: ["staff"] }, { allow: owner }]) {
+      id: ID!
+      name: String
+      description: String
+      secretValue: String @auth(rules: [{ allow: owner }])
+    }`;
+
+  let vtlTemplate: VelocityTemplateSimulator;
+  let secretValueResolver: string;
+
+  const renderAsCaller = (adminRoles: Array<string>, userArn: string): ReturnType<VelocityTemplateSimulator['render']> => {
+    const template = [`$util.qr($ctx.stash.put("adminRoles", ${JSON.stringify(adminRoles)}))`, secretValueResolver].join('\n');
+    const iamFieldContext: AppSyncVTLContext = { source: { secretValue: 'secretValue001' } };
+    const requestParameters: AppSyncGraphQLExecutionContext = {
+      requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AWS_IAM,
+      iamToken: { ...getIAMToken('caller'), userArn },
+      headers: {},
+    };
+    return vtlTemplate.render(template, { context: iamFieldContext, requestParameters });
+  };
+
+  beforeEach(() => {
+    const authConfig: AppSyncAuthConfiguration = {
+      defaultAuthentication: {
+        authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+      },
+      additionalAuthenticationProviders: [
+        {
+          authenticationType: 'AWS_IAM',
+        },
+      ],
+    };
+    secretValueResolver = testTransform({
+      schema: validSchema,
+      authConfig,
+      synthParameters: { adminRoles: [ADMIN_ROLE_NAME] },
+      transformers: [new ModelTransformer(), new AuthTransformer()],
+    }).resolvers['Student.secretValue.req.vtl'];
+
+    vtlTemplate = new VelocityTemplateSimulator({ authConfig });
+  });
+
+  test('authorizes a caller whose assumed role name is an admin role, whatever its session name', () => {
+    const response = renderAsCaller([ADMIN_ROLE_NAME], `arn:aws:sts::123456789012:assumed-role/${ADMIN_ROLE_NAME}/myFunc-dev`);
+
+    expect(response.hadException).toEqual(false);
+    expect(response.result).toEqual('secretValue001');
+  });
+
+  test('authorizes an admin ui caller matched on both its role and session name', () => {
+    const response = renderAsCaller([ADMIN_UI_ROLE], `arn:aws:sts::123456789012:assumed-role/${ADMIN_UI_ROLE}`);
+
+    expect(response.hadException).toEqual(false);
+    expect(response.result).toEqual('secretValue001');
+  });
+
+  test('denies a caller whose session name matches an admin role name', () => {
+    const response = renderAsCaller([ADMIN_ROLE_NAME], `arn:aws:sts::123456789012:assumed-role/UnrelatedRole/${ADMIN_ROLE_NAME}`);
+
+    expect(response.hadException).toEqual(true);
+    expect(response.result).not.toEqual('secretValue001');
+  });
+
+  test('denies a caller whose session name matches a qualified admin role entry', () => {
+    const response = renderAsCaller([ADMIN_UI_ROLE], `arn:aws:sts::123456789012:assumed-role/UnrelatedRole/${ADMIN_UI_ROLE}`);
+
+    expect(response.hadException).toEqual(true);
+    expect(response.result).not.toEqual('secretValue001');
+  });
+
+  test('denies a caller whose assumed role name merely ends with an admin role name', () => {
+    const response = renderAsCaller([ADMIN_ROLE_NAME], `arn:aws:sts::123456789012:assumed-role/unrelated${ADMIN_ROLE_NAME}/session`);
+
+    expect(response.hadException).toEqual(true);
+    expect(response.result).not.toEqual('secretValue001');
+  });
+
+  test('denies a caller whose assumed role name merely starts with an admin role name', () => {
+    const response = renderAsCaller([ADMIN_ROLE_NAME], `arn:aws:sts::123456789012:assumed-role/${ADMIN_ROLE_NAME}Extra/session`);
+
+    expect(response.hadException).toEqual(true);
+    expect(response.result).not.toEqual('secretValue001');
+  });
+
+  test('denies an iam user caller that cannot present an assumed role identity', () => {
+    const response = renderAsCaller([ADMIN_ROLE_NAME], `arn:aws:iam::123456789012:user/${ADMIN_ROLE_NAME}`);
+
+    expect(response.hadException).toEqual(true);
+    expect(response.result).not.toEqual('secretValue001');
+  });
+});
+
 describe('identity claim feature flag disabled', () => {
   describe('admin roles query checks', () => {
     const ADMIN_UI_ROLE = 'us-fake-1_uuid_Full-access/CognitoIdentityCredentials';


### PR DESCRIPTION
#### Description of changes

The admin-role allowlist used by the generated IAM authorization resolvers matched too broadly against
the caller's ARN. This narrows it to the segment it was always meant to compare, and corrects the value
the Gen 1 CLI plugin contributes for Lambda functions so that legitimate function callers keep working.

##### The generated resolvers matched the whole caller ARN

The admin-role check emitted into the DynamoDB auth resolvers established membership with a substring
search over the entire `$ctx.identity.userArn`:

```
#if( $ctx.identity.userArn.contains($adminRole) ... )
```

Since that ARN has the form `arn:aws:sts::<acct>:assumed-role/<RoleName>/<SessionName>`, an unanchored
search is satisfied by an admin role name appearing anywhere in the ARN — including the session-name
segment, a role whose name merely contains an admin role name, and IAM user ARNs. The check now
slash-terminates the ARN once and anchors each entry between `":assumed-role/"` and `"/"`:

```
#set( $userArnWithTrailingSlash = "${ctx.identity.userArn}/" )
#if( $userArnWithTrailingSlash.contains(":assumed-role/${adminRole}/") ... )
```

The appended slash is what lets a single pattern serve both entry shapes — a bare `<RoleName>` and a
qualified `<RoleName>/<SessionName>` — because it supplies the terminator a real ARN lacks after the
session name. `":assumed-role/"` occurs exactly once in an assumed-role ARN, so only the role-name
segment can satisfy the match, and a non-assumed-role ARN matches nothing.

##### Functions now contribute their execution role name

Anchoring on its own would have stopped matching legitimate function callers. A function's caller ARN is
`assumed-role/<execRoleName>/<functionName>`, so the entry `getAdminRoles` emitted for a function,
`<functionName>-<env>`, only ever appeared in the session-name segment — and the execution role name
`<appName>LambdaRole<shortId>-<env>` is not derivable from the function name. `getAdminRoles` therefore
now contributes the function's execution role name, read from the deployed stack output
`LambdaExecutionRole` and falling back to the `RoleName` declared in the function's local
CloudFormation template so that a first push resolves too. When reading that template, only the template's own
`ShouldNotCreateEnvResources` condition is evaluated — a role name guarded by any other condition is treated
as unresolvable. A function whose execution role name cannot
be resolved is now reported with a warning and granted no admin access, rather than silently receiving
an entry that can never match.

The deployed-output path relies on `Outputs.LambdaExecutionRole` being the role *name*: the function
template emits it as `{ "Ref": "LambdaExecutionRole" }`, and `Ref` on an `AWS::IAM::Role` returns the
name. The template uses `Fn::GetAtt ["LambdaExecutionRole", "Arn"]` wherever it wants the ARN, and the CLI
backfills a separate `LambdaExecutionRoleArn` output for that purpose, so the two are never conflated.

##### custom-roles.json entries are normalized

A fully qualified STS assumed-role ARN is reduced to its role-name segment, which preserves
configurations that happened to work under the old substring match. An IAM role ARN is reported and
ignored, since it can never appear in a caller identity and previously contributed nothing silently.
Every `${env}` placeholder in an entry is now substituted rather than only the first.

Admin-role entries keep their role-name shape, so the RDS resolver path that forwards them verbatim is
unaffected.

`no-template-curly-in-string` is disabled on the handful of lines where `${...}` is Velocity
interpolation destined for the generated template rather than a JavaScript placeholder. The disable
previously present in `getAdminRoles` for `${env}` is removed, since that substitution now uses a regex.

##### Upgrade note

Resolvers are regenerated on the next `amplify push`, so existing deployments keep their current
behaviour until then. Because a function granted API access is now matched by its Lambda execution role
name, a function whose execution role name cannot be resolved from either the deployed stack output or
its local CloudFormation template is not granted admin access, and a warning naming that function is
printed. Adding the execution role name to `adminRoleNames` in `custom-roles.json` restores access for
such a function.

##### CDK / CloudFormation Parameters Changed

None.

#### Issue #, if available

N/A

#### Description of how you validated changes

- Refreshed 10 VTL snapshots across two suites. Every hunk is the same single transformation, with only
  the two expected return-statement variants.
- The `iam-access` and all `rds-*` snapshots are **byte-identical**, confirming the RDS/SQL resolver path
  is untouched.
- Added velocity tests in `amplify-util-mock` that render the generated template through the VTL
  evaluator and assert the authorization outcome for representative caller ARNs — an admin role name with
  an arbitrary session name, a qualified role/session entry, role names that merely overlap an admin role
  name at either end, and an IAM user ARN. These exercise behaviour rather than template text, and the
  tightened cases fail against the previous template.
- Added unit tests for `getAdminRoles` covering the execution role name from the deployed stack output,
  resolution from the local CloudFormation template in both the env-suffixed and `NONE` cases, the
  unresolvable case, and both `custom-roles.json` normalization paths.
- `@aws-amplify/graphql-auth-transformer`: 4855 tests pass with its coverage gates (29 suites).
- `amplify-util-mock` velocity suite: 226 tests pass.
- `getAdminRoles` suite: 18 tests pass (9 new).
- `lerna run build` across both packages and their dependencies: 30 packages built successfully.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced) — n/a, no documented behaviour or public API change
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies — n/a, none added
- [x] Any CDK or CloudFormation parameter changes are called out explicitly — none

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
